### PR TITLE
Remove unused post history repository APIs and clean up tests

### DIFF
--- a/src/lib/storage/postHistoryRepository.ts
+++ b/src/lib/storage/postHistoryRepository.ts
@@ -43,11 +43,6 @@ export type PostHistoryVisibleQueryOptions = PostHistoryRepositoryOptions & {
     visibleUntil?: number | null;
 };
 
-export type PostHistoryVisiblePageOptions = PostHistoryVisibleQueryOptions & {
-    page: number;
-    pageSize: number;
-};
-
 export type PostHistoryTimelineCursor = Pick<
     PostHistoryRecord,
     "eventId" | "postedAt" | "createdAt"
@@ -115,9 +110,7 @@ export interface PostHistoryRepository {
         eventIds: string[];
     }): Promise<string[]>;
     getAll(options: PostHistoryRepositoryOptions): Promise<PostHistoryRecord[]>;
-    getVisibleAll(options: PostHistoryVisibleQueryOptions): Promise<PostHistoryRecord[]>;
     getPage(options: PostHistoryPageOptions): Promise<PostHistoryRecord[]>;
-    getVisiblePage(options: PostHistoryVisiblePageOptions): Promise<PostHistoryRecord[]>;
     getLatestVisibleChunk(options: PostHistoryVisibleChunkOptions): Promise<PostHistoryRecord[]>;
     getOlderVisibleChunk(options: PostHistoryVisibleChunkCursorOptions): Promise<PostHistoryRecord[]>;
     getNewerVisibleChunk(options: PostHistoryVisibleChunkCursorOptions): Promise<PostHistoryRecord[]>;
@@ -389,22 +382,6 @@ export class DexiePostHistoryRepository implements PostHistoryRepository {
         return sortPostHistoryRecords(records);
     }
 
