### PR TITLE
Refactor PostHistory event generation in tests

### DIFF
--- a/src/test/unit/postHistoryAuthoredPostsRealtimeService.test.ts
+++ b/src/test/unit/postHistoryAuthoredPostsRealtimeService.test.ts
@@ -19,11 +19,12 @@ import { PostHistoryAuthoredPostsRealtimeService } from "../../lib/postHistoryAu
 import { PostHistoryInboundInteractionsRealtimeService } from "../../lib/postHistoryInboundInteractionsRealtimeService";
 import { PostHistoryInboundReplyReconciliationService } from "../../lib/postHistoryInboundReplyReconciliationService";
 import type { NostrEvent } from "../../lib/types";
+import { createEvent as createPostHistoryEvent } from "../postHistoryEventTestUtils";
 
 const OWNER_PUBKEY = "a".repeat(64);
 
 function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
-    return {
+    return createPostHistoryEvent({
         id: "f".repeat(64),
         pubkey: OWNER_PUBKEY,
         kind: 1,
@@ -32,7 +33,7 @@ function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
         created_at: 100,
         sig: "c".repeat(128),
         ...overrides,
-    };
+    });
 }
 
 describe("PostHistoryAuthoredPostsRealtimeService", () => {

--- a/src/test/unit/postHistoryInboundInteractionsRealtimeService.test.ts
+++ b/src/test/unit/postHistoryInboundInteractionsRealtimeService.test.ts
@@ -17,13 +17,14 @@ vi.mock("rx-nostr", () => ({
 
 import { PostHistoryInboundInteractionsRealtimeService } from "../../lib/postHistoryInboundInteractionsRealtimeService";
 import type { NostrEvent } from "../../lib/types";
+import { createEvent as createPostHistoryEvent } from "../postHistoryEventTestUtils";
 
 const OWNER_PUBKEY = "a".repeat(64);
 const PARENT_ID = "1".repeat(64);
 const OTHER_PARENT_ID = "2".repeat(64);
 
 function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
-    return {
+    return createPostHistoryEvent({
         id: "f".repeat(64),
         pubkey: "b".repeat(64),
         kind: 1,
@@ -35,7 +36,7 @@ function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
         created_at: 100,
         sig: "c".repeat(128),
         ...overrides,
-    };
+    });
 }
 
 function createService() {

--- a/src/test/unit/postHistoryRelayFetchService.test.ts
+++ b/src/test/unit/postHistoryRelayFetchService.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FALLBACK_RELAYS } from "../../lib/constants";
+import type { NostrEvent } from "../../lib/types";
+import { createEvent as createPostHistoryEvent } from "../postHistoryEventTestUtils";
 
 const createRxBackwardReqMock = vi.hoisted(() => vi.fn((_rxReqId?: string) => ({
     emit: vi.fn(),
@@ -22,8 +24,8 @@ import {
 import { createMockConsole } from "../helpers";
 import type { MockConsole } from "../helpers";
 
-function createEvent(overrides: Record<string, any> = {}) {
-    return {
+function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
+    return createPostHistoryEvent({
         id: "a".repeat(64),
         pubkey: "b".repeat(64),
         kind: 1,
@@ -32,7 +34,7 @@ function createEvent(overrides: Record<string, any> = {}) {
         created_at: 100,
         sig: "c".repeat(128),
         ...overrides,
-    };
+    });
 }
 
 describe("PostHistoryRelayFetchService", () => {

--- a/src/test/unit/postHistoryThreadGraphUtils.test.ts
+++ b/src/test/unit/postHistoryThreadGraphUtils.test.ts
@@ -10,9 +10,10 @@ import {
     toEventFromReplyRecord,
 } from "../../lib/postHistoryThreadGraphUtils";
 import type { NostrEvent } from "../../lib/types";
+import { createEvent as createPostHistoryEvent } from "../postHistoryEventTestUtils";
 
 function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
-    return {
+    return createPostHistoryEvent({
         id: "1".repeat(64),
         pubkey: "a".repeat(64),
         kind: 1,
@@ -21,7 +22,7 @@ function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
         created_at: 100,
         sig: "b".repeat(128),
         ...overrides,
-    };
+    });
 }
 
 describe("postHistoryThreadGraphUtils", () => {


### PR DESCRIPTION
This pull request refactors the event generation logic in four PostHistory-related test files to utilize a common helper function, `createEvent`, from `postHistoryEventTestUtils.ts`. The changes aim to reduce code duplication while maintaining the integrity of existing test values and behaviors.

### Changes made:
- Replaced local event generation functions in the following test files with calls to `createEvent`:
  - `postHistoryRelayFetchService.test.ts`
  - `postHistoryAuthoredPostsRealtimeService.test.ts`
  - `postHistoryInboundInteractionsRealtimeService.test.ts`
  - `postHistoryThreadGraphUtils.test.ts`
- Kept test-specific default values (e.g., id, pubkey, kind, content, tags, created_at, sig) intact by wrapping them in small functions within each test file.
- Ensured that the order of overrides and the independence of event/array objects between calls are preserved.

### Verification:
- All targeted tests were executed successfully with no errors.
- Type checks passed without warnings.
- One unrelated test failure was noted in `fixedLegacyBridge.test.ts`, which is outside the scope of this change.

No modifications were made to production code or unrelated files. Dependencies were updated prior to testing to ensure a smooth verification process.