### PR TITLE
Refactor NostrEvent test helpers for PostHistory tests

### DIFF
--- a/src/test/postHistoryEventTestUtils.ts
+++ b/src/test/postHistoryEventTestUtils.ts
@@ -1,0 +1,14 @@
+import type { NostrEvent } from "../lib/types";
+
+export function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
+    return {
+        id: "1".repeat(64),
+        pubkey: "a".repeat(64),
+        created_at: 100,
+        kind: 1,
+        tags: [],
+        content: "",
+        sig: "b".repeat(128),
+        ...overrides,
+    };
+}

--- a/src/test/unit/postHistoryDeletionFetchService.test.ts
+++ b/src/test/unit/postHistoryDeletionFetchService.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NostrEvent } from "../../lib/types";
+import { createEvent as createBaseEvent } from "../postHistoryEventTestUtils";
 
 const rxNostrMock = vi.hoisted(() => ({
     emittedFilters: [] as any[],
@@ -18,17 +20,11 @@ vi.mock("rx-nostr", () => ({
 
 import { PostHistoryDeletionFetchService } from "../../lib/postHistoryDeletionFetchService";
 
-function createEvent(overrides: Record<string, any> = {}) {
-    return {
-        id: "1".repeat(64),
-        pubkey: "a".repeat(64),
-        kind: 1,
+function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
+    return createBaseEvent({
         content: "reply",
-        tags: [],
-        created_at: 100,
-        sig: "b".repeat(128),
         ...overrides,
-    };
+    });
 }
 
 describe("PostHistoryDeletionFetchService", () => {

--- a/src/test/unit/postHistoryInboundInteractionClassifier.test.ts
+++ b/src/test/unit/postHistoryInboundInteractionClassifier.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { classifyPostHistoryInboundInteraction } from "../../lib/postHistoryInboundInteractionClassifier";
 import type { NostrEvent } from "../../lib/types";
+import { createEvent as createBaseEvent } from "../postHistoryEventTestUtils";
 
 const OWNER_PUBKEY = "a".repeat(64);
 const PARENT_ID = "1".repeat(64);
@@ -8,7 +9,7 @@ const ROOT_ID = "2".repeat(64);
 const OTHER_PARENT_ID = "3".repeat(64);
 
 function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
-    return {
+    return createBaseEvent({
         id: "f".repeat(64),
         pubkey: "b".repeat(64),
         kind: 1,
@@ -17,7 +18,7 @@ function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
         created_at: 100,
         sig: "c".repeat(128),
         ...overrides,
-    };
+    });
 }
 
 describe("classifyPostHistoryInboundInteraction", () => {

--- a/src/test/unit/postHistoryRelatedTargetDiscoveryAdapter.test.ts
+++ b/src/test/unit/postHistoryRelatedTargetDiscoveryAdapter.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createEvent as createBaseEvent } from "../postHistoryEventTestUtils";
 import {
     postHistoryQuoteTargetDiscoveryAdapter,
     postHistoryReplyParentTargetDiscoveryAdapter,
@@ -12,7 +13,7 @@ function createHex(seed: string): string {
 }
 
 function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
-    return {
+    return createBaseEvent({
         id: createHex("a"),
         pubkey: createHex("b"),
         kind: 1,
@@ -21,7 +22,7 @@ function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
         created_at: 1,
         sig: createHex("c"),
         ...overrides,
-    };
+    });
 }
 
 function createRecord(overrides: Partial<PostHistoryRecord> = {}): PostHistoryRecord {

--- a/src/test/unit/postHistoryReplyFetchService.test.ts
+++ b/src/test/unit/postHistoryReplyFetchService.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NostrEvent } from "../../lib/types";
+import { createEvent as createBaseEvent } from "../postHistoryEventTestUtils";
 
 const rxNostrMock = vi.hoisted(() => ({
     emittedFilters: [] as any[],
@@ -18,17 +20,11 @@ vi.mock("rx-nostr", () => ({
 
 import { PostHistoryReplyFetchService } from "../../lib/postHistoryReplyFetchService";
 
-function createEvent(overrides: Record<string, any> = {}) {
-    return {
-        id: "1".repeat(64),
-        pubkey: "a".repeat(64),
-        kind: 1,
+function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
+    return createBaseEvent({
         content: "reply",
-        tags: [],
-        created_at: 100,
-        sig: "b".repeat(128),
         ...overrides,
-    };
+    });
 }
 
 describe("PostHistoryReplyFetchService", () => {


### PR DESCRIPTION
This pull request consolidates the standard NostrEvent generation logic used across multiple PostHistory-related tests into a new helper file. The changes include:

- Created a new helper file `postHistoryEventTestUtils.ts` to centralize the event creation logic.
- Updated the following test files to utilize the new helper while maintaining their existing functionality:
  - `postHistoryDeletionFetchService.test.ts`
  - `postHistoryReplyFetchService.test.ts`
  - `postHistoryRelatedTargetDiscoveryAdapter.test.ts`
  - `postHistoryInboundInteractionClassifier.test.ts`
- Ensured that all existing assertions and event properties remain unchanged, preserving the integrity of the tests.

This refactoring aims to reduce code duplication and improve maintainability without altering the behavior of the tests.