### PR TITLE
Refactor string array equality check into a common utility

### DIFF
--- a/src/lib/hooks/usePostHistoryThreadGraph.svelte.ts
+++ b/src/lib/hooks/usePostHistoryThreadGraph.svelte.ts
@@ -103,6 +103,7 @@ import {
     createPostHistoryProfileSyncCoordinator,
     type PostHistoryProfileSyncCoordinator,
 } from "../postHistoryProfileSync";
+import { areStringArraysEqual } from "../utils/arrayEqualityUtils";
 
 export type PostHistoryThreadGraphRepliesStatus =
     | "unloaded"
@@ -191,14 +192,6 @@ function buildInitialRepliesActionState(): PostHistoryThreadGraphRepliesActionSt
 
 function sanitizeRelayUrls(urls: string[]): string[] {
     return RelayConfigUtils.sanitizeExternalRelayUrls(urls, { limit: 8 });
-}
-
-function areStringArraysEqual(left: string[], right: string[]): boolean {
-    if (left.length !== right.length) {
-        return false;
-    }
-
-    return left.every((value, index) => value === right[index]);
 }
 
 function uniqueEventIds(eventIds: string[]): string[] {

--- a/src/lib/postHistoryRelatedTargetResolver.svelte.ts
+++ b/src/lib/postHistoryRelatedTargetResolver.svelte.ts
@@ -24,6 +24,7 @@ import {
     createPostHistoryProfileSyncCoordinator,
     type PostHistoryProfileSyncCoordinator,
 } from "./postHistoryProfileSync";
+import { areStringArraysEqual } from "./utils/arrayEqualityUtils";
 
 const POST_HISTORY_RELATED_TARGET_RELAY_LIMIT = 8;
 
@@ -92,14 +93,6 @@ function sanitizeRelayHints(relayHints: string[]): string[] {
     return RelayConfigUtils.sanitizeExternalRelayUrls(relayHints, {
         limit: POST_HISTORY_RELATED_TARGET_RELAY_LIMIT,
     });
-}
-
-function areStringArraysEqual(left: string[], right: string[]): boolean {
-    if (left.length !== right.length) {
-        return false;
-    }
-
-    return left.every((value, index) => value === right[index]);
 }
 
 function createSyntheticTargetEvent(

--- a/src/lib/storage/postHistoryChildInteractionsRepository.ts
+++ b/src/lib/storage/postHistoryChildInteractionsRepository.ts
@@ -6,6 +6,7 @@ import {
 } from "../postHistoryNip10Utils";
 import { RelayConfigUtils } from "../relayConfigUtils";
 import type { NostrEvent } from "../types";
+import { areStringArraysEqual } from "../utils/arrayEqualityUtils";
 import {
     ehagakiDb,
     type EHagakiDB,
@@ -58,16 +59,6 @@ function sortRelatedEvents(records: PostHistoryChildInteractionRecord[]): PostHi
 
         return left.eventId.localeCompare(right.eventId);
     });
-}
-
-function areStringArraysEqual(left: string[] | undefined, right: string[] | undefined): boolean {
-    const normalizedLeft = left ?? [];
-    const normalizedRight = right ?? [];
-    if (normalizedLeft.length !== normalizedRight.length) {
-        return false;
-    }
-
-    return normalizedLeft.every((value, index) => value === normalizedRight[index]);
 }
 
 function areTagsEqual(left: string[][], right: string[][]): boolean {

--- a/src/lib/storage/postHistoryDeletionRequestsRepository.ts
+++ b/src/lib/storage/postHistoryDeletionRequestsRepository.ts
@@ -10,6 +10,7 @@ import {
 } from "../postHistoryDeletionUtils";
 import { RelayConfigUtils } from "../relayConfigUtils";
 import type { NostrEvent } from "../types";
+import { areStringArraysEqual } from "../utils/arrayEqualityUtils";
 import {
     ehagakiDb,
     type EHagakiDB,
@@ -111,16 +112,6 @@ function addDeletedTarget(
     const eventIds = map.get(record.targetAuthorPubkey) ?? new Set<string>();
     eventIds.add(record.targetEventId);
     map.set(record.targetAuthorPubkey, eventIds);
-}
-
-function areStringArraysEqual(left: string[] | undefined, right: string[] | undefined): boolean {
-    const normalizedLeft = left ?? [];
-    const normalizedRight = right ?? [];
-    if (normalizedLeft.length !== normalizedRight.length) {
-        return false;
-    }
-
-    return normalizedLeft.every((value, index) => value === normalizedRight[index]);
 }
 
 function hasMaterialDeletionRequestChanges(

--- a/src/lib/storage/postHistoryRepository.ts
+++ b/src/lib/storage/postHistoryRepository.ts
@@ -15,6 +15,7 @@ import { markPostHistoryShouldReturnToLatestAfterLocalPost } from "../postHistor
 import { extractPostHistoryMedia } from "../postHistoryMediaUtils";
 import { RelayConfigUtils } from "../relayConfigUtils";
 import type { NostrEvent } from "../types";
+import { areStringArraysEqual } from "../utils/arrayEqualityUtils";
 import type {
     PostHistoryDeletionRequestRecord,
     PostHistoryRecord,
@@ -303,16 +304,6 @@ function normalizeFetchedEventItems(
     }
 
     return Array.from(normalized.values());
-}
-
-function areStringArraysEqual(left: string[] | undefined, right: string[] | undefined): boolean {
-    const normalizedLeft = left ?? [];
-    const normalizedRight = right ?? [];
-    if (normalizedLeft.length !== normalizedRight.length) {
-        return false;
-    }
-
-    return normalizedLeft.every((value, index) => value === normalizedRight[index]);
 }
 
 function areMediaArraysEqual(left: PostHistoryMediaRecord[], right: PostHistoryMediaRecord[]): boolean {

--- a/src/lib/storage/profilesRepository.ts
+++ b/src/lib/storage/profilesRepository.ts
@@ -6,6 +6,7 @@ import {
 } from "../profileEventComparison";
 import { RelayConfigUtils } from "../relayConfigUtils";
 import type { ProfileData } from "../types";
+import { areStringArraysEqual } from "../utils/arrayEqualityUtils";
 import { ehagakiDb, type EHagakiDB, type ProfileRecord } from "./ehagakiDb";
 
 const PROFILE_SCHEMA_VERSION = 2;
@@ -81,13 +82,6 @@ function toRecord(pubkeyHex: string, profile: ProfileData, now: () => number): P
 function normalizeProfileRelays(...relayLists: Array<string[] | undefined>): string[] | undefined {
     const normalized = RelayConfigUtils.sanitizeExternalRelayUrls(relayLists.flatMap((relays) => relays ?? []));
     return normalized.length > 0 ? normalized : undefined;
-}
-
-function areStringArraysEqual(left: string[] | undefined, right: string[] | undefined): boolean {
-    const leftValues = left ?? [];
-    const rightValues = right ?? [];
-    return leftValues.length === rightValues.length
-        && leftValues.every((value, index) => value === rightValues[index]);
 }
 
 function hasValidEventIdentity(record: ProfileRecord): record is ProfileRecord & ProfileEventIdentity {

--- a/src/lib/utils/arrayEqualityUtils.ts
+++ b/src/lib/utils/arrayEqualityUtils.ts
@@ -1,0 +1,13 @@
+export function areStringArraysEqual(
+    left: ReadonlyArray<string> | null | undefined,
+    right: ReadonlyArray<string> | null | undefined,
+): boolean {
+    const leftValues = left ?? [];
+    const rightValues = right ?? [];
+
+    if (leftValues.length !== rightValues.length) {
+        return false;
+    }
+
+    return leftValues.every((value, index) => value === rightValues[index]);
+}

--- a/src/test/unit/arrayEqualityUtils.test.ts
+++ b/src/test/unit/arrayEqualityUtils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { areStringArraysEqual } from "../../lib/utils/arrayEqualityUtils";
+
+describe("areStringArraysEqual", () => {
+    it("treats undefined and empty arrays as equal", () => {
+        expect(areStringArraysEqual(undefined, [])).toBe(true);
+    });
+
+    it("treats null and empty arrays as equal", () => {
+        expect(areStringArraysEqual(null, [])).toBe(true);
+    });
+
+    it("returns true for equal contents in the same order", () => {
+        expect(areStringArraysEqual(["a", "b"], ["a", "b"])).toBe(true);
+    });
+
+    it("returns false when the order differs", () => {
+        expect(areStringArraysEqual(["a", "b"], ["b", "a"])).toBe(false);
+    });
+
+    it("returns false when the lengths differ", () => {
+        expect(areStringArraysEqual(["a"], ["a", "b"])).toBe(false);
+    });
+
+    it("compares duplicate elements position by position", () => {
+        expect(areStringArraysEqual(["a", "a", "b"], ["a", "b", "a"])).toBe(false);
+    });
+
+    it("does not mutate the input arrays", () => {
+        const left = ["a", "b"];
+        const right = ["a", "b"];
+        const leftSnapshot = [...left];
+        const rightSnapshot = [...right];
+
+        expect(areStringArraysEqual(left, right)).toBe(true);
+        expect(left).toEqual(leftSnapshot);
+        expect(right).toEqual(rightSnapshot);
+    });
+});


### PR DESCRIPTION
This pull request consolidates the implementation of the `areStringArraysEqual` function across multiple files into a single utility function located in `src/lib/utils/arrayEqualityUtils.ts`. The changes aim to reduce code duplication and maintain consistent behavior for string array equality checks.

### Changes made:
- Created a new utility function `areStringArraysEqual` that:
  - Accepts `ReadonlyArray<string> | null | undefined`.
  - Treats `null` and `undefined` as equivalent to an empty array.
  - Performs strict length and index-based comparisons without normalization or sorting.
- Removed local implementations of `areStringArraysEqual` from the following files and replaced them with imports of the new utility:
  - `src/lib/storage/profilesRepository.ts`
  - `src/lib/storage/postHistoryDeletionRequestsRepository.ts`
  - `src/lib/storage/postHistoryChildInteractionsRepository.ts`
  - `src/lib/storage/postHistoryRepository.ts`
  - `src/lib/postHistoryRelatedTargetResolver.svelte.ts`
  - `src/lib/hooks/usePostHistoryThreadGraph.svelte.ts`
- Added unit tests for the new utility function in `src/test/unit/arrayEqualityUtils.test.ts`.

### Verification:
- All related unit tests passed successfully.
- Type checks and overall project tests were executed, with one unrelated test failure reported.