### PR TITLE
Refactor swProfileImageRequestUtils tests for clarity and reuse

### DIFF
--- a/src/test/unit/swProfileImageRequestUtils.test.ts
+++ b/src/test/unit/swProfileImageRequestUtils.test.ts
@@ -4,18 +4,67 @@ import {
     processServiceWorkerProfileImageRequest,
     resolveProfileImageRequestResult,
 } from '../../lib/swProfileImageRequestUtils';
+import { createMockConsole } from '../helpers';
+
+const profileImageUrl = 'https://example.com/image.jpg?profile=true';
+const loopbackProfileImageUrl = 'https://127.0.0.1/image.jpg?profile=true';
+
+const createProfileImageRequest = (url: string = profileImageUrl) => new Request(url);
+
+const createResolveProfileImageRequestResultArgs = ({
+    request = createProfileImageRequest(),
+    normalizeProfileImageUrl = vi.fn(() => profileImageUrl),
+    handleProfileImageCache = vi.fn(async () => null),
+    fetchAndCacheProfileImage = vi.fn(async () => null),
+    createTransparentImageResponse = vi.fn(),
+}: {
+    request?: Request;
+    normalizeProfileImageUrl?: any;
+    handleProfileImageCache?: any;
+    fetchAndCacheProfileImage?: any;
+    createTransparentImageResponse?: any;
+} = {}) => ({
+    request,
+    normalizeProfileImageUrl,
+    handleProfileImageCache,
+    fetchAndCacheProfileImage,
+    createTransparentImageResponse,
+});
+
+const createProcessServiceWorkerProfileImageRequestArgs = ({
+    request = createProfileImageRequest(),
+    logger = createMockConsole(),
+    normalizeProfileImageUrl = vi.fn(() => profileImageUrl),
+    handleProfileImageCache = vi.fn(async () => null),
+    fetchAndCacheProfileImage = vi.fn(async () => null),
+    createTransparentImageResponse = vi.fn(),
+}: {
+    request?: Request;
+    logger?: ReturnType<typeof createMockConsole>;
+    normalizeProfileImageUrl?: any;
+    handleProfileImageCache?: any;
+    fetchAndCacheProfileImage?: any;
+    createTransparentImageResponse?: any;
+} = {}) => ({
+    request,
+    logger,
+    normalizeProfileImageUrl,
+    handleProfileImageCache,
+    fetchAndCacheProfileImage,
+    createTransparentImageResponse,
+});
 
 describe('swProfileImageRequestUtils', () => {
     it('ポリシー外 URL では transparent image を返す', async () => {
         const transparent = new Response(null, { status: 200 });
 
-        const result = await resolveProfileImageRequestResult({
-            request: new Request('https://127.0.0.1/image.jpg?profile=true'),
-            normalizeProfileImageUrl: vi.fn(() => null),
-            handleProfileImageCache: vi.fn(),
-            fetchAndCacheProfileImage: vi.fn(),
-            createTransparentImageResponse: vi.fn(() => transparent),
-        });
+        const result = await resolveProfileImageRequestResult(
+            createResolveProfileImageRequestResultArgs({
+                request: createProfileImageRequest(loopbackProfileImageUrl),
+                normalizeProfileImageUrl: vi.fn(() => null),
+                createTransparentImageResponse: vi.fn(() => transparent),
+            }),
+        );
 
         expect(result).toEqual({
             source: 'policy-blocked',
@@ -26,13 +75,11 @@ describe('swProfileImageRequestUtils', () => {
     it('cache hit を優先して返す', async () => {
         const cached = new Response('cached', { status: 200 });
 
-        const result = await resolveProfileImageRequestResult({
-            request: new Request('https://example.com/image.jpg?profile=true'),
-            normalizeProfileImageUrl: vi.fn(() => 'https://example.com/image.jpg'),
-            handleProfileImageCache: vi.fn(async () => cached),
-            fetchAndCacheProfileImage: vi.fn(),
-            createTransparentImageResponse: vi.fn(),
-        });
+        const result = await resolveProfileImageRequestResult(
+            createResolveProfileImageRequestResultArgs({
+                handleProfileImageCache: vi.fn(async () => cached),
+            }),
+        );
 
         expect(result).toEqual({
             source: 'cache',
@@ -43,13 +90,11 @@ describe('swProfileImageRequestUtils', () => {
     it('cache miss 時は network response を返す', async () => {
         const network = new Response('network', { status: 200 });
 
-        const result = await resolveProfileImageRequestResult({
-            request: new Request('https://example.com/image.jpg?profile=true'),
-            normalizeProfileImageUrl: vi.fn(() => 'https://example.com/image.jpg'),
-            handleProfileImageCache: vi.fn(async () => null),
-            fetchAndCacheProfileImage: vi.fn(async () => network),
-            createTransparentImageResponse: vi.fn(),
-        });
+        const result = await resolveProfileImageRequestResult(
+            createResolveProfileImageRequestResultArgs({
+                fetchAndCacheProfileImage: vi.fn(async () => network),
+            }),
+        );
 
         expect(result).toEqual({
             source: 'network',
@@ -60,13 +105,12 @@ describe('swProfileImageRequestUtils', () => {
     it('cache も network も無い時は fallback を返す', async () => {
         const transparent = new Response(null, { status: 200 });
 
-        const result = await resolveProfileImageRequestResult({
-            request: new Request('https://example.com/image.jpg?profile=true'),
-            normalizeProfileImageUrl: vi.fn(() => 'https://example.com/image.jpg'),
-            handleProfileImageCache: vi.fn(async () => null),
-            fetchAndCacheProfileImage: vi.fn(async () => null),
-            createTransparentImageResponse: vi.fn(() => transparent),
-        });
+        const result = await resolveProfileImageRequestResult(
+            createResolveProfileImageRequestResultArgs({
+                fetchAndCacheProfileImage: vi.fn(async () => null),
+                createTransparentImageResponse: vi.fn(() => transparent),
+            }),
+        );
 
         expect(result).toEqual({
             source: 'fallback',
@@ -76,77 +120,62 @@ describe('swProfileImageRequestUtils', () => {
 
     it('processServiceWorkerProfileImageRequest は network response を返して log する', async () => {
         const network = new Response('network', { status: 200 });
-        const logger = {
-            log: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-        };
+        const logger = createMockConsole();
 
-        const result = await processServiceWorkerProfileImageRequest({
-            request: new Request('https://example.com/image.jpg?profile=true'),
-            logger,
-            normalizeProfileImageUrl: vi.fn(() => 'https://example.com/image.jpg'),
-            handleProfileImageCache: vi.fn(async () => null),
-            fetchAndCacheProfileImage: vi.fn(async () => network),
-            createTransparentImageResponse: vi.fn(),
-        });
+        const result = await processServiceWorkerProfileImageRequest(
+            createProcessServiceWorkerProfileImageRequestArgs({
+                logger,
+                fetchAndCacheProfileImage: vi.fn(async () => network),
+            }),
+        );
 
         expect(result).toBe(network);
         expect(logger.log).toHaveBeenCalledWith(
             'プロフィール画像リクエスト処理開始:',
-            'https://example.com/image.jpg?profile=true',
+            profileImageUrl,
         );
         expect(logger.log).toHaveBeenCalledWith(
             'プロフィール画像をネットワークから返却:',
-            'https://example.com/image.jpg?profile=true',
+            profileImageUrl,
         );
     });
 
     it('processServiceWorkerProfileImageRequest は policy-blocked 時に warning を出す', async () => {
         const transparent = new Response(null, { status: 200 });
-        const logger = {
-            log: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-        };
+        const logger = createMockConsole();
 
-        const result = await processServiceWorkerProfileImageRequest({
-            request: new Request('https://127.0.0.1/image.jpg?profile=true'),
-            logger,
-            normalizeProfileImageUrl: vi.fn(() => null),
-            handleProfileImageCache: vi.fn(),
-            fetchAndCacheProfileImage: vi.fn(),
-            createTransparentImageResponse: vi.fn(() => transparent),
-        });
+        const result = await processServiceWorkerProfileImageRequest(
+            createProcessServiceWorkerProfileImageRequestArgs({
+                request: createProfileImageRequest(loopbackProfileImageUrl),
+                logger,
+                normalizeProfileImageUrl: vi.fn(() => null),
+                createTransparentImageResponse: vi.fn(() => transparent),
+            }),
+        );
 
         expect(result).toBe(transparent);
         expect(logger.warn).toHaveBeenCalledWith(
             'プロフィール画像 URL がポリシー外のため transparent image を返却:',
-            'https://127.0.0.1/image.jpg?profile=true',
+            loopbackProfileImageUrl,
         );
     });
 
     it('processServiceWorkerProfileImageRequest は error 時に 404 transparent image を返す', async () => {
-        const logger = {
-            log: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-        };
+        const logger = createMockConsole();
         const createTransparentImageResponse = vi.fn((statusCode?: number) =>
             new Response(null, { status: statusCode ?? 200 }),
         );
         const failure = new Error('cache failed');
 
-        const result = await processServiceWorkerProfileImageRequest({
-            request: new Request('https://example.com/image.jpg?profile=true'),
-            logger,
-            normalizeProfileImageUrl: vi.fn(() => 'https://example.com/image.jpg'),
-            handleProfileImageCache: vi.fn(async () => {
-                throw failure;
+        const result = await processServiceWorkerProfileImageRequest(
+            createProcessServiceWorkerProfileImageRequestArgs({
+                logger,
+                handleProfileImageCache: vi.fn(async () => {
+                    throw failure;
+                }),
+                createTransparentImageResponse,
             }),
-            fetchAndCacheProfileImage: vi.fn(),
-            createTransparentImageResponse,
-        });
+        );
 
         expect(result.status).toBe(404);
         expect(logger.error).toHaveBeenCalledWith('プロフィール画像処理エラー:', failure);


### PR DESCRIPTION
This pull request refactors the `swProfileImageRequestUtils.test.ts` file to improve readability and maintainability by utilizing existing helper functions and constants. The changes include:

- Replaced repeated console mocks (`log`, `warn`, `error`) with the `createMockConsole()` helper.
- Organized repeated profile image URLs and request generation into constants and small local functions for clarity.
- Ensured that the intent of each test remains clear and distinguishable despite the refactoring.
- Maintained all existing test cases, names, and assertions to ensure no loss of coverage or functionality.

All tests have been successfully executed, and the code adheres to the specified requirements without modifying any production code or unrelated files.