### PR TITLE
初回投稿描画後に補助処理とメディア先読みを開始する

### DIFF
--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -618,6 +618,7 @@ export function usePostHistoryListing({
     let hasCompletedFirstPostPaint = false;
     let mediaPrefetchReady = $state(false);
     let firstPaintPubkeyKey = $state<string | null>(null);
+    let lastPrefetchedMediaUrlsKey: string | null = null;
     let totalCountRequestId = 0;
     let currentTotalCountRequest:
         | { requestId: number; pubkeyHex: string; promise: Promise<void> }
@@ -817,6 +818,7 @@ export function usePostHistoryListing({
         hasCompletedFirstPostPaint = false;
         mediaPrefetchReady = false;
         firstPaintPubkeyKey = null;
+        lastPrefetchedMediaUrlsKey = null;
     }
 
     async function waitForFirstPostPaint(
@@ -2552,13 +2554,13 @@ export function usePostHistoryListing({
     async function rebuildSearchResultsThroughPage(
         page: number,
         query: string,
+        requestId: number = ++searchLoadRequestId,
     ): Promise<boolean> {
         const pubkeyHex = getPubkeyHex();
         if (!pubkeyHex || !query) {
             return false;
         }
         const normalizedPage = Math.max(1, Math.trunc(page));
-        const requestId = ++searchLoadRequestId;
         isSearchPageLoading = true;
 
         try {
@@ -3840,6 +3842,12 @@ export function usePostHistoryListing({
             return;
         }
 
+        const urlsKey = [...urls].sort().join("\u0000");
+        if (urlsKey === lastPrefetchedMediaUrlsKey) {
+            return;
+        }
+        lastPrefetchedMediaUrlsKey = urlsKey;
+
         void Promise.resolve(
             postMediaCacheService.prefetchCachedMediaDescriptors(urls),
         ).catch(() => {
@@ -3913,9 +3921,21 @@ export function usePostHistoryListing({
         appliedSearchQuery = state.searchQuery;
         if (!searchResultsInitialized) {
             searchResultsInitialized = true;
+            const pubkeyHex = getPubkeyHex();
+            const query = state.searchQuery;
+            const requestId = ++searchLoadRequestId;
+            const hasRestoredSearchPosts = state.searchPosts.length > 0;
+            if (pubkeyHex && hasRestoredSearchPosts) {
+                void waitForFirstPostPaint(
+                    pubkeyHex,
+                    () => isCurrentSearchLoad(requestId, query, pubkeyHex),
+                    () => state.searchPosts.length > 0,
+                );
+            }
             void rebuildSearchResultsThroughPage(
                 state.searchPage,
-                state.searchQuery,
+                query,
+                requestId,
             );
         }
     });

--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -62,7 +62,7 @@ import {
 } from "../storage/postHistoryVisibleRangeRepository";
 import type { PostHistoryRecord } from "../storage/ehagakiDb";
 import type { RelayConfig } from "../types";
-import { tick } from "svelte";
+import { onDestroy, tick } from "svelte";
 
 export type PostHistorySyncStatus =
     | "idle"
@@ -615,6 +615,8 @@ export function usePostHistoryListing({
     });
 
     let loadRequestId = 0;
+    let hasCompletedFirstPostPaint = false;
+    let mediaPrefetchReady = $state(false);
     let totalCountRequestId = 0;
     let currentTotalCountRequest:
         | { requestId: number; pubkeyHex: string; promise: Promise<void> }
@@ -799,6 +801,46 @@ export function usePostHistoryListing({
 
     function isCurrentFetchRequest(requestId: number): boolean {
         return requestId === fetchRequestId;
+    }
+
+    function isCurrentPostHistoryLoad(
+        pubkeyHex: string,
+        requestId: number,
+    ): boolean {
+        return getShow()
+            && getPubkeyHex() === pubkeyHex
+            && requestId === loadRequestId;
+    }
+
+    async function waitForFirstPostPaint(
+        pubkeyHex: string,
+        requestId: number,
+    ): Promise<boolean> {
+        await tick();
+        if (!isCurrentPostHistoryLoad(pubkeyHex, requestId)) {
+            return false;
+        }
+
+        if (hasCompletedFirstPostPaint) {
+            return true;
+        }
+
+        if (state.loadedPosts.length === 0) {
+            hasCompletedFirstPostPaint = true;
+            mediaPrefetchReady = true;
+            return true;
+        }
+
+        await new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        });
+        if (!isCurrentPostHistoryLoad(pubkeyHex, requestId)) {
+            return false;
+        }
+
+        hasCompletedFirstPostPaint = true;
+        mediaPrefetchReady = true;
+        return true;
     }
 
     function cancelCurrentViewRefetch(): void {
@@ -1581,25 +1623,6 @@ export function usePostHistoryListing({
         state.hasSavedPostsOutsideVisibleRange = hasSavedPostsOutsideVisibleRange;
     }
 
-    async function prefetchCurrentPageMedia(
-        posts: PostHistoryRecord[],
-    ): Promise<void> {
-        if (!postMediaCacheService.canUsePersistentCache()) {
-            return;
-        }
-
-        const urls = collectPostHistoryMediaUrls(posts);
-        if (urls.length === 0) {
-            return;
-        }
-
-        try {
-            await postMediaCacheService.prefetchCachedMediaDescriptors(urls);
-        } catch {
-            // Media descriptor prefetch is best-effort and must not block listing updates.
-        }
-    }
-
     function toTimelineCursor(
         post: PostHistoryRecord | null | undefined,
     ): PostHistoryTimelineCursor | null {
@@ -1751,12 +1774,7 @@ export function usePostHistoryListing({
         state.listingMode = "contiguous";
         state.sparseSource = null;
         state.loadedPosts = latestPosts;
-        await tick();
-        if (
-            !getShow()
-            || getPubkeyHex() !== pubkeyHex
-            || requestId !== loadRequestId
-        ) {
+        if (!await waitForFirstPostPaint(pubkeyHex, requestId)) {
             return;
         }
         if (!skipTotalCountRefresh) {
@@ -1772,9 +1790,6 @@ export function usePostHistoryListing({
             requestId,
         ).catch(() => {
             // Saved-range detection is auxiliary and must not delay the first post.
-        });
-        void prefetchCurrentPageMedia(latestPosts).catch(() => {
-            // Media prefetch is auxiliary and must not create an unhandled rejection.
         });
 
         void refreshTimelineAvailability(pubkeyHex, latestPosts, requestId)
@@ -1840,11 +1855,13 @@ export function usePostHistoryListing({
             return;
         }
 
+        state.loadedPosts = nextPosts;
+        if (!await waitForFirstPostPaint(pubkeyHex, requestId)) {
+            return;
+        }
         if (!skipTotalCountRefresh) {
             refreshTotalCountFromRepository();
         }
-        state.loadedPosts = nextPosts;
-        void prefetchCurrentPageMedia(nextPosts);
         await refreshTimelineAvailability(pubkeyHex, nextPosts, requestId);
     }
 
@@ -1900,10 +1917,16 @@ export function usePostHistoryListing({
             return;
         }
 
-        refreshTotalCountFromRepository();
         state.hasNewerLocal = newerPosts.length > 0;
         state.hasOlderLocal = olderPosts.length > 0;
-        void prefetchCurrentPageMedia(currentPosts);
+        if (!await waitForFirstPostPaint(pubkeyHex, requestId)) {
+            return;
+        }
+        refreshTotalCountFromRepository();
+        await refreshTimelineAvailability(pubkeyHex, state.loadedPosts, requestId);
+        if (!isCurrentPostHistoryLoad(pubkeyHex, requestId)) {
+            return;
+        }
         startOpenRelayFetchAfterLocalLoad(pubkeyHex, state.loadedPosts);
     }
 
@@ -1964,10 +1987,15 @@ export function usePostHistoryListing({
             return false;
         }
 
-        refreshTotalCountFromRepository();
         state.loadedPosts = restoredPosts;
-        void prefetchCurrentPageMedia(restoredPosts);
+        if (!await waitForFirstPostPaint(pubkeyHex, requestId)) {
+            return false;
+        }
+        refreshTotalCountFromRepository();
         await refreshTimelineAvailability(pubkeyHex, restoredPosts, requestId);
+        if (!isCurrentPostHistoryLoad(pubkeyHex, requestId)) {
+            return false;
+        }
         void startOpenRelayFetchAfterLocalLoad(pubkeyHex, restoredPosts);
         return true;
     }
@@ -2069,7 +2097,6 @@ export function usePostHistoryListing({
             metrics.didTrimForOlderAppend = mergedResult.didTrimForOlderAppend;
             metrics.didDeferOlderPosts = mergedResult.didDeferOlderPosts;
         }
-        void prefetchCurrentPageMedia(mergedResult.posts);
         await refreshTimelineAvailability(pubkeyHex, mergedResult.posts, requestId);
         return true;
     }
@@ -2113,7 +2140,6 @@ export function usePostHistoryListing({
             options.anchorEventId,
         );
         state.loadedPosts = mergedResult.posts;
-        void prefetchCurrentPageMedia(mergedResult.posts);
         await refreshTimelineAvailability(pubkeyHex, mergedResult.posts, requestId);
         if (mergedResult.didDeferOlderPosts) {
             state.hasOlderLocal = true;
@@ -2162,7 +2188,6 @@ export function usePostHistoryListing({
             options.anchorEventId,
         );
         state.loadedPosts = mergedResult.posts;
-        void prefetchCurrentPageMedia(mergedResult.posts);
         await refreshTimelineAvailability(pubkeyHex, mergedResult.posts, requestId);
         if (mergedResult.didDeferOlderPosts) {
             state.hasOlderLocal = true;
@@ -2206,7 +2231,6 @@ export function usePostHistoryListing({
         }
 
         state.loadedPosts = nextPosts;
-        void prefetchCurrentPageMedia(nextPosts);
         return true;
     }
 
@@ -2243,7 +2267,6 @@ export function usePostHistoryListing({
             state.sparseSource = null;
             state.loadedPosts = contiguousDatePosts;
             resetOlderBackfillSearchState();
-            void prefetchCurrentPageMedia(contiguousDatePosts);
             await refreshTimelineAvailability(pubkeyHex, contiguousDatePosts, requestId);
             return true;
         }
@@ -2254,7 +2277,6 @@ export function usePostHistoryListing({
             state.sparseSource = null;
             state.loadedPosts = contiguousDatePosts;
             resetOlderBackfillSearchState();
-            void prefetchCurrentPageMedia(contiguousDatePosts);
             await refreshTimelineAvailability(pubkeyHex, contiguousDatePosts, requestId);
             return true;
         }
@@ -2290,7 +2312,6 @@ export function usePostHistoryListing({
                 state.sparseSource = "jump";
                 state.loadedPosts = sparseDatePosts;
                 resetOlderBackfillSearchState();
-                void prefetchCurrentPageMedia(sparseDatePosts);
                 await refreshTimelineAvailability(pubkeyHex, sparseDatePosts, requestId);
                 return true;
             }
@@ -2303,7 +2324,6 @@ export function usePostHistoryListing({
             state.sparseSource = null;
             state.loadedPosts = contiguousDatePosts;
             resetOlderBackfillSearchState();
-            void prefetchCurrentPageMedia(contiguousDatePosts);
             await refreshTimelineAvailability(pubkeyHex, contiguousDatePosts, requestId);
             return true;
         }
@@ -2382,7 +2402,6 @@ export function usePostHistoryListing({
         state.sparseSource = "jump";
         state.loadedPosts = sparseDatePosts;
         resetOlderBackfillSearchState();
-        void prefetchCurrentPageMedia(sparseDatePosts);
         await refreshTimelineAvailability(pubkeyHex, sparseDatePosts, requestId);
         void relationRepairCoordinator.repairJump({
             ownerPubkeyHex: pubkeyHex,
@@ -2483,7 +2502,6 @@ export function usePostHistoryListing({
                 : mergeSearchPageResults(state.searchPosts, result.items);
             state.searchPage = safePage;
             state.searchHasNext = result.hasNext;
-            void prefetchCurrentPageMedia(result.items);
             return true;
         } finally {
             if (requestId === searchLoadRequestId) {
@@ -2532,7 +2550,6 @@ export function usePostHistoryListing({
             state.searchTotalCount = firstPage.total;
             state.searchPage = lastPage;
             state.searchHasNext = lastResult.hasNext;
-            void prefetchCurrentPageMedia(rebuiltPosts);
             return true;
         } finally {
             if (requestId === searchLoadRequestId) {
@@ -2875,7 +2892,6 @@ export function usePostHistoryListing({
         state.sparseSource = "saved";
         state.loadedPosts = posts;
         refreshTotalCountFromRepository();
-        void prefetchCurrentPageMedia(posts);
         await refreshTimelineAvailability(pubkeyHex, posts, requestId);
         await refreshSavedPostsOutsideVisibleRange(pubkeyHex, visibleUntil, requestId);
         return true;
@@ -3525,7 +3541,6 @@ export function usePostHistoryListing({
             "newer",
         );
         state.loadedPosts = nextPosts;
-        void prefetchCurrentPageMedia(nextPosts);
         await refreshTimelineAvailability(pubkeyHex, nextPosts, requestId);
         return true;
     }
@@ -3744,7 +3759,16 @@ export function usePostHistoryListing({
     });
 
     $effect(() => {
-        if (!getShow()) {
+        if (getShow()) {
+            return;
+        }
+
+        hasCompletedFirstPostPaint = false;
+        mediaPrefetchReady = false;
+    });
+
+    $effect(() => {
+        if (!getShow() || !mediaPrefetchReady) {
             return;
         }
 
@@ -3753,7 +3777,25 @@ export function usePostHistoryListing({
             return;
         }
 
-        void prefetchCurrentPageMedia(currentPosts);
+        if (!postMediaCacheService.canUsePersistentCache()) {
+            return;
+        }
+
+        const urls = collectPostHistoryMediaUrls(currentPosts);
+        if (urls.length === 0) {
+            return;
+        }
+
+        void Promise.resolve(
+            postMediaCacheService.prefetchCachedMediaDescriptors(urls),
+        ).catch(() => {
+            // Media descriptor prefetch is best-effort and must not block listing updates.
+        });
+    });
+
+    onDestroy(() => {
+        loadRequestId += 1;
+        mediaPrefetchReady = false;
     });
 
     $effect(() => {

--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -617,6 +617,7 @@ export function usePostHistoryListing({
     let loadRequestId = 0;
     let hasCompletedFirstPostPaint = false;
     let mediaPrefetchReady = $state(false);
+    let firstPaintPubkeyKey = $state<string | null>(null);
     let totalCountRequestId = 0;
     let currentTotalCountRequest:
         | { requestId: number; pubkeyHex: string; promise: Promise<void> }
@@ -812,21 +813,30 @@ export function usePostHistoryListing({
             && requestId === loadRequestId;
     }
 
+    function resetFirstPostPaintState(): void {
+        hasCompletedFirstPostPaint = false;
+        mediaPrefetchReady = false;
+        firstPaintPubkeyKey = null;
+    }
+
     async function waitForFirstPostPaint(
         pubkeyHex: string,
-        requestId: number,
+        isCurrent: () => boolean,
+        hasPosts: () => boolean,
     ): Promise<boolean> {
         await tick();
-        if (!isCurrentPostHistoryLoad(pubkeyHex, requestId)) {
+        if (!isCurrent()) {
             return false;
         }
 
         if (hasCompletedFirstPostPaint) {
+            firstPaintPubkeyKey = resolveListingSnapshotKey(pubkeyHex);
             return true;
         }
 
-        if (state.loadedPosts.length === 0) {
+        if (!hasPosts()) {
             hasCompletedFirstPostPaint = true;
+            firstPaintPubkeyKey = resolveListingSnapshotKey(pubkeyHex);
             mediaPrefetchReady = true;
             return true;
         }
@@ -834,11 +844,12 @@ export function usePostHistoryListing({
         await new Promise<void>((resolve) => {
             requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
         });
-        if (!isCurrentPostHistoryLoad(pubkeyHex, requestId)) {
+        if (!isCurrent()) {
             return false;
         }
 
         hasCompletedFirstPostPaint = true;
+        firstPaintPubkeyKey = resolveListingSnapshotKey(pubkeyHex);
         mediaPrefetchReady = true;
         return true;
     }
@@ -926,6 +937,7 @@ export function usePostHistoryListing({
         searchLoadRequestId += 1;
         isSearchPageLoading = false;
         postHistoryLocalSearchService.clearCache?.();
+        resetFirstPostPaintState();
         state.searchInput = "";
         state.searchQuery = "";
         state.searchPage = 1;
@@ -1774,7 +1786,11 @@ export function usePostHistoryListing({
         state.listingMode = "contiguous";
         state.sparseSource = null;
         state.loadedPosts = latestPosts;
-        if (!await waitForFirstPostPaint(pubkeyHex, requestId)) {
+        if (!await waitForFirstPostPaint(
+            pubkeyHex,
+            () => isCurrentPostHistoryLoad(pubkeyHex, requestId),
+            () => state.loadedPosts.length > 0,
+        )) {
             return;
         }
         if (!skipTotalCountRefresh) {
@@ -1856,7 +1872,11 @@ export function usePostHistoryListing({
         }
 
         state.loadedPosts = nextPosts;
-        if (!await waitForFirstPostPaint(pubkeyHex, requestId)) {
+        if (!await waitForFirstPostPaint(
+            pubkeyHex,
+            () => isCurrentPostHistoryLoad(pubkeyHex, requestId),
+            () => state.loadedPosts.length > 0,
+        )) {
             return;
         }
         if (!skipTotalCountRefresh) {
@@ -1919,7 +1939,11 @@ export function usePostHistoryListing({
 
         state.hasNewerLocal = newerPosts.length > 0;
         state.hasOlderLocal = olderPosts.length > 0;
-        if (!await waitForFirstPostPaint(pubkeyHex, requestId)) {
+        if (!await waitForFirstPostPaint(
+            pubkeyHex,
+            () => isCurrentPostHistoryLoad(pubkeyHex, requestId),
+            () => state.loadedPosts.length > 0,
+        )) {
             return;
         }
         refreshTotalCountFromRepository();
@@ -1988,7 +2012,11 @@ export function usePostHistoryListing({
         }
 
         state.loadedPosts = restoredPosts;
-        if (!await waitForFirstPostPaint(pubkeyHex, requestId)) {
+        if (!await waitForFirstPostPaint(
+            pubkeyHex,
+            () => isCurrentPostHistoryLoad(pubkeyHex, requestId),
+            () => state.loadedPosts.length > 0,
+        )) {
             return false;
         }
         refreshTotalCountFromRepository();
@@ -2439,9 +2467,11 @@ export function usePostHistoryListing({
     function isCurrentSearchLoad(
         requestId: number,
         query: string,
+        pubkeyHex: string,
     ): boolean {
         return getShow()
             && requestId === searchLoadRequestId
+            && getPubkeyHex() === pubkeyHex
             && query === state.searchQuery;
     }
 
@@ -2462,7 +2492,7 @@ export function usePostHistoryListing({
             pageSize,
         });
 
-        return isCurrentSearchLoad(requestId, query) ? result : null;
+        return isCurrentSearchLoad(requestId, query, pubkeyHex) ? result : null;
     }
 
     async function loadSearchPage(page: number, query: string): Promise<boolean> {
@@ -2502,6 +2532,15 @@ export function usePostHistoryListing({
                 : mergeSearchPageResults(state.searchPosts, result.items);
             state.searchPage = safePage;
             state.searchHasNext = result.hasNext;
+            if (!hasCompletedFirstPostPaint) {
+                if (!await waitForFirstPostPaint(
+                    pubkeyHex,
+                    () => isCurrentSearchLoad(requestId, query, pubkeyHex),
+                    () => state.searchPosts.length > 0,
+                )) {
+                    return false;
+                }
+            }
             return true;
         } finally {
             if (requestId === searchLoadRequestId) {
@@ -2514,6 +2553,10 @@ export function usePostHistoryListing({
         page: number,
         query: string,
     ): Promise<boolean> {
+        const pubkeyHex = getPubkeyHex();
+        if (!pubkeyHex || !query) {
+            return false;
+        }
         const normalizedPage = Math.max(1, Math.trunc(page));
         const requestId = ++searchLoadRequestId;
         isSearchPageLoading = true;
@@ -2550,6 +2593,15 @@ export function usePostHistoryListing({
             state.searchTotalCount = firstPage.total;
             state.searchPage = lastPage;
             state.searchHasNext = lastResult.hasNext;
+            if (!hasCompletedFirstPostPaint) {
+                if (!await waitForFirstPostPaint(
+                    pubkeyHex,
+                    () => isCurrentSearchLoad(requestId, query, pubkeyHex),
+                    () => state.searchPosts.length > 0,
+                )) {
+                    return false;
+                }
+            }
             return true;
         } finally {
             if (requestId === searchLoadRequestId) {
@@ -3598,6 +3650,7 @@ export function usePostHistoryListing({
         }
 
         activePubkeyKey = nextPubkeyKey;
+        resetFirstPostPaintState();
         stateOwnerPubkeyKey = null;
         forceLatestInitialLoadKey = nextPubkeyKey;
         cancelCurrentSync();
@@ -3763,12 +3816,13 @@ export function usePostHistoryListing({
             return;
         }
 
-        hasCompletedFirstPostPaint = false;
-        mediaPrefetchReady = false;
+        resetFirstPostPaintState();
     });
 
     $effect(() => {
-        if (!getShow() || !mediaPrefetchReady) {
+        if (!getShow()
+            || !mediaPrefetchReady
+            || firstPaintPubkeyKey !== resolveListingSnapshotKey(getPubkeyHex())) {
             return;
         }
 
@@ -3795,6 +3849,8 @@ export function usePostHistoryListing({
 
     onDestroy(() => {
         loadRequestId += 1;
+        searchLoadRequestId += 1;
+        firstPaintPubkeyKey = null;
         mediaPrefetchReady = false;
     });
 
@@ -3804,6 +3860,8 @@ export function usePostHistoryListing({
         }
 
         if (!state.searchQuery) {
+            const wasSearchMode = appliedSearchQuery !== "";
+            resetFirstPostPaintState();
             searchLoadRequestId += 1;
             isSearchPageLoading = false;
             postHistoryLocalSearchService.clearCache?.();
@@ -3811,16 +3869,37 @@ export function usePostHistoryListing({
             searchResultsInitialized = false;
             if (state.searchPage !== 1) {
                 state.searchPage = 1;
+                if (wasSearchMode) {
+                    const pubkeyHex = getPubkeyHex();
+                    if (pubkeyHex) {
+                        void waitForFirstPostPaint(
+                            pubkeyHex,
+                            () => isCurrentPostHistoryLoad(pubkeyHex, loadRequestId),
+                            () => state.loadedPosts.length > 0,
+                        );
+                    }
+                }
                 return;
             }
 
             state.searchPosts = [];
             state.searchTotalCount = 0;
             state.searchHasNext = false;
+            if (wasSearchMode) {
+                const pubkeyHex = getPubkeyHex();
+                if (pubkeyHex) {
+                    void waitForFirstPostPaint(
+                        pubkeyHex,
+                        () => isCurrentPostHistoryLoad(pubkeyHex, loadRequestId),
+                        () => state.loadedPosts.length > 0,
+                    );
+                }
+            }
             return;
         }
 
         if (state.searchQuery !== appliedSearchQuery) {
+            resetFirstPostPaintState();
             if (appliedSearchQuery === "" && state.searchPosts.length === 0) {
                 state.searchPosts = state.loadedPosts;
             }

--- a/src/test/unit/postHistoryDialog.test.ts
+++ b/src/test/unit/postHistoryDialog.test.ts
@@ -535,6 +535,31 @@ function wait(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function controlAnimationFrames() {
+    let nextId = 1;
+    const callbacks = new Map<number, FrameRequestCallback>();
+    const requestAnimationFrameSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback: FrameRequestCallback) => {
+            const id = nextId++;
+            callbacks.set(id, callback);
+            return id;
+        });
+
+    return {
+        async flushFrame(): Promise<void> {
+            const pending = [...callbacks.values()];
+            callbacks.clear();
+            pending.forEach((callback) => callback(0));
+            await Promise.resolve();
+            await Promise.resolve();
+        },
+        restore(): void {
+            requestAnimationFrameSpy.mockRestore();
+        },
+    };
+}
+
 function createMockRect(top: number, height: number): DOMRect {
     return {
         x: 0,
@@ -1100,7 +1125,93 @@ describe('PostHistoryDialog', () => {
         deferredPosts.resolve([post]);
         await findHistoryItem(post.eventId);
 
-        expect(repositoryMock.countForPubkey).toHaveBeenCalledWith('a'.repeat(64));
+        await waitFor(() => {
+            expect(repositoryMock.countForPubkey).toHaveBeenCalledWith('a'.repeat(64));
+        });
+    });
+
+    it('[first-paint-order] 2回目の animation frame 後まで補助処理と media prefetch を開始しない', async () => {
+        const animationFrames = controlAnimationFrames();
+        const post = createRecord({
+            content: '初回 paint 後に補助処理を開始する投稿',
+        });
+        repositoryMock.getPage.mockResolvedValue([post]);
+
+        try {
+            render(PostHistoryDialog, {
+                props: {
+                    show: true,
+                    onClose: vi.fn(),
+                    pubkeyHex: 'a'.repeat(64),
+                },
+            });
+
+            await findHistoryItem(post.eventId);
+            expect(repositoryMock.countForPubkey).not.toHaveBeenCalled();
+            expect(repositoryMock.getNewerVisibleChunk).not.toHaveBeenCalled();
+            expect(repositoryMock.getOlderVisibleChunk).not.toHaveBeenCalled();
+            expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors).not.toHaveBeenCalled();
+
+            await animationFrames.flushFrame();
+            expect(repositoryMock.countForPubkey).not.toHaveBeenCalled();
+            expect(repositoryMock.getNewerVisibleChunk).not.toHaveBeenCalled();
+            expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors).not.toHaveBeenCalled();
+
+            await animationFrames.flushFrame();
+            await waitFor(() => {
+                expect(repositoryMock.countForPubkey).toHaveBeenCalledWith('a'.repeat(64));
+                expect(repositoryMock.getNewerVisibleChunk).toHaveBeenCalled();
+                expect(repositoryMock.getOlderVisibleChunk).toHaveBeenCalled();
+                expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors).toHaveBeenCalledTimes(1);
+            });
+        } finally {
+            animationFrames.restore();
+        }
+    });
+
+    it('[first-paint-stale] close または pubkey 切替後に古い初回 load の補助処理を開始しない', async () => {
+        const animationFrames = controlAnimationFrames();
+        const firstPubkey = 'a'.repeat(64);
+        const secondPubkey = 'b'.repeat(64);
+        const post = createRecord({ content: 'stale 初回 load', media: [] });
+        repositoryMock.getPage.mockResolvedValue([post]);
+
+        try {
+            const view = render(PostHistoryDialog, {
+                props: {
+                    show: true,
+                    onClose: vi.fn(),
+                    pubkeyHex: firstPubkey,
+                },
+            });
+            await findHistoryItem(post.eventId);
+
+            await view.rerender({
+                show: false,
+                onClose: vi.fn(),
+                pubkeyHex: firstPubkey,
+            });
+            await animationFrames.flushFrame();
+            await animationFrames.flushFrame();
+            expect(repositoryMock.countForPubkey).not.toHaveBeenCalled();
+
+            await view.rerender({
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: secondPubkey,
+            });
+            await waitFor(() => {
+                expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalledTimes(2);
+            });
+            await animationFrames.flushFrame();
+            await animationFrames.flushFrame();
+            await waitFor(() => {
+                expect(repositoryMock.countForPubkey).toHaveBeenCalledWith(secondPubkey);
+            });
+            expect(repositoryMock.countForPubkey).not.toHaveBeenCalledWith(firstPubkey);
+        } finally {
+            animationFrames.restore();
+        }
     });
 
     it('[count-survives-window-move] 古い投稿の表示中でも開始済みの総件数を適用する', async () => {
@@ -3752,10 +3863,12 @@ describe('PostHistoryDialog', () => {
             },
         });
 
-        await openPostActionMenu();
         await waitFor(() => {
             expect(screen.getByText('open refresh中の親投稿')).toBeTruthy();
             expect(screen.getByText('リレーと同期中...')).toBeTruthy();
+        });
+        await openPostActionMenu();
+        await waitFor(() => {
             expect(screen.getByRole('menuitem', { name: '返信を確認' })).toBeTruthy();
         });
 
@@ -4662,7 +4775,9 @@ describe('PostHistoryDialog', () => {
 
         expect(screen.queryByText('返信')).toBeNull();
         expect(screen.queryByText('自分の返信')).toBeNull();
-        expect(screen.getByText('1件')).toBeTruthy();
+        await waitFor(() => {
+            expect(screen.getByText('1件')).toBeTruthy();
+        });
         expect(repositoryMock.upsertFetchedEvents).not.toHaveBeenCalled();
         expect(replyEventsRepositoryMock.upsertDirectReplies).toHaveBeenCalledWith(expect.objectContaining({
             parentEventId: '1'.repeat(64),

--- a/src/test/unit/postHistoryDialog.test.ts
+++ b/src/test/unit/postHistoryDialog.test.ts
@@ -1214,6 +1214,85 @@ describe('PostHistoryDialog', () => {
         }
     });
 
+    it('[first-paint-pubkey-switch] 表示中の pubkey 切替でも新しい投稿の double RAF 後に補助処理を開始する', async () => {
+        const animationFrames = controlAnimationFrames();
+        const firstPubkey = 'a'.repeat(64);
+        const secondPubkey = 'b'.repeat(64);
+        const firstPost = createRecord({
+            eventId: 'first-paint-pubkey-a',
+            content: 'pubkey A の投稿',
+            pubkeyHex: firstPubkey,
+            media: [{ url: 'https://example.com/pubkey-a.jpg', mimeType: 'image/jpeg' }],
+        });
+        const secondPost = createRecord({
+            eventId: 'first-paint-pubkey-b',
+            content: 'pubkey B の投稿',
+            pubkeyHex: secondPubkey,
+            media: [{ url: 'https://example.com/pubkey-b.jpg', mimeType: 'image/jpeg' }],
+        });
+        const staleFirstCount = createDeferred<number>();
+        repositoryMock.countForPubkey.mockImplementation((pubkeyHex: string) =>
+            pubkeyHex === firstPubkey ? staleFirstCount.promise : Promise.resolve(1));
+        repositoryMock.getPage
+            .mockResolvedValueOnce([firstPost])
+            .mockResolvedValueOnce([secondPost]);
+
+        try {
+            const view = render(PostHistoryDialog, {
+                props: {
+                    show: true,
+                    onClose: vi.fn(),
+                    pubkeyHex: firstPubkey,
+                },
+            });
+
+            await findHistoryItem(firstPost.eventId);
+            await animationFrames.flushFrame();
+            await animationFrames.flushFrame();
+            await waitFor(() => {
+                expect(repositoryMock.countForPubkey).toHaveBeenCalledWith(firstPubkey);
+            });
+
+            repositoryMock.countForPubkey.mockClear();
+            repositoryMock.getNewerVisibleChunk.mockClear();
+            repositoryMock.getOlderVisibleChunk.mockClear();
+            postMediaCacheServiceMock.prefetchCachedMediaDescriptors.mockClear();
+
+            await view.rerender({
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: secondPubkey,
+            });
+            await findHistoryItem(secondPost.eventId);
+
+            expect(repositoryMock.countForPubkey).not.toHaveBeenCalled();
+            expect(repositoryMock.getNewerVisibleChunk).not.toHaveBeenCalled();
+            expect(repositoryMock.getOlderVisibleChunk).not.toHaveBeenCalled();
+            expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors).not.toHaveBeenCalled();
+
+            await animationFrames.flushFrame();
+            expect(repositoryMock.countForPubkey).not.toHaveBeenCalled();
+            expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors).not.toHaveBeenCalled();
+
+            await animationFrames.flushFrame();
+            await waitFor(() => {
+                expect(repositoryMock.countForPubkey).toHaveBeenCalledWith(secondPubkey);
+                expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors)
+                    .toHaveBeenCalledTimes(1);
+                expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors)
+                    .toHaveBeenCalledWith(['https://example.com/pubkey-b.jpg']);
+            });
+            expect(repositoryMock.countForPubkey).not.toHaveBeenCalledWith(firstPubkey);
+            staleFirstCount.resolve(99);
+            await waitFor(() => {
+                expect(screen.getByText('1件')).toBeTruthy();
+            });
+            view.unmount();
+        } finally {
+            animationFrames.restore();
+        }
+    });
+
     it('[count-survives-window-move] 古い投稿の表示中でも開始済みの総件数を適用する', async () => {
         const latestPost = createRecord({
             eventId: '1'.repeat(64),

--- a/src/test/unit/postHistoryDialogTestHarness.ts
+++ b/src/test/unit/postHistoryDialogTestHarness.ts
@@ -384,6 +384,10 @@ export async function waitForSearchDebounce(): Promise<void> {
 }
 
 export function resetPostHistoryDialogHarness(): void {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+    });
     postHistoryLightweightSyncCoordinator.cancelOwnerTasks(PUBKEY_HEX);
     clearPersistedPostHistoryListingSnapshots();
     clearPersistedPostHistoryViewState();

--- a/src/test/unit/postHistoryDialogTimeline.test.ts
+++ b/src/test/unit/postHistoryDialogTimeline.test.ts
@@ -950,7 +950,9 @@ describe('PostHistoryDialog timeline navigation', () => {
         expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalledTimes(1);
         expect(repositoryMock.getSparseChunk).not.toHaveBeenCalled();
         expect(repositoryMock.getVisibleChunkAroundEventId).not.toHaveBeenCalled();
-        expect(repositoryMock.countForPubkey).toHaveBeenCalledTimes(1);
+        await waitFor(() => {
+            expect(repositoryMock.countForPubkey).toHaveBeenCalledTimes(1);
+        });
         expect(repositoryMock.hasPostsBeforeCreatedAt).toHaveBeenCalledWith(
             PUBKEY_HEX,
             1_000,
@@ -1053,7 +1055,9 @@ describe('PostHistoryDialog timeline navigation', () => {
         expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalledTimes(1);
         expect(repositoryMock.getVisibleChunkFromCreatedAt).not.toHaveBeenCalled();
         expect(repositoryMock.getVisibleChunkAroundEventId).not.toHaveBeenCalled();
-        expect(repositoryMock.countForPubkey).toHaveBeenCalledTimes(1);
+        await waitFor(() => {
+            expect(repositoryMock.countForPubkey).toHaveBeenCalledTimes(1);
+        });
 
         view.unmount();
     });
@@ -1197,7 +1201,9 @@ describe('PostHistoryDialog timeline navigation', () => {
         expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalledTimes(1);
         expect(repositoryMock.getSparseChunk).not.toHaveBeenCalled();
         expect(repositoryMock.getVisibleChunkAroundEventId).not.toHaveBeenCalled();
-        expect(repositoryMock.countForPubkey).toHaveBeenCalledTimes(1);
+        await waitFor(() => {
+            expect(repositoryMock.countForPubkey).toHaveBeenCalledTimes(1);
+        });
         expect(localSearchServiceMock.searchLocalPosts).not.toHaveBeenCalled();
 
         view.unmount();
@@ -1338,7 +1344,9 @@ describe('PostHistoryDialog timeline navigation', () => {
         expect(repositoryMock.getSparseChunk).not.toHaveBeenCalled();
         expect(repositoryMock.getVisibleChunkAroundEventId).not.toHaveBeenCalled();
         expect(repositoryMock.getVisibleChunkFromCreatedAt).not.toHaveBeenCalled();
-        expect(repositoryMock.countForPubkey).toHaveBeenCalledTimes(1);
+        await waitFor(() => {
+            expect(repositoryMock.countForPubkey).toHaveBeenCalledTimes(1);
+        });
         expect(localSearchServiceMock.searchLocalPosts).not.toHaveBeenCalled();
 
         view.unmount();

--- a/src/test/unit/postHistoryDialogTimeline.test.ts
+++ b/src/test/unit/postHistoryDialogTimeline.test.ts
@@ -1723,7 +1723,9 @@ describe('PostHistoryDialog timeline navigation', () => {
         );
         expect(repositoryMock.getSparseChunk).not.toHaveBeenCalled();
         expect(repositoryMock.getVisibleChunkAroundEventId).not.toHaveBeenCalled();
-        expect(repositoryMock.countForPubkey).toHaveBeenCalledWith(otherPubkeyHex);
+        await waitFor(() => {
+            expect(repositoryMock.countForPubkey).toHaveBeenCalledWith(otherPubkeyHex);
+        });
 
         view.unmount();
     });

--- a/src/test/unit/postHistoryDialogTimelineRelay.test.ts
+++ b/src/test/unit/postHistoryDialogTimelineRelay.test.ts
@@ -867,6 +867,9 @@ describe('PostHistoryDialog timeline relay flows', () => {
         });
 
         await waitFor(() => {
+            expect(relayFetchServiceMock.fetchLatest).toHaveBeenCalled();
+        });
+        await waitFor(() => {
             expect(screen.queryByText('リレーと同期中...')).toBeNull();
         });
 
@@ -1055,6 +1058,9 @@ describe('PostHistoryDialog timeline relay flows', () => {
             },
         });
 
+        await waitFor(() => {
+            expect(relayFetchServiceMock.fetchLatest).toHaveBeenCalled();
+        });
         await waitFor(() => {
             expect(screen.queryByText('リレーと同期中...')).toBeNull();
         });
@@ -1255,6 +1261,7 @@ describe('PostHistoryDialog timeline relay flows', () => {
         });
 
         await waitFor(() => {
+            expect(relayFetchServiceMock.fetchLatest).toHaveBeenCalled();
             expect(screen.queryByText('リレーと同期中...')).toBeNull();
         });
         await clickEnabledMenuAction('表示中の投稿付近を再取得');

--- a/src/test/unit/postHistoryDialogTimelineSearch.test.ts
+++ b/src/test/unit/postHistoryDialogTimelineSearch.test.ts
@@ -44,6 +44,32 @@ function controlAnimationFrames() {
     };
 }
 
+async function persistSearchSnapshot(
+    query: string,
+    post: ReturnType<typeof createRecord>,
+): Promise<void> {
+    localSearchServiceMock.searchLocalPosts.mockResolvedValue({
+        items: [post],
+        total: 1,
+        hasNext: false,
+    });
+    const view = render(PostHistoryDialog, {
+        props: {
+            show: true,
+            onClose: vi.fn(),
+            pubkeyHex: PUBKEY_HEX,
+        },
+    });
+    const searchInput = await openSearchBar();
+    await fireEvent.input(searchInput, { target: { value: query } });
+    await waitForSearchDebounce();
+    await waitFor(() => {
+        expect(screen.getByText(String(post.content))).toBeTruthy();
+    });
+    await fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
+    view.unmount();
+}
+
 describe('PostHistoryDialog timeline search', () => {
     beforeEach(() => {
         resetPostHistoryDialogHarness();
@@ -586,7 +612,6 @@ describe('PostHistoryDialog timeline search', () => {
             });
             expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors).not.toHaveBeenCalled();
 
-            restoredSearchRequest.resolve(searchResult);
             await waitFor(() => {
                 expect(localSearchServiceMock.searchLocalPosts).toHaveBeenCalled();
             });
@@ -604,7 +629,177 @@ describe('PostHistoryDialog timeline search', () => {
                 expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors)
                     .toHaveBeenCalledWith([mediaUrl]);
             });
+
+            restoredSearchRequest.resolve(searchResult);
+            await waitFor(() => {
+                expect(screen.getByText('保存済み検索結果')).toBeTruthy();
+            });
+            expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors)
+                .toHaveBeenCalledTimes(1);
             secondView.unmount();
+        } finally {
+            animationFrames.restore();
+        }
+    });
+
+    it('保存済み検索snapshotのdouble RAF中にquery変更・closeを行うと古いprefetchを開始しない', async () => {
+        postMediaCacheServiceMock.canUsePersistentCache.mockReturnValue(true);
+        const alphaUrl = 'https://example.com/snapshot-alpha.jpg';
+        const alphaPost = createRecord({
+            eventId: 'snapshot-alpha',
+            content: 'snapshot alpha',
+            media: [{ url: alphaUrl, mimeType: 'image/jpeg' }],
+        });
+        await persistSearchSnapshot('alpha', alphaPost);
+
+        const alphaRequest = createDeferred<{
+            items: ReturnType<typeof createRecord>[];
+            total: number;
+            hasNext: boolean;
+        }>();
+        localSearchServiceMock.searchLocalPosts.mockReturnValue(alphaRequest.promise);
+        postMediaCacheServiceMock.prefetchCachedMediaDescriptors.mockClear();
+        const animationFrames = controlAnimationFrames();
+        try {
+            const view = render(PostHistoryDialog, {
+                props: {
+                    show: true,
+                    onClose: vi.fn(),
+                    pubkeyHex: PUBKEY_HEX,
+                },
+            });
+            await waitFor(() => expect(screen.getByText('snapshot alpha')).toBeTruthy());
+            await waitFor(() => {
+                expect(localSearchServiceMock.searchLocalPosts).toHaveBeenCalled();
+            });
+            await Promise.resolve();
+            await Promise.resolve();
+            await Promise.resolve();
+            await animationFrames.flushFrame();
+
+            const searchInput = await openSearchBar();
+            await fireEvent.input(searchInput, { target: { value: 'beta' } });
+            await waitForSearchDebounce();
+            await animationFrames.flushFrame();
+            expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors).not.toHaveBeenCalled();
+
+            await view.rerender({
+                show: false,
+                onClose: vi.fn(),
+                pubkeyHex: PUBKEY_HEX,
+            });
+            await animationFrames.flushFrame();
+            expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors).not.toHaveBeenCalled();
+            alphaRequest.resolve({ items: [alphaPost], total: 1, hasNext: false });
+            view.unmount();
+        } finally {
+            animationFrames.restore();
+        }
+    });
+
+    it('保存済み検索snapshotのdouble RAF中にpubkeyを変更すると旧pubkeyのprefetchを開始しない', async () => {
+        postMediaCacheServiceMock.canUsePersistentCache.mockReturnValue(true);
+        const alphaPost = createRecord({
+            eventId: 'snapshot-pubkey-alpha',
+            content: 'snapshot pubkey alpha',
+            media: [{ url: 'https://example.com/snapshot-pubkey-alpha.jpg', mimeType: 'image/jpeg' }],
+        });
+        await persistSearchSnapshot('alpha', alphaPost);
+
+        const alphaRequest = createDeferred<{
+            items: ReturnType<typeof createRecord>[];
+            total: number;
+            hasNext: boolean;
+        }>();
+        localSearchServiceMock.searchLocalPosts.mockReturnValue(alphaRequest.promise);
+        postMediaCacheServiceMock.prefetchCachedMediaDescriptors.mockClear();
+        const animationFrames = controlAnimationFrames();
+        try {
+            const view = render(PostHistoryDialog, {
+                props: {
+                    show: true,
+                    onClose: vi.fn(),
+                    pubkeyHex: PUBKEY_HEX,
+                },
+            });
+            await waitFor(() => expect(screen.getByText('snapshot pubkey alpha')).toBeTruthy());
+            await waitFor(() => {
+                expect(localSearchServiceMock.searchLocalPosts).toHaveBeenCalled();
+            });
+            await Promise.resolve();
+            await Promise.resolve();
+            await Promise.resolve();
+            await animationFrames.flushFrame();
+
+            await view.rerender({
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: 'b'.repeat(64),
+            });
+            await animationFrames.flushFrame();
+            expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors).not.toHaveBeenCalled();
+            alphaRequest.resolve({ items: [alphaPost], total: 1, hasNext: false });
+            view.unmount();
+        } finally {
+            animationFrames.restore();
+        }
+    });
+
+    it('保存済み検索snapshotの再構築結果が異なるmedia URLなら現在結果だけを追加prefetchする', async () => {
+        postMediaCacheServiceMock.canUsePersistentCache.mockReturnValue(true);
+        const oldUrl = 'https://example.com/snapshot-old.jpg';
+        const newUrl = 'https://example.com/snapshot-new.jpg';
+        const oldPost = createRecord({
+            eventId: 'snapshot-old',
+            content: 'snapshot old',
+            media: [{ url: oldUrl, mimeType: 'image/jpeg' }],
+        });
+        const newPost = createRecord({
+            eventId: 'snapshot-new',
+            content: 'snapshot new',
+            media: [{ url: newUrl, mimeType: 'image/jpeg' }],
+        });
+        await persistSearchSnapshot('alpha', oldPost);
+
+        const rebuiltRequest = createDeferred<{
+            items: ReturnType<typeof createRecord>[];
+            total: number;
+            hasNext: boolean;
+        }>();
+        localSearchServiceMock.searchLocalPosts.mockReturnValue(rebuiltRequest.promise);
+        postMediaCacheServiceMock.prefetchCachedMediaDescriptors.mockClear();
+        const animationFrames = controlAnimationFrames();
+        try {
+            const view = render(PostHistoryDialog, {
+                props: {
+                    show: true,
+                    onClose: vi.fn(),
+                    pubkeyHex: PUBKEY_HEX,
+                },
+            });
+            await waitFor(() => expect(screen.getByText('snapshot old')).toBeTruthy());
+            await waitFor(() => {
+                expect(localSearchServiceMock.searchLocalPosts).toHaveBeenCalled();
+            });
+            await Promise.resolve();
+            await Promise.resolve();
+            await Promise.resolve();
+            await animationFrames.flushFrame();
+            await animationFrames.flushFrame();
+            await waitFor(() => {
+                expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors)
+                    .toHaveBeenCalledWith([oldUrl]);
+            });
+
+            rebuiltRequest.resolve({ items: [newPost], total: 1, hasNext: false });
+            await waitFor(() => {
+                expect(screen.getByText('snapshot new')).toBeTruthy();
+                expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors)
+                    .toHaveBeenCalledWith([newUrl]);
+            });
+            expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors)
+                .toHaveBeenCalledTimes(2);
+            view.unmount();
         } finally {
             animationFrames.restore();
         }

--- a/src/test/unit/postHistoryDialogTimelineSearch.test.ts
+++ b/src/test/unit/postHistoryDialogTimelineSearch.test.ts
@@ -19,6 +19,31 @@ import {
 } from './postHistoryDialogTestHarness';
 import { readPersistedPostHistoryViewState } from '../../lib/postHistoryDialogViewState';
 
+function controlAnimationFrames() {
+    let nextId = 1;
+    const callbacks = new Map<number, FrameRequestCallback>();
+    const requestAnimationFrameSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback: FrameRequestCallback) => {
+            const id = nextId++;
+            callbacks.set(id, callback);
+            return id;
+        });
+
+    return {
+        async flushFrame(): Promise<void> {
+            const pending = [...callbacks.values()];
+            callbacks.clear();
+            pending.forEach((callback) => callback(0));
+            await Promise.resolve();
+            await Promise.resolve();
+        },
+        restore(): void {
+            requestAnimationFrameSpy.mockRestore();
+        },
+    };
+}
+
 describe('PostHistoryDialog timeline search', () => {
     beforeEach(() => {
         resetPostHistoryDialogHarness();
@@ -509,6 +534,80 @@ describe('PostHistoryDialog timeline search', () => {
         });
 
         view.unmount();
+    });
+
+    it('保存済み検索結果を再表示した場合も double RAF 後に media prefetch を一度だけ実行する', async () => {
+        postMediaCacheServiceMock.canUsePersistentCache.mockReturnValue(true);
+        const mediaUrl = 'https://example.com/restored-search.jpg';
+        const savedSearchPost = createRecord({
+            eventId: 'restored-search-media',
+            content: '保存済み検索結果',
+            media: [{ url: mediaUrl, mimeType: 'image/jpeg' }],
+        });
+        const searchResult = {
+            items: [savedSearchPost],
+            total: 1,
+            hasNext: false,
+        };
+        repositoryMock.getLatestVisibleChunk.mockResolvedValue([]);
+        localSearchServiceMock.searchLocalPosts.mockResolvedValue(searchResult);
+
+        const firstView = render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: PUBKEY_HEX,
+            },
+        });
+        const searchInput = await openSearchBar();
+        await fireEvent.input(searchInput, { target: { value: 'restored' } });
+        await waitForSearchDebounce();
+        await waitFor(() => {
+            expect(screen.getByText('保存済み検索結果')).toBeTruthy();
+        });
+        await fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
+        firstView.unmount();
+
+        postMediaCacheServiceMock.prefetchCachedMediaDescriptors.mockClear();
+        const animationFrames = controlAnimationFrames();
+        try {
+            const restoredSearchRequest = createDeferred<typeof searchResult>();
+            localSearchServiceMock.searchLocalPosts.mockReturnValue(restoredSearchRequest.promise);
+            const secondView = render(PostHistoryDialog, {
+                props: {
+                    show: true,
+                    onClose: vi.fn(),
+                    pubkeyHex: PUBKEY_HEX,
+                },
+            });
+
+            await waitFor(() => {
+                expect(screen.getByText('保存済み検索結果')).toBeTruthy();
+            });
+            expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors).not.toHaveBeenCalled();
+
+            restoredSearchRequest.resolve(searchResult);
+            await waitFor(() => {
+                expect(localSearchServiceMock.searchLocalPosts).toHaveBeenCalled();
+            });
+            await Promise.resolve();
+            await Promise.resolve();
+            await Promise.resolve();
+
+            await animationFrames.flushFrame();
+            expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors).not.toHaveBeenCalled();
+
+            await animationFrames.flushFrame();
+            await waitFor(() => {
+                expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors)
+                    .toHaveBeenCalledTimes(1);
+                expect(postMediaCacheServiceMock.prefetchCachedMediaDescriptors)
+                    .toHaveBeenCalledWith([mediaUrl]);
+            });
+            secondView.unmount();
+        } finally {
+            animationFrames.restore();
+        }
     });
 
     it('検索中の古い側移動は relay older fetch を呼ばずローカル検索ページだけ進める', async () => {


### PR DESCRIPTION
## Summary

- 初回投稿の描画完了後まで件数更新・タイムライン処理・メディア先読みを遅延
- ダイアログ終了や公開鍵切り替え時に古いロードの補助処理を抑止
- 初回描画順序と stale load の回帰テストを追加
- 非同期タイミングに合わせて既存テストの待機処理を調整

## Testing

- Not run (not requested)