### PR TITLE
Add shared JSON response helper for upload tests

### DIFF
--- a/src/test/integration/file-upload-flow.integration.test.ts
+++ b/src/test/integration/file-upload-flow.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ImageCompressionService } from '../../lib/imageCompressionService';
 import { MimeTypeSupport } from '../../lib/mimeTypeSupport';
 import { NostrAuthService } from '../../lib/nostrAuthService';
+import { createJsonResponse } from '../uploadResponseTestUtils';
 import {
     NIP46_BACKGROUND_RECOVERY_THRESHOLD_MS,
     registerNip46VisibilityHandler,
@@ -418,19 +419,18 @@ describe('ファイルアップロードフロー統合テスト', () => {
             }));
             const { visibilityRecovery, cleanup } = await prepareRecovery({ signEvent });
             const fetchMock = vi.fn()
-                .mockResolvedValueOnce(new Response(JSON.stringify({
+               .mockResolvedValueOnce(createJsonResponse({
                     status: 'success',
                     nip94_event: {
                         tags: [['url', 'https://upload.example/photo.png']],
                     },
-                }), {
+               }, {
                     status: 200,
-                    headers: { 'content-type': 'application/json' },
-                }))
-                .mockResolvedValue(new Response(null, {
-                    status: 200,
-                    headers: { 'content-type': 'image/png' },
-                }));
+               }))
+               .mockResolvedValue(new Response(null, {
+                   status: 200,
+                   headers: { 'content-type': 'image/png' },
+               }));
 
             const uploadPromise = new Nip96UploadAdapter().upload({
                 file: new File([new Uint8Array([1, 2, 3])], 'photo.png', { type: 'image/png' }),
@@ -468,19 +468,18 @@ describe('ファイルアップロードフロー統合テスト', () => {
             };
             const { visibilityRecovery, cleanup } = await prepareRecovery(signer);
             const fetchMock = vi.fn()
-                .mockResolvedValueOnce(new Response(JSON.stringify({
+               .mockResolvedValueOnce(createJsonResponse({
                     url: 'https://blossom.example/photo.png',
                     sha256: 'a'.repeat(64),
                     size: 3,
                     type: 'image/png',
-                }), {
+               }, {
                     status: 200,
-                    headers: { 'content-type': 'application/json' },
-                }))
-                .mockResolvedValue(new Response(null, {
-                    status: 200,
-                    headers: { 'content-type': 'image/png' },
-                }));
+               }))
+               .mockResolvedValue(new Response(null, {
+                   status: 200,
+                   headers: { 'content-type': 'image/png' },
+               }));
 
             const uploadPromise = new BlossomUploadAdapter().upload({
                 file: new File([new Uint8Array([1, 2, 3])], 'photo.png', { type: 'image/png' }),
@@ -512,19 +511,18 @@ describe('ファイルアップロードフロー統合テスト', () => {
             };
             (keyManager.getFromStore as any).mockReturnValue('nsec1test');
             const fetchMock = vi.fn()
-                .mockResolvedValueOnce(new Response(JSON.stringify({
+               .mockResolvedValueOnce(createJsonResponse({
                     status: 'success',
                     nip94_event: {
                         tags: [['url', 'https://upload.example/nsec-photo.png']],
                     },
-                }), {
+               }, {
                     status: 200,
-                    headers: { 'content-type': 'application/json' },
-                }))
-                .mockResolvedValue(new Response(null, {
-                    status: 200,
-                    headers: { 'content-type': 'image/png' },
-                }));
+               }))
+               .mockResolvedValue(new Response(null, {
+                   status: 200,
+                   headers: { 'content-type': 'image/png' },
+               }));
 
             const result = await new Nip96UploadAdapter().upload({
                 file: new File([new Uint8Array([1, 2, 3])], 'photo.png', { type: 'image/png' }),

--- a/src/test/unit/blossomUploadAdapter.test.ts
+++ b/src/test/unit/blossomUploadAdapter.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BlossomUploadAdapter } from "../../lib/upload/BlossomUploadAdapter";
 import type { UploadDestination } from "../../lib/types";
+import { createJsonResponse } from "../uploadResponseTestUtils";
 
 vi.mock("../../lib/utils/fileUtils", () => ({
     calculateSHA256Hex: vi.fn(async () => "a".repeat(64)),
@@ -66,14 +67,13 @@ describe("BlossomUploadAdapter", () => {
 
         const adapter = new BlossomUploadAdapter();
         const fetchMock = vi.fn()
-            .mockResolvedValueOnce(new Response(JSON.stringify({
+            .mockResolvedValueOnce(createJsonResponse({
                 url: "https://npub1example.blossom.band/mockhash.png",
                 sha256: "a".repeat(64),
                 size: 4,
                 type: "image/png",
-            }), {
+            }, {
                 status: 200,
-                headers: { "content-type": "application/json" },
             }))
             .mockResolvedValueOnce(new Response(null, {
                 status: 200,
@@ -118,14 +118,13 @@ describe("BlossomUploadAdapter", () => {
         const adapter = new BlossomUploadAdapter();
         const imageSpy = mockImageLoads([false, true]);
         const fetchMock = vi.fn()
-            .mockResolvedValueOnce(new Response(JSON.stringify({
+            .mockResolvedValueOnce(createJsonResponse({
                 url: "https://npub1example.blossom.band/mockhash.png",
                 sha256: "a".repeat(64),
                 size: 4,
                 type: "image/png",
-            }), {
+            }, {
                 status: 200,
-                headers: { "content-type": "application/json" },
             }))
             .mockRejectedValue(new TypeError("Failed to fetch"));
         const signer = {

--- a/src/test/unit/nip96UploadAdapter.test.ts
+++ b/src/test/unit/nip96UploadAdapter.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Nip96UploadAdapter } from "../../lib/upload/Nip96UploadAdapter";
 import type { UploadDestination } from "../../lib/types";
+import { createJsonResponse } from "../uploadResponseTestUtils";
 
 function createDestination(): UploadDestination {
     return {
@@ -61,18 +62,17 @@ describe("Nip96UploadAdapter", () => {
             return image as unknown as HTMLImageElement;
         });
         const fetchMock = vi.fn()
-            .mockResolvedValueOnce(new Response(JSON.stringify({
+            .mockResolvedValueOnce(createJsonResponse({
                 status: "processing",
                 processing_url: "https://share.yabu.me/1811",
-            }), {
+            }, {
                 status: 202,
-                headers: { "content-type": "application/json" },
             }))
             .mockResolvedValueOnce(new Response("Not Found", {
                 status: 404,
                 statusText: "Not Found",
             }))
-            .mockResolvedValueOnce(new Response(JSON.stringify({
+            .mockResolvedValueOnce(createJsonResponse({
                 status: "success",
                 nip94_event: {
                     tags: [
@@ -81,9 +81,8 @@ describe("Nip96UploadAdapter", () => {
                         ["m", "image/png"],
                     ],
                 },
-            }), {
+            }, {
                 status: 200,
-                headers: { "content-type": "application/json" },
             }));
         const authService = {
             buildAuthHeader: vi.fn(async (_url: string, method: string) => `Bearer ${method}`),

--- a/src/test/uploadResponseTestUtils.ts
+++ b/src/test/uploadResponseTestUtils.ts
@@ -1,0 +1,16 @@
+export type JsonResponseInit = Omit<ResponseInit, "body" | "headers"> & {
+    headers?: HeadersInit;
+};
+
+export function createJsonResponse(body: unknown, init: JsonResponseInit = {}): Response {
+    const headers = new Headers(init.headers);
+
+    if (!headers.has("content-type")) {
+        headers.set("content-type", "application/json");
+    }
+
+    return new Response(JSON.stringify(body), {
+        ...init,
+        headers,
+    });
+}


### PR DESCRIPTION
This pull request introduces a new helper for generating JSON responses in upload-related tests, streamlining the process and reducing code duplication. The following changes were made:

- Created `uploadResponseTestUtils.ts` to encapsulate the logic for creating JSON responses.
- Refactored the following test files to utilize the new helper:
  - `file-upload-flow.integration.test.ts`
  - `blossomUploadAdapter.test.ts`
  - `nip96UploadAdapter.test.ts`
  
Key features of the new helper include:
- Ability to specify the JSON body, HTTP status, status text, and additional headers.
- Automatic setting of `content-type: application/json` without losing necessary values from existing tests.
- Maintained existing behaviors for JSON.stringify responses, HTTP status, and other headers.

All targeted tests and type checks have passed successfully, while two unrelated failures remain in the full test suite.