### PR TITLE
Refactor HEX64 validation utility to eliminate duplication

### DIFF
--- a/src/lib/postHistoryInboundInteractionClassifier.ts
+++ b/src/lib/postHistoryInboundInteractionClassifier.ts
@@ -4,6 +4,7 @@ import {
     type PostHistoryThreadReferences,
 } from "./postHistoryNip10Utils";
 import type { NostrEvent } from "./types";
+import { isHex64 } from "./utils/nostrHexUtils";
 
 export type PostHistoryInboundInteractionType =
     | "direct-reply"
@@ -21,12 +22,6 @@ export interface PostHistoryInboundInteractionClassification {
     targetEventId: string | null;
     targetAuthorPubkey: string | null;
     reason: string;
-}
-
-const HEX_64_PATTERN = /^[0-9a-f]{64}$/i;
-
-function isHex64(value: unknown): value is string {
-    return typeof value === "string" && HEX_64_PATTERN.test(value);
 }
 
 function eventHasPTag(event: NostrEvent, pubkeyHex: string): boolean {

--- a/src/lib/postHistoryNip10Utils.ts
+++ b/src/lib/postHistoryNip10Utils.ts
@@ -1,5 +1,6 @@
 import { RelayConfigUtils } from "./relayConfigUtils";
 import type { NostrEvent } from "./types";
+import { isHex64 } from "./utils/nostrHexUtils";
 
 export interface PostHistoryThreadReferenceTag {
     eventId: string;
@@ -34,8 +35,6 @@ export type PostHistoryThreadReferenceIssue =
     | "conflicting-reply-targets"
     | "reply-target-is-channel";
 
-const HEX_64_PATTERN = /^[0-9a-f]{64}$/i;
-
 const EMPTY_REFERENCES: PostHistoryThreadReferences = {
     rootId: null,
     replyId: null,
@@ -54,10 +53,6 @@ const EMPTY_REFERENCES: PostHistoryThreadReferences = {
     issues: [],
 };
 
-function isValidHexId(value: unknown): value is string {
-    return typeof value === "string" && HEX_64_PATTERN.test(value);
-}
-
 function normalizeMarker(value: unknown): string | null {
     if (typeof value !== "string") {
         return null;
@@ -69,7 +64,7 @@ function normalizeMarker(value: unknown): string | null {
 
 function parseETag(tag: string[]): PostHistoryThreadReferenceTag | null {
     const eventId = tag[1];
-    if (!isValidHexId(eventId)) {
+    if (!isHex64(eventId)) {
         return null;
     }
 
@@ -77,7 +72,7 @@ function parseETag(tag: string[]): PostHistoryThreadReferenceTag | null {
         typeof tag[2] === "string" && tag[2].length > 0 ? [tag[2]] : [],
         { limit: 1 },
     )[0] ?? null;
-    const authorHint = isValidHexId(tag[4]) ? tag[4] : null;
+    const authorHint = isHex64(tag[4]) ? tag[4] : null;
 
     return {
         eventId,
@@ -141,7 +136,7 @@ function normalizeReactionTargetMarker(value: unknown): "reply" | "root" | "unkn
     }
 
     const trimmed = value.trim().toLowerCase();
-    if (trimmed.length === 0 || isValidHexId(trimmed)) {
+    if (trimmed.length === 0 || isHex64(trimmed)) {
         return null;
     }
 
@@ -160,7 +155,7 @@ export function resolveKind7ReactionTargetEventId(
     }
 
     const eTags = event.tags.filter(
-        (tag): tag is string[] => Array.isArray(tag) && tag[0] === "e" && isValidHexId(tag[1]),
+        (tag): tag is string[] => Array.isArray(tag) && tag[0] === "e" && isHex64(tag[1]),
     );
     if (eTags.length === 0) {
         return null;

--- a/src/lib/postHistoryQuoteUtils.ts
+++ b/src/lib/postHistoryQuoteUtils.ts
@@ -1,6 +1,7 @@
 import { nip19 } from "nostr-tools";
 import { RelayConfigUtils } from "./relayConfigUtils";
 import type { NostrEvent } from "./types";
+import { isHex64 } from "./utils/nostrHexUtils";
 
 export interface PostHistoryQuoteReference {
     eventId: string;
@@ -8,16 +9,11 @@ export interface PostHistoryQuoteReference {
     authorHint: string | null;
 }
 
-const HEX_64_PATTERN = /^[0-9a-f]{64}$/i;
 const INLINE_NOSTR_URI_PATTERN = /nostr:[^\s<>"']+/gi;
 const TRAILING_INLINE_NOSTR_URI_PUNCTUATION_PATTERN =
     /[),.!?:;\]\u3001\u3002\uff01\uff08\uff09\uff0c\uff0e\uff1a\uff1b\u300d\u300f\u3011]+$/u;
 const PUNCTUATION_ONLY_LINE_PATTERN =
     /^[\s),.!?:;\]\u3001\u3002\uff01\uff08\uff09\uff0c\uff0e\uff1a\uff1b\u300d\u300f\u3011]+$/u;
-
-function isValidHexId(value: unknown): value is string {
-    return typeof value === "string" && HEX_64_PATTERN.test(value);
-}
 
 function parseRelayHint(value: unknown): string | null {
     return RelayConfigUtils.sanitizeExternalRelayUrls(
@@ -94,12 +90,12 @@ export function parsePostHistoryQuoteReferences(
         }
 
         const eventId = tag[1];
-        if (!isValidHexId(eventId)) {
+        if (!isHex64(eventId)) {
             continue;
         }
 
         const relayHint = parseRelayHint(tag[2]);
-        const authorHint = isValidHexId(tag[3]) ? tag[3] : null;
+        const authorHint = isHex64(tag[3]) ? tag[3] : null;
         const existing = quotesByEventId.get(eventId);
 
         if (!existing) {

--- a/src/lib/utils/nostrHexUtils.ts
+++ b/src/lib/utils/nostrHexUtils.ts
@@ -1,0 +1,5 @@
+const HEX_64_PATTERN = /^[0-9a-f]{64}$/i;
+
+export function isHex64(value: unknown): value is string {
+    return typeof value === "string" && HEX_64_PATTERN.test(value);
+}

--- a/src/test/unit/nostrHexUtils.test.ts
+++ b/src/test/unit/nostrHexUtils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { isHex64 } from "../../lib/utils/nostrHexUtils";
+
+describe("isHex64", () => {
+    it("accepts lowercase 64-character hex strings", () => {
+        expect(isHex64("a".repeat(64))).toBe(true);
+    });
+
+    it("accepts uppercase characters in 64-character hex strings", () => {
+        expect(isHex64("A".repeat(32) + "b".repeat(32))).toBe(true);
+    });
+
+    it("rejects strings with 63 or 65 characters", () => {
+        expect(isHex64("a".repeat(63))).toBe(false);
+        expect(isHex64("a".repeat(65))).toBe(false);
+    });
+
+    it("rejects non-hex characters", () => {
+        expect(isHex64("g".repeat(64))).toBe(false);
+        expect(isHex64("0".repeat(63) + "g")).toBe(false);
+    });
+
+    it("rejects non-string values", () => {
+        expect(isHex64(123)).toBe(false);
+        expect(isHex64(null)).toBe(false);
+        expect(isHex64(undefined)).toBe(false);
+        expect(isHex64({ value: "a".repeat(64) })).toBe(false);
+    });
+});


### PR DESCRIPTION
This pull request consolidates the 64-character HEX validation logic across multiple files into a single utility function. The changes include:

- Created a new utility file `nostrHexUtils.ts` that exports the `isHex64` function, which checks if a value is a valid 64-character HEX string.
- Removed duplicate validation logic from the following files:
  - `postHistoryQuoteUtils.ts`
  - `postHistoryNip10Utils.ts`
  - `postHistoryInboundInteractionClassifier.ts`
- Updated the three target files to use the new `isHex64` function directly, eliminating unnecessary wrappers.
- Added unit tests in `nostrHexUtils.test.ts` to ensure the new function behaves as expected, covering various valid and invalid cases.

All existing tests related to the modified files were executed successfully, confirming that the refactor did not alter any existing functionality.