### PR TITLE
Refactor PostHistory sync result fixtures for common usage

### DIFF
--- a/src/test/postHistorySyncResultTestUtils.ts
+++ b/src/test/postHistorySyncResultTestUtils.ts
@@ -1,0 +1,91 @@
+import type { PostHistoryInboundInteractionsSyncResult } from "../lib/postHistoryInboundInteractionsSyncService";
+import type { PostHistoryRelayFetchResult } from "../lib/postHistoryRelayFetchService";
+import type { NostrEvent } from "../lib/types";
+
+export type PostHistoryInboundInteractionsSyncResultFixture = PostHistoryInboundInteractionsSyncResult & {
+    savedParentEventIds: string[];
+};
+
+export type PostHistoryAuthoredSyncResultFixture = {
+    fetchResult: PostHistoryRelayFetchResult;
+    upsertSummary: { insertedCount: number; updatedCount: number; unchangedCount: number };
+    savedSelfPostEventIds: string[];
+};
+
+export function createAuthoredFetchResult(
+    event: NostrEvent,
+    overrides: Partial<PostHistoryRelayFetchResult> = {},
+    defaults: Partial<PostHistoryRelayFetchResult> = {},
+): PostHistoryRelayFetchResult {
+    return {
+        status: "success",
+        events: [{ event, relayUrls: [] }],
+        fetchedAt: 1_000,
+        nextUntil: null,
+        hasMore: false,
+        relayUrls: [],
+        observedRelayUrls: [],
+        rawCount: 1,
+        uniqueCount: 1,
+        duplicateCount: 0,
+        perRelayCounts: [],
+        oldestCreatedAt: event.created_at,
+        newestCreatedAt: event.created_at,
+        requestedRelayUrls: [],
+        eventRelayUrls: [],
+        eoseRelayUrls: [],
+        closedRelayUrls: [],
+        errorRelayUrls: [],
+        downRelayUrls: [],
+        completedByRxNostr: true,
+        completedByLocalTimeout: false,
+        hasAnyRelayResponse: true,
+        allRelaysFailed: false,
+        ...defaults,
+        ...overrides,
+    };
+}
+
+export function createAuthoredSyncResult(
+    event: NostrEvent,
+    overrides: Partial<PostHistoryRelayFetchResult> = {},
+    defaults: Partial<PostHistoryRelayFetchResult> = {},
+): PostHistoryAuthoredSyncResultFixture {
+    const fetchResult = createAuthoredFetchResult(event, overrides, defaults);
+
+    return {
+        fetchResult,
+        upsertSummary: { insertedCount: 1, updatedCount: 0, unchangedCount: 0 },
+        savedSelfPostEventIds: [event.id],
+    };
+}
+
+export function createInboundSyncResult(
+    overrides: Partial<PostHistoryInboundInteractionsSyncResultFixture> = {},
+    defaults: Partial<PostHistoryInboundInteractionsSyncResultFixture> = {},
+): PostHistoryInboundInteractionsSyncResultFixture {
+    return {
+        status: "success",
+        fetchedAt: 1_000,
+        since: 10,
+        limit: 100,
+        relayUrls: [],
+        rawCount: 0,
+        uniqueCount: 0,
+        saturated: false,
+        maybeIncomplete: false,
+        newestSeenCreatedAt: null,
+        changedParentEventIds: [],
+        savedDirectReplyCount: 0,
+        savedParentEventIds: [],
+        classifications: {
+            "direct-reply": 0,
+            "direct-reply-candidate": 0,
+            "mention-like": 0,
+            reaction: 0,
+            unsupported: 0,
+        },
+        ...defaults,
+        ...overrides,
+    };
+}

--- a/src/test/unit/postHistoryForegroundPeriodicSyncService.test.ts
+++ b/src/test/unit/postHistoryForegroundPeriodicSyncService.test.ts
@@ -3,7 +3,9 @@ import {
     PostHistoryForegroundPeriodicSyncService,
 } from "../../lib/postHistoryForegroundPeriodicSyncService";
 import type { PostHistoryAuthoredSyncState } from "../../lib/storage/postHistoryAuthoredSyncStateRepository";
+import type { PostHistoryRelayFetchResult } from "../../lib/postHistoryRelayFetchService";
 import type { NostrEvent } from "../../lib/types";
