### PR TITLE
Consolidate mockConsole helpers in unit tests

### DIFF
--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -4,6 +4,24 @@ import { vi } from 'vitest';
 import type { RxNostr } from 'rx-nostr';
 import type { KeyManagerInterface } from '../lib/types';
 
+export type MockConsole = Console & {
+    log: ReturnType<typeof vi.fn>;
+    debug: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+};
+
+export function createMockConsole(): MockConsole {
+    return {
+        log: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    } as unknown as MockConsole;
+}
+
 // Mock Storage implementation
 export class MockStorage implements Storage {
     private store: Record<string, string> = {};

--- a/src/test/unit/accountManager.test.ts
+++ b/src/test/unit/accountManager.test.ts
@@ -1,15 +1,16 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AccountManager } from '../../lib/accountManager';
 import { STORAGE_KEYS } from '../../lib/constants';
-import { MockStorage } from '../helpers';
+import { createMockConsole, type MockConsole, MockStorage } from '../helpers';
 
 describe('AccountManager', () => {
     let storage: MockStorage;
     let manager: AccountManager;
-    const mockConsole = { error: vi.fn(), warn: vi.fn(), log: vi.fn(), info: vi.fn(), debug: vi.fn() } as unknown as Console;
+    let mockConsole: MockConsole;
 
     beforeEach(() => {
         storage = new MockStorage();
+        mockConsole = createMockConsole();
         manager = new AccountManager({ localStorage: storage, console: mockConsole });
         vi.clearAllMocks();
     });

--- a/src/test/unit/embedComposerContextService.test.ts
+++ b/src/test/unit/embedComposerContextService.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EMBED_MESSAGE_NAMESPACE } from '../../lib/embedProtocol';
 import { EmbedComposerContextService } from '../../lib/embedComposerContextService';
+import { createMockConsole, type MockConsole } from '../helpers';
 
 function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.com') {
     const listeners = new Map<string, (event: MessageEvent) => void>();
@@ -25,14 +26,10 @@ function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.c
 }
 
 describe('EmbedComposerContextService', () => {
-    let mockConsole: Console;
+    let mockConsole: MockConsole;
 
     beforeEach(() => {
-        mockConsole = {
-            log: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-        } as unknown as Console;
+        mockConsole = createMockConsole();
     });
 
     it('composer.setContext を受け取ると listener を呼ぶ', () => {

--- a/src/test/unit/embedIndexedDbService.test.ts
+++ b/src/test/unit/embedIndexedDbService.test.ts
@@ -6,6 +6,7 @@ import {
 import { EmbedIndexedDbService } from "../../lib/embedIndexedDbService";
 import type { UploadDestinationRecord } from "../../lib/storage/ehagakiDb";
 import { UPLOAD_DESTINATION_GLOBAL_SCOPE } from "../../lib/upload/uploadDestinationPresets";
+import { createMockConsole, type MockConsole } from "../helpers";
 
 function createMockWindow(search = "?parentOrigin=https%3A%2F%2Fparent.example.com") {
     const listeners = new Map<string, (event: MessageEvent) => void>();
@@ -55,14 +56,10 @@ function createDestinationRecord(id = "destination"): UploadDestinationRecord {
 }
 
 describe("EmbedIndexedDbService", () => {
-    let mockConsole: Console;
+    let mockConsole: MockConsole;
 
     beforeEach(() => {
-        mockConsole = {
-            log: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-        } as unknown as Console;
+        mockConsole = createMockConsole();
     });
 
     it("iframe と parentOrigin がない場合は初期化しない", () => {

--- a/src/test/unit/embedSettingsService.test.ts
+++ b/src/test/unit/embedSettingsService.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EMBED_MESSAGE_NAMESPACE } from '../../lib/embedProtocol';
 import { EmbedSettingsService } from '../../lib/embedSettingsService';
+import { createMockConsole, type MockConsole } from '../helpers';
 
 function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.com') {
     const listeners = new Map<string, (event: MessageEvent) => void>();
@@ -22,14 +23,10 @@ function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.c
 }
 
 describe('EmbedSettingsService', () => {
-    let mockConsole: Console;
+    let mockConsole: MockConsole;
 
     beforeEach(() => {
-        mockConsole = {
-            log: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-        } as unknown as Console;
+        mockConsole = createMockConsole();
     });
 
     it('settings.set を受け取ると listener を呼ぶ', () => {

--- a/src/test/unit/embedStorageService.test.ts
+++ b/src/test/unit/embedStorageService.test.ts
@@ -5,7 +5,7 @@ import {
     EMBED_MESSAGE_VERSION,
 } from '../../lib/embedProtocol';
 import { EmbedStorageService } from '../../lib/embedStorageService';
-import { MockStorage } from '../helpers';
+import { createMockConsole, type MockConsole, MockStorage } from '../helpers';
 
 function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.com') {
     const listeners = new Map<string, (event: MessageEvent) => void>();
@@ -27,14 +27,10 @@ function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.c
 }
 
 describe('EmbedStorageService', () => {
-    let mockConsole: Console;
+    let mockConsole: MockConsole;
 
     beforeEach(() => {
-        mockConsole = {
-            log: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-        } as unknown as Console;
+        mockConsole = createMockConsole();
     });
 
     it('iframe と parentOrigin がない場合は初期化しない', () => {

--- a/src/test/unit/iframeMessageService.test.ts
+++ b/src/test/unit/iframeMessageService.test.ts
@@ -2,17 +2,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { IframeMessageService } from "../../lib/iframeMessageService";
 import type { IframeMessagePayload } from "../../lib/iframeMessageService";
 import { EMBED_MESSAGE_NAMESPACE, EMBED_MESSAGE_VERSION } from '../../lib/embedProtocol';
+import { createMockConsole, type MockConsole } from "../helpers";
 
 describe("IframeMessageService", () => {
   let mockWindow: any;
-  let mockConsole: Console;
+  let mockConsole: MockConsole;
 
   beforeEach(() => {
-    mockConsole = {
-      log: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    } as any;
+    mockConsole = createMockConsole();
   });
 
   describe("isInIframe", () => {

--- a/src/test/unit/keyManager.test.ts
+++ b/src/test/unit/keyManager.test.ts
@@ -21,7 +21,7 @@ import {
     KeyValidator
 } from '../../lib/keyManager.svelte';
 import type { KeyManagerDeps } from '../../lib/types';
-import { MockStorage } from '../helpers';
+import { createMockConsole, type MockConsole, MockStorage } from '../helpers';
 
 // appUtilsのモック（実際の関数を実装）
 vi.mock("../lib/utils/appUtils", () => ({
@@ -94,16 +94,12 @@ describe('KeyValidator', () => {
 describe('KeyStorage', () => {
     let storage: KeyStorage;
     let mockLocalStorage: MockStorage;
-    let mockConsole: Console;
+    let mockConsole: MockConsole;
     let mockSecretKeyStore: { value: string | null; set: (value: string | null) => void };
 
     beforeEach(() => {
         mockLocalStorage = new MockStorage();
-        mockConsole = {
-            log: vi.fn(),
-            error: vi.fn(),
-            warn: vi.fn()
-        } as any;
+        mockConsole = createMockConsole();
         mockSecretKeyStore = {
             value: null,
             set: vi.fn()

--- a/src/test/unit/nip07AuthService.test.ts
+++ b/src/test/unit/nip07AuthService.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Nip07AuthService } from '../../lib/nip07AuthService';
+import { createMockConsole, type MockConsole } from '../helpers';
 
 // nip07-awaiterをモック（AuthService経由で使われる場合のデフォルト値）
 vi.mock('nip07-awaiter', () => ({
@@ -14,16 +15,8 @@ function createMockWindow(nostr?: any): Window {
     return { nostr } as any;
 }
 
-function createMockConsole(): Console {
-    return {
-        log: vi.fn(),
-        error: vi.fn(),
-        warn: vi.fn(),
-    } as unknown as Console;
-}
-
 describe('Nip07AuthService', () => {
-    let mockConsole: Console;
+    let mockConsole: MockConsole;
 
     beforeEach(() => {
         mockConsole = createMockConsole();

--- a/src/test/unit/parentClientAuthService.test.ts
+++ b/src/test/unit/parentClientAuthService.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../../lib/parentClientAuthService';
 import { STORAGE_KEYS } from '../../lib/constants';
 import type { ParentClientSessionData } from '../../lib/types';
-import { MockStorage } from '../helpers';
+import { createMockConsole, type MockConsole, MockStorage } from '../helpers';
 import { EMBED_MESSAGE_NAMESPACE } from '../../lib/embedProtocol';
 
 function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.com') {
@@ -32,14 +32,10 @@ function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.c
 }
 
 describe('ParentClientAuthService', () => {
-    let mockConsole: Console;
+    let mockConsole: MockConsole;
 
     beforeEach(() => {
-        mockConsole = {
-            log: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-        } as unknown as Console;
+        mockConsole = createMockConsole();
     });
 
     it('auth.request/auth.result で接続し signer を生成する', async () => {


### PR DESCRIPTION
This pull request refactors the unit tests to consolidate the creation of `mockConsole` instances into a reusable helper function, `createMockConsole()`, located in `src/test/helpers.ts`. The changes aim to reduce redundancy and improve maintainability across multiple test files.

### Changes made:
- Added `createMockConsole()` to `src/test/helpers.ts`, which generates `log`, `debug`, `info`, `warn`, and `error` methods as `vi.fn()`.
- Replaced local `mockConsole` definitions in the following test files with calls to `createMockConsole()`:
  - `nip07AuthService.test.ts`
  - `keyManager.test.ts`
  - `accountManager.test.ts`
  - `parentClientAuthService.test.ts`
  - `embedStorageService.test.ts`
  - `embedSettingsService.test.ts`
  - `embedIndexedDbService.test.ts`
  - `embedComposerContextService.test.ts`
  - `iframeMessageService.test.ts`
- Ensured that existing assertions and test structures remain unchanged, allowing for continued verification of `mockConsole.warn` and `mockConsole.error` calls.
- The test file `authService.authenticate.test.ts` was left unchanged as it utilized dependency-injected console instead of a local mock.

### Verification:
- All modified tests were executed successfully, with 132 tests passing in total.
- `npm run check` and `npm run test:unit` were executed, resulting in 291 tests passing and 1 unrelated failure in `fixedLegacyBridge.test.ts`. 

This refactor enhances the clarity and efficiency of the test suite while maintaining the integrity of existing tests.