### PR TITLE
Extract common window mock generation for embed tests

### DIFF
--- a/src/test/embedWindowTestUtils.ts
+++ b/src/test/embedWindowTestUtils.ts
@@ -1,0 +1,32 @@
+import { vi } from 'vitest';
+
+const DEFAULT_PARENT_ORIGIN_SEARCH = '?parentOrigin=https%3A%2F%2Fparent.example.com';
+
+export interface MockWindowHarness {
+    windowObj: Window;
+    parent: { postMessage: ReturnType<typeof vi.fn> };
+    listeners: Map<string, (event: MessageEvent) => void>;
+}
+
+export function createMockWindow(search = DEFAULT_PARENT_ORIGIN_SEARCH): MockWindowHarness {
+    const listeners = new Map<string, (event: MessageEvent) => void>();
+    const parent = {
+        postMessage: vi.fn(),
+    };
+
+    const windowObj = {
+        self: {},
+        top: {},
+        parent,
+        location: { search },
+        document: { referrer: '' },
+        addEventListener: vi.fn((type: string, handler: (event: MessageEvent) => void) => {
+            listeners.set(type, handler);
+        }),
+        removeEventListener: vi.fn((type: string) => {
+            listeners.delete(type);
+        }),
+    } as unknown as Window;
+
+    return { windowObj, parent, listeners };
+}

--- a/src/test/unit/embedComposerContextService.test.ts
+++ b/src/test/unit/embedComposerContextService.test.ts
@@ -2,28 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EMBED_MESSAGE_NAMESPACE } from '../../lib/embedProtocol';
 import { EmbedComposerContextService } from '../../lib/embedComposerContextService';
 import { createMockConsole, type MockConsole } from '../helpers';
