### PR TITLE
Replace local console mocks with createMockConsole in tests

### DIFF
--- a/src/test/unit/channelContextService.test.ts
+++ b/src/test/unit/channelContextService.test.ts
@@ -7,6 +7,8 @@ import {
 import { CHANNEL_TEMPORARY_READ_RELAY_LIMIT } from "../../lib/channelContextConstants";
 import { FALLBACK_RELAYS } from "../../lib/constants";
 import type { NostrEvent } from "../../lib/types";
+import { createMockConsole } from "../helpers";
+import type { MockConsole } from "../helpers";
 
 const channelId = "a".repeat(64);
 const authorPubkey = "b".repeat(64);
@@ -41,14 +43,10 @@ function createRxNostr(
 
 describe("ChannelContextService", () => {
     let service: ChannelContextService;
-    let mockConsole: Console;
+    let mockConsole: MockConsole;
 
     beforeEach(() => {
-        mockConsole = {
-            log: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-        } as any;
+        mockConsole = createMockConsole();
         service = new ChannelContextService({ console: mockConsole });
     });
 

--- a/src/test/unit/postHistoryRelayFetchService.test.ts
+++ b/src/test/unit/postHistoryRelayFetchService.test.ts
@@ -19,6 +19,8 @@ import {
     POST_HISTORY_FETCH_TIMEOUT_MS,
     PostHistoryRelayFetchService,
 } from "../../lib/postHistoryRelayFetchService";
+import { createMockConsole } from "../helpers";
+import type { MockConsole } from "../helpers";
 
 function createEvent(overrides: Record<string, any> = {}) {
     return {
@@ -35,15 +37,11 @@ function createEvent(overrides: Record<string, any> = {}) {
 
 describe("PostHistoryRelayFetchService", () => {
     let service: PostHistoryRelayFetchService;
-    let mockConsole: Console;
+    let mockConsole: MockConsole;
 
     beforeEach(() => {
         vi.clearAllMocks();
-        mockConsole = {
-            log: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-        } as unknown as Console;
+        mockConsole = createMockConsole();
         service = new PostHistoryRelayFetchService({
             console: mockConsole,
             now: () => 9000,

--- a/src/test/unit/relayManager.test.ts
+++ b/src/test/unit/relayManager.test.ts
@@ -7,7 +7,8 @@ import {
 } from '../../lib/relayManager';
 import type { RelayConfig, RelayManagerDeps } from '../../lib/types';
 import type { RxNostr } from 'rx-nostr';
-import { MockStorage, createMockRxNostr } from '../helpers';
+import { MockStorage, createMockRxNostr, createMockConsole } from '../helpers';
+import type { MockConsole } from '../helpers';
 import { EHagakiDB } from '../../lib/storage/ehagakiDb';
 import { DexieRelayConfigsRepository } from '../../lib/storage/relayConfigsRepository';
 import { FALLBACK_RELAYS } from '../../lib/constants';
@@ -132,17 +133,13 @@ describe('RelayConfigParser', () => {
 describe('RelayStorage', () => {
     let storage: RelayStorage;
     let mockLocalStorage: MockStorage;
-    let mockConsole: Console;
+    let mockConsole: MockConsole;
     let mockRelayListUpdatedStore: RelayManagerDeps['relayListUpdatedStore'];
     let repository: DexieRelayConfigsRepository;
 
     beforeEach(() => {
         mockLocalStorage = new MockStorage();
-        mockConsole = {
-            log: vi.fn(),
-            error: vi.fn(),
-            warn: vi.fn()
-        } as any;
+        mockConsole = createMockConsole();
         mockRelayListUpdatedStore = {
             value: 0,
             set: vi.fn()
@@ -283,7 +280,7 @@ describe('RelayStorage', () => {
 describe('RelayNetworkFetcher', () => {
     let fetcher: RelayNetworkFetcher;
     let mockRxNostr: RxNostr;
-    let mockConsole: Console;
+    let mockConsole: MockConsole;
     let mockSetTimeout: any;
     let mockClearTimeout: any;
     let mockSubscription: any;
@@ -302,10 +299,7 @@ describe('RelayNetworkFetcher', () => {
             setDefaultRelays: vi.fn()
         } as any;
 
-        mockConsole = {
-            log: vi.fn(),
-            error: vi.fn()
-        } as any;
+        mockConsole = createMockConsole();
 
         mockSetTimeout = vi.fn();
         mockClearTimeout = vi.fn();
@@ -440,6 +434,7 @@ describe('RelayManager統合テスト', () => {
     let mockRxNostr: RxNostr;
     let mockDeps: RelayManagerDeps;
     let mockStorage: MockStorage;
+    let mockConsole: MockConsole;
     let mockSetTimeout: any;
     let mockClearTimeout: any;
     let subscribeFn: any;
@@ -457,14 +452,11 @@ describe('RelayManager統合テスト', () => {
             return 'timeout-id';
         });
         mockClearTimeout = vi.fn();
+        mockConsole = createMockConsole();
 
         mockDeps = {
             localStorage: mockStorage,
-            console: {
-                log: vi.fn(),
-                error: vi.fn(),
-                warn: vi.fn()
-            } as any,
+            console: mockConsole,
             setTimeoutFn: mockSetTimeout,
             clearTimeoutFn: mockClearTimeout,
             relayListUpdatedStore: {

--- a/src/test/unit/replyQuoteService.test.ts
+++ b/src/test/unit/replyQuoteService.test.ts
@@ -1,21 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ReplyQuoteService } from "../../lib/replyQuoteService";
 import type { NostrEvent, ReplyQuoteState } from "../../lib/types";
-import { createMockRxNostr, createMockObservable } from "../helpers";
+import { createMockConsole, createMockRxNostr, createMockObservable } from "../helpers";
+import type { MockConsole } from "../helpers";
 import type { RxNostr } from "rx-nostr";
 import { nip19 } from "nostr-tools";
 import { FALLBACK_RELAYS } from "../../lib/constants";
 
 describe("ReplyQuoteService", () => {
     let service: ReplyQuoteService;
-    let mockConsole: Console;
+    let mockConsole: MockConsole;
 
     beforeEach(() => {
-        mockConsole = {
-            log: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-        } as any;
+        mockConsole = createMockConsole();
         service = new ReplyQuoteService({ console: mockConsole });
     });
 


### PR DESCRIPTION
This pull request replaces the local standard Console mocks in four unit test files with the existing `createMockConsole()` and `MockConsole` helpers. The changes ensure that:

- Local mock definitions for `log`, `warn`, and `error` are removed.
- Each test file now uses `createMockConsole()` to generate a new console mock in `beforeEach`.
- Existing assertions and injection points for the console remain unchanged.
- Type safety is maintained by using `MockConsole` where necessary.

The affected files are:
- `src/test/unit/relayManager.test.ts`
- `src/test/unit/postHistoryRelayFetchService.test.ts`
- `src/test/unit/channelContextService.test.ts`
- `src/test/unit/replyQuoteService.test.ts`

All tests have been run successfully, and the repository checks have passed without modifying any unrelated files or the `src/test/helpers.ts`.