### PR TITLE
Decouple post history rendering from total count loading

### DIFF
--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -669,6 +669,8 @@
         return translateDialogMessage(
             resolvePostHistoryCountSummaryState({
                 totalCount: history.displayTotalCount,
+                totalCountKnown: history.state.totalCountKnown,
+                totalCountStatus: history.state.totalCountStatus,
                 isSearchMode: history.isSearchMode,
             }),
         );

--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -1703,7 +1703,13 @@ export function usePostHistoryListing({
     }
 
     async function loadLatestVisiblePosts(
-        { forceTotalCount = false }: { forceTotalCount?: boolean } = {},
+        {
+            forceTotalCount = false,
+            skipTotalCountRefresh = false,
+        }: {
+            forceTotalCount?: boolean;
+            skipTotalCountRefresh?: boolean;
+        } = {},
     ): Promise<void> {
         const pubkeyHex = getPubkeyHex();
         if (!pubkeyHex) {
@@ -1715,7 +1721,9 @@ export function usePostHistoryListing({
         const requestId = ++loadRequestId;
         const visibleUntil = await refreshVisibleUntil(pubkeyHex);
         await refreshJumpCacheAnchorAvailability(pubkeyHex);
-        refreshTotalCountFromRepository({ force: forceTotalCount });
+        if (!skipTotalCountRefresh) {
+            refreshTotalCountFromRepository({ force: forceTotalCount });
+        }
         const latestPosts = await postHistoryRepository.getLatestVisibleChunk({
             pubkeyHex,
             limit: pageSize,
@@ -1736,17 +1744,19 @@ export function usePostHistoryListing({
         void startOpenRelayFetchAfterLocalLoad(pubkeyHex, latestPosts);
     }
 
-    async function reloadVisibleWindowFromCurrentNewest(): Promise<void> {
+    async function reloadVisibleWindowFromCurrentNewest(
+        { skipTotalCountRefresh = false }: { skipTotalCountRefresh?: boolean } = {},
+    ): Promise<void> {
         const pubkeyHex = getPubkeyHex();
         if (!pubkeyHex || state.loadedPosts.length === 0) {
-            await loadLatestVisiblePosts();
+            await loadLatestVisiblePosts({ skipTotalCountRefresh });
             return;
         }
 
         const newestPost = state.loadedPosts[0];
         const newestCursor = toTimelineCursor(newestPost);
         if (!newestCursor) {
-            await loadLatestVisiblePosts();
+            await loadLatestVisiblePosts({ skipTotalCountRefresh });
             return;
         }
 
@@ -1779,7 +1789,9 @@ export function usePostHistoryListing({
             return;
         }
 
-        refreshTotalCountFromRepository();
+        if (!skipTotalCountRefresh) {
+            refreshTotalCountFromRepository();
+        }
         state.loadedPosts = nextPosts;
         void prefetchCurrentPageMedia(nextPosts);
         await refreshTimelineAvailability(pubkeyHex, nextPosts, requestId);
@@ -3252,9 +3264,7 @@ export function usePostHistoryListing({
             pubkeyHex,
             relayConfig: getRelayConfig(),
             preferredRanges,
-            onProgress: async () => {
-                refreshTotalCountFromRepository({ force: true });
-            },
+            onProgress: async () => undefined,
         });
         currentViewRefetchTask = task;
 
@@ -3282,9 +3292,13 @@ export function usePostHistoryListing({
                     state.searchQuery,
                 );
             } else if (state.loadedPosts.length === 0 || !state.hasNewerLocal) {
-                await loadLatestVisiblePosts();
+                await loadLatestVisiblePosts({ skipTotalCountRefresh: true });
             } else {
-                await reloadVisibleWindowFromCurrentNewest();
+                await reloadVisibleWindowFromCurrentNewest({ skipTotalCountRefresh: true });
+            }
+
+            if (!state.searchQuery) {
+                refreshTotalCountFromRepository({ force: true });
             }
 
             let childInteractionRepairResult: PostHistoryRelationRepairSummary | null = null;
@@ -3369,7 +3383,6 @@ export function usePostHistoryListing({
 
         cancelCurrentSync();
         cancelCurrentViewRefetch();
-        invalidateTotalCountRequest();
 
         const results = await Promise.allSettled([
             postHistoryRepository.deleteLocalHistoryForPubkey(pubkeyHex),
@@ -3378,6 +3391,13 @@ export function usePostHistoryListing({
         ]);
 
         if (results.some((result) => result.status === "rejected")) {
+            if (getShow() && getPubkeyHex() === pubkeyHex) {
+                invalidateTotalCountRequest();
+                setTotalCountState({
+                    known: state.totalCountKnown,
+                    status: "failed",
+                });
+            }
             clearCurrentViewRefetchFeedback();
             state.currentViewRefetchMessageKey = "postHistory.deleteLocalHistoryFailed";
             state.currentViewRefetchMessageValues = null;

--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -71,6 +71,13 @@ export type PostHistorySyncStatus =
     | "failed"
     | "no-more";
 
+export type PostHistoryTotalCountStatus =
+    | "unknown"
+    | "loading"
+    | "ready"
+    | "refreshing"
+    | "failed";
+
 type PostHistoryListingMode = "contiguous" | "sparse";
 type PostHistorySparseSource = "jump" | "saved" | null;
 
@@ -107,6 +114,8 @@ interface PersistedPostHistoryListingSnapshot {
     searchPosts: PostHistoryRecord[];
     searchQuery: string;
     totalCount: number;
+    totalCountKnown?: boolean;
+    totalCountFailed?: boolean;
     searchTotalCount: number;
     searchHasNext: boolean;
     hasMoreRemote: boolean;
@@ -276,6 +285,8 @@ const DEFAULT_PERSISTED_POST_HISTORY_LISTING_SNAPSHOT: PersistedPostHistoryListi
     searchPosts: [],
     searchQuery: "",
     totalCount: 0,
+    totalCountKnown: false,
+    totalCountFailed: false,
     searchTotalCount: 0,
     searchHasNext: false,
     hasMoreRemote: false,
@@ -472,6 +483,11 @@ function cloneListingSnapshot(
         searchPosts: [...snapshot.searchPosts],
         searchQuery: snapshot.searchQuery ?? "",
         totalCount: snapshot.totalCount,
+        // Older in-memory snapshots did not distinguish a zero count from an
+        // unavailable count. A positive legacy value is safe to preserve; a
+        // legacy zero is deliberately treated as unknown until refreshed.
+        totalCountKnown: snapshot.totalCountKnown ?? snapshot.totalCount > 0,
+        totalCountFailed: snapshot.totalCountFailed ?? false,
         searchTotalCount: snapshot.searchTotalCount,
         searchHasNext: snapshot.searchHasNext,
         hasMoreRemote: snapshot.hasMoreRemote,
@@ -556,6 +572,15 @@ export function usePostHistoryListing({
     const restoredSearchState =
         persistedListingSnapshot.searchQuery === persistedViewState.searchQuery
         && persistedViewState.searchQuery.length > 0;
+    const persistedTotalCountKnown =
+        persistedListingSnapshot.totalCountKnown ??
+        persistedListingSnapshot.totalCount > 0;
+    const persistedTotalCountStatus: PostHistoryTotalCountStatus =
+        persistedListingSnapshot.totalCountFailed
+            ? "failed"
+            : persistedTotalCountKnown
+              ? "ready"
+              : "unknown";
     const state = $state({
         loadedPosts: persistedListingSnapshot.loadedPosts,
         searchPosts: restoredSearchState
@@ -566,6 +591,8 @@ export function usePostHistoryListing({
         currentPage: 1,
         searchPage: restoredSearchState ? persistedViewState.searchPage : 1,
         totalCount: persistedListingSnapshot.totalCount,
+        totalCountKnown: persistedTotalCountKnown,
+        totalCountStatus: persistedTotalCountStatus as PostHistoryTotalCountStatus,
         searchTotalCount: persistedListingSnapshot.searchTotalCount,
         searchHasNext: persistedListingSnapshot.searchHasNext,
         syncStatus: "idle" as PostHistorySyncStatus,
@@ -587,6 +614,10 @@ export function usePostHistoryListing({
     });
 
     let loadRequestId = 0;
+    let totalCountRequestId = 0;
+    let currentTotalCountRequest:
+        | { requestId: number; pubkeyHex: string; promise: Promise<void> }
+        | null = null;
     let searchLoadRequestId = 0;
     let isSearchPageLoading = $state(false);
     let hasStartedInitialSync = false;
@@ -862,8 +893,9 @@ export function usePostHistoryListing({
     }
 
     function clearCurrentListingState(): void {
+        invalidateTotalCountRequest();
         state.loadedPosts = [];
-        state.totalCount = 0;
+        setTotalCountState({ known: false, status: "unknown" });
         state.currentPage = 1;
         state.syncStatus = "idle";
         state.hasMoreRemote = false;
@@ -890,10 +922,11 @@ export function usePostHistoryListing({
     }
 
     function resetListingStateAfterLocalDelete(): void {
+        invalidateTotalCountRequest();
         relationRepairCoordinator.resetOlderRevealRepairContext();
         state.loadedPosts = [];
         state.searchPosts = [];
-        state.totalCount = 0;
+        setTotalCountState({ count: 0, known: true, status: "ready" });
         state.searchTotalCount = 0;
         state.searchHasNext = false;
         state.currentPage = 1;
@@ -952,6 +985,7 @@ export function usePostHistoryListing({
         cancelCurrentSync();
         cancelCurrentViewRefetch();
         invalidatePendingLoadRequests();
+        invalidateTotalCountRequest();
         postHistoryLocalSearchService.clearCache?.();
         relationRepairCoordinator.resetOlderRevealRepairContext();
         return shouldClearAllSessionScrollState;
@@ -962,6 +996,7 @@ export function usePostHistoryListing({
         cancelCurrentSync();
         cancelCurrentViewRefetch();
         invalidatePendingLoadRequests();
+        invalidateTotalCountRequest();
         postHistoryLocalSearchService.clearCache?.();
         relationRepairCoordinator.resetOlderRevealRepairContext();
         state.syncStatus = "idle";
@@ -1413,12 +1448,97 @@ export function usePostHistoryListing({
             : currentOldestCreatedAt < visibleUntil;
     }
 
-    async function countDisplayPosts(
+    function setTotalCountState({
+        count,
+        known,
+        status,
+    }: {
+        count?: number;
+        known: boolean;
+        status: PostHistoryTotalCountStatus;
+    }): void {
+        if (typeof count === "number") {
+            state.totalCount = count;
+        }
+        state.totalCountKnown = known;
+        state.totalCountStatus = status;
+    }
+
+    function invalidateTotalCountRequest(): void {
+        totalCountRequestId += 1;
+        currentTotalCountRequest = null;
+        setTotalCountState({
+            known: state.totalCountKnown,
+            status: state.totalCountKnown ? "ready" : "unknown",
+        });
+    }
+
+    function requestTotalCount(
         pubkeyHex: string,
-        _visibleUntil: number | null,
-        _currentPosts: PostHistoryRecord[] = state.loadedPosts,
-    ): Promise<number> {
-        return postHistoryRepository.countForPubkey(pubkeyHex);
+        { force = false }: { force?: boolean } = {},
+    ): void {
+        if (!getShow() || getPubkeyHex() !== pubkeyHex) {
+            return;
+        }
+
+        if (!force && currentTotalCountRequest?.pubkeyHex === pubkeyHex) {
+            return;
+        }
+
+        const requestId = ++totalCountRequestId;
+        setTotalCountState({
+            known: state.totalCountKnown,
+            status: state.totalCountKnown ? "refreshing" : "loading",
+        });
+
+        const promise = postHistoryRepository.countForPubkey(pubkeyHex)
+            .then((count) => {
+                if (
+                    requestId !== totalCountRequestId
+                    || !getShow()
+                    || getPubkeyHex() !== pubkeyHex
+                ) {
+                    return;
+                }
+
+                setTotalCountState({
+                    count,
+                    known: true,
+                    status: "ready",
+                });
+            })
+            .catch(() => {
+                if (
+                    requestId !== totalCountRequestId
+                    || !getShow()
+                    || getPubkeyHex() !== pubkeyHex
+                ) {
+                    return;
+                }
+
+                setTotalCountState({
+                    known: state.totalCountKnown,
+                    status: "failed",
+                });
+            })
+            .finally(() => {
+                if (currentTotalCountRequest?.requestId === requestId) {
+                    currentTotalCountRequest = null;
+                }
+            });
+
+        currentTotalCountRequest = { requestId, pubkeyHex, promise };
+    }
+
+    function refreshTotalCountFromRepository(
+        { force = false }: { force?: boolean } = {},
+    ): void {
+        const pubkeyHex = getPubkeyHex();
+        if (!pubkeyHex || !getShow()) {
+            return;
+        }
+
+        requestTotalCount(pubkeyHex, { force });
     }
 
     async function refreshSavedPostsOutsideVisibleRange(
@@ -1582,7 +1702,9 @@ export function usePostHistoryListing({
         state.hasOlderLocal = olderPosts.length > 0;
     }
 
-    async function loadLatestVisiblePosts(): Promise<void> {
+    async function loadLatestVisiblePosts(
+        { forceTotalCount = false }: { forceTotalCount?: boolean } = {},
+    ): Promise<void> {
         const pubkeyHex = getPubkeyHex();
         if (!pubkeyHex) {
             stateOwnerPubkeyKey = null;
@@ -1593,21 +1715,18 @@ export function usePostHistoryListing({
         const requestId = ++loadRequestId;
         const visibleUntil = await refreshVisibleUntil(pubkeyHex);
         await refreshJumpCacheAnchorAvailability(pubkeyHex);
-        const [count, latestPosts] = await Promise.all([
-            countDisplayPosts(pubkeyHex, visibleUntil),
-            postHistoryRepository.getLatestVisibleChunk({
-                pubkeyHex,
-                limit: pageSize,
-                visibleUntil,
-            }),
-        ]);
+        refreshTotalCountFromRepository({ force: forceTotalCount });
+        const latestPosts = await postHistoryRepository.getLatestVisibleChunk({
+            pubkeyHex,
+            limit: pageSize,
+            visibleUntil,
+        });
 
         if (!getShow() || requestId !== loadRequestId) {
             return;
         }
 
         markStateOwner(pubkeyHex);
-        state.totalCount = count;
         state.listingMode = "contiguous";
         state.sparseSource = null;
         state.loadedPosts = latestPosts;
@@ -1637,10 +1756,8 @@ export function usePostHistoryListing({
             visibleUntil,
             state.loadedPosts,
         );
-        const [count, nextPosts] = isSparseContext
-            ? await Promise.all([
-                countDisplayPosts(pubkeyHex, visibleUntil, state.loadedPosts),
-                postHistoryRepository.getVisibleChunkFromCreatedAt({
+        const nextPosts = isSparseContext
+            ? await postHistoryRepository.getVisibleChunkFromCreatedAt({
                     pubkeyHex,
                     visibleUntil,
                     createdAt: newestPost.createdAt,
@@ -1648,43 +1765,24 @@ export function usePostHistoryListing({
                     query: {
                         contiguous: false,
                     },
-                }),
-            ])
-            : await Promise.all([
-                countDisplayPosts(pubkeyHex, visibleUntil, state.loadedPosts),
-                state.loadedPosts.length > 1
+                })
+            : await (state.loadedPosts.length > 1
                     ? postHistoryRepository.getOlderVisibleChunk({
                         pubkeyHex,
                         visibleUntil,
                         cursor: newestCursor,
                         limit: state.loadedPosts.length - 1,
                     }).then((olderPosts) => [newestPost, ...olderPosts])
-                    : Promise.resolve([newestPost]),
-            ]);
+                    : Promise.resolve([newestPost]));
 
         if (!getShow() || requestId !== loadRequestId) {
             return;
         }
 
-        state.totalCount = count;
+        refreshTotalCountFromRepository();
         state.loadedPosts = nextPosts;
         void prefetchCurrentPageMedia(nextPosts);
         await refreshTimelineAvailability(pubkeyHex, nextPosts, requestId);
-    }
-
-    async function refreshTotalCountFromRepository(): Promise<void> {
-        const pubkeyHex = getPubkeyHex();
-        if (!pubkeyHex || !getShow()) {
-            return;
-        }
-
-        const visibleUntil = await refreshVisibleUntil(pubkeyHex);
-        const count = await countDisplayPosts(pubkeyHex, visibleUntil);
-        if (!getShow()) {
-            return;
-        }
-
-        state.totalCount = count;
     }
 
     function shouldApplyPendingLatestRequest(
@@ -1711,8 +1809,7 @@ export function usePostHistoryListing({
 
         const requestId = ++loadRequestId;
         const visibleUntil = await refreshVisibleUntil(pubkeyHex);
-        const [count, newerPosts, olderPosts] = await Promise.all([
-            countDisplayPosts(pubkeyHex, visibleUntil, currentPosts),
+        const [newerPosts, olderPosts] = await Promise.all([
             newestCursor
                 ? postHistoryRepository.getNewerVisibleChunk({
                     pubkeyHex,
@@ -1740,7 +1837,7 @@ export function usePostHistoryListing({
             return;
         }
 
-        state.totalCount = count;
+        refreshTotalCountFromRepository();
         state.hasNewerLocal = newerPosts.length > 0;
         state.hasOlderLocal = olderPosts.length > 0;
         void prefetchCurrentPageMedia(currentPosts);
@@ -1786,16 +1883,13 @@ export function usePostHistoryListing({
 
         const requestId = ++loadRequestId;
         const visibleUntil = await refreshVisibleUntil(pubkeyHex);
-        const [count, restoredPosts] = await Promise.all([
-            countDisplayPosts(pubkeyHex, visibleUntil),
-            postHistoryRepository.getVisibleChunkAroundEventId({
+        const restoredPosts = await postHistoryRepository.getVisibleChunkAroundEventId({
                 pubkeyHex,
                 visibleUntil,
                 eventId: scrollState.anchor.eventId,
                 limit: maxVisiblePosts,
                 keepAbove: pageSize,
-            }),
-        ]);
+            });
 
         if (!getShow() || requestId !== loadRequestId) {
             return false;
@@ -1807,7 +1901,7 @@ export function usePostHistoryListing({
             return false;
         }
 
-        state.totalCount = count;
+        refreshTotalCountFromRepository();
         state.loadedPosts = restoredPosts;
         void prefetchCurrentPageMedia(restoredPosts);
         await refreshTimelineAvailability(pubkeyHex, restoredPosts, requestId);
@@ -2061,22 +2155,19 @@ export function usePostHistoryListing({
 
         const requestId = ++loadRequestId;
         const visibleUntil = await refreshVisibleUntil(pubkeyHex);
-        const [count, contiguousDatePosts] = await Promise.all([
-            countDisplayPosts(pubkeyHex, visibleUntil),
-            postHistoryRepository.getVisibleChunkFromCreatedAt({
+        const contiguousDatePosts = await postHistoryRepository.getVisibleChunkFromCreatedAt({
                 pubkeyHex,
                 visibleUntil,
                 createdAt,
                 limit: pageSize,
-            }),
-        ]);
+            });
 
         if (!getShow() || requestId !== loadRequestId) {
             return false;
         }
 
         if (contiguousDatePosts.length === 0) {
-            state.totalCount = count;
+            refreshTotalCountFromRepository();
             state.loadedPosts = [];
             state.hasOlderLocal = false;
             state.hasNewerLocal = false;
@@ -2084,7 +2175,7 @@ export function usePostHistoryListing({
         }
 
         if (!didDateChunkMissTarget(contiguousDatePosts, createdAt)) {
-            state.totalCount = count;
+            refreshTotalCountFromRepository();
             state.listingMode = "contiguous";
             state.sparseSource = null;
             state.loadedPosts = contiguousDatePosts;
@@ -2095,7 +2186,7 @@ export function usePostHistoryListing({
         }
 
         if (createdAt <= 0) {
-            state.totalCount = count;
+            refreshTotalCountFromRepository();
             state.listingMode = "contiguous";
             state.sparseSource = null;
             state.loadedPosts = contiguousDatePosts;
@@ -2131,13 +2222,7 @@ export function usePostHistoryListing({
             }
 
             if (!didDateChunkMissTarget(sparseDatePosts, createdAt)) {
-                const sparseTotalCount =
-                    await postHistoryRepository.countForPubkey(pubkeyHex);
-                if (!getShow() || requestId !== loadRequestId) {
-                    return false;
-                }
-
-                state.totalCount = sparseTotalCount;
+                refreshTotalCountFromRepository();
                 state.listingMode = "sparse";
                 state.sparseSource = "jump";
                 state.loadedPosts = sparseDatePosts;
@@ -2150,7 +2235,7 @@ export function usePostHistoryListing({
 
         const rxNostr = getRxNostr();
         if (!rxNostr) {
-            state.totalCount = count;
+            refreshTotalCountFromRepository();
             state.listingMode = "contiguous";
             state.sparseSource = null;
             state.loadedPosts = contiguousDatePosts;
@@ -2229,14 +2314,7 @@ export function usePostHistoryListing({
             return false;
         }
 
-        const sparseTotalCount = await postHistoryRepository.countForPubkey(
-            pubkeyHex,
-        );
-        if (!getShow() || requestId !== loadRequestId) {
-            return false;
-        }
-
-        state.totalCount = sparseTotalCount;
+        refreshTotalCountFromRepository({ force: relayResult.events.length > 0 });
         state.listingMode = "sparse";
         state.sparseSource = "jump";
         state.loadedPosts = sparseDatePosts;
@@ -2478,9 +2556,14 @@ export function usePostHistoryListing({
                 state.searchQuery,
             );
         } else if (state.loadedPosts.length === 0 || !state.hasNewerLocal) {
-            await loadLatestVisiblePosts();
+            await loadLatestVisiblePosts({
+                forceTotalCount:
+                    upsertSummary.insertedCount + upsertSummary.updatedCount > 0,
+            });
         } else {
-            await refreshTotalCountFromRepository();
+            refreshTotalCountFromRepository({
+                force: upsertSummary.insertedCount + upsertSummary.updatedCount > 0,
+            });
             await refreshTimelineAvailability(pubkeyHex);
         }
 
@@ -2570,11 +2653,15 @@ export function usePostHistoryListing({
                 state.searchQuery,
             );
         } else if (refreshDecision.applyAction === "load-latest-visible-posts") {
-            await loadLatestVisiblePosts();
+            await loadLatestVisiblePosts({
+                forceTotalCount: refreshDecision.didMateriallyChange,
+            });
         } else if (
             refreshDecision.applyAction === "refresh-count-and-availability"
         ) {
-            await refreshTotalCountFromRepository();
+            refreshTotalCountFromRepository({
+                force: refreshDecision.didMateriallyChange,
+            });
             await refreshTimelineAvailability(pubkeyHex);
         }
     }
@@ -2724,7 +2811,7 @@ export function usePostHistoryListing({
         state.listingMode = "sparse";
         state.sparseSource = "saved";
         state.loadedPosts = posts;
-        state.totalCount = await postHistoryRepository.countForPubkey(pubkeyHex);
+        refreshTotalCountFromRepository();
         void prefetchCurrentPageMedia(posts);
         await refreshTimelineAvailability(pubkeyHex, posts, requestId);
         await refreshSavedPostsOutsideVisibleRange(pubkeyHex, visibleUntil, requestId);
@@ -2836,15 +2923,6 @@ export function usePostHistoryListing({
                 clickStartVisibleCount = previousCount;
             }
 
-            const previousStoredCount = await postHistoryRepository.countForPubkey(pubkeyHex);
-            if (
-                !isCurrentFetchRequest(requestId) ||
-                !getShow() ||
-                getPubkeyHex() !== pubkeyHex
-            ) {
-                return batchChanged;
-            }
-
             let didMateriallyChange = false;
             let upsertSummary = {
                 insertedCount: 0,
@@ -2938,11 +3016,6 @@ export function usePostHistoryListing({
                 return batchChanged;
             }
 
-            const nextStoredCount = await postHistoryRepository.countForPubkey(pubkeyHex);
-            if (!isCurrentFetchRequest(requestId) || !getShow()) {
-                return batchChanged;
-            }
-
             await refreshSavedPostsOutsideVisibleRange(
                 pubkeyHex,
                 effectiveVisibleUntil,
@@ -3021,7 +3094,7 @@ export function usePostHistoryListing({
                     state.searchQuery,
                 );
             } else {
-                state.totalCount = nextStoredCount;
+                refreshTotalCountFromRepository({ force: didMateriallyChange });
                 if (didVisibleCountIncrease || didMateriallyChange) {
                     didLoadFetchedOlderPosts = state.sparseSource === "saved"
                         ? await loadOlderSavedPosts(pubkeyHex, loadRequestId, {
@@ -3180,7 +3253,7 @@ export function usePostHistoryListing({
             relayConfig: getRelayConfig(),
             preferredRanges,
             onProgress: async () => {
-                await refreshTotalCountFromRepository();
+                refreshTotalCountFromRepository({ force: true });
             },
         });
         currentViewRefetchTask = task;
@@ -3296,6 +3369,7 @@ export function usePostHistoryListing({
 
         cancelCurrentSync();
         cancelCurrentViewRefetch();
+        invalidateTotalCountRequest();
 
         const results = await Promise.allSettled([
             postHistoryRepository.deleteLocalHistoryForPubkey(pubkeyHex),
@@ -3323,6 +3397,9 @@ export function usePostHistoryListing({
         });
         writePersistedListingSnapshot(pubkeyHex, {
             ...DEFAULT_PERSISTED_POST_HISTORY_LISTING_SNAPSHOT,
+            totalCount: 0,
+            totalCountKnown: true,
+            totalCountFailed: false,
         });
         return true;
     }
@@ -3378,13 +3455,13 @@ export function usePostHistoryListing({
             const pubkeyHex = getPubkeyHex();
             if (!pubkeyHex) return;
             const visibleUntil = await refreshVisibleUntil(pubkeyHex);
-            state.totalCount = await postHistoryRepository.countForPubkey(pubkeyHex);
+            refreshTotalCountFromRepository({ force: true });
             await refreshTimelineAvailability(pubkeyHex);
             await refreshSavedPostsOutsideVisibleRange(pubkeyHex, visibleUntil);
             return;
         }
 
-        await loadLatestVisiblePosts();
+        await loadLatestVisiblePosts({ forceTotalCount: true });
     }
 
     function patchDeletedPost(
@@ -3462,6 +3539,8 @@ export function usePostHistoryListing({
             searchPosts: state.searchPosts,
             searchQuery: state.searchQuery,
             totalCount: state.totalCount,
+            totalCountKnown: state.totalCountKnown,
+            totalCountFailed: state.totalCountStatus === "failed",
             searchTotalCount: state.searchTotalCount,
             searchHasNext: state.searchHasNext,
             hasMoreRemote: state.hasMoreRemote,

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -137,6 +137,8 @@
     "visibleRange": "{from} → {to}",
     "visibleCountSummary": "{total} saved",
     "searchCountSummary": "{total} posts",
+    "countLoading": "Checking count...",
+    "countUnavailable": "Count unavailable",
     "loadOlder": "Show older posts",
     "loadNewer": "Show newer posts",
     "loadOlderSearchResults": "Show older search results",

--- a/src/lib/i18n/ja.json
+++ b/src/lib/i18n/ja.json
@@ -137,6 +137,8 @@
     "visibleRange": "{from} → {to}",
     "visibleCountSummary": "{total}件保存",
     "searchCountSummary": "{total}件",
+    "countLoading": "件数を確認中...",
+    "countUnavailable": "件数を確認できません",
     "loadOlder": "さらに古い投稿を表示",
     "loadNewer": "新しい投稿を表示",
     "loadOlderSearchResults": "さらに古い検索結果を表示",

--- a/src/lib/postHistoryDialogPresentation.ts
+++ b/src/lib/postHistoryDialogPresentation.ts
@@ -32,10 +32,14 @@ const reactionGraphemeSegmenter = new Intl.Segmenter(undefined, {
 
 export function resolvePostHistoryCountSummaryState(input: {
     totalCount: number;
+    totalCountKnown?: boolean;
+    totalCountStatus?: "unknown" | "loading" | "ready" | "refreshing" | "failed";
     isSearchMode: boolean;
 }): PostHistoryDialogMessageState | null {
-    if (input.totalCount <= 0) {
-        return null;
+    if (!input.isSearchMode && !input.totalCountKnown) {
+        return input.totalCountStatus === "failed"
+            ? { key: "postHistory.countUnavailable" }
+            : { key: "postHistory.countLoading" };
     }
 
     return {

--- a/src/lib/postHistoryDialogPresentation.ts
+++ b/src/lib/postHistoryDialogPresentation.ts
@@ -36,16 +36,27 @@ export function resolvePostHistoryCountSummaryState(input: {
     totalCountStatus?: "unknown" | "loading" | "ready" | "refreshing" | "failed";
     isSearchMode: boolean;
 }): PostHistoryDialogMessageState | null {
-    if (!input.isSearchMode && !input.totalCountKnown) {
+    if (input.isSearchMode) {
+        if (input.totalCount <= 0) {
+            return null;
+        }
+
+        return {
+            key: "postHistory.searchCountSummary",
+            values: {
+                total: input.totalCount,
+            },
+        };
+    }
+
+    if (!input.totalCountKnown) {
         return input.totalCountStatus === "failed"
             ? { key: "postHistory.countUnavailable" }
             : { key: "postHistory.countLoading" };
     }
 
     return {
-        key: input.isSearchMode
-            ? "postHistory.searchCountSummary"
-            : "postHistory.visibleCountSummary",
+        key: "postHistory.visibleCountSummary",
         values: {
             total: input.totalCount,
         },

--- a/src/test/unit/postHistoryDialog.test.ts
+++ b/src/test/unit/postHistoryDialog.test.ts
@@ -20,6 +20,8 @@ const mockTranslate = vi.hoisted(() => (key: string, options?: { values?: Record
         'postHistory.visibleRange': `表示中: ${options?.values?.from}〜${options?.values?.to}`,
         'postHistory.visibleCountSummary': `${options?.values?.total}件`,
         'postHistory.searchCountSummary': `${options?.values?.total}件`,
+        'postHistory.countLoading': '件数を確認中...',
+        'postHistory.countUnavailable': '件数を確認できません',
         'postHistory.loadOlder': 'さらに古い投稿を表示',
         'postHistory.loadNewer': '新しい投稿を表示',
         'postHistory.loadOlderSearchResults': 'さらに古い検索結果を表示',
@@ -1051,6 +1053,65 @@ describe('PostHistoryDialog', () => {
             });
             expect(screen.queryByRole('searchbox', { name: '検索' })).toBeNull();
             expect(screen.getByText('投稿履歴はありません')).toBeTruthy();
+        });
+    });
+
+    it('[first-post-before-count] 総件数の完了を待たずに最新投稿を表示する', async () => {
+        const post = createRecord({ content: '件数より先に表示する投稿' });
+        const deferredCount = createDeferred<number>();
+        repositoryMock.getPage.mockResolvedValue([post]);
+        repositoryMock.countForPubkey.mockReturnValue(deferredCount.promise);
+
+        render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: 'a'.repeat(64),
+            },
+        });
+
+        await findHistoryItem(post.eventId);
+        expect(screen.getByText('件数を確認中...')).toBeTruthy();
+
+        deferredCount.resolve(1);
+        await waitFor(() => {
+            expect(screen.getByText('1件')).toBeTruthy();
+        });
+    });
+
+    it('[count-survives-window-move] 古い投稿の表示中でも開始済みの総件数を適用する', async () => {
+        const latestPost = createRecord({
+            eventId: '1'.repeat(64),
+            content: '最新投稿',
+        });
+        const olderPost = createRecord({
+            eventId: '2'.repeat(64),
+            content: '古い投稿',
+            createdAt: 1_699_999_000,
+            postedAt: Date.UTC(2024, 0, 1, 3, 4, 0),
+        });
+        const deferredCount = createDeferred<number>();
+        repositoryMock.getPage.mockResolvedValue([latestPost]);
+        repositoryMock.getOlderVisibleChunk.mockResolvedValue([olderPost]);
+        repositoryMock.countForPubkey.mockReturnValue(deferredCount.promise);
+
+        render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: 'a'.repeat(64),
+            },
+        });
+
+        await findHistoryItem(latestPost.eventId);
+        await fireEvent.click(await screen.findByRole('button', {
+            name: 'さらに古い投稿を表示',
+        }));
+        await findHistoryItem(olderPost.eventId);
+
+        deferredCount.resolve(2);
+        await waitFor(() => {
+            expect(screen.getByText('2件')).toBeTruthy();
         });
     });
 

--- a/src/test/unit/postHistoryDialog.test.ts
+++ b/src/test/unit/postHistoryDialog.test.ts
@@ -6022,4 +6022,38 @@ describe('PostHistoryDialog', () => {
         });
     });
 
+    it('[delete-local-history-failure-count-state] 件数取得中の削除失敗は実体のない確認中状態を残さない', async () => {
+        const countDeferred = createDeferred<number>();
+        repositoryMock.countForPubkey.mockReturnValueOnce(countDeferred.promise);
+        repositoryMock.getPage.mockResolvedValue([
+            createRecord({ eventId: 'local-history-post', content: '削除対象' }),
+        ]);
+        repositoryMock.deleteLocalHistoryForPubkey.mockRejectedValueOnce(new Error('delete failed'));
+
+        render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: 'a'.repeat(64),
+            },
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('削除対象')).toBeTruthy();
+            expect(screen.getByText('件数を確認中...')).toBeTruthy();
+        });
+
+        await openPostHistoryMenu();
+        await fireEvent.click(await screen.findByRole('menuitem', { name: '保存済み投稿履歴をクリア' }));
+        await fireEvent.click(screen.getByRole('button', { name: 'クリアする' }));
+
+        await waitFor(() => {
+            expect(screen.getByText('保存済み投稿履歴のクリアに失敗しました')).toBeTruthy();
+            expect(screen.getByText('件数を確認できません')).toBeTruthy();
+            expect(screen.queryByText('件数を確認中...')).toBeNull();
+        });
+
+        countDeferred.resolve(1);
+    });
+
 });

--- a/src/test/unit/postHistoryDialogPresentation.test.ts
+++ b/src/test/unit/postHistoryDialogPresentation.test.ts
@@ -48,6 +48,10 @@ describe("postHistoryDialogPresentation", () => {
             key: "postHistory.searchCountSummary",
             values: { total: 3 },
         });
+        expect(resolvePostHistoryCountSummaryState({
+            totalCount: 0,
+            isSearchMode: true,
+        })).toBeNull();
     });
 
     it("older/newer の nav label key は検索モードだけ検索結果用に切り替える", () => {

--- a/src/test/unit/postHistoryDialogPresentation.test.ts
+++ b/src/test/unit/postHistoryDialogPresentation.test.ts
@@ -11,13 +11,31 @@ import {
 } from "../../lib/postHistoryDialogPresentation";
 
 describe("postHistoryDialogPresentation", () => {
-    it("件数 summary は0件以下では非表示にし、通常/検索で key を切り替える", () => {
+    it("通常表示の件数 summary は未知状態を0件と扱わず、既知の0件は表示する", () => {
         expect(resolvePostHistoryCountSummaryState({
             totalCount: 0,
+            totalCountKnown: false,
+            totalCountStatus: "loading",
             isSearchMode: false,
-        })).toBeNull();
+        })).toEqual({ key: "postHistory.countLoading" });
+        expect(resolvePostHistoryCountSummaryState({
+            totalCount: 0,
+            totalCountKnown: false,
+            totalCountStatus: "failed",
+            isSearchMode: false,
+        })).toEqual({ key: "postHistory.countUnavailable" });
+        expect(resolvePostHistoryCountSummaryState({
+            totalCount: 0,
+            totalCountKnown: true,
+            totalCountStatus: "ready",
+            isSearchMode: false,
+        })).toEqual({
+            key: "postHistory.visibleCountSummary",
+            values: { total: 0 },
+        });
         expect(resolvePostHistoryCountSummaryState({
             totalCount: 3,
+            totalCountKnown: true,
             isSearchMode: false,
         })).toEqual({
             key: "postHistory.visibleCountSummary",

--- a/src/test/unit/postHistoryDialogTimelineRelay.test.ts
+++ b/src/test/unit/postHistoryDialogTimelineRelay.test.ts
@@ -759,6 +759,8 @@ describe('PostHistoryDialog timeline relay flows', () => {
             expect(screen.queryByText('リレーと同期中...')).toBeNull();
         });
 
+        const countCallCountBeforeRepair = repositoryMock.countForPubkey.mock.calls.length;
+
         await clickEnabledMenuAction('表示中の投稿付近を再取得');
 
         await waitFor(() => {
@@ -776,10 +778,17 @@ describe('PostHistoryDialog timeline relay flows', () => {
             totalUpdatedCount: 0,
             totalUnchangedCount: 0,
         });
-
-        await waitFor(() => {
-            expect(screen.getByText('51件')).toBeTruthy();
+        await repairParams.onProgress({
+            insertedCount: 1,
+            updatedCount: 0,
+            unchangedCount: 0,
+            processedRangeCount: 2,
+            attemptedRangeCount: 2,
+            addedCount: 2,
+            totalUpdatedCount: 0,
+            totalUnchangedCount: 0,
         });
+        expect(repositoryMock.countForPubkey.mock.calls.length).toBe(countCallCountBeforeRepair);
 
         repairComplete.resolve({
             status: 'success',
@@ -795,7 +804,9 @@ describe('PostHistoryDialog timeline relay flows', () => {
         await waitFor(() => {
             expect(screen.getByText('1件追加')).toBeTruthy();
             expect(screen.getByText('修復された投稿')).toBeTruthy();
+            expect(screen.getByText('51件')).toBeTruthy();
         });
+        expect(repositoryMock.countForPubkey.mock.calls.length).toBe(countCallCountBeforeRepair + 1);
 
         view.unmount();
     });


### PR DESCRIPTION
## Summary

- Show the latest post history immediately without waiting for the total count query.
- Track total-count availability and loading/failure states across refreshes and persisted snapshots.
- Preserve in-flight count results when navigating to older posts and add localized loading/unavailable messages.
- Add coverage for immediate rendering, count updates, and known zero-count presentation.

## Testing

- Added and updated unit tests for post-history dialog rendering and count-summary states.