### PR TITLE
Refactor file generation into shared helper

### DIFF
--- a/src/test/fileTestUtils.ts
+++ b/src/test/fileTestUtils.ts
@@ -1,7 +1,6 @@
 export interface TestFileOptions {
     name?: string;
     type?: string;
-    size?: number;
     content?: string | Blob | ArrayBuffer | ArrayBufferView;
     lastModified?: number;
 }
@@ -9,26 +8,14 @@ export interface TestFileOptions {
 export function createTestFile({
     name = "test.png",
     type = "image/png",
-    size,
     content,
-    lastModified = 0,
+    lastModified,
 }: TestFileOptions = {}): File {
-    if (content === undefined && size !== undefined) {
-        if (size > 10 * 1024 * 1024) {
-            const buffer = new ArrayBuffer(Math.min(size, 1024));
-            return new File([buffer], name, { type, lastModified });
-        }
+    const fileOptions: FilePropertyBag = { type };
 
-        const bytes = new Uint8Array(Math.min(size, 1024));
-        for (let index = 0; index < bytes.length; index += 1) {
-            bytes[index] = index % 256;
-        }
-        return new File([bytes], name, { type, lastModified });
+    if (lastModified !== undefined) {
+        fileOptions.lastModified = lastModified;
     }
 
-    if (content === undefined) {
-        content = "content";
-    }
-
-    return new File([content], name, { type, lastModified });
+    return new File([content ?? "content"], name, fileOptions);
 }

--- a/src/test/fileTestUtils.ts
+++ b/src/test/fileTestUtils.ts
@@ -1,0 +1,34 @@
+export interface TestFileOptions {
+    name?: string;
+    type?: string;
+    size?: number;
+    content?: string | Blob | ArrayBuffer | ArrayBufferView;
+    lastModified?: number;
+}
+
+export function createTestFile({
+    name = "test.png",
+    type = "image/png",
+    size,
+    content,
+    lastModified = 0,
+}: TestFileOptions = {}): File {
+    if (content === undefined && size !== undefined) {
+        if (size > 10 * 1024 * 1024) {
+            const buffer = new ArrayBuffer(Math.min(size, 1024));
+            return new File([buffer], name, { type, lastModified });
+        }
+
+        const bytes = new Uint8Array(Math.min(size, 1024));
+        for (let index = 0; index < bytes.length; index += 1) {
+            bytes[index] = index % 256;
+        }
+        return new File([bytes], name, { type, lastModified });
+    }
+
+    if (content === undefined) {
+        content = "content";
+    }
+
+    return new File([content], name, { type, lastModified });
+}

--- a/src/test/unit/fileUploadManager.test.ts
+++ b/src/test/unit/fileUploadManager.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FileUploadManager } from '../../lib/fileUploadManager';
 import { MimeTypeSupport } from '../../lib/mimeTypeSupport';
 import { setImageSizeInfoFromFileSize } from '../../stores/uploadStore.svelte';
+import { createTestFile } from '../fileTestUtils';
 import type {
     FileUploadDependencies,
     CompressionService,
@@ -193,19 +194,6 @@ class MockResponse {
     }
 }
 
-// --- テストヘルパー関数 ---
-function createMockFile(name: string, type: string, size: number): File {
-    // メモリ効率の改善：大きなファイルに対しては空のArrayBufferを使用
-    if (size > 10 * 1024 * 1024) { // 10MB以上の場合
-        const buffer = new ArrayBuffer(Math.min(size, 1024)); // 最大1KBまでに制限
-        return new File([buffer], name, { type });
-    }
-
-    const content = new Array(Math.min(size, 1024)).fill(0).map((_, i) => i % 256);
-    const blob = new Blob([new Uint8Array(content)], { type });
-    return new File([blob], name, { type });
-}
-
 function createMockResponse(ok: boolean, status: number, jsonData: any): Response {
     return new MockResponse(ok, status, jsonData) as Response;
 }
@@ -287,13 +275,13 @@ describe('FileUploadManager', () => {
 
     describe('ファイルバリデーション', () => {
         it('有効な画像ファイルを受け入れる', () => {
-            const file = createMockFile('test.jpg', 'image/jpeg', 1000000); // 1MB
+            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000000 }); // 1MB
             const result = uploadManager.validateImageFile(file);
             expect(result.isValid).toBe(true);
         });
 
         it('画像以外のファイルを拒否する', () => {
-            const file = createMockFile('test.txt', 'text/plain', 1000);
+            const file = createTestFile({ name: 'test.txt', type: 'text/plain', size: 1000 });
             const result = uploadManager.validateImageFile(file);
             expect(result.isValid).toBe(false);
             expect(result.errorMessage).toBe('only_images_allowed');
@@ -317,7 +305,7 @@ describe('FileUploadManager', () => {
 
     describe('ファイルアップロード', () => {
         it('注入された中止判定で圧縮と送信に進まずabortedを返す', async () => {
-            const file = createMockFile('test.jpg', 'image/jpeg', 1000);
+            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 });
             const isUploadAborted = vi.fn(() => true);
             mockDependencies.isUploadAborted = isUploadAborted;
 
@@ -350,7 +338,7 @@ describe('FileUploadManager', () => {
         });
 
         it('成功時に正しいレスポンスを返す', async () => {
-            const file = createMockFile('test.jpg', 'image/jpeg', 1000); // 1KB
+            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 }); // 1KB
 
             // 認証モック
             const mockAuthService: AuthService = {
@@ -394,7 +382,7 @@ describe('FileUploadManager', () => {
         });
 
         it('成功時に圧縮後ファイルを投稿履歴メディアキャッシュへ保存する', async () => {
-            const file = createMockFile('cached.webp', 'image/webp', 1000);
+            const file = createTestFile({ name: 'cached.webp', type: 'image/webp', size: 1000 });
             const compressedFile = new File([new Uint8Array([1, 2, 3, 4])], 'cached.webp', {
                 type: 'image/webp',
             });
@@ -439,7 +427,7 @@ describe('FileUploadManager', () => {
         });
 
         it('保存済みアップロード先がない場合はロケール既定の送信先を使うが localStorage へは書き戻さない', async () => {
-            const file = createMockFile('test.jpg', 'image/jpeg', 1000);
+            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 });
 
             mockDependencies.navigator = {
                 language: 'ja-JP',
@@ -490,7 +478,7 @@ describe('FileUploadManager', () => {
         });
 
         it('destination が指定された場合は legacy uploadEndpoint を読まず Blossom adapter で送信する', async () => {
-            const file = createMockFile('test.jpg', 'image/jpeg', 1000);
+            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 });
             mockDependencies.localStorage.setItem('uploadEndpoint', 'https://nostr.build/api/v2/nip96/upload');
             const signer = {
                 getPublicKey: vi.fn().mockResolvedValue('f'.repeat(64)),
@@ -588,8 +576,8 @@ describe('FileUploadManager', () => {
         });
 
         it('圧縮後画像サイズを nip94 metadata に反映する', async () => {
-            const originalFile = createMockFile('test.jpg', 'image/jpeg', 5000);
-            const compressedFile = createMockFile('test.webp', 'image/webp', 2000);
+            const originalFile = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 5000 });
+            const compressedFile = createTestFile({ name: 'test.webp', type: 'image/webp', size: 2000 });
 
             const mockAuthService: AuthService = {
                 buildAuthHeader: vi.fn().mockResolvedValue('Bearer mock-token')
@@ -630,7 +618,7 @@ describe('FileUploadManager', () => {
         });
 
         it('uploadFileWithCallbacks 成功時にサイズ情報表示 action を呼び出す', async () => {
-            const file = createMockFile('test.jpg', 'image/jpeg', 1000);
+            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 });
 
             const mockAuthService: AuthService = {
                 buildAuthHeader: vi.fn().mockResolvedValue('Bearer mock-token')
@@ -673,7 +661,7 @@ describe('FileUploadManager', () => {
         });
 
         it('注入されたサイズ情報 callback を優先して呼ぶ', async () => {
-            const file = createMockFile('test.jpg', 'image/jpeg', 1000);
+            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 });
             const injectedSetImageSizeInfo = vi.fn();
             mockDependencies.setImageSizeInfoFromFileSize = injectedSetImageSizeInfo;
 
@@ -712,7 +700,7 @@ describe('FileUploadManager', () => {
         });
 
         it('ネットワークエラーを適切に処理する', async () => {
-            const file = createMockFile('test.jpg', 'image/jpeg', 1000); // 1KB
+            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 }); // 1KB
 
             // 認証サービスをモックして認証エラーを回避
             const mockAuthService: AuthService = {
@@ -746,7 +734,7 @@ describe('FileUploadManager', () => {
         });
 
         it('処理URLによる非同期処理を正しく扱う', async () => {
-            const file = createMockFile('test.jpg', 'image/jpeg', 1000); // 1KB
+            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 }); // 1KB
 
             const mockAuthService: AuthService = {
                 buildAuthHeader: vi.fn().mockResolvedValue('Bearer mock-token')
@@ -781,8 +769,8 @@ describe('FileUploadManager', () => {
     describe('複数ファイルアップロード', () => {
         it('複数ファイルを並列アップロードする', async () => {
             const files = [
-                createMockFile('test1.jpg', 'image/jpeg', 1000), // 1KB
-                createMockFile('test2.jpg', 'image/jpeg', 1000)  // 1KB
+                createTestFile({ name: 'test1.jpg', type: 'image/jpeg', size: 1000 }), // 1KB
+                createTestFile({ name: 'test2.jpg', type: 'image/jpeg', size: 1000 })  // 1KB
             ];
 
             // 認証サービスをモックして認証エラーを回避
@@ -876,7 +864,7 @@ describe('FileUploadManager', () => {
             // 非同期でメッセージを送信
             setTimeout(() => {
                 const mockSharedData: SharedMediaData = {
-                    images: [createMockFile('shared.jpg', 'image/jpeg', 1000000)],
+                    images: [createTestFile({ name: 'shared.jpg', type: 'image/jpeg', size: 1000000 })],
                     metadata: [{ name: 'shared.jpg' }]
                 };
 
@@ -925,7 +913,7 @@ describe('FileUploadManager', () => {
         });
 
         it('JSONパースエラーを適切に処理する', async () => {
-            const file = createMockFile('test.jpg', 'image/jpeg', 1000); // 1KB
+            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 }); // 1KB
 
             // 認証サービスをモックして認証エラーを回避
             const mockAuthService: AuthService = {

--- a/src/test/unit/fileUploadManager.test.ts
+++ b/src/test/unit/fileUploadManager.test.ts
@@ -198,6 +198,20 @@ function createMockResponse(ok: boolean, status: number, jsonData: any): Respons
     return new MockResponse(ok, status, jsonData) as Response;
 }
 
+function createMockFile(name: string, type: string, size: number): File {
+    if (size > 10 * 1024 * 1024) {
+        const buffer = new ArrayBuffer(Math.min(size, 1024));
+        return createTestFile({ name, type, content: buffer });
+    }
+
+    const bytes = new Uint8Array(Math.min(size, 1024));
+    for (let index = 0; index < bytes.length; index += 1) {
+        bytes[index] = index % 256;
+    }
+
+    return createTestFile({ name, type, content: bytes });
+}
+
 function createMockDependencies(): FileUploadDependencies {
     return {
         localStorage: new MockStorage(),
@@ -275,13 +289,13 @@ describe('FileUploadManager', () => {
 
     describe('ファイルバリデーション', () => {
         it('有効な画像ファイルを受け入れる', () => {
-            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000000 }); // 1MB
+            const file = createMockFile('test.jpg', 'image/jpeg', 1000000); // 1MB
             const result = uploadManager.validateImageFile(file);
             expect(result.isValid).toBe(true);
         });
 
         it('画像以外のファイルを拒否する', () => {
-            const file = createTestFile({ name: 'test.txt', type: 'text/plain', size: 1000 });
+            const file = createMockFile('test.txt', 'text/plain', 1000);
             const result = uploadManager.validateImageFile(file);
             expect(result.isValid).toBe(false);
             expect(result.errorMessage).toBe('only_images_allowed');
@@ -305,7 +319,7 @@ describe('FileUploadManager', () => {
 
     describe('ファイルアップロード', () => {
         it('注入された中止判定で圧縮と送信に進まずabortedを返す', async () => {
-            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 });
+            const file = createMockFile('test.jpg', 'image/jpeg', 1000);
             const isUploadAborted = vi.fn(() => true);
             mockDependencies.isUploadAborted = isUploadAborted;
 
@@ -338,7 +352,7 @@ describe('FileUploadManager', () => {
         });
 
         it('成功時に正しいレスポンスを返す', async () => {
-            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 }); // 1KB
+            const file = createMockFile('test.jpg', 'image/jpeg', 1000); // 1KB
 
             // 認証モック
             const mockAuthService: AuthService = {
@@ -382,7 +396,7 @@ describe('FileUploadManager', () => {
         });
 
         it('成功時に圧縮後ファイルを投稿履歴メディアキャッシュへ保存する', async () => {
-            const file = createTestFile({ name: 'cached.webp', type: 'image/webp', size: 1000 });
+            const file = createMockFile('cached.webp', 'image/webp', 1000);
             const compressedFile = new File([new Uint8Array([1, 2, 3, 4])], 'cached.webp', {
                 type: 'image/webp',
             });
@@ -427,7 +441,7 @@ describe('FileUploadManager', () => {
         });
 
         it('保存済みアップロード先がない場合はロケール既定の送信先を使うが localStorage へは書き戻さない', async () => {
-            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 });
+            const file = createMockFile('test.jpg', 'image/jpeg', 1000);
 
             mockDependencies.navigator = {
                 language: 'ja-JP',
@@ -478,7 +492,7 @@ describe('FileUploadManager', () => {
         });
 
         it('destination が指定された場合は legacy uploadEndpoint を読まず Blossom adapter で送信する', async () => {
-            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 });
+            const file = createMockFile('test.jpg', 'image/jpeg', 1000);
             mockDependencies.localStorage.setItem('uploadEndpoint', 'https://nostr.build/api/v2/nip96/upload');
             const signer = {
                 getPublicKey: vi.fn().mockResolvedValue('f'.repeat(64)),
@@ -576,8 +590,8 @@ describe('FileUploadManager', () => {
         });
 
         it('圧縮後画像サイズを nip94 metadata に反映する', async () => {
-            const originalFile = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 5000 });
-            const compressedFile = createTestFile({ name: 'test.webp', type: 'image/webp', size: 2000 });
+            const originalFile = createMockFile('test.jpg', 'image/jpeg', 5000);
+            const compressedFile = createMockFile('test.webp', 'image/webp', 2000);
 
             const mockAuthService: AuthService = {
                 buildAuthHeader: vi.fn().mockResolvedValue('Bearer mock-token')
@@ -618,7 +632,7 @@ describe('FileUploadManager', () => {
         });
 
         it('uploadFileWithCallbacks 成功時にサイズ情報表示 action を呼び出す', async () => {
-            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 });
+            const file = createMockFile('test.jpg', 'image/jpeg', 1000);
 
             const mockAuthService: AuthService = {
                 buildAuthHeader: vi.fn().mockResolvedValue('Bearer mock-token')
@@ -661,7 +675,7 @@ describe('FileUploadManager', () => {
         });
 
         it('注入されたサイズ情報 callback を優先して呼ぶ', async () => {
-            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 });
+            const file = createMockFile('test.jpg', 'image/jpeg', 1000);
             const injectedSetImageSizeInfo = vi.fn();
             mockDependencies.setImageSizeInfoFromFileSize = injectedSetImageSizeInfo;
 
@@ -700,7 +714,7 @@ describe('FileUploadManager', () => {
         });
 
         it('ネットワークエラーを適切に処理する', async () => {
-            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 }); // 1KB
+            const file = createMockFile('test.jpg', 'image/jpeg', 1000); // 1KB
 
             // 認証サービスをモックして認証エラーを回避
             const mockAuthService: AuthService = {
@@ -734,7 +748,7 @@ describe('FileUploadManager', () => {
         });
 
         it('処理URLによる非同期処理を正しく扱う', async () => {
-            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 }); // 1KB
+            const file = createMockFile('test.jpg', 'image/jpeg', 1000); // 1KB
 
             const mockAuthService: AuthService = {
                 buildAuthHeader: vi.fn().mockResolvedValue('Bearer mock-token')
@@ -769,8 +783,8 @@ describe('FileUploadManager', () => {
     describe('複数ファイルアップロード', () => {
         it('複数ファイルを並列アップロードする', async () => {
             const files = [
-                createTestFile({ name: 'test1.jpg', type: 'image/jpeg', size: 1000 }), // 1KB
-                createTestFile({ name: 'test2.jpg', type: 'image/jpeg', size: 1000 })  // 1KB
+                createMockFile('test1.jpg', 'image/jpeg', 1000), // 1KB
+                createMockFile('test2.jpg', 'image/jpeg', 1000)  // 1KB
             ];
 
             // 認証サービスをモックして認証エラーを回避
@@ -864,7 +878,7 @@ describe('FileUploadManager', () => {
             // 非同期でメッセージを送信
             setTimeout(() => {
                 const mockSharedData: SharedMediaData = {
-                    images: [createTestFile({ name: 'shared.jpg', type: 'image/jpeg', size: 1000000 })],
+                    images: [createMockFile('shared.jpg', 'image/jpeg', 1000000)],
                     metadata: [{ name: 'shared.jpg' }]
                 };
 
@@ -913,7 +927,7 @@ describe('FileUploadManager', () => {
         });
 
         it('JSONパースエラーを適切に処理する', async () => {
-            const file = createTestFile({ name: 'test.jpg', type: 'image/jpeg', size: 1000 }); // 1KB
+            const file = createMockFile('test.jpg', 'image/jpeg', 1000); // 1KB
 
             // 認証サービスをモックして認証エラーを回避
             const mockAuthService: AuthService = {

--- a/src/test/unit/shareHandler.test.ts
+++ b/src/test/unit/shareHandler.test.ts
@@ -65,7 +65,8 @@ describe("ShareHandler", () => {
     });
 
     it("SHARED_MEDIAメッセージでupdateSharedMediaStoreが呼ばれる", () => {
-        const file = createTestFile({ name: "test.jpg", type: "image/jpeg", size: 1234 });
+        const file = createTestFile({ name: "test.jpg", type: "image/jpeg", content: new Uint8Array(1234) });
+        expect(file.size).toBe(1234);
         const metadata: SharedMediaMetadata = { name: "test.jpg" };
         const event = { data: { type: "SHARED_MEDIA", data: { images: [file], metadata: [metadata] } } };
         // @ts-ignore
@@ -106,7 +107,7 @@ describe("ShareHandler", () => {
 
     it("processSharedMediaOnLaunchが成功時にストアが更新される", async () => {
         // FileUploadManagerのprocessSharedMediaOnLaunchをモック
-        const file = createTestFile({ name: "test.jpg", type: "image/jpeg", size: 1234 });
+        const file = createTestFile({ name: "test.jpg", type: "image/jpeg", content: new Uint8Array(1234) });
         const metadata = { name: "test.jpg" };
         // @ts-ignore
         handler.fileUploadManager.processSharedMediaOnLaunch = vi.fn().mockResolvedValue({

--- a/src/test/unit/shareHandler.test.ts
+++ b/src/test/unit/shareHandler.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ShareHandler, getSharedMediaFromServiceWorker, checkIfOpenedFromShare } from "../../lib/shareHandler";
 import type { SharedMediaMetadata } from "../../lib/types";
+import { createTestFile } from "../fileTestUtils";
 
 vi.mock("../../stores/sharedContentStore.svelte", () => ({
     clearSharedMediaStore: vi.fn(),
@@ -22,11 +23,6 @@ vi.mock("../../lib/storage/sharedMediaRepository", () => ({
 }));
 
 const mockSharedMediaRepository = vi.mocked(await import("../../lib/storage/sharedMediaRepository"));
-
-// モック用ファイル生成
-function createMockFile(name = "test.jpg", type = "image/jpeg", size = 1234): File {
-    return new File([new Uint8Array(size)], name, { type });
-}
 
 describe("ShareHandler", () => {
     let handler: ShareHandler;
@@ -69,7 +65,7 @@ describe("ShareHandler", () => {
     });
 
     it("SHARED_MEDIAメッセージでupdateSharedMediaStoreが呼ばれる", () => {
-        const file = createMockFile();
+        const file = createTestFile({ name: "test.jpg", type: "image/jpeg", size: 1234 });
         const metadata: SharedMediaMetadata = { name: "test.jpg" };
         const event = { data: { type: "SHARED_MEDIA", data: { images: [file], metadata: [metadata] } } };
         // @ts-ignore
@@ -110,7 +106,7 @@ describe("ShareHandler", () => {
 
     it("processSharedMediaOnLaunchが成功時にストアが更新される", async () => {
         // FileUploadManagerのprocessSharedMediaOnLaunchをモック
-        const file = createMockFile();
+        const file = createTestFile({ name: "test.jpg", type: "image/jpeg", size: 1234 });
         const metadata = { name: "test.jpg" };
         // @ts-ignore
         handler.fileUploadManager.processSharedMediaOnLaunch = vi.fn().mockResolvedValue({

--- a/src/test/unit/uploadHelper.test.ts
+++ b/src/test/unit/uploadHelper.test.ts
@@ -23,6 +23,7 @@ import type {
     UploadDestination,
 } from "../../lib/types";
 import { NodeSelection } from "prosemirror-state";
+import { createTestFile } from "../fileTestUtils";
 
 const uploadDestinationsRepositoryMock = vi.hoisted(() => ({
     getDefault: vi.fn(),
@@ -262,7 +263,7 @@ describe("uploadHelper", () => {
 
     describe("processFilesForUpload", () => {
         it("processes files and calculates ox and dimensions", async () => {
-            const file = new File(["content"], "test.png", { type: "image/png" });
+            const file = createTestFile({ name: "test.png", type: "image/png", content: "content" });
             const results = await processFilesForUpload([file], mockDependencies);
 
             expect(results).toHaveLength(1);
@@ -277,7 +278,7 @@ describe("uploadHelper", () => {
 
     describe("insertPlaceholdersIntoEditor", () => {
         it("inserts placeholders for valid files", () => {
-            const file = new File(["content"], "test.png", { type: "image/png" });
+            const file = createTestFile({ name: "test.png", type: "image/png", content: "content" });
             const processingResults = [{
                 file,
                 index: 0,
@@ -307,7 +308,7 @@ describe("uploadHelper", () => {
         });
 
         it("shows error for invalid files", () => {
-            const invalidFile = new File(["content"], "test.txt", { type: "text/plain" });
+            const invalidFile = createTestFile({ name: "test.txt", type: "text/plain", content: "content" });
             const processingResults = [{ file: invalidFile, index: 0 }];
             const showUploadError = vi.fn();
 
@@ -346,8 +347,8 @@ describe("uploadHelper", () => {
         });
 
         it("inserts after selected image node when image is selected", () => {
-            const file1 = new File(["content1"], "test1.png", { type: "image/png" });
-            const file2 = new File(["content2"], "test2.png", { type: "image/png" });
+            const file1 = createTestFile({ name: "test1.png", type: "image/png", content: "content1" });
+            const file2 = createTestFile({ name: "test2.png", type: "image/png", content: "content2" });
             const processingResults = [
                 { file: file1, index: 0, ox: "hash1", dimensions: { width: 100, height: 200, displayWidth: 100, displayHeight: 200 } },
                 { file: file2, index: 1, ox: "hash2", dimensions: { width: 150, height: 300, displayWidth: 150, displayHeight: 300 } }
@@ -421,7 +422,7 @@ describe("uploadHelper", () => {
     describe("prepareMetadataList", () => {
         it("prepares metadata for files", () => {
             const fileContent = new Uint8Array(1024);
-            const file = new File([fileContent], "test.png", { type: "image/png" });
+            const file = createTestFile({ name: "test.png", type: "image/png", content: fileContent });
 
             const metadata = prepareMetadataList([file]);
 
@@ -449,7 +450,7 @@ describe("uploadHelper", () => {
             })) as unknown as new () => FileUploadManagerInterface;
             const placeholderMap: PlaceholderEntry[] = [
                 {
-                    file: new File(["content"], "test.png", { type: "image/png" }),
+                    file: createTestFile({ name: "test.png", type: "image/png", content: "content" }),
                     placeholderId: "placeholder-1",
                 },
             ];
@@ -506,7 +507,7 @@ describe("uploadHelper", () => {
 
     describe("uploadHelper integration", () => {
         it("merges store updates with external progress callbacks", async () => {
-            const file = new File(["content"], "test.png", { type: "image/png" });
+            const file = createTestFile({ name: "test.png", type: "image/png", content: "content" });
             const updateUploadState = vi.fn();
             const externalOnProgress = vi.fn();
             const externalOnVideoCompressionProgress = vi.fn();
@@ -583,7 +584,7 @@ describe("uploadHelper", () => {
         });
 
         it("uploads a single valid file successfully", async () => {
-            const file = new File(["content"], "test.png", { type: "image/png" });
+            const file = createTestFile({ name: "test.png", type: "image/png", content: "content" });
             const showUploadError = vi.fn();
             const updateUploadState = vi.fn();
 
@@ -605,7 +606,7 @@ describe("uploadHelper", () => {
         });
 
         it("forwards a resolved blossom destination instead of falling back to the legacy upload endpoint", async () => {
-            const file = new File(["content"], "test.png", { type: "image/png" });
+            const file = createTestFile({ name: "test.png", type: "image/png", content: "content" });
             const showUploadError = vi.fn();
             const updateUploadState = vi.fn();
             const destination: UploadDestination = {
@@ -682,7 +683,7 @@ describe("uploadHelper", () => {
         });
 
         it("uses injected abort checker for upload checkpoints", async () => {
-            const file = new File(["content"], "test.png", { type: "image/png" });
+            const file = createTestFile({ name: "test.png", type: "image/png", content: "content" });
             const showUploadError = vi.fn();
             const updateUploadState = vi.fn();
             const isUploadAborted = vi.fn()
@@ -710,7 +711,7 @@ describe("uploadHelper", () => {
         });
 
         it("handles validation errors", async () => {
-            const invalidFile = new File(["content"], "test.txt", { type: "text/plain" });
+            const invalidFile = createTestFile({ name: "test.txt", type: "text/plain", content: "content" });
             const showUploadError = vi.fn();
             const updateUploadState = vi.fn();
 
@@ -750,8 +751,8 @@ describe("uploadHelper", () => {
         });
 
         it("handles multiple files with mixed results", async () => {
-            const validFile = new File(["content"], "valid.png", { type: "image/png" });
-            const invalidFile = new File(["content"], "invalid.txt", { type: "text/plain" });
+            const validFile = createTestFile({ name: "valid.png", type: "image/png", content: "content" });
+            const invalidFile = createTestFile({ name: "invalid.txt", type: "text/plain", content: "content" });
             const showUploadError = vi.fn();
             const updateUploadState = vi.fn();
 
@@ -840,8 +841,8 @@ describe("uploadHelper", () => {
 
         // 複数有効ファイルのテストケースを修正
         it("handles multiple valid files successfully", async () => {
-            const validFile1 = new File(["content1"], "valid1.png", { type: "image/png" });
-            const validFile2 = new File(["content2"], "valid2.png", { type: "image/png" });
+            const validFile1 = createTestFile({ name: "valid1.png", type: "image/png", content: "content1" });
+            const validFile2 = createTestFile({ name: "valid2.png", type: "image/png", content: "content2" });
             const showUploadError = vi.fn();
             const updateUploadState = vi.fn();
 
@@ -924,8 +925,8 @@ describe("uploadHelper", () => {
 
         // 実際の複数プレースホルダーテストを修正
         it("creates unique placeholder IDs for multiple files", () => {
-            const file1 = new File(["content1"], "test1.png", { type: "image/png" });
-            const file2 = new File(["content2"], "test2.png", { type: "image/png" });
+            const file1 = createTestFile({ name: "test1.png", type: "image/png", content: "content1" });
+            const file2 = createTestFile({ name: "test2.png", type: "image/png", content: "content2" });
             const processingResults = [
                 { file: file1, index: 0, ox: "hash1", dimensions: { width: 100, height: 200, displayWidth: 100, displayHeight: 200 } },
                 { file: file2, index: 1, ox: "hash2", dimensions: { width: 150, height: 300, displayWidth: 150, displayHeight: 300 } }
@@ -988,7 +989,7 @@ describe("uploadHelper", () => {
 
         describe("insertPlaceholdersIntoEditor edge cases", () => {
             it("returns empty array if currentEditor is null", () => {
-                const file = new File(["content"], "test.png", { type: "image/png" });
+                const file = createTestFile({ name: "test.png", type: "image/png", content: "content" });
                 const processingResults = [{
                     file,
                     index: 0,
@@ -1011,7 +1012,7 @@ describe("uploadHelper", () => {
             });
 
             it("handles error thrown by image node creation", () => {
-                const file = new File(["content"], "test.png", { type: "image/png" });
+                const file = createTestFile({ name: "test.png", type: "image/png", content: "content" });
                 const processingResults = [{
                     file,
                     index: 0,
@@ -1059,7 +1060,7 @@ describe("uploadHelper", () => {
             });
 
             it("replaces empty paragraph with image if doc is only empty paragraph", () => {
-                const file = new File(["content"], "test.png", { type: "image/png" });
+                const file = createTestFile({ name: "test.png", type: "image/png", content: "content" });
                 const processingResults = [{
                     file,
                     index: 0,
@@ -1113,7 +1114,7 @@ describe("uploadHelper", () => {
             });
 
             it("updates imageSizeMapStore when dimensions are present", () => {
-                const file = new File(["content"], "test.png", { type: "image/png" });
+                const file = createTestFile({ name: "test.png", type: "image/png", content: "content" });
                 const processingResults = [{
                     file,
                     index: 0,
@@ -1144,7 +1145,7 @@ describe("uploadHelper", () => {
             });
 
             it("does not update imageSizeMapStore if dimensions are missing", () => {
-                const file = new File(["content"], "test.png", { type: "image/png" });
+                const file = createTestFile({ name: "test.png", type: "image/png", content: "content" });
                 const processingResults = [{
                     file,
                     index: 0,


### PR DESCRIPTION
This pull request consolidates the file generation logic used in three test files into a new shared helper located at `src/test/fileTestUtils.ts`. The changes ensure that:

- The file generation code is now centralized, reducing duplication across `shareHandler.test.ts`, `fileUploadManager.test.ts`, and `uploadHelper.test.ts`.
- Each test retains its original assertions and behavior, ensuring no existing functionality is broken.
- The shared helper is designed to accept only the necessary parameters for the three tests, avoiding unnecessary complexity.

### Changes made:
- Created `src/test/fileTestUtils.ts` to house the shared file generation logic.
- Updated `shareHandler.test.ts`, `fileUploadManager.test.ts`, and `uploadHelper.test.ts` to utilize the new helper while maintaining their existing assertions and file semantics.
- Ensured that all tests pass successfully, with the exception of a known issue unrelated to these changes.

This refactor improves maintainability and clarity in the test suite while adhering to the specified constraints and requirements.