### PR TITLE
Add clear buttons to bunker URL and secret key inputs in LoginDialog

### DIFF
--- a/src/components/LoginDialog.svelte
+++ b/src/components/LoginDialog.svelte
@@ -3,7 +3,6 @@
     import { Dialog, Tabs } from "bits-ui";
     import { PublicKeyState } from "../lib/keyManager.svelte";
     import { BUNKER_REGEX } from "../lib/nip46Service";
-    import { derivePublicKeyFromNsec, isValidNsec } from "../lib/utils/nostrUtils";
     import { preventKeyboardFocusChange } from "../lib/utils/keyboardFocusUtils";
     import {
         createNip46ConnectionRelayDrafts,
@@ -13,6 +12,7 @@
         validateNip46ConnectionRelayDrafts,
     } from "../lib/nip46ConnectUiUtils";
     import { tryCopyToClipboard } from "../lib/utils/clipboardUtils";
+    import { toNprofile, toNpub } from "../lib/utils/nostrUtils";
     import Button from "./Button.svelte";
     import DialogWrapper from "./DialogWrapper.svelte";
     import FloatingMessage from "./FloatingMessage.svelte";
@@ -85,26 +85,22 @@
     let isParentClientEnabled = $derived(isParentClientAvailable);
 
     // --- 公開鍵状態管理 ---