-
-function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.com') {
-    const listeners = new Map<string, (event: MessageEvent) => void>();
-    const parent = {
-        postMessage: vi.fn(),
-    };
-
-    const windowObj = {
-        self: {},
-        top: {},
-        parent,
-        location: { search },
-        addEventListener: vi.fn((type: string, handler: (event: MessageEvent) => void) => {
-            listeners.set(type, handler);
-        }),
-        removeEventListener: vi.fn((type: string) => {
-            listeners.delete(type);
-        }),
-    } as unknown as Window;
-
-    return { windowObj, parent, listeners };
-}
+import { createMockWindow } from '../embedWindowTestUtils';
 
 describe('EmbedComposerContextService', () => {
     let mockConsole: MockConsole;

--- a/src/test/unit/embedIndexedDbService.test.ts
+++ b/src/test/unit/embedIndexedDbService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
     EMBED_MESSAGE_NAMESPACE,
     EMBED_MESSAGE_VERSION,
@@ -7,25 +7,7 @@ import { EmbedIndexedDbService } from "../../lib/embedIndexedDbService";
 import type { UploadDestinationRecord } from "../../lib/storage/ehagakiDb";
 import { UPLOAD_DESTINATION_GLOBAL_SCOPE } from "../../lib/upload/uploadDestinationPresets";
 import { createMockConsole, type MockConsole } from "../helpers";
-
-function createMockWindow(search = "?parentOrigin=https%3A%2F%2Fparent.example.com") {
-    const listeners = new Map<string, (event: MessageEvent) => void>();
-    const parent = {
-        postMessage: vi.fn(),
-    };
-
-    const windowObj = {
-        self: {},
-        top: {},
-        parent,
-        location: { search },
-        addEventListener: vi.fn((type: string, handler: (event: MessageEvent) => void) => {
-            listeners.set(type, handler);
-        }),
-    } as unknown as Window;
-
-    return { windowObj, parent, listeners };
-}
+import { createMockWindow } from "../embedWindowTestUtils";
 
 function createDestinationRecord(id = "destination"): UploadDestinationRecord {
     return {

--- a/src/test/unit/embedSettingsService.test.ts
+++ b/src/test/unit/embedSettingsService.test.ts
@@ -2,25 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EMBED_MESSAGE_NAMESPACE } from '../../lib/embedProtocol';
 import { EmbedSettingsService } from '../../lib/embedSettingsService';
 import { createMockConsole, type MockConsole } from '../helpers';
-
-function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.com') {
-    const listeners = new Map<string, (event: MessageEvent) => void>();
-    const parent = {
-        postMessage: vi.fn(),
-    };
-
-    const windowObj = {
-        self: {},
-        top: {},
-        parent,
-        location: { search },
-        addEventListener: vi.fn((type: string, handler: (event: MessageEvent) => void) => {
-            listeners.set(type, handler);
-        }),
-    } as unknown as Window;
-
-    return { windowObj, parent, listeners };
-}
+import { createMockWindow } from '../embedWindowTestUtils';
 
 describe('EmbedSettingsService', () => {
     let mockConsole: MockConsole;

--- a/src/test/unit/embedStorageService.test.ts
+++ b/src/test/unit/embedStorageService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { STORAGE_KEYS } from '../../lib/constants';
 import {
     EMBED_MESSAGE_NAMESPACE,
@@ -6,25 +6,7 @@ import {
 } from '../../lib/embedProtocol';
 import { EmbedStorageService } from '../../lib/embedStorageService';
 import { createMockConsole, type MockConsole, MockStorage } from '../helpers';
-
-function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.com') {
-    const listeners = new Map<string, (event: MessageEvent) => void>();
-    const parent = {
-        postMessage: vi.fn(),
-    };
-
-    const windowObj = {
-        self: {},
-        top: {},
-        parent,
-        location: { search },
-        addEventListener: vi.fn((type: string, handler: (event: MessageEvent) => void) => {
-            listeners.set(type, handler);
-        }),
-    } as unknown as Window;
-
-    return { windowObj, parent, listeners };
-}
+import { createMockWindow } from '../embedWindowTestUtils';
 
 describe('EmbedStorageService', () => {
     let mockConsole: MockConsole;

--- a/src/test/unit/parentClientAuthService.test.ts
+++ b/src/test/unit/parentClientAuthService.test.ts
@@ -7,29 +7,7 @@ import { STORAGE_KEYS } from '../../lib/constants';
 import type { ParentClientSessionData } from '../../lib/types';
 import { createMockConsole, type MockConsole, MockStorage } from '../helpers';
 import { EMBED_MESSAGE_NAMESPACE } from '../../lib/embedProtocol';
-
-function createMockWindow(search = '?parentOrigin=https%3A%2F%2Fparent.example.com') {
-    const listeners = new Map<string, (event: MessageEvent) => void>();
-    const parent = {
-        postMessage: vi.fn(),
-    };
-
-    const windowObj = {
-        self: {},
-        top: {},
-        parent,
-        location: { search },
-        document: { referrer: '' },
-        addEventListener: vi.fn((type: string, handler: (event: MessageEvent) => void) => {
-            listeners.set(type, handler);
-        }),
-        removeEventListener: vi.fn((type: string) => {
-            listeners.delete(type);
-        }),
-    } as unknown as Window;
-
-    return { windowObj, parent, listeners };
-}
+import { createMockWindow } from '../embedWindowTestUtils';
 
 describe('ParentClientAuthService', () => {
     let mockConsole: MockConsole;


### PR DESCRIPTION
This pull request introduces a new utility file for shared window mock generation, which consolidates duplicate code across multiple test files. The changes include:

- Created `src/test/embedWindowTestUtils.ts` to house the common mock generation logic.
- Refactored the following test files to utilize the new utility, removing redundant code:
  - `embedStorageService.test.ts`
  - `embedSettingsService.test.ts`
  - `embedIndexedDbService.test.ts`
  - `embedComposerContextService.test.ts`
  - `parentClientAuthService.test.ts`
  
Key features of the new utility include:
- Ability to specify `location.search`.
- Maintenance of default search values.
- Proper relationships between `self`, `top`, and `parent` for iframe detection.
- Mocking of `parent.postMessage` for verification.
- Registration and invocation of message event listeners.

All existing assertions and test behaviors have been preserved, and the relevant test suites have been verified to ensure they pass successfully.