### PR TITLE
Remove local createDeferred usage in specified test files

### DIFF
--- a/src/test/unit/appComponentLoader.test.ts
+++ b/src/test/unit/appComponentLoader.test.ts
@@ -1,16 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { createDeferred } from "../deferredTestUtils";
 import { createComponentLoader } from "../../lib/appComponentLoader";
-
-function createDeferred<T>() {
-    let resolve!: (value: T) => void;
-    let reject!: (reason?: unknown) => void;
-    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-        resolve = resolvePromise;
-        reject = rejectPromise;
-    });
-    return { promise, resolve, reject };
-}
 
 describe("createComponentLoader", () => {
     it("成功時はcomponentとPromiseをcacheする", async () => {

--- a/src/test/unit/customEmojiStore.test.ts
+++ b/src/test/unit/customEmojiStore.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createDeferred } from "../deferredTestUtils";
+
 const customEmojiMocks = vi.hoisted(() => ({
     cacheCustomEmojiImages: vi.fn(),
     fetchCustomEmojiList: vi.fn(),
@@ -28,17 +30,6 @@ function createEmoji(shortcode: string, src: string, sortIndex = 0): CustomEmoji
         sourceType: "kind10030",
         sourceAddress: null,
     };
-}
-
-function createDeferred<T>() {
-    let resolve!: (value: T) => void;
-    let reject!: (reason?: unknown) => void;
-    const promise = new Promise<T>((promiseResolve, promiseReject) => {
-        resolve = promiseResolve;
-        reject = promiseReject;
-    });
-
-    return { promise, resolve, reject };
 }
 
 describe("customEmojiStore", () => {

--- a/src/test/unit/postHistoryProfileSync.test.ts
+++ b/src/test/unit/postHistoryProfileSync.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { createDeferred } from "../deferredTestUtils";
 import { createPostHistoryProfileSyncCoordinator } from "../../lib/postHistoryProfileSync";
 import type { ProfileData } from "../../lib/types";
 
@@ -11,14 +12,6 @@ function createProfile(name: string): ProfileData {
         npub: `npub-${name}`,
         nprofile: `nprofile-${name}`,
     };
-}
-
-function createDeferred<T>() {
-    let resolve!: (value: T) => void;
-    const promise = new Promise<T>((nextResolve) => {
-        resolve = nextResolve;
-    });
-    return { promise, resolve };
 }
 
 describe("postHistoryProfileSync", () => {


### PR DESCRIPTION
This pull request removes the local implementations of `createDeferred` from the following test files and replaces them with imports from `src/test/deferredTestUtils.ts`:

- `src/test/unit/customEmojiStore.test.ts`
- `src/test/unit/appComponentLoader.test.ts`
- `src/test/unit/postHistoryProfileSync.test.ts`

### Changes made:
- Deleted local `createDeferred` functions in the specified test files.
- Imported `createDeferred` from `src/test/deferredTestUtils.ts`.
- Ensured that the usage of generics, promises, resolve, and reject remains unchanged.
- Maintained the order of promise resolution and the sequence of mock calls.
- Verified that all existing test cases, expected values, and target processing remain intact.

### Verification:
- All targeted tests were run successfully using `npx vitest`.
- Confirmed that the changes meet the specified requirements without introducing unrelated modifications.