### PR TITLE
Fix service worker cache deletion logic and update tests

### DIFF
--- a/src/lib/swProfileCacheActionUtils.ts
+++ b/src/lib/swProfileCacheActionUtils.ts
@@ -69,9 +69,11 @@ export async function cleanupServiceWorkerDuplicateProfileCache<
 
         let deletedCount = 0;
         for (const duplicateKey of duplicateKeys) {
-            await cache.delete(duplicateKey);
-            deletedCount++;
-            logger.log('重複キャッシュを削除:', duplicateKey.url);
+            const deleted = await cache.delete(duplicateKey);
+            if (deleted) {
+                deletedCount++;
+                logger.log('重複キャッシュを削除:', duplicateKey.url);
+            }
         }
 
         logger.log(`重複プロフィールキャッシュクリーンアップ完了: ${deletedCount}件削除`);

--- a/src/test/unit/swProfileCacheActionUtils.test.ts
+++ b/src/test/unit/swProfileCacheActionUtils.test.ts
@@ -59,4 +59,37 @@ describe('swProfileCacheActionUtils', () => {
         expect(logger.log).toHaveBeenCalledWith('重複キャッシュを削除:', duplicateRequest.url);
         expect(logger.log).toHaveBeenCalledWith('重複プロフィールキャッシュクリーンアップ完了: 1件削除');
     });
+
+    it('cleanupServiceWorkerDuplicateProfileCache does not count failed deletions', async () => {
+        const baseRequest = { url: 'https://example.com/profile.jpg' };
+        const duplicateRequest = { url: 'https://example.com/profile.jpg?profile=true' };
+        const unrelatedRequest = { url: 'https://example.com/other.jpg?profile=true' };
+        const cache = {
+            keys: vi.fn().mockResolvedValue([baseRequest, duplicateRequest, unrelatedRequest]),
+            delete: vi.fn().mockResolvedValue(false),
+        };
+        const cacheStorage = {
+            open: vi.fn().mockResolvedValue(cache),
+        };
+        const logger = {
+            log: vi.fn(),
+            error: vi.fn(),
+        };
+
+        const result = await cleanupServiceWorkerDuplicateProfileCache({
+            cacheStorage,
+            cacheName: 'profile-cache',
+            logger,
+            getBaseUrl: (url) => {
+                const parsed = new URL(url);
+                return `${parsed.origin}${parsed.pathname}`;
+            },
+        });
+
+        expect(result).toEqual({ success: true, deletedCount: 0 });
+        expect(cache.delete).toHaveBeenCalledTimes(1);
+        expect(cache.delete).toHaveBeenCalledWith(duplicateRequest);
+        expect(logger.log).not.toHaveBeenCalledWith('重複キャッシュを削除:', duplicateRequest.url);
+        expect(logger.log).toHaveBeenCalledWith('重複プロフィールキャッシュクリーンアップ完了: 0件削除');
+    });
 });


### PR DESCRIPTION
This pull request addresses an issue with the `cleanupServiceWorkerDuplicateProfileCache()` function where the deletion count was incorrectly incremented even when `cache.delete()` returned false. The following changes were made:

- Updated the logic to only increment `deletedCount` and log success when `cache.delete()` returns true.
- Ensured that if `cache.delete()` returns false, the process continues without throwing an exception, and the final `deletedCount` reflects only successful deletions.
- Added a unit test case to verify the behavior when `cache.delete()` returns false, ensuring:
  - `deletedCount` is 0.
  - No individual success logs are emitted.
  - The completion log indicates 0 deletions.

All changes have been tested with Vitest to confirm that the functionality meets the specified requirements.