### PR TITLE
Refactor window mock creation for embedded tests into a helper

### DIFF
--- a/src/test/embedWindowTestUtils.ts
+++ b/src/test/embedWindowTestUtils.ts
@@ -1,0 +1,37 @@
+import { vi } from 'vitest';
+
+export type EmbedTestWindowMock = {
+    windowObj: Window;
+    parent: {
+        postMessage: ReturnType<typeof vi.fn>;
+    };
+    listeners: Map<string, (event: MessageEvent) => void>;
+};
+
+const DEFAULT_EMBED_TEST_SEARCH = '?parentOrigin=https%3A%2F%2Fparent.example.com';
+
+export function createEmbedTestWindow(
+    search = DEFAULT_EMBED_TEST_SEARCH,
+    options?: { documentReferrer?: string },
+): EmbedTestWindowMock {
+    const listeners = new Map<string, (event: MessageEvent) => void>();
+    const parent = {
+        postMessage: vi.fn(),
+    };
+
+    const windowObj = {
+        self: {} as Window,
+        top: {} as Window,
+        parent,
+        location: { search },
+        addEventListener: vi.fn((type: string, handler: (event: MessageEvent) => void) => {
+            listeners.set(type, handler);
+        }),
+        removeEventListener: vi.fn((type: string) => {
+            listeners.delete(type);
+        }),
+        document: { referrer: options?.documentReferrer ?? '' },
+    } as unknown as Window;
+
+    return { windowObj, parent, listeners };
+}

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -12,6 +12,16 @@ export type MockConsole = Console & {
     error: ReturnType<typeof vi.fn>;
 };
 