-    async getVisibleAll(options: PostHistoryVisibleQueryOptions): Promise<PostHistoryRecord[]> {
-        if (!options.pubkeyHex) return [];
-
-        const visibleUntil = normalizeVisibleUntil(options.visibleUntil);
-        if (visibleUntil === null) {
-            return this.getAll(options);
-        }
-
-        const records = await this.db.postHistory
-            .where("[pubkeyHex+createdAt]")
-            .between([options.pubkeyHex, visibleUntil], [options.pubkeyHex, Dexie.maxKey])
-            .toArray();
-
-        return sortPostHistoryRecords(records);
-    }
-
     async getPage(options: PostHistoryPageOptions): Promise<PostHistoryRecord[]> {
         if (!options.pubkeyHex) return [];
 
@@ -419,14 +396,6 @@ export class DexiePostHistoryRepository implements PostHistoryRepository {
             .offset((page - 1) * pageSize)
             .limit(pageSize)
             .toArray();
-    }
-
-    async getVisiblePage(options: PostHistoryVisiblePageOptions): Promise<PostHistoryRecord[]> {
-        const page = normalizePageNumber(options.page);
-        const pageSize = normalizePageSize(options.pageSize);
-        const records = await this.getVisibleAll(options);
-
-        return records.slice((page - 1) * pageSize, page * pageSize);
     }
 
     async getLatestVisibleChunk(

--- a/src/test/unit/postHistoryDialog.test.ts
+++ b/src/test/unit/postHistoryDialog.test.ts
@@ -122,7 +122,6 @@ const mockTranslate = vi.hoisted(() => (key: string, options?: { values?: Record
 const repositoryMock = vi.hoisted(() => ({
     getByEventId: vi.fn(),
     getPage: vi.fn(),
-    getVisiblePage: vi.fn(),
     getLatestVisibleChunk: vi.fn(),
     getOlderVisibleChunk: vi.fn(),
     getNewerVisibleChunk: vi.fn(),
@@ -842,26 +841,14 @@ describe('PostHistoryDialog', () => {
         clearPersistedPostHistoryViewState();
         vi.clearAllMocks();
         repositoryMock.getPage.mockResolvedValue([]);
-        repositoryMock.getVisiblePage.mockImplementation(async ({ pubkeyHex, page, pageSize }: Record<string, any>) =>
-            repositoryMock.getPage({ pubkeyHex, page, pageSize }),
-        );
         repositoryMock.getByEventId.mockResolvedValue(null);
-        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) => {
-            if (typeof visibleUntil === 'number') {
-                return repositoryMock.getVisiblePage({
-                    pubkeyHex,
-                    visibleUntil,
-                    page: 1,
-                    pageSize: limit,
-                });
-            }
-
-            return repositoryMock.getPage({
+        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, limit }: Record<string, any>) =>
+            repositoryMock.getPage({
                 pubkeyHex,
                 page: 1,
                 pageSize: limit,
-            });
-        });
+            }),
+        );
         repositoryMock.getOlderVisibleChunk.mockResolvedValue([]);
         repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
         repositoryMock.getVisibleChunkFromCreatedAt.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) =>

--- a/src/test/unit/postHistoryDialogPart1B.test.ts
+++ b/src/test/unit/postHistoryDialogPart1B.test.ts
@@ -89,7 +89,6 @@ const mockTranslate = vi.hoisted(() => (key: string, options?: { values?: Record
 const repositoryMock = vi.hoisted(() => ({
     getByEventId: vi.fn(),
     getPage: vi.fn(),
-    getVisiblePage: vi.fn(),
     getLatestVisibleChunk: vi.fn(),
     getOlderVisibleChunk: vi.fn(),
     getNewerVisibleChunk: vi.fn(),
@@ -404,26 +403,14 @@ describe('PostHistoryDialog', () => {
         clearPersistedPostHistoryViewState();
         vi.clearAllMocks();
         repositoryMock.getPage.mockResolvedValue([]);
-        repositoryMock.getVisiblePage.mockImplementation(async ({ pubkeyHex, page, pageSize }: Record<string, any>) =>
-            repositoryMock.getPage({ pubkeyHex, page, pageSize }),
-        );
         repositoryMock.getByEventId.mockResolvedValue(null);
-        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) => {
-            if (typeof visibleUntil === 'number') {
-                return repositoryMock.getVisiblePage({
-                    pubkeyHex,
-                    visibleUntil,
-                    page: 1,
-                    pageSize: limit,
-                });
-            }
-
-            return repositoryMock.getPage({
+        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, limit }: Record<string, any>) =>
+            repositoryMock.getPage({
                 pubkeyHex,
                 page: 1,
                 pageSize: limit,
-            });
-        });
+            }),
+        );
         repositoryMock.getOlderVisibleChunk.mockResolvedValue([]);
         repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
         repositoryMock.getVisibleChunkFromCreatedAt.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) =>

--- a/src/test/unit/postHistoryDialogPart2.test.ts
+++ b/src/test/unit/postHistoryDialogPart2.test.ts
@@ -89,7 +89,6 @@ const mockTranslate = vi.hoisted(() => (key: string, options?: { values?: Record
 const repositoryMock = vi.hoisted(() => ({
     getByEventId: vi.fn(),
     getPage: vi.fn(),
-    getVisiblePage: vi.fn(),
     getLatestVisibleChunk: vi.fn(),
     getOlderVisibleChunk: vi.fn(),
     getNewerVisibleChunk: vi.fn(),
@@ -388,26 +387,14 @@ describe('PostHistoryDialog', () => {
         clearPersistedPostHistoryViewState();
         vi.clearAllMocks();
         repositoryMock.getPage.mockResolvedValue([]);
-        repositoryMock.getVisiblePage.mockImplementation(async ({ pubkeyHex, page, pageSize }: Record<string, any>) =>
-            repositoryMock.getPage({ pubkeyHex, page, pageSize }),
-        );
         repositoryMock.getByEventId.mockResolvedValue(null);
-        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) => {
-            if (typeof visibleUntil === 'number') {
-                return repositoryMock.getVisiblePage({
-                    pubkeyHex,
-                    visibleUntil,
-                    page: 1,
-                    pageSize: limit,
-                });
-            }
-
-            return repositoryMock.getPage({
+        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, limit }: Record<string, any>) =>
+            repositoryMock.getPage({
                 pubkeyHex,
                 page: 1,
                 pageSize: limit,
-            });
-        });
+            }),
+        );
         repositoryMock.getOlderVisibleChunk.mockResolvedValue([]);
         repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
         repositoryMock.getVisibleChunkFromCreatedAt.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) =>

--- a/src/test/unit/postHistoryDialogPart3.test.ts
+++ b/src/test/unit/postHistoryDialogPart3.test.ts
@@ -89,7 +89,6 @@ const mockTranslate = vi.hoisted(() => (key: string, options?: { values?: Record
 const repositoryMock = vi.hoisted(() => ({
     getByEventId: vi.fn(),
     getPage: vi.fn(),
-    getVisiblePage: vi.fn(),
     getLatestVisibleChunk: vi.fn(),
     getOlderVisibleChunk: vi.fn(),
     getNewerVisibleChunk: vi.fn(),
@@ -388,26 +387,14 @@ describe('PostHistoryDialog', () => {
         clearPersistedPostHistoryViewState();
         vi.clearAllMocks();
         repositoryMock.getPage.mockResolvedValue([]);
-        repositoryMock.getVisiblePage.mockImplementation(async ({ pubkeyHex, page, pageSize }: Record<string, any>) =>
-            repositoryMock.getPage({ pubkeyHex, page, pageSize }),
-        );
         repositoryMock.getByEventId.mockResolvedValue(null);
-        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) => {
-            if (typeof visibleUntil === 'number') {
-                return repositoryMock.getVisiblePage({
-                    pubkeyHex,
-                    visibleUntil,
-                    page: 1,
-                    pageSize: limit,
-                });
-            }
-
-            return repositoryMock.getPage({
+        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, limit }: Record<string, any>) =>
+            repositoryMock.getPage({
                 pubkeyHex,
                 page: 1,
                 pageSize: limit,
-            });
-        });
+            }),
+        );
         repositoryMock.getOlderVisibleChunk.mockResolvedValue([]);
         repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
         repositoryMock.getVisibleChunkFromCreatedAt.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) =>

--- a/src/test/unit/postHistoryDialogPart3B.test.ts
+++ b/src/test/unit/postHistoryDialogPart3B.test.ts
@@ -89,7 +89,6 @@ const mockTranslate = vi.hoisted(() => (key: string, options?: { values?: Record
 const repositoryMock = vi.hoisted(() => ({
     getByEventId: vi.fn(),
     getPage: vi.fn(),
-    getVisiblePage: vi.fn(),
     getLatestVisibleChunk: vi.fn(),
     getOlderVisibleChunk: vi.fn(),
     getNewerVisibleChunk: vi.fn(),
@@ -388,26 +387,14 @@ describe('PostHistoryDialog', () => {
         clearPersistedPostHistoryViewState();
         vi.clearAllMocks();
         repositoryMock.getPage.mockResolvedValue([]);
-        repositoryMock.getVisiblePage.mockImplementation(async ({ pubkeyHex, page, pageSize }: Record<string, any>) =>
-            repositoryMock.getPage({ pubkeyHex, page, pageSize }),
-        );
         repositoryMock.getByEventId.mockResolvedValue(null);
-        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) => {
-            if (typeof visibleUntil === 'number') {
-                return repositoryMock.getVisiblePage({
-                    pubkeyHex,
-                    visibleUntil,
-                    page: 1,
-                    pageSize: limit,
-                });
-            }
-
-            return repositoryMock.getPage({
+        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, limit }: Record<string, any>) =>
+            repositoryMock.getPage({
                 pubkeyHex,
                 page: 1,
                 pageSize: limit,
-            });
-        });
+            }),
+        );
         repositoryMock.getOlderVisibleChunk.mockResolvedValue([]);
         repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
         repositoryMock.getVisibleChunkFromCreatedAt.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) =>

--- a/src/test/unit/postHistoryDialogPart4.test.ts
+++ b/src/test/unit/postHistoryDialogPart4.test.ts
@@ -89,7 +89,6 @@ const mockTranslate = vi.hoisted(() => (key: string, options?: { values?: Record
 const repositoryMock = vi.hoisted(() => ({
     getByEventId: vi.fn(),
     getPage: vi.fn(),
-    getVisiblePage: vi.fn(),
     getLatestVisibleChunk: vi.fn(),
     getOlderVisibleChunk: vi.fn(),
     getNewerVisibleChunk: vi.fn(),
@@ -388,26 +387,14 @@ describe('PostHistoryDialog', () => {
         clearPersistedPostHistoryViewState();
         vi.clearAllMocks();
         repositoryMock.getPage.mockResolvedValue([]);
-        repositoryMock.getVisiblePage.mockImplementation(async ({ pubkeyHex, page, pageSize }: Record<string, any>) =>
-            repositoryMock.getPage({ pubkeyHex, page, pageSize }),
-        );
         repositoryMock.getByEventId.mockResolvedValue(null);
-        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) => {
-            if (typeof visibleUntil === 'number') {
-                return repositoryMock.getVisiblePage({
-                    pubkeyHex,
-                    visibleUntil,
-                    page: 1,
-                    pageSize: limit,
-                });
-            }
-
-            return repositoryMock.getPage({
+        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, limit }: Record<string, any>) =>
+            repositoryMock.getPage({
                 pubkeyHex,
                 page: 1,
                 pageSize: limit,
-            });
-        });
+            }),
+        );
         repositoryMock.getOlderVisibleChunk.mockResolvedValue([]);
         repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
         repositoryMock.getVisibleChunkFromCreatedAt.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) =>

--- a/src/test/unit/postHistoryDialogPart5.test.ts
+++ b/src/test/unit/postHistoryDialogPart5.test.ts
@@ -89,7 +89,6 @@ const mockTranslate = vi.hoisted(() => (key: string, options?: { values?: Record
 const repositoryMock = vi.hoisted(() => ({
     getByEventId: vi.fn(),
     getPage: vi.fn(),
-    getVisiblePage: vi.fn(),
     getLatestVisibleChunk: vi.fn(),
     getOlderVisibleChunk: vi.fn(),
     getNewerVisibleChunk: vi.fn(),
@@ -379,26 +378,14 @@ describe('PostHistoryDialog', () => {
         clearPersistedPostHistoryViewState();
         vi.clearAllMocks();
         repositoryMock.getPage.mockResolvedValue([]);
-        repositoryMock.getVisiblePage.mockImplementation(async ({ pubkeyHex, page, pageSize }: Record<string, any>) =>
-            repositoryMock.getPage({ pubkeyHex, page, pageSize }),
-        );
         repositoryMock.getByEventId.mockResolvedValue(null);
-        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) => {
-            if (typeof visibleUntil === 'number') {
-                return repositoryMock.getVisiblePage({
-                    pubkeyHex,
-                    visibleUntil,
-                    page: 1,
-                    pageSize: limit,
-                });
-            }
-
-            return repositoryMock.getPage({
+        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, limit }: Record<string, any>) =>
+            repositoryMock.getPage({
                 pubkeyHex,
                 page: 1,
                 pageSize: limit,
-            });
-        });
+            }),
+        );
         repositoryMock.getOlderVisibleChunk.mockResolvedValue([]);
         repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
         repositoryMock.getVisibleChunkFromCreatedAt.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) =>

--- a/src/test/unit/postHistoryDialogPart5B.test.ts
+++ b/src/test/unit/postHistoryDialogPart5B.test.ts
@@ -89,7 +89,6 @@ const mockTranslate = vi.hoisted(() => (key: string, options?: { values?: Record
 const repositoryMock = vi.hoisted(() => ({
     getByEventId: vi.fn(),
     getPage: vi.fn(),
-    getVisiblePage: vi.fn(),
     getLatestVisibleChunk: vi.fn(),
     getOlderVisibleChunk: vi.fn(),
     getNewerVisibleChunk: vi.fn(),
@@ -379,26 +378,14 @@ describe('PostHistoryDialog', () => {
         clearPersistedPostHistoryViewState();
         vi.clearAllMocks();
         repositoryMock.getPage.mockResolvedValue([]);
-        repositoryMock.getVisiblePage.mockImplementation(async ({ pubkeyHex, page, pageSize }: Record<string, any>) =>
-            repositoryMock.getPage({ pubkeyHex, page, pageSize }),
-        );
         repositoryMock.getByEventId.mockResolvedValue(null);
-        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) => {
-            if (typeof visibleUntil === 'number') {
-                return repositoryMock.getVisiblePage({
-                    pubkeyHex,
-                    visibleUntil,
-                    page: 1,
-                    pageSize: limit,
-                });
-            }
-
-            return repositoryMock.getPage({
+        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, limit }: Record<string, any>) =>
+            repositoryMock.getPage({
                 pubkeyHex,
                 page: 1,
                 pageSize: limit,
-            });
-        });
+            }),
+        );
         repositoryMock.getOlderVisibleChunk.mockResolvedValue([]);
         repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
         repositoryMock.getVisibleChunkFromCreatedAt.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) =>

--- a/src/test/unit/postHistoryDialogPart5C.test.ts
+++ b/src/test/unit/postHistoryDialogPart5C.test.ts
@@ -89,7 +89,6 @@ const mockTranslate = vi.hoisted(() => (key: string, options?: { values?: Record
 const repositoryMock = vi.hoisted(() => ({
     getByEventId: vi.fn(),
     getPage: vi.fn(),
-    getVisiblePage: vi.fn(),
     getLatestVisibleChunk: vi.fn(),
     getOlderVisibleChunk: vi.fn(),
     getNewerVisibleChunk: vi.fn(),
@@ -379,26 +378,14 @@ describe('PostHistoryDialog', () => {
         clearPersistedPostHistoryViewState();
         vi.clearAllMocks();
         repositoryMock.getPage.mockResolvedValue([]);
-        repositoryMock.getVisiblePage.mockImplementation(async ({ pubkeyHex, page, pageSize }: Record<string, any>) =>
-            repositoryMock.getPage({ pubkeyHex, page, pageSize }),
-        );
         repositoryMock.getByEventId.mockResolvedValue(null);
-        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) => {
-            if (typeof visibleUntil === 'number') {
-                return repositoryMock.getVisiblePage({
-                    pubkeyHex,
-                    visibleUntil,
-                    page: 1,
-                    pageSize: limit,
-                });
-            }
-
-            return repositoryMock.getPage({
+        repositoryMock.getLatestVisibleChunk.mockImplementation(async ({ pubkeyHex, limit }: Record<string, any>) =>
+            repositoryMock.getPage({
                 pubkeyHex,
                 page: 1,
                 pageSize: limit,
-            });
-        });
+            }),
+        );
         repositoryMock.getOlderVisibleChunk.mockResolvedValue([]);
         repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
         repositoryMock.getVisibleChunkFromCreatedAt.mockImplementation(async ({ pubkeyHex, visibleUntil, limit }: Record<string, any>) =>

--- a/src/test/unit/postHistoryRepository.test.ts
+++ b/src/test/unit/postHistoryRepository.test.ts
@@ -369,83 +369,6 @@ describe("DexiePostHistoryRepository", () => {
         db.close();
     });
 
-    it("visibleUntil を指定した件数取得とページ取得は createdAt inclusive で絞り込む", async () => {
-        const db = createTestDb();
-        const repository = new DexiePostHistoryRepository(db, () => 1000);
-        const pubkey = "b".repeat(64);
-
-        await repository.putPostedEvent({
-            event: createSignedEvent({ id: "1".repeat(64), pubkey, created_at: 500 }),
-            postedAt: 500000,
-        });
-        await repository.putPostedEvent({
-            event: createSignedEvent({ id: "2".repeat(64), pubkey, created_at: 1000 }),
-            postedAt: 1000000,
-        });
-        await repository.putPostedEvent({
-            event: createSignedEvent({ id: "3".repeat(64), pubkey, created_at: 1100 }),
-            postedAt: 1100000,
-        });
-        await repository.putPostedEvent({
-            event: createSignedEvent({ id: "4".repeat(64), pubkey, created_at: 1200 }),
-            postedAt: 1200000,
-        });
-
-        await expect(repository.countVisibleForPubkey(pubkey, 1000)).resolves.toBe(3);
-        await expect(repository.getVisiblePage({
-            pubkeyHex: pubkey,
-            visibleUntil: 1000,
-            page: 1,
-            pageSize: 10,
-        })).resolves.toMatchObject([
-            { eventId: "4".repeat(64), createdAt: 1200 },
-            { eventId: "3".repeat(64), createdAt: 1100 },
-            { eventId: "2".repeat(64), createdAt: 1000 },
-        ]);
-        await expect(repository.getVisiblePage({
-            pubkeyHex: pubkey,
-            visibleUntil: 1000,
-            page: 2,
-            pageSize: 2,
-        })).resolves.toMatchObject([
-            { eventId: "2".repeat(64), createdAt: 1000 },
-        ]);
-
-        db.close();
-    });
-
-    it("visible query でも表示順は postedAt desc / createdAt desc を維持する", async () => {
-        const db = createTestDb();
-        const repository = new DexiePostHistoryRepository(db, () => 1000);
-        const pubkey = "b".repeat(64);
-
-        await repository.putPostedEvent({
-            event: createSignedEvent({ id: "1".repeat(64), pubkey, created_at: 1000 }),
-            postedAt: 4000,
-        });
-        await repository.putPostedEvent({
-            event: createSignedEvent({ id: "2".repeat(64), pubkey, created_at: 1100 }),
-            postedAt: 3000,
-        });
-        await repository.putPostedEvent({
-            event: createSignedEvent({ id: "3".repeat(64), pubkey, created_at: 1050 }),
-            postedAt: 4000,
-        });
-
-        const records = await repository.getVisibleAll({
-            pubkeyHex: pubkey,
-            visibleUntil: 1000,
-        });
-
-        expect(records.map((record) => record.eventId)).toEqual([
-            "3".repeat(64),
-            "1".repeat(64),
-            "2".repeat(64),
-        ]);
-
-        db.close();
-    });
-
     it("timeline chunk API は stable cursor で older/newer window を返す", async () => {
         const db = createTestDb();
         const repository = new DexiePostHistoryRepository(db, () => 1000);
@@ -895,7 +818,6 @@ describe("DexiePostHistoryRepository", () => {
         });
         const { db, materializedCounts, queriedIndexes } = createInstrumentedTimelineDb(records);
         const repository = new DexiePostHistoryRepository(db as any, () => 1000);
-        const getVisibleAll = vi.spyOn(repository, "getVisibleAll");
 
         const latest = await repository.getLatestVisibleChunk({
             pubkeyHex: pubkey,
@@ -931,7 +853,6 @@ describe("DexiePostHistoryRepository", () => {
         expect([latest, older, dateChunk, around].map((chunk) => chunk.length))
             .toEqual([25, 25, 25, 25]);
         expect(newer).toHaveLength(10);
-        expect(getVisibleAll).not.toHaveBeenCalled();
         expect(queriedIndexes).not.toContain("[pubkeyHex+postedAt]");
         expect(queriedIndexes.every((index) => index === POST_HISTORY_TIMELINE_INDEX))
             .toBe(true);

--- a/src/test/unit/postHistoryRepository.test.ts
+++ b/src/test/unit/postHistoryRepository.test.ts
@@ -369,6 +369,40 @@ describe("DexiePostHistoryRepository", () => {
         db.close();
     });
 
+    it("countVisibleForPubkey は visibleUntil 境界を inclusive に扱い他 pubkey を含めない", async () => {
+        const db = createTestDb();
+        const repository = new DexiePostHistoryRepository(db, () => 1000);
+        const pubkey = "b".repeat(64);
+        const otherPubkey = "c".repeat(64);
+
+        await repository.putPostedEvent({
+            event: createSignedEvent({ id: "1".repeat(64), pubkey, created_at: 500 }),
+            postedAt: 500000,
+        });
+        await repository.putPostedEvent({
+            event: createSignedEvent({ id: "2".repeat(64), pubkey, created_at: 1000 }),
+            postedAt: 1000000,
+        });
+        await repository.putPostedEvent({
+            event: createSignedEvent({ id: "3".repeat(64), pubkey, created_at: 1100 }),
+            postedAt: 1100000,
+        });
+        await repository.putPostedEvent({
+            event: createSignedEvent({ id: "4".repeat(64), pubkey, created_at: 1200 }),
+            postedAt: 1200000,
+        });
+        await repository.putPostedEvent({
+            event: createSignedEvent({ id: "5".repeat(64), pubkey: otherPubkey, created_at: 1500 }),
+            postedAt: 1500000,
+        });
+
+        await expect(repository.countVisibleForPubkey(pubkey, 1000)).resolves.toBe(3);
+        await expect(repository.countVisibleForPubkey(pubkey, 1001)).resolves.toBe(2);
+        await expect(repository.countVisibleForPubkey(otherPubkey, 1000)).resolves.toBe(1);
+
+        db.close();
+    });
+
     it("timeline chunk API は stable cursor で older/newer window を返す", async () => {
         const db = createTestDb();
         const repository = new DexiePostHistoryRepository(db, () => 1000);


### PR DESCRIPTION
This pull request removes unused APIs from the `PostHistoryRepository` and cleans up related tests and mocks. The following changes were made:

- Deleted `getVisiblePage()` and `getVisibleAll()` methods from the repository interface.
- Removed the corresponding implementation in `DexiePostHistoryRepository`.
- Eliminated the `PostHistoryVisiblePageOptions` type.
- Cleaned up repository tests that were specifically targeting the removed APIs.
- Updated dialog-related tests and mocks to remove unnecessary definitions.

The changes ensure that the repository is streamlined by removing deprecated methods while maintaining the functionality of `getAll()` and `getPage()`, which are still in use. All tests have been run successfully to confirm that no regressions were introduced.