-    let publicKeyState = $state(new PublicKeyState());
-    let isValid = $state(false);
-    let npubValue = $state("");
-    let nprofileValue = $state("");
-
-    function syncPublicKeyState(): void {
-        const nextSecretKey = secretKey?.trim() ?? "";
-
-        if (!nextSecretKey || !isValidNsec(nextSecretKey)) {
-            isValid = false;
-            npubValue = "";
-            nprofileValue = "";
-            return;
+    const publicKeyState = new PublicKeyState();
+    let publicKeyStateView = $derived.by(() => {
+        if (secretKey !== undefined) {
+            publicKeyState.setNsec(secretKey);
         }
-
-        const derivedData = derivePublicKeyFromNsec(nextSecretKey);
-        isValid = Boolean(derivedData.hex);
-        npubValue = derivedData.npub;
-        nprofileValue = derivedData.nprofile;
-    }
+        return {
+            isValid: publicKeyState.currentIsValid,
+            npub: publicKeyState.currentHex ? toNpub(publicKeyState.currentHex) : "",
+            nprofile: publicKeyState.currentHex
+                ? toNprofile(publicKeyState.currentHex)
+                : "",
+        };
+    });
+    let isValid = $derived(publicKeyStateView.isValid);
+    let npubValue = $derived(publicKeyStateView.npub);
+    let nprofileValue = $derived(publicKeyStateView.nprofile);
 
     // --- エラーメッセージ管理 ---
     let inputEl: HTMLInputElement | null = $state(null);
@@ -268,15 +264,8 @@
 
     // --- 秘密鍵入力の監視と公開鍵状態の更新 ---
     $effect(() => {
-        if (secretKey !== undefined) {
-            publicKeyState.setNsec(secretKey);
-            syncPublicKeyState();
-            // 入力値が空の場合のみエラーをクリア
-            if (inputEl) {
-                if (!secretKey) {
-                    inputEl.setCustomValidity("");
-                }
-            }
+        if (secretKey !== undefined && inputEl && !secretKey) {
+            inputEl.setCustomValidity("");
         }
     });
 
@@ -296,18 +285,8 @@
             return;
         }
         secretKey = "";
-        publicKeyState.setNsec("");
-        syncPublicKeyState();
         inputEl?.setCustomValidity("");
         inputEl?.focus({ preventScroll: true });
-    }
-
-    function handleSecretKeyInput(event: Event): void {
-        const nextValue = (event.currentTarget as HTMLInputElement | null)?.value ?? "";
-        secretKey = nextValue;
-        publicKeyState.setNsec(nextValue);
-        syncPublicKeyState();
-        inputEl?.setCustomValidity("");
     }
 
     function handleSave() {
@@ -1117,7 +1096,7 @@
                         maxlength="63"
                         bind:this={inputEl}
                         title={$_("loginDialog.hint_input_secret")}
-                        oninput={handleSecretKeyInput}
+                        oninput={() => inputEl?.setCustomValidity("")}
                     />
                     {#if secretKey.length > 0}
                         <Button

--- a/src/components/LoginDialog.svelte
+++ b/src/components/LoginDialog.svelte
@@ -3,6 +3,8 @@
     import { Dialog, Tabs } from "bits-ui";
     import { PublicKeyState } from "../lib/keyManager.svelte";
     import { BUNKER_REGEX } from "../lib/nip46Service";
+    import { derivePublicKeyFromNsec, isValidNsec } from "../lib/utils/nostrUtils";
+    import { preventKeyboardFocusChange } from "../lib/utils/keyboardFocusUtils";
     import {
         createNip46ConnectionRelayDrafts,
         ensureNip46ConnectionRelayDraftRows,
@@ -83,7 +85,26 @@
     let isParentClientEnabled = $derived(isParentClientAvailable);
 
     // --- 公開鍵状態管理 ---
-    const publicKeyState = new PublicKeyState();
+    let publicKeyState = $state(new PublicKeyState());
+    let isValid = $state(false);
+    let npubValue = $state("");
+    let nprofileValue = $state("");
+
+    function syncPublicKeyState(): void {
+        const nextSecretKey = secretKey?.trim() ?? "";
+
+        if (!nextSecretKey || !isValidNsec(nextSecretKey)) {
+            isValid = false;
+            npubValue = "";
+            nprofileValue = "";
+            return;
+        }
+
+        const derivedData = derivePublicKeyFromNsec(nextSecretKey);
+        isValid = Boolean(derivedData.hex);
+        npubValue = derivedData.npub;
+        nprofileValue = derivedData.nprofile;
+    }
 
     // --- エラーメッセージ管理 ---
     let inputEl: HTMLInputElement | null = $state(null);
@@ -249,6 +270,7 @@
     $effect(() => {
         if (secretKey !== undefined) {
             publicKeyState.setNsec(secretKey);
+            syncPublicKeyState();
             // 入力値が空の場合のみエラーをクリア
             if (inputEl) {
                 if (!secretKey) {
@@ -258,12 +280,36 @@
         }
     });
 
-    // --- 公開鍵状態を $derived で直接参照（svelte/store subscribe パターンを廃止）---
-    let isValid = $derived(publicKeyState.isValid);
-    let npubValue = $derived(publicKeyState.npub);
-    let nprofileValue = $derived(publicKeyState.nprofile);
-
     // --- UIイベントハンドラ ---
+    function handleClearBunkerUrl(): void {
+        if (!bunkerUrl) {
+            return;
+        }
+        bunkerUrl = "";
+        nip46ErrorMessage = "";
+        bunkerInputEl?.setCustomValidity("");
+        bunkerInputEl?.focus({ preventScroll: true });
+    }
+
+    function handleClearSecretKey(): void {
+        if (!secretKey) {
+            return;
+        }
+        secretKey = "";
+        publicKeyState.setNsec("");
+        syncPublicKeyState();
+        inputEl?.setCustomValidity("");
+        inputEl?.focus({ preventScroll: true });
+    }
+
+    function handleSecretKeyInput(event: Event): void {
+        const nextValue = (event.currentTarget as HTMLInputElement | null)?.value ?? "";
+        secretKey = nextValue;
+        publicKeyState.setNsec(nextValue);
+        syncPublicKeyState();
+        inputEl?.setCustomValidity("");
+    }
+
     function handleSave() {
         cleanupNostrConnectDirectOpenState();
         if (inputEl) {
@@ -978,21 +1024,40 @@
                             }}
                         >
                             <div class="bunker-input-row">
-                                <input
-                                    type="password"
-                                    bind:value={bunkerUrl}
-                                    placeholder="bunker://..."
-                                    class="bunker-input u-control"
-                                    required
-                                    autocomplete="off"
-                                    bind:this={bunkerInputEl}
-                                    disabled={isLoadingNip46}
-                                    oninput={() => {
-                                        nip46ErrorMessage = "";
-                                        if (bunkerInputEl)
-                                            bunkerInputEl.setCustomValidity("");
-                                    }}
-                                />
+                                <div class="input-shell">
+                                    <input
+                                        type="password"
+                                        bind:value={bunkerUrl}
+                                        placeholder="bunker://..."
+                                        class="bunker-input u-control"
+                                        required
+                                        autocomplete="off"
+                                        bind:this={bunkerInputEl}
+                                        disabled={isLoadingNip46}
+                                        oninput={() => {
+                                            nip46ErrorMessage = "";
+                                            if (bunkerInputEl)
+                                                bunkerInputEl.setCustomValidity("");
+                                        }}
+                                    />
+                                    {#if bunkerUrl.length > 0}
+                                        <Button
+                                            variant="secondary"
+                                            type="button"
+                                            className="clear-input-btn"
+                                            ariaLabel={$_("clearInput") || "入力内容を消去"}
+                                            onClick={handleClearBunkerUrl}
+                                            onmousedown={preventKeyboardFocusChange}
+                                            ontouchstart={preventKeyboardFocusChange}
+                                            disabled={isLoadingNip46}
+                                        >
+                                            <div
+                                                class="clear-input-icon svg-icon"
+                                                aria-hidden="true"
+                                            ></div>
+                                        </Button>
+                                    {/if}
+                                </div>
                                 <Button
                                     variant="primary"
                                     shape="square"
@@ -1038,25 +1103,40 @@
 
         <form novalidate onsubmit={handleFormSubmit}>
             <div class="secret-input-row">
-                <input
-                    type="password"
-                    bind:value={secretKey}
-                    placeholder="nsec1..."
-                    class="secret-input u-control"
-                    id="secretKey"
-                    name="secretKey"
-                    autocomplete="current-password"
-                    required
-                    minlength="63"
-                    maxlength="63"
-                    bind:this={inputEl}
-                    title={$_("loginDialog.hint_input_secret")}
-                    oninput={() => {
-                        // 入力時はエラーをクリアするだけ
-                        if (inputEl) inputEl.setCustomValidity("");
-                    }}
-                />
-
+                <div class="input-shell">
+                    <input
+                        type="password"
+                        bind:value={secretKey}
+                        placeholder="nsec1..."
+                        class="secret-input u-control"
+                        id="secretKey"
+                        name="secretKey"
+                        autocomplete="current-password"
+                        required
+                        minlength="63"
+                        maxlength="63"
+                        bind:this={inputEl}
+                        title={$_("loginDialog.hint_input_secret")}
+                        oninput={handleSecretKeyInput}
+                    />
+                    {#if secretKey.length > 0}
+                        <Button
+                            variant="secondary"
+                            type="button"
+                            className="clear-input-btn"
+                            ariaLabel={$_("clearInput") || "入力内容を消去"}
+                            onClick={handleClearSecretKey}
+                            onmousedown={preventKeyboardFocusChange}
+                            ontouchstart={preventKeyboardFocusChange}
+                        >
+                            <div
+                                class="clear-input-icon svg-icon"
+                                aria-hidden="true"
+                            ></div>
+                        </Button>
+                    {/if}
+                </div>
+ 
                 <Button
                     variant="primary"
                     shape="square"
@@ -1242,14 +1322,47 @@
         flex: none;
     }
 
+    .input-shell {
+        position: relative;
+        display: flex;
+        align-items: center;
+        flex: 1;
+        min-width: 0;
+    }
+
     .secret-input,
     .bunker-input {
         font-family: monospace;
         font-size: 1rem;
-        padding: 0.6rem;
+        padding: 0.6rem 3.25rem 0.6rem 0.6rem;
         background-color: var(--btn-bg);
         border: none;
         flex: 1;
+        min-width: 0;
+    }
+
+    :global(.clear-input-btn) {
+        position: absolute;
+        inset: 50% auto 50% auto;
+        right: 8px;
+        transform: translateY(-50%);
+        width: 44px;
+        min-width: 44px;
+        height: 44px;
+        min-height: 44px;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 999px;
+        flex: 0 0 auto;
+        z-index: 1;
+    }
+
+    .clear-input-icon {
+        width: 20px;
+        height: 20px;
+        mask-image: url("/icons/close_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg");
     }
 
     .secret-heading-row h3 {

--- a/src/components/LoginDialog.svelte
+++ b/src/components/LoginDialog.svelte
@@ -12,7 +12,6 @@
         validateNip46ConnectionRelayDrafts,
     } from "../lib/nip46ConnectUiUtils";
     import { tryCopyToClipboard } from "../lib/utils/clipboardUtils";
-    import { toNprofile, toNpub } from "../lib/utils/nostrUtils";
     import Button from "./Button.svelte";
     import DialogWrapper from "./DialogWrapper.svelte";
     import FloatingMessage from "./FloatingMessage.svelte";
@@ -86,21 +85,14 @@
 
     // --- 公開鍵状態管理 ---
     const publicKeyState = new PublicKeyState();
-    let publicKeyStateView = $derived.by(() => {
-        if (secretKey !== undefined) {
-            publicKeyState.setNsec(secretKey);
-        }
-        return {
-            isValid: publicKeyState.currentIsValid,
-            npub: publicKeyState.currentHex ? toNpub(publicKeyState.currentHex) : "",
-            nprofile: publicKeyState.currentHex
-                ? toNprofile(publicKeyState.currentHex)
-                : "",
-        };
-    });
-    let isValid = $derived(publicKeyStateView.isValid);
-    let npubValue = $derived(publicKeyStateView.npub);
-    let nprofileValue = $derived(publicKeyStateView.nprofile);
+    let isValid = $derived(publicKeyState.isValid);
+    let npubValue = $derived(publicKeyState.npub);
+    let nprofileValue = $derived(publicKeyState.nprofile);
+    let clearInputLabel = $derived(
+        $_("clearInput") === "clearInput"
+            ? "入力内容を消去"
+            : $_("clearInput"),
+    );
 
     // --- エラーメッセージ管理 ---
     let inputEl: HTMLInputElement | null = $state(null);
@@ -264,12 +256,26 @@
 
     // --- 秘密鍵入力の監視と公開鍵状態の更新 ---
     $effect(() => {
+        if (secretKey !== undefined) {
+            publicKeyState.setNsec(secretKey);
+        }
+    });
+
+    $effect(() => {
         if (secretKey !== undefined && inputEl && !secretKey) {
             inputEl.setCustomValidity("");
         }
     });
 
     // --- UIイベントハンドラ ---
+    function handleBunkerInput(event: Event): void {
+        bunkerUrl = (event.currentTarget as HTMLInputElement).value;
+        nip46ErrorMessage = "";
+        if (bunkerInputEl) {
+            bunkerInputEl.setCustomValidity("");
+        }
+    }
+
     function handleClearBunkerUrl(): void {
         if (!bunkerUrl) {
             return;
@@ -278,6 +284,11 @@
         nip46ErrorMessage = "";
         bunkerInputEl?.setCustomValidity("");
         bunkerInputEl?.focus({ preventScroll: true });
+    }
+
+    function handleSecretKeyInput(event: Event): void {
+        secretKey = (event.currentTarget as HTMLInputElement).value;
+        inputEl?.setCustomValidity("");
     }
 
     function handleClearSecretKey(): void {
@@ -1006,25 +1017,21 @@
                                 <div class="input-shell">
                                     <input
                                         type="password"
-                                        bind:value={bunkerUrl}
+                                        value={bunkerUrl}
                                         placeholder="bunker://..."
                                         class="bunker-input u-control"
                                         required
                                         autocomplete="off"
                                         bind:this={bunkerInputEl}
                                         disabled={isLoadingNip46}
-                                        oninput={() => {
-                                            nip46ErrorMessage = "";
-                                            if (bunkerInputEl)
-                                                bunkerInputEl.setCustomValidity("");
-                                        }}
+                                        oninput={handleBunkerInput}
                                     />
                                     {#if bunkerUrl.length > 0}
                                         <Button
                                             variant="secondary"
                                             type="button"
                                             className="clear-input-btn"
-                                            ariaLabel={$_("clearInput") || "入力内容を消去"}
+                                            ariaLabel={clearInputLabel}
                                             onClick={handleClearBunkerUrl}
                                             onmousedown={preventKeyboardFocusChange}
                                             ontouchstart={preventKeyboardFocusChange}
@@ -1085,7 +1092,7 @@
                 <div class="input-shell">
                     <input
                         type="password"
-                        bind:value={secretKey}
+                        value={secretKey}
                         placeholder="nsec1..."
                         class="secret-input u-control"
                         id="secretKey"
@@ -1096,14 +1103,14 @@
                         maxlength="63"
                         bind:this={inputEl}
                         title={$_("loginDialog.hint_input_secret")}
-                        oninput={() => inputEl?.setCustomValidity("")}
+                        oninput={handleSecretKeyInput}
                     />
                     {#if secretKey.length > 0}
                         <Button
                             variant="secondary"
                             type="button"
                             className="clear-input-btn"
-                            ariaLabel={$_("clearInput") || "入力内容を消去"}
+                            ariaLabel={clearInputLabel}
                             onClick={handleClearSecretKey}
                             onmousedown={preventKeyboardFocusChange}
                             ontouchstart={preventKeyboardFocusChange}

--- a/src/components/LoginDialog.svelte
+++ b/src/components/LoginDialog.svelte
@@ -286,11 +286,6 @@
         bunkerInputEl?.focus({ preventScroll: true });
     }
 
-    function handleSecretKeyInput(event: Event): void {
-        secretKey = (event.currentTarget as HTMLInputElement).value;
-        inputEl?.setCustomValidity("");
-    }
-
     function handleClearSecretKey(): void {
         if (!secretKey) {
             return;
@@ -1091,8 +1086,8 @@
             <div class="secret-input-row">
                 <div class="input-shell">
                     <input
+                        bind:value={secretKey}
                         type="password"
-                        value={secretKey}
                         placeholder="nsec1..."
                         class="secret-input u-control"
                         id="secretKey"
@@ -1103,7 +1098,7 @@
                         maxlength="63"
                         bind:this={inputEl}
                         title={$_("loginDialog.hint_input_secret")}
-                        oninput={handleSecretKeyInput}
+                        oninput={() => inputEl?.setCustomValidity("")}
                     />
                     {#if secretKey.length > 0}
                         <Button

--- a/src/test/mocks/keyManager.ts
+++ b/src/test/mocks/keyManager.ts
@@ -38,60 +38,27 @@ const mockKeyManager = {
     PublicKeyState: vi.fn().mockImplementation(function () {
         let _currentIsValid = false;
         let _currentHex = '';
-        let _currentNsec = '';
-        let _currentNpub = '';
-        let _currentNprofile = '';
 
         return {
             setNsec: vi.fn((nsec) => {
-                _currentNsec = nsec ?? '';
                 // 簡易的な実装（テスト用）
                 if (nsec && nsec.startsWith('nsec')) {
                     _currentIsValid = true;
-                    _currentHex = '00'.repeat(32);
-                    _currentNpub = 'npub1' + '00'.repeat(32).slice(0, 10) + '...';
-                    _currentNprofile = 'nprofile1' + '00'.repeat(32).slice(0, 10) + '...';
+                    _currentHex = 'test-hex';
                 } else {
                     _currentIsValid = false;
                     _currentHex = '';
-                    _currentNpub = '';
-                    _currentNprofile = '';
                 }
             }),
             clear: vi.fn(() => {
-                _currentNsec = '';
                 _currentIsValid = false;
                 _currentHex = '';
-                _currentNpub = '';
-                _currentNprofile = '';
             }),
             get currentIsValid() {
                 return _currentIsValid;
             },
             get currentHex() {
                 return _currentHex;
-            },
-            get isValid() {
-                return _currentIsValid;
-            },
-            get hex() {
-                return _currentHex;
-            },
-            get nsec() {
-                return _currentNsec;
-            },
-            get npub() {
-                return _currentNpub;
-            },
-            get nprofile() {
-                return _currentNprofile;
-            },
-            get data() {
-                return {
-                    hex: _currentHex,
-                    npub: _currentNpub,
-                    nprofile: _currentNprofile,
-                };
             }
         };
     })

--- a/src/test/mocks/keyManager.ts
+++ b/src/test/mocks/keyManager.ts
@@ -38,27 +38,60 @@ const mockKeyManager = {
     PublicKeyState: vi.fn().mockImplementation(function () {
         let _currentIsValid = false;
         let _currentHex = '';
+        let _currentNsec = '';
+        let _currentNpub = '';
+        let _currentNprofile = '';
 
         return {
             setNsec: vi.fn((nsec) => {
+                _currentNsec = nsec ?? '';
                 // 簡易的な実装（テスト用）
                 if (nsec && nsec.startsWith('nsec')) {
                     _currentIsValid = true;
-                    _currentHex = 'test-hex';
+                    _currentHex = '00'.repeat(32);
+                    _currentNpub = 'npub1' + '00'.repeat(32).slice(0, 10) + '...';
+                    _currentNprofile = 'nprofile1' + '00'.repeat(32).slice(0, 10) + '...';
                 } else {
                     _currentIsValid = false;
                     _currentHex = '';
+                    _currentNpub = '';
+                    _currentNprofile = '';
                 }
             }),
             clear: vi.fn(() => {
+                _currentNsec = '';
                 _currentIsValid = false;
                 _currentHex = '';
+                _currentNpub = '';
+                _currentNprofile = '';
             }),
             get currentIsValid() {
                 return _currentIsValid;
             },
             get currentHex() {
                 return _currentHex;
+            },
+            get isValid() {
+                return _currentIsValid;
+            },
+            get hex() {
+                return _currentHex;
+            },
+            get nsec() {
+                return _currentNsec;
+            },
+            get npub() {
+                return _currentNpub;
+            },
+            get nprofile() {
+                return _currentNprofile;
+            },
+            get data() {
+                return {
+                    hex: _currentHex,
+                    npub: _currentNpub,
+                    nprofile: _currentNprofile,
+                };
             }
         };
     })

--- a/src/test/unit/loginDialog.test.ts
+++ b/src/test/unit/loginDialog.test.ts
@@ -5,6 +5,7 @@ import { locale, waitLocale } from 'svelte-i18n';
 
 const mockTranslate = vi.hoisted(() => (key: string) => {
     const translations: Record<string, string> = {
+        'clearInput': '入力内容を消去',
         'loginDialog.input_secret': '秘密鍵',
         'loginDialog.hint_input_secret': 'nsec1から始まる秘密鍵を入力',
         'loginDialog.add_account_title': 'アカウントを追加',
@@ -80,36 +81,17 @@ vi.mock('../../lib/utils/clipboardUtils', () => ({
     tryCopyToClipboard: vi.fn().mockResolvedValue(true),
 }));
 
-vi.mock('../../lib/keyManager.svelte', () => ({
-    PublicKeyState: class MockPublicKeyState {
-        private valid = false;
-        private npubValue = '';
-        private nprofileValue = '';
-
-        setNsec(value: string) {
-            this.valid = value.startsWith('nsec1');
-            this.npubValue = this.valid ? 'npub1test' : '';
-            this.nprofileValue = this.valid ? 'nprofile1test' : '';
-        }
-
-        get isValid() {
-            return this.valid;
-        }
-
-        get npub() {
-            return this.npubValue;
-        }
-
-        get nprofile() {
-            return this.nprofileValue;
-        }
-    },
-}));
-
 import LoginDialog from '../../components/LoginDialog.svelte';
 import { DEFAULT_NIP46_CONNECTION_RELAY_CANDIDATES } from '../../lib/nip46ConnectUiUtils';
 
 describe('LoginDialog', () => {
+    const validSecret = 'nsec1qy352euf40x77qfrg4ncn27dauqjx3t83x4ummcpydzk0zdtehhs80zqrl';
+
+    const setInputValue = (input: HTMLInputElement, value: string) => {
+        input.value = value;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+    };
+
     const defaultProps = {
         show: true,
         secretKey: '',
@@ -192,11 +174,10 @@ describe('LoginDialog', () => {
 
         const secretInput = screen.getByPlaceholderText('nsec1...') as HTMLInputElement;
         const form = secretInput.closest('form');
-        const validSecret = 'nsec1' + 'a'.repeat(58);
 
-        await fireEvent.input(secretInput, {
-            target: { value: validSecret },
-        });
+        setInputValue(secretInput, validSecret);
+        await waitFor(() => expect(secretInput.value).toBe(validSecret));
+        await screen.findByText(/npub1/);
         await fireEvent.keyDown(secretInput, { key: 'Enter', code: 'Enter' });
         await fireEvent.submit(form as HTMLFormElement);
 
@@ -215,14 +196,219 @@ describe('LoginDialog', () => {
 
         const secretInput = screen.getByPlaceholderText('nsec1...') as HTMLInputElement;
         const saveButton = screen.getByRole('button', { name: '保存' });
-        const validSecret = 'nsec1' + 'a'.repeat(58);
 
-        await fireEvent.input(secretInput, {
-            target: { value: validSecret },
-        });
+        setInputValue(secretInput, validSecret);
+        await waitFor(() => expect(secretInput.value).toBe(validSecret));
+        await screen.findByText(/npub1/);
         await fireEvent.click(saveButton);
 
         expect(onSave).toHaveBeenCalledTimes(1);
+    });
+
+    it('bunker URLが空のときクリアボタンが表示されない', () => {
+        render(LoginDialog, {
+            props: defaultProps,
+        });
+
+        expect(
+            screen.queryByRole('button', { name: /clearInput|入力内容を消去/ }),
+        ).toBeNull();
+    });
+
+    it('bunker URLを入力するとクリアボタンが表示される', async () => {
+        render(LoginDialog, {
+            props: defaultProps,
+        });
+
+        await fireEvent.click(screen.getByText('bunker:// を入力'));
+        await waitFor(() => expect(screen.getByPlaceholderText('bunker://...')).toBeTruthy());
+
+        const bunkerInput = screen.getByPlaceholderText('bunker://...') as HTMLInputElement;
+
+        setInputValue(bunkerInput, 'bunker://example?relay=wss://relay.example.com');
+        await waitFor(() => expect(screen.getByRole('button', { name: /clearInput|入力内容を消去/ })).toBeTruthy());
+        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        expect(clearButton).toBeTruthy();
+        expect((clearButton as HTMLButtonElement).type).toBe('button');
+    });
+
+    it('bunker URLをクリアすると値とエラーが消える', async () => {
+        const onNip46Login = vi.fn<() => Promise<string | undefined>>().mockResolvedValue('nip46_connection_failed');
+
+        render(LoginDialog, {
+            props: {
+                ...defaultProps,
+                onNip46Login,
+            },
+        });
+
+        await fireEvent.click(screen.getByText('bunker:// を入力'));
+        await waitFor(() => expect(screen.getByPlaceholderText('bunker://...')).toBeTruthy());
+
+        const bunkerInput = screen.getByPlaceholderText('bunker://...') as HTMLInputElement;
+
+        await fireEvent.input(bunkerInput, {
+            target: { value: 'bunker://example?relay=wss://relay.example.com' },
+        });
+        await fireEvent.click(screen.getByText('接続'));
+
+        expect(await screen.findByText('接続に失敗しました')).toBeTruthy();
+
+        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        await fireEvent.click(clearButton);
+
+        expect(bunkerInput.value).toBe('');
+        expect(screen.queryByText('接続に失敗しました')).toBeNull();
+        expect(bunkerInput.validity.customError).toBe(false);
+    });
+
+    it('bunker URLクリア後に入力欄へフォーカスが戻る', async () => {
+        render(LoginDialog, {
+            props: defaultProps,
+        });
+
+        await fireEvent.click(screen.getByText('bunker:// を入力'));
+        await waitFor(() => expect(screen.getByPlaceholderText('bunker://...')).toBeTruthy());
+
+        const bunkerInput = screen.getByPlaceholderText('bunker://...') as HTMLInputElement;
+        await fireEvent.input(bunkerInput, {
+            target: { value: 'bunker://example' },
+        });
+        await waitFor(() => expect(screen.getByRole('button', { name: /clearInput|入力内容を消去/ })).toBeTruthy());
+
+        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        await fireEvent.mouseDown(clearButton);
+        await fireEvent.click(clearButton);
+
+        expect(document.activeElement).toBe(bunkerInput);
+    });
+
+    it('bunker URLクリアでonNip46Loginが呼ばれない', async () => {
+        const onNip46Login = vi.fn<() => Promise<string | undefined>>().mockResolvedValue(undefined);
+
+        render(LoginDialog, {
+            props: {
+                ...defaultProps,
+                onNip46Login,
+            },
+        });
+
+        await fireEvent.click(screen.getByText('bunker:// を入力'));
+        await waitFor(() => expect(screen.getByPlaceholderText('bunker://...')).toBeTruthy());
+
+        const bunkerInput = screen.getByPlaceholderText('bunker://...') as HTMLInputElement;
+        await fireEvent.input(bunkerInput, {
+            target: { value: 'bunker://example' },
+        });
+        await waitFor(() => expect(screen.getByRole('button', { name: /clearInput|入力内容を消去/ })).toBeTruthy());
+
+        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        await fireEvent.click(clearButton);
+
+        expect(onNip46Login).not.toHaveBeenCalled();
+    });
+
+    it('isLoadingNip46中はクリアボタンが操作不可になる', async () => {
+        render(LoginDialog, {
+            props: {
+                ...defaultProps,
+                isLoadingNip46: true,
+            },
+        });
+
+        await fireEvent.click(screen.getByText('bunker:// を入力'));
+        await waitFor(() => expect(screen.getByPlaceholderText('bunker://...')).toBeTruthy());
+
+        const bunkerInput = screen.getByPlaceholderText('bunker://...') as HTMLInputElement;
+        await fireEvent.input(bunkerInput, {
+            target: { value: 'bunker://example' },
+        });
+
+        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ }) as HTMLButtonElement;
+        expect(clearButton.disabled).toBe(true);
+    });
+
+    it('秘密鍵が空のときクリアボタンが表示されない', () => {
+        render(LoginDialog, {
+            props: defaultProps,
+        });
+
+        expect(
+            screen.queryAllByRole('button', { name: /clearInput|入力内容を消去/ }),
+        ).toHaveLength(0);
+    });
+
+    it('秘密鍵を入力するとクリアボタンが表示される', async () => {
+        render(LoginDialog, {
+            props: defaultProps,
+        });
+
+        const secretInput = screen.getByPlaceholderText('nsec1...') as HTMLInputElement;
+        setInputValue(secretInput, validSecret);
+        await waitFor(() => expect(screen.getByRole('button', { name: /clearInput|入力内容を消去/ })).toBeTruthy());
+
+        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        expect(clearButton).toBeTruthy();
+    });
+
+    it('秘密鍵をクリアすると値と公開鍵表示が消える', async () => {
+        render(LoginDialog, {
+            props: defaultProps,
+        });
+
+        const secretInput = screen.getByPlaceholderText('nsec1...') as HTMLInputElement;
+        setInputValue(secretInput, validSecret);
+
+        await waitFor(() => expect(secretInput.value).toBe(validSecret));
+        await waitFor(() => {
+            expect(screen.getByText(/npub1/)).toBeTruthy();
+            expect(screen.getByText(/nprofile1/)).toBeTruthy();
+        });
+
+        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        await fireEvent.click(clearButton);
+
+        expect(secretInput.value).toBe('');
+        await waitFor(() => {
+            expect(screen.queryByText(/npub1/)).toBeNull();
+            expect(screen.queryByText(/nprofile1/)).toBeNull();
+        });
+    });
+
+    it('秘密鍵クリア後に入力欄へフォーカスが戻る', async () => {
+        render(LoginDialog, {
+            props: defaultProps,
+        });
+
+        const secretInput = screen.getByPlaceholderText('nsec1...') as HTMLInputElement;
+        setInputValue(secretInput, validSecret);
+        await waitFor(() => expect(screen.getByRole('button', { name: /clearInput|入力内容を消去/ })).toBeTruthy());
+
+        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        await fireEvent.mouseDown(clearButton);
+        await fireEvent.click(clearButton);
+
+        expect(document.activeElement).toBe(secretInput);
+    });
+
+    it('秘密鍵クリアでonSaveが呼ばれない', async () => {
+        const onSave = vi.fn();
+
+        render(LoginDialog, {
+            props: {
+                ...defaultProps,
+                onSave,
+            },
+        });
+
+        const secretInput = screen.getByPlaceholderText('nsec1...') as HTMLInputElement;
+        setInputValue(secretInput, validSecret);
+        await waitFor(() => expect(screen.getByRole('button', { name: /clearInput|入力内容を消去/ })).toBeTruthy());
+
+        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        await fireEvent.click(clearButton);
+
+        expect(onSave).not.toHaveBeenCalled();
     });
 
     it('親クライアント連携ログイン失敗時にローカライズ済みエラーを表示する', async () => {
@@ -495,8 +681,10 @@ describe('LoginDialog', () => {
         expect(saveButton.disabled).toBe(false);
 
         await fireEvent.input(secretInput, {
-            target: { value: 'nsec1' + 'a'.repeat(58) },
+            target: { value: validSecret },
         });
+        await waitFor(() => expect(secretInput.value).toBe(validSecret));
+        await screen.findByText(/npub1/);
         await fireEvent.click(parentButton);
         await fireEvent.click(extensionButton);
         await fireEvent.click(saveButton);

--- a/src/test/unit/loginDialog.test.ts
+++ b/src/test/unit/loginDialog.test.ts
@@ -81,6 +81,16 @@ vi.mock('../../lib/utils/clipboardUtils', () => ({
     tryCopyToClipboard: vi.fn().mockResolvedValue(true),
 }));
 
+vi.mock('../../lib/keyManager.svelte', async () => {
+    const actual = await vi.importActual<typeof import('../../lib/keyManager.svelte')>('../../lib/keyManager.svelte');
+    return actual;
+});
+
+vi.mock('../../lib/keyManager.svelte.ts', async () => {
+    const actual = await vi.importActual<typeof import('../../lib/keyManager.svelte')>('../../lib/keyManager.svelte');
+    return actual;
+});
+
 import LoginDialog from '../../components/LoginDialog.svelte';
 import { DEFAULT_NIP46_CONNECTION_RELAY_CANDIDATES } from '../../lib/nip46ConnectUiUtils';
 
@@ -211,7 +221,7 @@ describe('LoginDialog', () => {
         });
 
         expect(
-            screen.queryByRole('button', { name: /clearInput|入力内容を消去/ }),
+            screen.queryByRole('button', { name: '入力内容を消去' }),
         ).toBeNull();
     });
 
@@ -226,8 +236,8 @@ describe('LoginDialog', () => {
         const bunkerInput = screen.getByPlaceholderText('bunker://...') as HTMLInputElement;
 
         setInputValue(bunkerInput, 'bunker://example?relay=wss://relay.example.com');
-        await waitFor(() => expect(screen.getByRole('button', { name: /clearInput|入力内容を消去/ })).toBeTruthy());
-        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        await waitFor(() => expect(screen.getByRole('button', { name: '入力内容を消去' })).toBeTruthy());
+        const clearButton = screen.getByRole('button', { name: '入力内容を消去' });
         expect(clearButton).toBeTruthy();
         expect((clearButton as HTMLButtonElement).type).toBe('button');
     });
@@ -254,7 +264,7 @@ describe('LoginDialog', () => {
 
         expect(await screen.findByText('接続に失敗しました')).toBeTruthy();
 
-        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        const clearButton = screen.getByRole('button', { name: '入力内容を消去' });
         await fireEvent.click(clearButton);
 
         expect(bunkerInput.value).toBe('');
@@ -274,9 +284,9 @@ describe('LoginDialog', () => {
         await fireEvent.input(bunkerInput, {
             target: { value: 'bunker://example' },
         });
-        await waitFor(() => expect(screen.getByRole('button', { name: /clearInput|入力内容を消去/ })).toBeTruthy());
+        await waitFor(() => expect(screen.getByRole('button', { name: '入力内容を消去' })).toBeTruthy());
 
-        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        const clearButton = screen.getByRole('button', { name: '入力内容を消去' });
         await fireEvent.mouseDown(clearButton);
         await fireEvent.click(clearButton);
 
@@ -300,9 +310,9 @@ describe('LoginDialog', () => {
         await fireEvent.input(bunkerInput, {
             target: { value: 'bunker://example' },
         });
-        await waitFor(() => expect(screen.getByRole('button', { name: /clearInput|入力内容を消去/ })).toBeTruthy());
+        await waitFor(() => expect(screen.getByRole('button', { name: '入力内容を消去' })).toBeTruthy());
 
-        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        const clearButton = screen.getByRole('button', { name: '入力内容を消去' });
         await fireEvent.click(clearButton);
 
         expect(onNip46Login).not.toHaveBeenCalled();
@@ -324,7 +334,7 @@ describe('LoginDialog', () => {
             target: { value: 'bunker://example' },
         });
 
-        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ }) as HTMLButtonElement;
+        const clearButton = screen.getByRole('button', { name: '入力内容を消去' }) as HTMLButtonElement;
         expect(clearButton.disabled).toBe(true);
     });
 
@@ -334,7 +344,7 @@ describe('LoginDialog', () => {
         });
 
         expect(
-            screen.queryAllByRole('button', { name: /clearInput|入力内容を消去/ }),
+            screen.queryAllByRole('button', { name: '入力内容を消去' }),
         ).toHaveLength(0);
     });
 
@@ -345,9 +355,9 @@ describe('LoginDialog', () => {
 
         const secretInput = screen.getByPlaceholderText('nsec1...') as HTMLInputElement;
         setInputValue(secretInput, validSecret);
-        await waitFor(() => expect(screen.getByRole('button', { name: /clearInput|入力内容を消去/ })).toBeTruthy());
+        await waitFor(() => expect(screen.getByRole('button', { name: '入力内容を消去' })).toBeTruthy());
 
-        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        const clearButton = screen.getByRole('button', { name: '入力内容を消去' });
         expect(clearButton).toBeTruthy();
     });
 
@@ -365,7 +375,7 @@ describe('LoginDialog', () => {
             expect(screen.getByText(/nprofile1/)).toBeTruthy();
         });
 
-        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        const clearButton = screen.getByRole('button', { name: '入力内容を消去' });
         await fireEvent.click(clearButton);
 
         expect(secretInput.value).toBe('');
@@ -382,9 +392,9 @@ describe('LoginDialog', () => {
 
         const secretInput = screen.getByPlaceholderText('nsec1...') as HTMLInputElement;
         setInputValue(secretInput, validSecret);
-        await waitFor(() => expect(screen.getByRole('button', { name: /clearInput|入力内容を消去/ })).toBeTruthy());
+        await waitFor(() => expect(screen.getByRole('button', { name: '入力内容を消去' })).toBeTruthy());
 
-        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        const clearButton = screen.getByRole('button', { name: '入力内容を消去' });
         await fireEvent.mouseDown(clearButton);
         await fireEvent.click(clearButton);
 
@@ -403,9 +413,9 @@ describe('LoginDialog', () => {
 
         const secretInput = screen.getByPlaceholderText('nsec1...') as HTMLInputElement;
         setInputValue(secretInput, validSecret);
-        await waitFor(() => expect(screen.getByRole('button', { name: /clearInput|入力内容を消去/ })).toBeTruthy());
+        await waitFor(() => expect(screen.getByRole('button', { name: '入力内容を消去' })).toBeTruthy());
 
-        const clearButton = screen.getByRole('button', { name: /clearInput|入力内容を消去/ });
+        const clearButton = screen.getByRole('button', { name: '入力内容を消去' });
         await fireEvent.click(clearButton);
 
         expect(onSave).not.toHaveBeenCalled();


### PR DESCRIPTION
This pull request introduces clear buttons for the bunker URL and secret key input fields in the LoginDialog component. The changes include:

- **Clear Button Implementation**: Added clear buttons that appear only when there is input in the respective fields.
- **Focus Management**: Ensured that focus returns to the input field after clearing the content, without using `setTimeout`.
- **Accessibility**: Used the existing `clearInput` translation key for the button's accessible name.
- **Validation Handling**: Cleared relevant validation messages and states upon clearing the inputs.
- **Layout Adjustments**: Wrapped input fields and buttons in a common shell to maintain layout consistency across desktop and mobile views.
- **Unit Tests**: Expanded the test suite to cover the new clear button functionality, ensuring that all existing behaviors remain intact.

The implementation has been validated through unit tests and browser checks to confirm that the new buttons function correctly without disrupting existing features.