+export type EmbedTestWindowMock = {
+    windowObj: Window;
+    parent: {
+        postMessage: ReturnType<typeof vi.fn>;
+    };
+    listeners: Map<string, (event: MessageEvent) => void>;
+};
+
+const DEFAULT_EMBED_TEST_SEARCH = '?parentOrigin=https%3A%2F%2Fparent.example.com';
+
 export function createMockConsole(): MockConsole {
     return {
         log: vi.fn(),
@@ -20,6 +30,32 @@ export function createMockConsole(): MockConsole {
         warn: vi.fn(),
         error: vi.fn(),
     } as unknown as MockConsole;
+}
+
+export function createEmbedTestWindow(
+    search = DEFAULT_EMBED_TEST_SEARCH,
+    extraWindowProperties: Record<string, unknown> = {},
+): EmbedTestWindowMock {
+    const listeners = new Map<string, (event: MessageEvent) => void>();
+    const parent = {
+        postMessage: vi.fn(),
+    };
+
+    const windowObj = {
+        self: {} as Window,
+        top: {} as Window,
+        parent,
+        location: { search },
+        addEventListener: vi.fn((type: string, handler: (event: MessageEvent) => void) => {
+            listeners.set(type, handler);
+        }),
+        removeEventListener: vi.fn((type: string) => {
+            listeners.delete(type);
+        }),
+        ...extraWindowProperties,
+    } as unknown as Window;
+
+    return { windowObj, parent, listeners };
 }
 
 // Mock Storage implementation

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -12,16 +12,6 @@ export type MockConsole = Console & {
     error: ReturnType<typeof vi.fn>;
 };
 
-export type EmbedTestWindowMock = {
-    windowObj: Window;
-    parent: {
-        postMessage: ReturnType<typeof vi.fn>;
-    };
-    listeners: Map<string, (event: MessageEvent) => void>;
-};
-
-const DEFAULT_EMBED_TEST_SEARCH = '?parentOrigin=https%3A%2F%2Fparent.example.com';
-
 export function createMockConsole(): MockConsole {
     return {
         log: vi.fn(),
@@ -30,32 +20,6 @@ export function createMockConsole(): MockConsole {
         warn: vi.fn(),
         error: vi.fn(),
     } as unknown as MockConsole;
-}
-
-export function createEmbedTestWindow(
-    search = DEFAULT_EMBED_TEST_SEARCH,
-    extraWindowProperties: Record<string, unknown> = {},
-): EmbedTestWindowMock {
-    const listeners = new Map<string, (event: MessageEvent) => void>();
-    const parent = {
-        postMessage: vi.fn(),
-    };
-
-    const windowObj = {
-        self: {} as Window,
-        top: {} as Window,
-        parent,
-        location: { search },
-        addEventListener: vi.fn((type: string, handler: (event: MessageEvent) => void) => {
-            listeners.set(type, handler);
-        }),
-        removeEventListener: vi.fn((type: string) => {
-            listeners.delete(type);
-        }),
-        ...extraWindowProperties,
-    } as unknown as Window;
-
-    return { windowObj, parent, listeners };
 }
 
 // Mock Storage implementation

--- a/src/test/unit/embedComposerContextService.test.ts
+++ b/src/test/unit/embedComposerContextService.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EMBED_MESSAGE_NAMESPACE } from '../../lib/embedProtocol';
 import { EmbedComposerContextService } from '../../lib/embedComposerContextService';
-import { createEmbedTestWindow, createMockConsole, type MockConsole } from '../helpers';
+import { createMockConsole, type MockConsole } from '../helpers';
+import { createEmbedTestWindow } from '../embedWindowTestUtils';
 
 describe('EmbedComposerContextService', () => {
     let mockConsole: MockConsole;

--- a/src/test/unit/embedComposerContextService.test.ts
+++ b/src/test/unit/embedComposerContextService.test.ts
@@ -1,29 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { EMBED_MESSAGE_NAMESPACE } from '../../lib/embedProtocol';
 import { EmbedComposerContextService } from '../../lib/embedComposerContextService';
-import { createMockConsole, type MockConsole } from '../helpers';
-
-function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.com') {
-    const listeners = new Map<string, (event: MessageEvent) => void>();
-    const parent = {
-        postMessage: vi.fn(),
-    };
-
-    const windowObj = {
-        self: {},
-        top: {},
-        parent,
-        location: { search },
-        addEventListener: vi.fn((type: string, handler: (event: MessageEvent) => void) => {
-            listeners.set(type, handler);
-        }),
-        removeEventListener: vi.fn((type: string) => {
-            listeners.delete(type);
-        }),
-    } as unknown as Window;
-
-    return { windowObj, parent, listeners };
-}
+import { createEmbedTestWindow, createMockConsole, type MockConsole } from '../helpers';
 
 describe('EmbedComposerContextService', () => {
     let mockConsole: MockConsole;
@@ -33,7 +11,7 @@ describe('EmbedComposerContextService', () => {
     });
 
     it('composer.setContext を受け取ると listener を呼ぶ', () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedComposerContextService(windowObj, mockConsole);
         const onRemoteSetContext = vi.fn();
         service.onRemoteSetContext(onRemoteSetContext);
@@ -66,7 +44,7 @@ describe('EmbedComposerContextService', () => {
     });
 
     it('quotes が null の composer.setContext を受け取ると listener を呼ぶ', () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedComposerContextService(windowObj, mockConsole);
         const onRemoteSetContext = vi.fn();
         service.onRemoteSetContext(onRemoteSetContext);
@@ -97,7 +75,7 @@ describe('EmbedComposerContextService', () => {
     });
 
     it('origin が一致しないメッセージは無視する', () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedComposerContextService(windowObj, mockConsole);
         const onRemoteSetContext = vi.fn();
         service.onRemoteSetContext(onRemoteSetContext);
@@ -120,7 +98,7 @@ describe('EmbedComposerContextService', () => {
     });
 
     it('有効requestIdの不正payloadもControllerがerror ackできるようlistenerへ渡す', () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedComposerContextService(windowObj, mockConsole);
         const onRemoteSetContext = vi.fn();
         service.onRemoteSetContext(onRemoteSetContext);
@@ -147,7 +125,7 @@ describe('EmbedComposerContextService', () => {
     });
 
     it('requestId がない composer.setContext は無視する', () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedComposerContextService(windowObj, mockConsole);
         const onRemoteSetContext = vi.fn();
         service.onRemoteSetContext(onRemoteSetContext);

--- a/src/test/unit/embedIndexedDbService.test.ts
+++ b/src/test/unit/embedIndexedDbService.test.ts
@@ -6,7 +6,8 @@ import {
 import { EmbedIndexedDbService } from "../../lib/embedIndexedDbService";
 import type { UploadDestinationRecord } from "../../lib/storage/ehagakiDb";
 import { UPLOAD_DESTINATION_GLOBAL_SCOPE } from "../../lib/upload/uploadDestinationPresets";
-import { createEmbedTestWindow, createMockConsole, type MockConsole } from "../helpers";
+import { createMockConsole, type MockConsole } from "../helpers";
+import { createEmbedTestWindow } from "../embedWindowTestUtils";
 
 function createDestinationRecord(id = "destination"): UploadDestinationRecord {
     return {

--- a/src/test/unit/embedIndexedDbService.test.ts
+++ b/src/test/unit/embedIndexedDbService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
     EMBED_MESSAGE_NAMESPACE,
     EMBED_MESSAGE_VERSION,
@@ -6,26 +6,7 @@ import {
 import { EmbedIndexedDbService } from "../../lib/embedIndexedDbService";
 import type { UploadDestinationRecord } from "../../lib/storage/ehagakiDb";
 import { UPLOAD_DESTINATION_GLOBAL_SCOPE } from "../../lib/upload/uploadDestinationPresets";
-import { createMockConsole, type MockConsole } from "../helpers";
-
-function createMockWindow(search = "?parentOrigin=https%3A%2F%2Fparent.example.com") {
-    const listeners = new Map<string, (event: MessageEvent) => void>();
-    const parent = {
-        postMessage: vi.fn(),
-    };
-
-    const windowObj = {
-        self: {},
-        top: {},
-        parent,
-        location: { search },
-        addEventListener: vi.fn((type: string, handler: (event: MessageEvent) => void) => {
-            listeners.set(type, handler);
-        }),
-    } as unknown as Window;
-
-    return { windowObj, parent, listeners };
-}
+import { createEmbedTestWindow, createMockConsole, type MockConsole } from "../helpers";
 
 function createDestinationRecord(id = "destination"): UploadDestinationRecord {
     return {
@@ -63,14 +44,14 @@ describe("EmbedIndexedDbService", () => {
     });
 
     it("iframe と parentOrigin がない場合は初期化しない", () => {
-        const { windowObj } = createMockWindow("");
+        const { windowObj } = createEmbedTestWindow("");
         const service = new EmbedIndexedDbService(windowObj, mockConsole);
 
         expect(service.initialize()).toBe(false);
     });
 
     it("idb.getSnapshot を送信し、uploadDestinations records を返す", async () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedIndexedDbService(windowObj, mockConsole);
         service.initialize();
 
@@ -110,7 +91,7 @@ describe("EmbedIndexedDbService", () => {
     });
 
     it("records が省略された snapshot は未保存として null を返す", async () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedIndexedDbService(windowObj, mockConsole);
         service.initialize();
 
@@ -137,7 +118,7 @@ describe("EmbedIndexedDbService", () => {
     });
 
     it("不正な idb.result payload は無視して timeout する", async () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedIndexedDbService(windowObj, mockConsole, 10);
         service.initialize();
 
@@ -167,7 +148,7 @@ describe("EmbedIndexedDbService", () => {
     });
 
     it("origin が一致しない idb.result は無視して timeout する", async () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedIndexedDbService(windowObj, mockConsole, 10);
         service.initialize();
 

--- a/src/test/unit/embedSettingsService.test.ts
+++ b/src/test/unit/embedSettingsService.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { EMBED_MESSAGE_NAMESPACE } from '../../lib/embedProtocol';
 import { EmbedSettingsService } from '../../lib/embedSettingsService';
-import { createEmbedTestWindow, createMockConsole, type MockConsole } from '../helpers';
+import { createMockConsole, type MockConsole } from '../helpers';
+import { createEmbedTestWindow } from '../embedWindowTestUtils';
 
 describe('EmbedSettingsService', () => {
     let mockConsole: MockConsole;

--- a/src/test/unit/embedSettingsService.test.ts
+++ b/src/test/unit/embedSettingsService.test.ts
@@ -1,26 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { EMBED_MESSAGE_NAMESPACE } from '../../lib/embedProtocol';
 import { EmbedSettingsService } from '../../lib/embedSettingsService';
-import { createMockConsole, type MockConsole } from '../helpers';
-
-function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.com') {
-    const listeners = new Map<string, (event: MessageEvent) => void>();
-    const parent = {
-        postMessage: vi.fn(),
-    };
-
-    const windowObj = {
-        self: {},
-        top: {},
-        parent,
-        location: { search },
-        addEventListener: vi.fn((type: string, handler: (event: MessageEvent) => void) => {
-            listeners.set(type, handler);
-        }),
-    } as unknown as Window;
-
-    return { windowObj, parent, listeners };
-}
+import { createEmbedTestWindow, createMockConsole, type MockConsole } from '../helpers';
 
 describe('EmbedSettingsService', () => {
     let mockConsole: MockConsole;
@@ -30,7 +11,7 @@ describe('EmbedSettingsService', () => {
     });
 
     it('settings.set を受け取ると listener を呼ぶ', () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedSettingsService(windowObj, mockConsole);
         const onRemoteSetSettings = vi.fn();
         service.onRemoteSetSettings(onRemoteSetSettings);
@@ -63,7 +44,7 @@ describe('EmbedSettingsService', () => {
     });
 
     it('origin が一致しない settings.set は無視する', () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedSettingsService(windowObj, mockConsole);
         const onRemoteSetSettings = vi.fn();
         service.onRemoteSetSettings(onRemoteSetSettings);
@@ -85,7 +66,7 @@ describe('EmbedSettingsService', () => {
     });
 
     it('requestId がない settings.set は拒否する', () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedSettingsService(windowObj, mockConsole);
         const onRemoteSetSettings = vi.fn();
         const onRemoteSettingsError = vi.fn();
@@ -113,7 +94,7 @@ describe('EmbedSettingsService', () => {
     });
 
     it('不正な payload は settings error listener を呼ぶ', () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedSettingsService(windowObj, mockConsole);
         const onRemoteSetSettings = vi.fn();
         const onRemoteSettingsError = vi.fn();

--- a/src/test/unit/embedStorageService.test.ts
+++ b/src/test/unit/embedStorageService.test.ts
@@ -5,7 +5,8 @@ import {
     EMBED_MESSAGE_VERSION,
 } from '../../lib/embedProtocol';
 import { EmbedStorageService } from '../../lib/embedStorageService';
-import { createEmbedTestWindow, createMockConsole, type MockConsole, MockStorage } from '../helpers';
+import { createMockConsole, type MockConsole, MockStorage } from '../helpers';
+import { createEmbedTestWindow } from '../embedWindowTestUtils';
 
 describe('EmbedStorageService', () => {
     let mockConsole: MockConsole;

--- a/src/test/unit/embedStorageService.test.ts
+++ b/src/test/unit/embedStorageService.test.ts
@@ -1,30 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { STORAGE_KEYS } from '../../lib/constants';
 import {
     EMBED_MESSAGE_NAMESPACE,
     EMBED_MESSAGE_VERSION,
 } from '../../lib/embedProtocol';
 import { EmbedStorageService } from '../../lib/embedStorageService';
-import { createMockConsole, type MockConsole, MockStorage } from '../helpers';
-
-function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.com') {
-    const listeners = new Map<string, (event: MessageEvent) => void>();
-    const parent = {
-        postMessage: vi.fn(),
-    };
-
-    const windowObj = {
-        self: {},
-        top: {},
-        parent,
-        location: { search },
-        addEventListener: vi.fn((type: string, handler: (event: MessageEvent) => void) => {
-            listeners.set(type, handler);
-        }),
-    } as unknown as Window;
-
-    return { windowObj, parent, listeners };
-}
+import { createEmbedTestWindow, createMockConsole, type MockConsole, MockStorage } from '../helpers';
 
 describe('EmbedStorageService', () => {
     let mockConsole: MockConsole;
@@ -34,14 +15,14 @@ describe('EmbedStorageService', () => {
     });
 
     it('iframe と parentOrigin がない場合は初期化しない', () => {
-        const { windowObj } = createMockWindow('');
+        const { windowObj } = createEmbedTestWindow('');
         const service = new EmbedStorageService(windowObj, mockConsole);
 
         expect(service.initialize()).toBe(false);
     });
 
     it('storage.get を送信し、storage.result を返す', async () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedStorageService(windowObj, mockConsole);
         service.initialize();
 
@@ -81,7 +62,7 @@ describe('EmbedStorageService', () => {
     });
 
     it('origin が一致しない storage.result は無視して timeout する', async () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow();
         const service = new EmbedStorageService(windowObj, mockConsole, 10);
         service.initialize();
 
@@ -111,7 +92,7 @@ describe('EmbedStorageService', () => {
     });
 
     it('localStorage の値と削除状態を親へ保存要求する', () => {
-        const { windowObj, parent } = createMockWindow();
+        const { windowObj, parent } = createEmbedTestWindow();
         const storage = new MockStorage();
         storage.setItem(STORAGE_KEYS.THEME_MODE, 'dark');
 

--- a/src/test/unit/parentClientAuthService.test.ts
+++ b/src/test/unit/parentClientAuthService.test.ts
@@ -5,7 +5,8 @@ import {
 } from '../../lib/parentClientAuthService';
 import { STORAGE_KEYS } from '../../lib/constants';
 import type { ParentClientSessionData } from '../../lib/types';
-import { createEmbedTestWindow, createMockConsole, type MockConsole, MockStorage } from '../helpers';
+import { createMockConsole, type MockConsole, MockStorage } from '../helpers';
+import { createEmbedTestWindow } from '../embedWindowTestUtils';
 import { EMBED_MESSAGE_NAMESPACE } from '../../lib/embedProtocol';
 
 describe('ParentClientAuthService', () => {
@@ -16,7 +17,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('auth.request/auth.result で接続し signer を生成する', async () => {
-        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { documentReferrer: '' });
         const service = new ParentClientAuthService(windowObj, mockConsole);
 
         const promise = service.connect({ capabilities: ['signEvent'] });
@@ -54,7 +55,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('rpc.request/rpc.result で signEvent を委譲する', async () => {
-        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { documentReferrer: '' });
         const service = new ParentClientAuthService(windowObj, mockConsole);
 
         const connectPromise = service.connect({ capabilities: ['signEvent'] });
@@ -101,7 +102,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('capabilities 未指定時は signEvent のみを既定要求する', () => {
-        const { windowObj, parent } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
+        const { windowObj, parent } = createEmbedTestWindow(undefined, { documentReferrer: '' });
         const service = new ParentClientAuthService(windowObj, mockConsole);
 
         void service.connect({ timeoutMs: 1 }).catch(() => undefined);
@@ -156,7 +157,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('auth.error を受け取ると接続要求を明示的な認証エラーとして reject する', async () => {
-        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { documentReferrer: '' });
         const service = new ParentClientAuthService(windowObj, mockConsole);
 
         const promise = service.connect({ capabilities: ['signEvent'] });
@@ -181,7 +182,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('要求していない capability を含む auth.result を reject する', async () => {
-        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { documentReferrer: '' });
         const service = new ParentClientAuthService(windowObj, mockConsole);
 
         const promise = service.connect({ capabilities: ['signEvent'] });
@@ -205,7 +206,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('malformed な rpc.result を reject する', async () => {
-        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { documentReferrer: '' });
         const service = new ParentClientAuthService(windowObj, mockConsole);
 
         const connectPromise = service.connect({ capabilities: ['signEvent'] });
@@ -248,7 +249,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('requestId がない auth.result は warn して無視する', async () => {
-        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { documentReferrer: '' });
         const service = new ParentClientAuthService(windowObj, mockConsole);
 
         const promise = service.connect({ capabilities: ['signEvent'] });
@@ -290,7 +291,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('auth.logout を受け取ると remote logout listener が呼ばれる', async () => {
-        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { documentReferrer: '' });
         const service = new ParentClientAuthService(windowObj, mockConsole);
         const onRemoteLogout = vi.fn();
         service.onRemoteLogout(onRemoteLogout);
@@ -331,7 +332,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('auth.login を受け取ると remote login listener が呼ばれる', () => {
-        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { documentReferrer: '' });
         const service = new ParentClientAuthService(windowObj, mockConsole);
         const onRemoteLogin = vi.fn();
         service.onRemoteLogin(onRemoteLogin);

--- a/src/test/unit/parentClientAuthService.test.ts
+++ b/src/test/unit/parentClientAuthService.test.ts
@@ -5,31 +5,8 @@ import {
 } from '../../lib/parentClientAuthService';
 import { STORAGE_KEYS } from '../../lib/constants';
 import type { ParentClientSessionData } from '../../lib/types';
-import { createMockConsole, type MockConsole, MockStorage } from '../helpers';
+import { createEmbedTestWindow, createMockConsole, type MockConsole, MockStorage } from '../helpers';
 import { EMBED_MESSAGE_NAMESPACE } from '../../lib/embedProtocol';
-
-function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.com') {
-    const listeners = new Map<string, (event: MessageEvent) => void>();
-    const parent = {
-        postMessage: vi.fn(),
-    };
-
-    const windowObj = {
-        self: {},
-        top: {},
-        parent,
-        location: { search },
-        document: { referrer: '' },
-        addEventListener: vi.fn((type: string, handler: (event: MessageEvent) => void) => {
-            listeners.set(type, handler);
-        }),
-        removeEventListener: vi.fn((type: string) => {
-            listeners.delete(type);
-        }),
-    } as unknown as Window;
-
-    return { windowObj, parent, listeners };
-}
 
 describe('ParentClientAuthService', () => {
     let mockConsole: MockConsole;
@@ -39,7 +16,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('auth.request/auth.result で接続し signer を生成する', async () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
         const service = new ParentClientAuthService(windowObj, mockConsole);
 
         const promise = service.connect({ capabilities: ['signEvent'] });
@@ -77,7 +54,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('rpc.request/rpc.result で signEvent を委譲する', async () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
         const service = new ParentClientAuthService(windowObj, mockConsole);
 
         const connectPromise = service.connect({ capabilities: ['signEvent'] });
@@ -124,7 +101,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('capabilities 未指定時は signEvent のみを既定要求する', () => {
-        const { windowObj, parent } = createMockWindow();
+        const { windowObj, parent } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
         const service = new ParentClientAuthService(windowObj, mockConsole);
 
         void service.connect({ timeoutMs: 1 }).catch(() => undefined);
@@ -179,7 +156,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('auth.error を受け取ると接続要求を明示的な認証エラーとして reject する', async () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
         const service = new ParentClientAuthService(windowObj, mockConsole);
 
         const promise = service.connect({ capabilities: ['signEvent'] });
@@ -204,7 +181,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('要求していない capability を含む auth.result を reject する', async () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
         const service = new ParentClientAuthService(windowObj, mockConsole);
 
         const promise = service.connect({ capabilities: ['signEvent'] });
@@ -228,7 +205,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('malformed な rpc.result を reject する', async () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
         const service = new ParentClientAuthService(windowObj, mockConsole);
 
         const connectPromise = service.connect({ capabilities: ['signEvent'] });
@@ -271,7 +248,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('requestId がない auth.result は warn して無視する', async () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
         const service = new ParentClientAuthService(windowObj, mockConsole);
 
         const promise = service.connect({ capabilities: ['signEvent'] });
@@ -313,7 +290,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('auth.logout を受け取ると remote logout listener が呼ばれる', async () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
         const service = new ParentClientAuthService(windowObj, mockConsole);
         const onRemoteLogout = vi.fn();
         service.onRemoteLogout(onRemoteLogout);
@@ -354,7 +331,7 @@ describe('ParentClientAuthService', () => {
     });
 
     it('auth.login を受け取ると remote login listener が呼ばれる', () => {
-        const { windowObj, parent, listeners } = createMockWindow();
+        const { windowObj, parent, listeners } = createEmbedTestWindow(undefined, { document: { referrer: '' } });
         const service = new ParentClientAuthService(windowObj, mockConsole);
         const onRemoteLogin = vi.fn();
         service.onRemoteLogin(onRemoteLogin);


### PR DESCRIPTION
This pull request consolidates the duplicated `createMockWindow` logic across multiple test files into a single helper function, `createEmbedTestWindow`, located in `src/test/helpers.ts`. The changes aim to streamline the creation of mock windows for embedded-related tests, ensuring consistency and reducing redundancy.

### Changes made:
- Added a common helper function `createEmbedTestWindow` in `src/test/helpers.ts`.
- Removed local implementations of `createMockWindow` from the following test files:
  - `src/test/unit/embedStorageService.test.ts`
  - `src/test/unit/embedSettingsService.test.ts`
  - `src/test/unit/embedIndexedDbService.test.ts`
  - `src/test/unit/embedComposerContextService.test.ts`
  - `src/test/unit/parentClientAuthService.test.ts`

### Key features of the new helper:
- Provides `parent.postMessage` as a `vi.fn()` for testing.
- Maintains the default `location.search` value.
- Supports adding and removing message event listeners.
- Allows retrieval of registered message listeners for testing.
- Ensures that each call generates a new mock, listener, and state.
- Accommodates specific properties like `document.referrer` for certain tests.

### Verification:
- All relevant tests passed successfully.
- The existing assertions and validation logic in the tests remain intact.
- No unrelated files or dependencies were modified.

This refactor enhances maintainability and clarity in the test suite while preserving existing functionality.