### PR TITLE
Refactor tests to use shared createEvent helper

### DIFF
--- a/src/test/unit/channelContextService.test.ts
+++ b/src/test/unit/channelContextService.test.ts
@@ -9,12 +9,13 @@ import { FALLBACK_RELAYS } from "../../lib/constants";
 import type { NostrEvent } from "../../lib/types";
 import { createMockConsole } from "../helpers";
 import type { MockConsole } from "../helpers";
+import { createEvent as createBaseEvent } from "../postHistoryEventTestUtils";
 
 const channelId = "a".repeat(64);
 const authorPubkey = "b".repeat(64);
 
 function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
-    return {
+    return createBaseEvent({
         id: channelId,
         pubkey: authorPubkey,
         created_at: 100,
@@ -23,7 +24,7 @@ function createEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
         content: JSON.stringify({ name: "General", about: "Root about" }),
         sig: "sig",
         ...overrides,
-    };
+    });
 }
 
 function createRxNostr(

--- a/src/test/unit/draftDisplayUtils.test.ts
+++ b/src/test/unit/draftDisplayUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { createDraftListDisplay, type DraftContextLabels } from '../../lib/draftDisplayUtils';
 import type { Draft, DraftReplyQuoteEntryData, NostrEvent } from '../../lib/types';
+import { createEvent as createBaseEvent } from '../postHistoryEventTestUtils';
 
 const labels: DraftContextLabels = {
     channel: 'チャンネル',
@@ -12,7 +13,7 @@ const labels: DraftContextLabels = {
 };
 
 function createEvent(content: string): NostrEvent {
-    return {
+    return createBaseEvent({
         id: 'event-id',
         pubkey: 'pubkey',
         created_at: 1,
@@ -20,7 +21,7 @@ function createEvent(content: string): NostrEvent {
         tags: [],
         content,
         sig: 'sig',
-    };
+    });
 }
 
 function createReference(

--- a/src/test/unit/postHistoryNip10Utils.test.ts
+++ b/src/test/unit/postHistoryNip10Utils.test.ts
@@ -5,6 +5,7 @@ import {
     resolveKind7ReactionTargetEventId,
 } from "../../lib/postHistoryNip10Utils";
 import type { NostrEvent } from "../../lib/types";
+import { createEvent as createBaseEvent } from "../postHistoryEventTestUtils";
 
 const ROOT_ID = "1".repeat(64);
 const REPLY_ID = "2".repeat(64);
@@ -14,7 +15,7 @@ const LEGACY_ID = "5".repeat(64);
 const AUTHOR_HINT = "a".repeat(64);
 
 function createEvent(tags: string[][], kind = 1): NostrEvent {
-    return {
+    return createBaseEvent({
         id: "f".repeat(64),
         pubkey: "b".repeat(64),
         kind,
@@ -22,7 +23,7 @@ function createEvent(tags: string[][], kind = 1): NostrEvent {
         tags,
         created_at: 100,
         sig: "sig",
-    };
+    });
 }
 
 describe("parseKind1ThreadReferences", () => {

--- a/src/test/unit/postHistoryRelatedEventCard.test.ts
+++ b/src/test/unit/postHistoryRelatedEventCard.test.ts
@@ -8,11 +8,12 @@ vi.mock("svelte-i18n", () => ({
 
 import PostHistoryRelatedEventCard from "../../components/PostHistoryRelatedEventCard.svelte";
 import type { NostrEvent, ProfileData } from "../../lib/types";
+import { createEvent as createBaseEvent } from "../postHistoryEventTestUtils";
 
 const pubkey = "a".repeat(64);
 
 function createEvent(content = "reply"): NostrEvent {
-    return {
+    return createBaseEvent({
         id: "1".repeat(64),
         pubkey,
         kind: 1,
@@ -20,7 +21,7 @@ function createEvent(content = "reply"): NostrEvent {
         tags: [],
         created_at: 100,
         sig: "2".repeat(128),
-    };
+    });
 }
 
 describe("PostHistoryRelatedEventCard", () => {


### PR DESCRIPTION
This pull request refactors four test files to eliminate duplication in NostrEvent generation by utilizing the existing `createEvent` helper function. The changes ensure that:

- Local event creation functions in the following test files have been replaced with thin wrappers around the shared `createEvent`:
  - `draftDisplayUtils.test.ts`
  - `postHistoryNip10Utils.test.ts`
  - `postHistoryRelatedEventCard.test.ts`
  - `channelContextService.test.ts`
  
- The existing test values for `id`, `pubkey`, `kind`, `content`, `tags`, `created_at`, and `sig` remain unchanged.
- The structure of the tests, including invocation, expected values, test case names, and asynchronous handling, has not been modified.
- The `src/test/postHistoryEventTestUtils.ts` file and production code remain untouched.

All tests were executed successfully using `npx vitest run` and `npm run check`, confirming that the refactor meets the specified requirements without introducing any unintended changes.