### PR TITLE
Refactor tests to use shared createDeferred helper

### DIFF
--- a/src/test/deferredTestUtils.ts
+++ b/src/test/deferredTestUtils.ts
@@ -1,0 +1,18 @@
+export interface Deferred<T> {
+    promise: Promise<T>;
+    resolve: (value?: T | PromiseLike<T>) => void;
+    reject: (reason?: unknown) => void;
+}
+
+export function createDeferred<T>(): Deferred<T> {
+    let resolve!: (value?: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = (value?: T | PromiseLike<T>) => {
+            resolvePromise(value as T | PromiseLike<T>);
+        };
+        reject = rejectPromise;
+    });
+
+    return { promise, resolve, reject };
+}

--- a/src/test/unit/nip46AuthFlowCoordinator.test.ts
+++ b/src/test/unit/nip46AuthFlowCoordinator.test.ts
@@ -2,17 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { createNip46AuthFlowController } from '../../lib/nip46AuthFlowCoordinator';
 import type { PendingNip46AuthSession } from '../../lib/authService';
-
-function createDeferred<T>() {
-    let resolve!: (value: T) => void;
-    let reject!: (reason?: unknown) => void;
-    const promise = new Promise<T>((res, rej) => {
-        resolve = res;
-        reject = rej;
-    });
-
-    return { promise, resolve, reject };
-}
+import { createDeferred } from '../deferredTestUtils';
 
 function createPendingSession() {
     const ready = createDeferred<void>();

--- a/src/test/unit/nip46Service.test.ts
+++ b/src/test/unit/nip46Service.test.ts
@@ -10,6 +10,7 @@ import {
     NIP46_REQUESTED_PERMS,
     normalizeSupportedNip46FinalRelay,
 } from '../../lib/nip46Service';
+import { createDeferred } from '../deferredTestUtils';
 import { MockStorage } from '../helpers';
 
 describe('NIP46_REQUESTED_PERMISSIONS', () => {
@@ -181,21 +182,6 @@ describe('normalizeSupportedNip46FinalRelay', () => {
 describe('Nip46Service', () => {
     let service: Nip46Service;
     let mockStorage: MockStorage;
-
-    function createDeferred<T>() {
-        let resolve: ((value: T | PromiseLike<T>) => void) | undefined;
-        let reject: ((reason?: unknown) => void) | undefined;
-        const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-            resolve = resolvePromise;
-            reject = rejectPromise;
-        });
-
-        return {
-            promise,
-            resolve: resolve!,
-            reject: reject!,
-        };
-    }
 
     function getNostrConnectUriRelays(uri: string): string[] {
         return new URL(uri).searchParams.getAll('relay');

--- a/src/test/unit/nostrAuthService.test.ts
+++ b/src/test/unit/nostrAuthService.test.ts
@@ -11,6 +11,7 @@ import {
     createNip42Authenticator,
     NostrAuthService,
 } from '../../lib/nostrAuthService';
+import { createDeferred } from '../deferredTestUtils';
 import { mockAuthStoreModule } from '../mocks/storeModules';
 
 // nostr-tools/nip98 をモック（buildAuthHeader のユニットテスト用）
@@ -89,14 +90,6 @@ describe('nostr-tools/nip98 インポート整合性', () => {
 // =============================================================================
 describe('NostrAuthService', () => {
     let service: NostrAuthService;
-
-    function createDeferred<T>() {
-        let resolve!: (value: T) => void;
-        const promise = new Promise<T>((resolvePromise) => {
-            resolve = resolvePromise;
-        });
-        return { promise, resolve };
-    }
 
     beforeEach(() => {
         service = new NostrAuthService();


### PR DESCRIPTION
This pull request introduces a new utility file `deferredTestUtils.ts` that centralizes the implementation of the `createDeferred` function, which is now used across three test files: `nostrAuthService.test.ts`, `nip46AuthFlowCoordinator.test.ts`, and `nip46Service.test.ts`. 

### Changes made:
- Added `src/test/deferredTestUtils.ts` with a shared `createDeferred<T>()` function.
- Removed local `createDeferred` implementations from the three specified test files.
- Updated the imports in the affected test files to use the new shared helper.
- Ensured that the existing promise control flow, resolve/reject call positions, and asynchronous test behavior remain unchanged.

### Verification:
- All targeted tests were executed successfully.
- Type checks and `npm run check` passed without issues.
- Confirmed that no unintended changes were made to excluded files or the production code. 

This refactor improves code maintainability by reducing duplication and centralizing the deferred promise logic.