### PR TITLE
Batch query deletion requests in upsertFetchedEvents()

### DIFF
--- a/src/lib/storage/postHistoryRepository.ts
+++ b/src/lib/storage/postHistoryRepository.ts
@@ -306,6 +306,33 @@ function normalizeFetchedEventItems(
     return Array.from(normalized.values());
 }
 
+async function getDeletionRequestsByTargetEventIds(
+    db: Pick<EHagakiDB, "postHistoryDeletionRequests">,
+    targetEventIds: string[],
+): Promise<Map<string, PostHistoryDeletionRequestRecord[]>> {
+    if (targetEventIds.length === 0) {
+        return new Map();
+    }
+
+    const records = await db.postHistoryDeletionRequests
+        .where("targetEventId")
+        .anyOf(targetEventIds)
+        .toArray();
+    const grouped = new Map<string, PostHistoryDeletionRequestRecord[]>();
+
+    for (const record of records) {
+        const existing = grouped.get(record.targetEventId);
+        if (existing) {
+            existing.push(record);
+            continue;
+        }
+
+        grouped.set(record.targetEventId, [record]);
+    }
+
+    return grouped;
+}
+
 function areMediaArraysEqual(left: PostHistoryMediaRecord[], right: PostHistoryMediaRecord[]): boolean {
     if (left.length !== right.length) {
         return false;
@@ -754,25 +781,16 @@ export class DexiePostHistoryRepository implements PostHistoryRepository {
             async () => {
                 const existingRecords = await this.db.postHistory.bulkGet(eventIds);
                 const existingMap = new Map<string, PostHistoryRecord>();
-                const deletionRequestsByTargetEventId = new Map<
-                    string,
-                    PostHistoryDeletionRequestRecord[]
-                >();
+                const deletionRequestsByTargetEventId = await getDeletionRequestsByTargetEventIds(
+                    this.db,
+                    eventIds,
+                );
 
                 existingRecords.forEach((record) => {
                     if (record) {
                         existingMap.set(record.eventId, record);
                     }
                 });
-                for (const eventId of eventIds) {
-                    deletionRequestsByTargetEventId.set(
-                        eventId,
-                        await this.db.postHistoryDeletionRequests
-                            .where("targetEventId")
-                            .equals(eventId)
-                            .toArray(),
-                    );
-                }
 
                 const verifiedRequestUpdates: PostHistoryDeletionRequestRecord[] = [];
                 const nextRecords = normalizedItems.map((item) => {

--- a/src/test/unit/postHistoryRepository.test.ts
+++ b/src/test/unit/postHistoryRepository.test.ts
@@ -46,6 +46,19 @@ function createSignedEvent(overrides: Record<string, any> = {}) {
     };
 }
 
+function createDeletionEvent(targetEventId: string, overrides: Record<string, any> = {}) {
+    return {
+        id: "d".repeat(64),
+        pubkey: "b".repeat(64),
+        kind: 5,
+        content: "",
+        tags: [["e", targetEventId]],
+        created_at: 100,
+        sig: "e".repeat(128),
+        ...overrides,
+    };
+}
+
 function createPostHistoryRecord(input: {
     eventId: string;
     pubkeyHex: string;
@@ -177,6 +190,32 @@ function createInstrumentedTimelineDb(records: PostHistoryRecord[]) {
         materializedCounts,
         queriedIndexes,
     };
+}
+
+function monitorDeletionRequestTargetQueries(db: EHagakiDB) {
+    const originalWhere = db.postHistoryDeletionRequests.where.bind(db.postHistoryDeletionRequests);
+    const anyOfArgs: string[][] = [];
+    const equalsArgs: string[] = [];
+    const whereSpy = vi.spyOn(db.postHistoryDeletionRequests, "where");
+
+    whereSpy.mockImplementation(((index: string) => {
+        const clause = originalWhere(index as any) as any;
+        const originalAnyOf = clause.anyOf.bind(clause);
+        const originalEquals = clause.equals.bind(clause);
+
+        clause.anyOf = ((keys: string[]) => {
+            anyOfArgs.push([...keys]);
+            return originalAnyOf(keys);
+        }) as any;
+        clause.equals = ((key: string) => {
+            equalsArgs.push(key);
+            return originalEquals(key);
+        }) as any;
+
+        return clause;
+    }) as any);
+
+    return { anyOfArgs, equalsArgs, whereSpy };
 }
 
 afterEach(async () => {
@@ -1072,6 +1111,151 @@ describe("DexiePostHistoryRepository", () => {
         db.close();
     });
 
+    it("複数 fetched event を一括 upsert しても削除要求取得は targetEventId index の batch query 1回で済む", async () => {
+        const db = createTestDb();
+        const repository = new DexiePostHistoryRepository(db, () => 2000);
+        const deletionRepository = new DexiePostHistoryDeletionRequestsRepository(db, () => 1000);
+        const pubkey = "b".repeat(64);
+        const foreignPubkey = "c".repeat(64);
+        const unchangedEvent = createSignedEvent({ id: "1".repeat(64), pubkey, content: "same", created_at: 100 });
+        const updatedEvent = createSignedEvent({ id: "2".repeat(64), pubkey, content: "same", created_at: 200 });
+        const insertedEvent = createSignedEvent({ id: "3".repeat(64), pubkey, content: "new", created_at: 300 });
+        const unmatchedEvent = createSignedEvent({
+            id: "4".repeat(64),
+            pubkey: foreignPubkey,
+            content: "foreign",
+            created_at: 400,
+        });
+
+        await deletionRepository.upsertImportedDeletionEvents({
+            ownerPubkeyHex: pubkey,
+            deletionEvents: [
+                createDeletionEvent(unchangedEvent.id, {
+                    id: "a".repeat(64),
+                    pubkey,
+                    created_at: 700,
+                }),
+                createDeletionEvent(updatedEvent.id, {
+                    id: "b".repeat(64),
+                    pubkey,
+                    created_at: 900,
+                }),
+                createDeletionEvent(updatedEvent.id, {
+                    id: "c".repeat(64),
+                    pubkey,
+                    created_at: 800,
+                }),
+                createDeletionEvent(unmatchedEvent.id, {
+                    id: "f".repeat(64),
+                    pubkey,
+                    created_at: 600,
+                }),
+            ],
+        });
+        await repository.putPostedEvent({ event: unchangedEvent });
+        await repository.putPostedEvent({ event: updatedEvent });
+
+        const { anyOfArgs, equalsArgs, whereSpy } = monitorDeletionRequestTargetQueries(db);
+
+        const result = await repository.upsertFetchedEvents({
+            events: [
+                { event: unchangedEvent },
+                { event: updatedEvent, relayUrls: ["wss://updated.example.com"] },
+                { event: insertedEvent },
+                { event: insertedEvent, relayUrls: ["wss://dedup.example.com"] },
+                { event: unmatchedEvent },
+            ],
+        });
+
+        expect(whereSpy).toHaveBeenCalledTimes(1);
+        expect(whereSpy).toHaveBeenCalledWith("targetEventId");
+        expect(anyOfArgs).toEqual([[
+            unchangedEvent.id,
+            updatedEvent.id,
+            insertedEvent.id,
+            unmatchedEvent.id,
+        ]]);
+        expect(equalsArgs).toEqual([]);
+        expect(result).toEqual({
+            insertedCount: 2,
+            updatedCount: 1,
+            unchangedCount: 1,
+            appliedDeletionCount: 2,
+        });
+
+        await expect(db.postHistory.get(unchangedEvent.id)).resolves.toMatchObject({
+            deletedAt: 700_000,
+            deletionEventId: "a".repeat(64),
+        });
+        await expect(db.postHistory.get(updatedEvent.id)).resolves.toMatchObject({
+            deletedAt: 800_000,
+            deletionEventId: "c".repeat(64),
+            fetchedRelays: ["wss://updated.example.com/"],
+        });
+        await expect(db.postHistory.get(insertedEvent.id)).resolves.toMatchObject({
+            fetchedRelays: ["wss://dedup.example.com/"],
+        });
+        const savedUnmatched = await db.postHistory.get(unmatchedEvent.id);
+        expect(savedUnmatched).toBeDefined();
+        expect(savedUnmatched).not.toHaveProperty("deletedAt");
+
+        const deletionRecords = await db.postHistoryDeletionRequests.toArray();
+        expect(deletionRecords).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                targetEventId: unchangedEvent.id,
+                deletionEventId: "a".repeat(64),
+                targetVerified: true,
+            }),
+            expect.objectContaining({
+                targetEventId: updatedEvent.id,
+                deletionEventId: "b".repeat(64),
+                targetVerified: true,
+            }),
+            expect.objectContaining({
+                targetEventId: updatedEvent.id,
+                deletionEventId: "c".repeat(64),
+                targetVerified: true,
+            }),
+            expect.objectContaining({
+                targetEventId: unmatchedEvent.id,
+                deletionEventId: "f".repeat(64),
+                targetVerified: false,
+            }),
+        ]));
+
+        whereSpy.mockRestore();
+        db.close();
+    });
+
+    it("削除要求が0件でも複数 fetched event を batch 保存できる", async () => {
+        const db = createTestDb();
+        const repository = new DexiePostHistoryRepository(db, () => 2000);
+        const firstEvent = createSignedEvent({ id: "5".repeat(64), created_at: 500 });
+        const secondEvent = createSignedEvent({ id: "6".repeat(64), created_at: 600 });
+        const { anyOfArgs, equalsArgs, whereSpy } = monitorDeletionRequestTargetQueries(db);
+
+        const result = await repository.upsertFetchedEvents({
+            events: [{ event: firstEvent }, { event: secondEvent }],
+        });
+
+        expect(whereSpy).toHaveBeenCalledTimes(1);
+        expect(anyOfArgs).toEqual([[firstEvent.id, secondEvent.id]]);
+        expect(equalsArgs).toEqual([]);
+        expect(result).toEqual({
+            insertedCount: 2,
+            updatedCount: 0,
+            unchangedCount: 0,
+            appliedDeletionCount: 0,
+        });
+        await expect(db.postHistory.bulkGet([firstEvent.id, secondEvent.id])).resolves.toEqual([
+            expect.objectContaining({ eventId: firstEvent.id }),
+            expect.objectContaining({ eventId: secondEvent.id }),
+        ]);
+
+        whereSpy.mockRestore();
+        db.close();
+    });
+
     it("後着した新規投稿とpending削除を同時適用して基本分類と削除件数を分離する", async () => {
         const db = createTestDb();
         const repository = new DexiePostHistoryRepository(db, () => 2000);
@@ -1299,6 +1483,40 @@ describe("DexiePostHistoryRepository", () => {
         await expect(db.postHistory.get(event.id)).resolves.not.toHaveProperty("deletedAt");
         await expect(db.postHistoryDeletionRequests.toArray()).resolves.toMatchObject([
             { targetVerified: false },
+        ]);
+
+        db.close();
+    });
+
+    it("upsertFetchedEvents の transaction が失敗した場合は verified 更新も投稿保存も巻き戻す", async () => {
+        const db = createTestDb();
+        const repository = new DexiePostHistoryRepository(db, () => 2000);
+        const deletionRepository = new DexiePostHistoryDeletionRequestsRepository(db, () => 1000);
+        const event = createSignedEvent({ id: "7".repeat(64) });
+        await deletionRepository.upsertImportedDeletionEvents({
+            ownerPubkeyHex: event.pubkey,
+            deletionEvents: [createDeletionEvent(event.id, {
+                id: "8".repeat(64),
+                pubkey: event.pubkey,
+                created_at: 300,
+            })],
+        });
+
+        const bulkPutSpy = vi.spyOn(db.postHistory, "bulkPut")
+            .mockRejectedValue(new Error("post history bulkPut failed"));
+
+        await expect(repository.upsertFetchedEvents({
+            events: [{ event }],
+        })).rejects.toThrow("post history bulkPut failed");
+
+        bulkPutSpy.mockRestore();
+
+        await expect(db.postHistory.get(event.id)).resolves.toBeUndefined();
+        await expect(db.postHistoryDeletionRequests.toArray()).resolves.toEqual([
+            expect.objectContaining({
+                targetEventId: event.id,
+                targetVerified: false,
+            }),
         ]);
 
         db.close();


### PR DESCRIPTION
This pull request modifies the `upsertFetchedEvents()` method to batch query deletion requests for multiple event IDs, reducing the number of IndexedDB queries from potentially 100 to just one.

### Changes made:
- Introduced a new method `getDeletionRequestsByTargetEventIds()` to fetch deletion requests using `anyOf()` on the `targetEventId` index, allowing for a single batch query.
- Maintained the existing transaction scope in `upsertFetchedEvents()` and grouped the fetched results into a `Map<targetEventId, PostHistoryDeletionRequestRecord[]>` for further processing.
- Ensured that existing logic for verifying deletion requests, updating verified requests, and counting applied deletions remains unchanged.
- Added and enhanced tests to verify that the batch query works correctly and that existing behaviors are preserved, including handling cases with zero deletion requests.

### Testing:
- Confirmed that the batch query is executed only once for multiple events.
- Verified that the existing functionality, such as transaction rollback on failure and the handling of verified requests, remains intact.
- All relevant tests passed successfully, except for unrelated legacy bridge tests.

This implementation aims to improve performance by reducing the number of database queries while ensuring that the application's existing behavior is preserved.