### PR TITLE
Consolidate ProfileData generation into a common helper

### DIFF
--- a/src/test/profileTestUtils.ts
+++ b/src/test/profileTestUtils.ts
@@ -1,0 +1,12 @@
+import type { ProfileData } from "../lib/types";
+
+export function createProfileData(overrides: Partial<ProfileData> = {}): ProfileData {
+    return {
+        name: "name",
+        displayName: "displayName",
+        picture: "https://example.com/profile.png",
+        npub: "npub1profile",
+        nprofile: "nprofile1profile",
+        ...overrides,
+    };
+}

--- a/src/test/unit/postHistoryThreadGraphProfileSync.test.ts
+++ b/src/test/unit/postHistoryThreadGraphProfileSync.test.ts
@@ -12,6 +12,7 @@ import {
 import type { PostHistoryRecord } from "../../lib/storage/ehagakiDb";
 import type { ProfileData } from "../../lib/types";
 import { createPostHistoryThreadGraphHookHarness } from "../helpers/postHistoryThreadGraphHookHarness.svelte";
+import { createProfileData } from "../profileTestUtils";
 
 const authorPubkey = "a".repeat(64);
 const otherPubkey = "b".repeat(64);
@@ -41,13 +42,10 @@ function createPost(
 }
 
 function createProfile(displayName: string): ProfileData {
-    return {
-        name: "name",
+    return createProfileData({
         displayName,
         picture: `https://example.com/${displayName}.png`,
-        npub: "npub1profile",
-        nprofile: "nprofile1profile",
-    };
+    });
 }
 
 function createProfileSync(

--- a/src/test/unit/profileMetadataCache.test.ts
+++ b/src/test/unit/profileMetadataCache.test.ts
@@ -12,6 +12,7 @@ import type {
 } from "../../lib/storage/profilesRepository";
 import type { ProfileRecord } from "../../lib/storage/ehagakiDb";
 import type { ProfileData } from "../../lib/types";
+import { createProfileData } from "../profileTestUtils";
 
 const repositoryMock = vi.hoisted(() => ({
     get: vi.fn(),
@@ -40,14 +41,14 @@ const otherPubkey = "b".repeat(64);
 const eventId = "1".repeat(64);
 
 function createProfile(overrides: Partial<ProfileData> = {}): ProfileData {
-    return {
+    return createProfileData({
         name: "Cached",
         displayName: "Cached User",
         picture: "https://example.com/cached.png?profile=true",
         npub: "npub1cached",
         nprofile: "nprofile1cached",
         ...overrides,
-    };
+    });
 }
 
 function createProfileRecord(

--- a/src/test/unit/replyQuoteProfileSync.test.ts
+++ b/src/test/unit/replyQuoteProfileSync.test.ts
@@ -5,6 +5,7 @@ import type {
     ReplyQuoteComposerState,
     ReplyQuoteState,
 } from "../../lib/types";
+import { createProfileData } from "../profileTestUtils";
 
 const ownerTokens = new Map<string, symbol>();
 
@@ -51,13 +52,13 @@ function createReference(
 }
 
 function createProfile(name: string, picture = `https://example.com/${name}.png`): ProfileData {
-    return {
+    return createProfileData({
         name,
         displayName: name,
         picture,
         npub: `npub-${name}`,
         nprofile: `nprofile-${name}`,
-    };
+    });
 }
 
 describe("replyQuoteProfileSync", () => {


### PR DESCRIPTION
This pull request introduces a new helper file to streamline the generation of `ProfileData` across multiple test files, addressing the duplication identified in the user request. 

### Changes made:
- Created a new helper file at `src/test/profileTestUtils.ts` with a function `createProfileData(overrides)` to generate base `ProfileData` values.
- Refactored three test files to utilize this common helper, specifically:
  - `src/test/unit/replyQuoteProfileSync.test.ts`
  - `src/test/unit/postHistoryThreadGraphProfileSync.test.ts`
  - `src/test/unit/profileMetadataCache.test.ts`
- Ensured that all specific values, expected results, and behaviors in the tests remain unchanged, with only thin local wrappers left where necessary.
- No changes were made to production code.

### Verification:
- All tests passed successfully when running:
  - `npx vitest run src/test/unit/replyQuoteProfileSync.test.ts src/test/unit/postHistoryThreadGraphProfileSync.test.ts src/test/unit/profileMetadataCache.test.ts`
- No errors or warnings were found during the check:
  - `npm run check`