### PR TITLE
Fix MockStorage to handle empty strings correctly and add tests

### DIFF
--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -29,7 +29,7 @@ export class MockStorage implements Storage {
     get length() { return Object.keys(this.store).length; }
 
     getItem(key: string): string | null {
-        return this.store[key] || null;
+        return this.store[key] ?? null;
     }
 
     setItem(key: string, value: string): void {
@@ -46,7 +46,7 @@ export class MockStorage implements Storage {
 
     key(index: number): string | null {
         const keys = Object.keys(this.store);
-        return keys[index] || null;
+        return keys[index] ?? null;
     }
 }
 

--- a/src/test/unit/mockStorage.test.ts
+++ b/src/test/unit/mockStorage.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { MockStorage } from '../helpers';
+
+describe('MockStorage', () => {
+    it('stores and retrieves normal keys and values', () => {
+        const storage = new MockStorage();
+
+        storage.setItem('key', 'value');
+
+        expect(storage.getItem('key')).toBe('value');
+        expect(storage.length).toBe(1);
+        expect(storage.key(0)).toBe('key');
+    });
+
+    it('preserves empty-string values and empty-string keys', () => {
+        const storage = new MockStorage();
+        storage.setItem('key', '');
+
+        expect(storage.getItem('key')).toBe('');
+        expect(storage.length).toBe(1);
+        expect(storage.key(0)).toBe('key');
+
+        const storageWithEmptyKey = new MockStorage();
+        storageWithEmptyKey.setItem('', 'value');
+
+        expect(storageWithEmptyKey.getItem('')).toBe('value');
+        expect(storageWithEmptyKey.length).toBe(1);
+        expect(storageWithEmptyKey.key(0)).toBe('');
+    });
+
+    it('returns null for missing keys and out-of-range indexes', () => {
+        const storage = new MockStorage();
+
+        expect(storage.getItem('missing')).toBeNull();
+        expect(storage.key(0)).toBeNull();
+        expect(storage.key(1)).toBeNull();
+        expect(storage.key(-1)).toBeNull();
+    });
+
+    it('updates length and contents after removeItem and clear', () => {
+        const storage = new MockStorage();
+        storage.setItem('first', 'one');
+        storage.setItem('second', 'two');
+
+        storage.removeItem('first');
+
+        expect(storage.length).toBe(1);
+        expect(storage.getItem('first')).toBeNull();
+        expect(storage.getItem('second')).toBe('two');
+        expect(storage.key(0)).toBe('second');
+
+        storage.clear();
+
+        expect(storage.length).toBe(0);
+        expect(storage.getItem('second')).toBeNull();
+        expect(storage.key(0)).toBeNull();
+    });
+});


### PR DESCRIPTION
This pull request addresses an issue in the `MockStorage` implementation where it incorrectly handles empty strings as values or keys. The following changes have been made:

- Updated the `getItem` method to return an empty string instead of `null` when retrieving a key that has been set to an empty string.
- Ensured that retrieving a key with an empty string returns the expected results.
- Maintained existing behaviors for `length`, `removeItem`, and `clear` methods.
- Created a new unit test file to cover various scenarios, including:
  - Saving and retrieving normal keys and values.
  - Saving and retrieving empty string values.
  - Accessing keys with empty strings.
  - Ensuring non-existent keys return `null`.
  - Confirming that out-of-bounds indices return `null`.
  - Verifying that `removeItem` and `clear` correctly update the length and retrieval results.

All new tests have passed, and existing tests were validated to ensure no unintended changes were introduced.