+import { createAuthoredSyncResult, createInboundSyncResult } from "../postHistorySyncResultTestUtils";
 
 const OWNER_PUBKEY = "a".repeat(64);
 
@@ -19,62 +21,19 @@ function createEvent(createdAt = 950): NostrEvent {
     };
 }
 
-function createAuthoredResult(overrides: Record<string, unknown> = {}) {
+function createAuthoredResult(overrides: Partial<PostHistoryRelayFetchResult> = {}) {
     const event = createEvent();
-    return {
-        fetchResult: {
-            status: "success",
-            events: [{ event, relayUrls: [] }],
-            fetchedAt: 2_000,
-            nextUntil: null,
-            hasMore: false,
-            relayUrls: [],
-            observedRelayUrls: [],
-            rawCount: 1,
-            uniqueCount: 1,
-            duplicateCount: 0,
-            perRelayCounts: [],
-            oldestCreatedAt: event.created_at,
-            newestCreatedAt: event.created_at,
-            requestedRelayUrls: [],
-            eventRelayUrls: [],
-            eoseRelayUrls: [],
-            closedRelayUrls: [],
-            errorRelayUrls: [],
-            downRelayUrls: [],
-            completedByRxNostr: true,
-            completedByLocalTimeout: false,
-            hasAnyRelayResponse: true,
-            allRelaysFailed: false,
-            ...overrides,
-        },
-        upsertSummary: { insertedCount: 1, updatedCount: 0, unchangedCount: 0 },
-        savedSelfPostEventIds: [event.id],
-    } as any;
+    return createAuthoredSyncResult(event, overrides, {
+        fetchedAt: 2_000,
+    });
 }
 
 function createInboundResult() {
-    return {
-        status: "success",
+    return createInboundSyncResult({}, {
         fetchedAt: 2_000,
         since: 100,
         limit: 100,
-        relayUrls: [],
-        rawCount: 0,
-        uniqueCount: 0,
-        saturated: false,
-        maybeIncomplete: false,
-        newestSeenCreatedAt: null,
-        savedParentEventIds: [],
-        savedDirectReplyCount: 0,
-        classifications: {
-            "direct-reply": 0,
-            "direct-reply-candidate": 0,
-            "mention-like": 0,
-            reaction: 0,
-            unsupported: 0,
-        },
-    } as const;
+    });
 }
 
 function createState(overrides: Partial<PostHistoryAuthoredSyncState> = {}): PostHistoryAuthoredSyncState {

--- a/src/test/unit/postHistoryLightweightSyncCoordinator.test.ts
+++ b/src/test/unit/postHistoryLightweightSyncCoordinator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { PostHistoryLightweightSyncCoordinator } from "../../lib/postHistoryLightweightSyncCoordinator";
 import type { NostrEvent } from "../../lib/types";
+import { createAuthoredFetchResult, createInboundSyncResult } from "../postHistorySyncResultTestUtils";
 
 const OWNER_PUBKEY = "a".repeat(64);
 const OTHER_OWNER_PUBKEY = "b".repeat(64);
@@ -27,55 +28,11 @@ function createEvent(): NostrEvent {
 }
 
 function createAuthoredResult(event = createEvent()) {
-    return {
-        status: "success",
-        events: [{ event, relayUrls: [] }],
-        fetchedAt: 1000,
-        nextUntil: null,
-        hasMore: false,
-        relayUrls: [],
-        observedRelayUrls: [],
-        rawCount: 1,
-        uniqueCount: 1,
-        duplicateCount: 0,
-        perRelayCounts: [],
-        oldestCreatedAt: event.created_at,
-        newestCreatedAt: event.created_at,
-        requestedRelayUrls: [],
-        eventRelayUrls: [],
-        eoseRelayUrls: [],
-        closedRelayUrls: [],
-        errorRelayUrls: [],
-        downRelayUrls: [],
-        completedByRxNostr: true,
-        completedByLocalTimeout: false,
-        hasAnyRelayResponse: true,
-        allRelaysFailed: false,
-    } as const;
+    return createAuthoredFetchResult(event, {}, { fetchedAt: 1000 });
 }
 
 function createInboundResult() {
-    return {
-        status: "success",
-        fetchedAt: 1000,
-        since: 10,
-        limit: 100,
-        relayUrls: [],
-        rawCount: 0,
-        uniqueCount: 0,
-        saturated: false,
-        maybeIncomplete: false,
-        newestSeenCreatedAt: null,
-        savedParentEventIds: [],
-        savedDirectReplyCount: 0,
-        classifications: {
-            "direct-reply": 0,
-            "direct-reply-candidate": 0,
-            "mention-like": 0,
-            reaction: 0,
-            unsupported: 0,
-        },
-    } as const;
+    return createInboundSyncResult({}, { fetchedAt: 1000, since: 10, limit: 100 });
 }
 
 function createAuthoredStateRepository() {

--- a/src/test/unit/postHistoryVisibilityResumeSyncService.test.ts
+++ b/src/test/unit/postHistoryVisibilityResumeSyncService.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { PostHistoryVisibilityResumeSyncService } from "../../lib/postHistoryVisibilityResumeSyncService";
 import type { NostrEvent } from "../../lib/types";
+import { createAuthoredFetchResult, createInboundSyncResult } from "../postHistorySyncResultTestUtils";
 
 const OWNER_PUBKEY = "a".repeat(64);
 
@@ -18,55 +19,23 @@ function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
 }
 
 function createAuthoredResult(event = createEvent()) {
-    return {
-        status: "success",
+    return createAuthoredFetchResult(event, {
         events: [{ event, relayUrls: ["wss://relay.example.com/"] }],
-        fetchedAt: 1_700_000_000_000,
-        nextUntil: null,
-        hasMore: false,
         relayUrls: ["wss://read.example.com/"],
         observedRelayUrls: ["wss://relay.example.com/"],
-        rawCount: 1,
-        uniqueCount: 1,
-        duplicateCount: 0,
-        perRelayCounts: [],
-        oldestCreatedAt: event.created_at,
-        newestCreatedAt: event.created_at,
         requestedRelayUrls: ["wss://read.example.com/"],
         eventRelayUrls: ["wss://relay.example.com/"],
-        eoseRelayUrls: [],
-        closedRelayUrls: [],
-        errorRelayUrls: [],
-        downRelayUrls: [],
-        completedByRxNostr: true,
-        completedByLocalTimeout: false,
-        hasAnyRelayResponse: true,
-        allRelaysFailed: false,
-    } as const;
+    }, {
+        fetchedAt: 1_700_000_000_000,
+    });
 }
 
 function createInboundResult() {
-    return {
-        status: "success",
+    return createInboundSyncResult({}, {
         fetchedAt: 1_700_000_000_000,
         since: 50,
         limit: 150,
-        relayUrls: [],
-        rawCount: 0,
-        uniqueCount: 0,
-        saturated: false,
-        maybeIncomplete: false,
-        newestSeenCreatedAt: null,
-        savedParentEventIds: [],
-        savedDirectReplyCount: 0,
-        classifications: {
-            "direct-reply": 0,
-            "direct-reply-candidate": 0,
-            "mention-like": 0,
-            reaction: 0,
-            unsupported: 0,
-        },
-    } as const;
+    });
 }
 
 describe("PostHistoryVisibilityResumeSyncService", () => {


### PR DESCRIPTION
This pull request introduces a common fixture for PostHistory sync results, allowing for reduced duplication across multiple test files. The following changes were made:

- **New File Created**: 
  - `src/test/postHistorySyncResultTestUtils.ts` 
    - Added utility functions for creating common fixtures:
      - `createAuthoredFetchResult` for authored fetch results.
      - `createAuthoredSyncResult` for authored sync result envelopes.
      - `createInboundSyncResult` for inbound sync results.
    - Maintained compatibility with existing `savedParentEventIds`.

- **Refactored Test Files**:
  - Updated the following test files to utilize the new common fixtures:
    - `src/test/unit/postHistoryLightweightSyncCoordinator.test.ts`
    - `src/test/unit/postHistoryVisibilityResumeSyncService.test.ts`
    - `src/test/unit/postHistoryForegroundPeriodicSyncService.test.ts`

### Implementation Details
- Each test maintains its specific values for time, event content, relay URLs, count values, saturation/incomplete states, classifications, and overrides.
- Mutable arrays and objects are returned as new instances on each helper call to prevent shared state.
- No changes were made to the production code or unrelated test logic.

### Validation Results
- All targeted tests passed successfully.
- Type checks showed no errors or warnings.
- One unrelated failure was noted in a different test file, which is not addressed in this PR.