### PR TITLE
Fix post history loading empty state

### DIFF
--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -88,6 +88,7 @@
     };
 
     const POST_HISTORY_REACTION_CUSTOM_EMOJI_SIZE = 18;
+    const POST_HISTORY_LIST_LOADING_DELAY_MS = 200;
 
     interface Props {
         show: boolean;
@@ -277,6 +278,7 @@
     let showImageFullscreen = $state(false);
     let historyContainer = $state<HTMLDivElement | null>(null);
     let searchInputElement = $state<HTMLInputElement | null>(null);
+    let showDelayedListLoading = $state(false);
     const previewCollapse = usePostHistoryPreviewCollapse({
         getShow: () => show,
         getPosts: () => history.posts,
@@ -373,6 +375,17 @@
     );
     let canUseJumpToOldest = $derived(
         history.canJumpToOldest || !historyViewport.isHistoryScrolledToBottom,
+    );
+    let isHistoryListLoading = $derived(
+        history.isSearchMode
+            ? history.searchResultStatus === "loading"
+            : history.initialLocalLoadStatus === "loading",
+    );
+    let canShowEmptyHistoryState = $derived(
+        history.posts.length === 0
+        && (history.isSearchMode
+            ? history.searchResultStatus === "ready"
+            : history.initialLocalLoadStatus === "ready"),
     );
 
     function addRelatedPreviewModel(
@@ -545,6 +558,24 @@
         }
 
         resetDialogState();
+    });
+
+    $effect(() => {
+        if (!show || !isHistoryListLoading) {
+            showDelayedListLoading = false;
+            return;
+        }
+
+        showDelayedListLoading = false;
+        const timeoutId = setTimeout(() => {
+            if (show && isHistoryListLoading) {
+                showDelayedListLoading = true;
+            }
+        }, POST_HISTORY_LIST_LOADING_DELAY_MS);
+
+        return () => {
+            clearTimeout(timeoutId);
+        };
     });
 
     onDestroy(() => {
@@ -1753,8 +1784,17 @@
         class="post-history-container"
         bind:this={historyContainer}
         onscroll={historyViewport.handleHistoryScroll}
+        aria-busy={isHistoryListLoading ? "true" : "false"}
     >
-        {#if history.posts.length === 0}
+        {#if history.posts.length === 0 && showDelayedListLoading}
+            <div class="post-history-list-loading" aria-hidden="true">
+                <LoadingPlaceholder
+                    variant="spinner"
+                    showLoader={true}
+                    loaderSize={24}
+                />
+            </div>
+        {:else if canShowEmptyHistoryState}
             <div class="empty-state">
                 <div class="empty-message">
                     {history.isSearchMode
@@ -3429,6 +3469,12 @@
         gap: 8px;
         min-height: 100px;
         align-content: center;
+    }
+
+    .post-history-list-loading {
+        display: grid;
+        min-height: 100px;
+        place-items: center;
     }
 
     .empty-message {

--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -2539,6 +2539,12 @@ export function usePostHistoryListing({
                 pageSize,
             );
             if (safePage !== normalizedPage) {
+                if (
+                    requestId === searchLoadRequestId
+                    && isCurrentSearchLoad(requestId, query, pubkeyHex)
+                ) {
+                    searchResultStatus = "ready";
+                }
                 return false;
             }
 
@@ -3926,6 +3932,8 @@ export function usePostHistoryListing({
     onDestroy(() => {
         loadRequestId += 1;
         searchLoadRequestId += 1;
+        initialLocalLoadGeneration += 1;
+        initialLocalLoadStatus = "idle";
         firstPaintPubkeyKey = null;
         mediaPrefetchReady = false;
     });

--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -79,6 +79,12 @@ export type PostHistoryTotalCountStatus =
     | "refreshing"
     | "failed";
 
+export type PostHistoryLocalLoadStatus =
+    | "idle"
+    | "loading"
+    | "ready"
+    | "failed";
+
 type PostHistoryListingMode = "contiguous" | "sparse";
 type PostHistorySparseSource = "jump" | "saved" | null;
 
@@ -625,9 +631,12 @@ export function usePostHistoryListing({
         | null = null;
     let searchLoadRequestId = 0;
     let isSearchPageLoading = $state(false);
+    let searchResultStatus = $state<PostHistoryLocalLoadStatus>("idle");
     let hasStartedInitialSync = false;
     let hasAttemptedInitialLocalLoad = false;
     let initialLocalLoadKey: string | null = null;
+    let initialLocalLoadStatus = $state<PostHistoryLocalLoadStatus>("idle");
+    let initialLocalLoadGeneration = 0;
     let activePubkeyKey = resolveListingSnapshotKey(getPubkeyHex());
     let stateOwnerPubkeyKey = $state<string | null>(activePubkeyKey);
     let forceLatestInitialLoadKey: string | null = null;
@@ -938,6 +947,7 @@ export function usePostHistoryListing({
     function resetSearchState(): void {
         searchLoadRequestId += 1;
         isSearchPageLoading = false;
+        searchResultStatus = "idle";
         postHistoryLocalSearchService.clearCache?.();
         resetFirstPostPaintState();
         state.searchInput = "";
@@ -1035,6 +1045,7 @@ export function usePostHistoryListing({
         loadRequestId += 1;
         searchLoadRequestId += 1;
         isSearchPageLoading = false;
+        searchResultStatus = "idle";
     }
 
     function prepareForClose(): boolean {
@@ -1063,6 +1074,8 @@ export function usePostHistoryListing({
         hasStartedInitialSync = false;
         hasAttemptedInitialLocalLoad = false;
         initialLocalLoadKey = null;
+        initialLocalLoadGeneration += 1;
+        initialLocalLoadStatus = "idle";
         searchResultsInitialized = false;
     }
 
@@ -2509,6 +2522,7 @@ export function usePostHistoryListing({
         const requestId = ++searchLoadRequestId;
         const normalizedPage = Math.max(1, Math.trunc(page));
         isSearchPageLoading = true;
+        searchResultStatus = "loading";
         try {
             const result = await fetchSearchPage(
                 normalizedPage,
@@ -2534,6 +2548,7 @@ export function usePostHistoryListing({
                 : mergeSearchPageResults(state.searchPosts, result.items);
             state.searchPage = safePage;
             state.searchHasNext = result.hasNext;
+            searchResultStatus = "ready";
             if (!hasCompletedFirstPostPaint) {
                 if (!await waitForFirstPostPaint(
                     pubkeyHex,
@@ -2544,6 +2559,11 @@ export function usePostHistoryListing({
                 }
             }
             return true;
+        } catch {
+            if (requestId === searchLoadRequestId) {
+                searchResultStatus = "failed";
+            }
+            return false;
         } finally {
             if (requestId === searchLoadRequestId) {
                 isSearchPageLoading = false;
@@ -2562,6 +2582,7 @@ export function usePostHistoryListing({
         }
         const normalizedPage = Math.max(1, Math.trunc(page));
         isSearchPageLoading = true;
+        searchResultStatus = "loading";
 
         try {
             const firstPage = await fetchSearchPage(1, query, requestId);
@@ -2595,6 +2616,7 @@ export function usePostHistoryListing({
             state.searchTotalCount = firstPage.total;
             state.searchPage = lastPage;
             state.searchHasNext = lastResult.hasNext;
+            searchResultStatus = "ready";
             if (!hasCompletedFirstPostPaint) {
                 if (!await waitForFirstPostPaint(
                     pubkeyHex,
@@ -2605,6 +2627,11 @@ export function usePostHistoryListing({
                 }
             }
             return true;
+        } catch {
+            if (requestId === searchLoadRequestId) {
+                searchResultStatus = "failed";
+            }
+            return false;
         } finally {
             if (requestId === searchLoadRequestId) {
                 isSearchPageLoading = false;
@@ -3645,6 +3672,38 @@ export function usePostHistoryListing({
         state.searchPosts = applyDeletedState(state.searchPosts);
     }
 
+    function startInitialLocalLoad(load: () => Promise<unknown>): void {
+        const pubkeyHex = getPubkeyHex();
+        const pubkeyKey = resolveListingSnapshotKey(pubkeyHex);
+        if (!pubkeyHex || !pubkeyKey) {
+            return;
+        }
+
+        const generation = ++initialLocalLoadGeneration;
+        initialLocalLoadStatus = "loading";
+        void load()
+            .then(() => {
+                if (
+                    getShow()
+                    && getPubkeyHex() === pubkeyHex
+                    && initialLocalLoadKey === pubkeyKey
+                    && generation === initialLocalLoadGeneration
+                ) {
+                    initialLocalLoadStatus = "ready";
+                }
+            })
+            .catch(() => {
+                if (
+                    getShow()
+                    && getPubkeyHex() === pubkeyHex
+                    && initialLocalLoadKey === pubkeyKey
+                    && generation === initialLocalLoadGeneration
+                ) {
+                    initialLocalLoadStatus = "failed";
+                }
+            });
+    }
+
     $effect(() => {
         const nextPubkeyKey = resolveListingSnapshotKey(getPubkeyHex());
         if (nextPubkeyKey === activePubkeyKey) {
@@ -3666,6 +3725,8 @@ export function usePostHistoryListing({
         hasStartedInitialSync = false;
         hasAttemptedInitialLocalLoad = false;
         initialLocalLoadKey = null;
+        initialLocalLoadGeneration += 1;
+        initialLocalLoadStatus = "idle";
     });
 
     $effect(() => {
@@ -3757,6 +3818,9 @@ export function usePostHistoryListing({
         }
 
         const nextSearchQuery = state.searchInput.trim();
+        if (nextSearchQuery !== state.searchQuery) {
+            searchResultStatus = "loading";
+        }
         const timeoutId = setTimeout(() => {
             state.searchQuery = nextSearchQuery;
         }, searchDebounceMs);
@@ -3784,7 +3848,7 @@ export function usePostHistoryListing({
 
         if (forceLatestInitialLoadKey === nextInitialLoadKey) {
             forceLatestInitialLoadKey = null;
-            void loadLatestVisiblePosts();
+            startInitialLocalLoad(loadLatestVisiblePosts);
             return;
         }
 
@@ -3793,24 +3857,28 @@ export function usePostHistoryListing({
             consumePostHistoryShouldReturnToLatestAfterLocalPost(getPubkeyHex());
         if (shouldApplyPendingLatestRequest(pendingLatestRequest, sessionScrollState)) {
             onSessionScrollStateInvalidated();
-            void loadLatestVisiblePosts();
+            startInitialLocalLoad(loadLatestVisiblePosts);
             return;
         }
 
         if (canPreserveSessionVisibleWindow(sessionScrollState)) {
-            void refreshPreservedVisibleWindow(
-                sessionScrollState,
-                pendingLatestRequest,
+            startInitialLocalLoad(() =>
+                refreshPreservedVisibleWindow(
+                    sessionScrollState,
+                    pendingLatestRequest,
+                ),
             );
             return;
         }
 
         if (sessionScrollState) {
-            void loadVisibleWindowAroundSessionAnchor(sessionScrollState);
+            startInitialLocalLoad(() =>
+                loadVisibleWindowAroundSessionAnchor(sessionScrollState),
+            );
             return;
         }
 
-        void loadLatestVisiblePosts();
+        startInitialLocalLoad(loadLatestVisiblePosts);
     });
 
     $effect(() => {
@@ -3872,6 +3940,7 @@ export function usePostHistoryListing({
             resetFirstPostPaintState();
             searchLoadRequestId += 1;
             isSearchPageLoading = false;
+            searchResultStatus = "idle";
             postHistoryLocalSearchService.clearCache?.();
             appliedSearchQuery = "";
             searchResultsInitialized = false;
@@ -4031,6 +4100,12 @@ export function usePostHistoryListing({
         },
         get isSearchPageLoading() {
             return isSearchPageLoading;
+        },
+        get searchResultStatus() {
+            return searchResultStatus;
+        },
+        get initialLocalLoadStatus() {
+            return initialLocalLoadStatus;
         },
         get canRefetchAroundCurrentView() {
             return canRefetchAroundCurrentView;

--- a/src/test/unit/postHistoryDialog.test.ts
+++ b/src/test/unit/postHistoryDialog.test.ts
@@ -1081,6 +1081,155 @@ describe('PostHistoryDialog', () => {
         });
     });
 
+    it('[initial-local-load] IndexedDB 読込中は空状態を表示しない', async () => {
+        const deferredPosts = createDeferred<any[]>();
+        repositoryMock.getLatestVisibleChunk.mockReturnValue(deferredPosts.promise);
+
+        render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: 'a'.repeat(64),
+            },
+        });
+
+        await waitFor(() => {
+            expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalled();
+        });
+        expect(screen.queryByText('投稿履歴はありません')).toBeNull();
+
+        deferredPosts.resolve([]);
+        await waitFor(() => {
+            expect(screen.getByText('投稿履歴はありません')).toBeTruthy();
+        });
+    });
+
+    it('[initial-local-load] 200ms 未満で完了した読込は loading 表示を出さない', async () => {
+        vi.useFakeTimers();
+        const deferredPosts = createDeferred<any[]>();
+        repositoryMock.getLatestVisibleChunk.mockReturnValue(deferredPosts.promise);
+
+        render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: 'a'.repeat(64),
+            },
+        });
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(screen.queryByText('投稿履歴はありません')).toBeNull();
+        expect(document.querySelector('.post-history-list-loading')).toBeNull();
+
+        deferredPosts.resolve([]);
+        await vi.advanceTimersByTimeAsync(199);
+        expect(document.querySelector('.post-history-list-loading')).toBeNull();
+        expect(screen.getByText('投稿履歴はありません')).toBeTruthy();
+    });
+
+    it('[initial-local-load] 読込失敗を空状態として表示しない', async () => {
+        repositoryMock.getLatestVisibleChunk.mockRejectedValue(new Error('IndexedDB read failed'));
+
+        render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: 'a'.repeat(64),
+            },
+        });
+
+        await waitFor(() => {
+            expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalled();
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(screen.queryByText('投稿履歴はありません')).toBeNull();
+    });
+
+    it('[search-empty] 現在の検索 request が完了するまで空状態を表示しない', async () => {
+        const post = createRecord({ content: '検索前に表示する投稿' });
+        const deferredSearch = createDeferred<{
+            items: any[];
+            total: number;
+            hasNext: boolean;
+        }>();
+        repositoryMock.getPage.mockResolvedValue([post]);
+        localSearchServiceMock.searchLocalPosts.mockReturnValue(deferredSearch.promise);
+
+        render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: 'a'.repeat(64),
+            },
+        });
+        await findHistoryItem(post.eventId);
+
+        const searchInput = await openSearchBar();
+        await fireEvent.input(searchInput, { target: { value: '一致しない検索語' } });
+        await waitFor(() => {
+            expect(localSearchServiceMock.searchLocalPosts).toHaveBeenCalled();
+        });
+        expect(screen.queryByText('一致する投稿はありません')).toBeNull();
+
+        deferredSearch.resolve({ items: [], total: 0, hasNext: false });
+        await waitFor(() => {
+            expect(screen.getByText('一致する投稿はありません')).toBeTruthy();
+        });
+    });
+
+    it('[search-empty] 次の検索語の debounce 中は前の0件結果を表示しない', async () => {
+        const post = createRecord({ content: 'debounce 検索前の投稿' });
+        repositoryMock.getPage.mockResolvedValue([post]);
+        localSearchServiceMock.searchLocalPosts.mockResolvedValue({
+            items: [],
+            total: 0,
+            hasNext: false,
+        });
+
+        render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: 'a'.repeat(64),
+            },
+        });
+        await findHistoryItem(post.eventId);
+
+        const searchInput = await openSearchBar();
+        await fireEvent.input(searchInput, { target: { value: '最初の検索語' } });
+        await waitFor(() => {
+            expect(screen.getByText('一致する投稿はありません')).toBeTruthy();
+        });
+
+        await fireEvent.input(searchInput, { target: { value: '次の検索語' } });
+        expect(screen.queryByText('一致する投稿はありません')).toBeNull();
+    });
+
+    it('[search-empty] 検索失敗を空状態として表示しない', async () => {
+        const post = createRecord({ content: '検索失敗前に表示する投稿' });
+        repositoryMock.getPage.mockResolvedValue([post]);
+        localSearchServiceMock.searchLocalPosts.mockRejectedValue(new Error('search failed'));
+
+        render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: 'a'.repeat(64),
+            },
+        });
+        await findHistoryItem(post.eventId);
+
+        const searchInput = await openSearchBar();
+        await fireEvent.input(searchInput, { target: { value: '失敗する検索語' } });
+        await waitFor(() => {
+            expect(localSearchServiceMock.searchLocalPosts).toHaveBeenCalled();
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(screen.queryByText('一致する投稿はありません')).toBeNull();
+    });
+
     it('[first-post-before-count] 総件数の完了を待たずに最新投稿を表示する', async () => {
         const post = createRecord({ content: '件数より先に表示する投稿' });
         const deferredCount = createDeferred<number>();

--- a/src/test/unit/postHistoryDialog.test.ts
+++ b/src/test/unit/postHistoryDialog.test.ts
@@ -508,11 +508,13 @@ function createRecord(overrides: Record<string, any> = {}) {
 
 function createDeferred<T>() {
     let resolve!: (value: T) => void;
-    const promise = new Promise<T>((resolvePromise) => {
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
         resolve = resolvePromise;
+        reject = rejectPromise;
     });
 
-    return { promise, resolve };
+    return { promise, resolve, reject };
 }
 
 function createQuoteNoteUri(eventId: string): string {
@@ -1144,6 +1146,52 @@ describe('PostHistoryDialog', () => {
         await Promise.resolve();
         await Promise.resolve();
         expect(screen.queryByText('投稿履歴はありません')).toBeNull();
+        expect(document.querySelector('.post-history-list-loading')).toBeNull();
+        expect(document.querySelector('.post-history-container')?.getAttribute('aria-busy')).toBe('false');
+    });
+
+    it('[initial-local-load] unmount 後の遅延読込 resolve は状態を適用しない', async () => {
+        const deferredPosts = createDeferred<any[]>();
+        repositoryMock.getLatestVisibleChunk.mockReturnValue(deferredPosts.promise);
+
+        const view = render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: 'a'.repeat(64),
+            },
+        });
+        await waitFor(() => {
+            expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalled();
+        });
+
+        view.unmount();
+        deferredPosts.resolve([]);
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(document.querySelector('.post-history-container')).toBeNull();
+    });
+
+    it('[initial-local-load] unmount 後の遅延読込 reject は状態を適用せず未処理拒否を残さない', async () => {
+        const deferredPosts = createDeferred<any[]>();
+        repositoryMock.getLatestVisibleChunk.mockReturnValue(deferredPosts.promise);
+
+        const view = render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: 'a'.repeat(64),
+            },
+        });
+        await waitFor(() => {
+            expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalled();
+        });
+
+        view.unmount();
+        deferredPosts.reject(new Error('late IndexedDB read failure'));
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(document.querySelector('.post-history-container')).toBeNull();
     });
 
     it('[search-empty] 現在の検索 request が完了するまで空状態を表示しない', async () => {

--- a/src/test/unit/postHistoryDialogTimelineSearch.test.ts
+++ b/src/test/unit/postHistoryDialogTimelineSearch.test.ts
@@ -143,6 +143,80 @@ describe('PostHistoryDialog timeline search', () => {
         view.unmount();
     });
 
+    it('存在しない検索ページの結果では表示・ページ状態を維持し、loadingを解除する', async () => {
+        vi.useFakeTimers();
+        const secondPage = createDeferred<{
+            items: ReturnType<typeof createRecord>[];
+            total: number;
+            hasNext: boolean;
+        }>();
+        localSearchServiceMock.searchLocalPosts.mockImplementation(
+            ({ page }: { page: number }) => page === 1
+                ? Promise.resolve({
+                    items: [createRecord({ eventId: 'missing-page-1', content: '検索1ページ目' })],
+                    total: 51,
+                    hasNext: true,
+                })
+                : secondPage.promise,
+        );
+
+        const view = render(PostHistoryDialog, {
+            props: { show: true, onClose: vi.fn(), pubkeyHex: PUBKEY_HEX },
+        });
+        const searchInput = await openSearchBar();
+        await fireEvent.input(searchInput, { target: { value: 'alpha' } });
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.advanceTimersByTimeAsync(0);
+        await waitFor(() => {
+            expect(screen.getByText('検索1ページ目')).toBeTruthy();
+            expect(screen.getByRole('button', { name: 'さらに古い検索結果を表示' })).toBeTruthy();
+        });
+
+        await fireEvent.click(screen.getByRole('button', { name: 'さらに古い検索結果を表示' }));
+        expect(getHistoryContainer().getAttribute('aria-busy')).toBe('true');
+
+        secondPage.resolve({
+            items: [createRecord({ eventId: 'missing-page-2', content: '存在しないページの結果' })],
+            total: 1,
+            hasNext: false,
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        await waitFor(() => {
+            expect(screen.getByText('検索1ページ目')).toBeTruthy();
+            expect(screen.queryByText('存在しないページの結果')).toBeNull();
+            expect(getHistoryContainer().getAttribute('aria-busy')).toBe('false');
+        });
+
+        await vi.advanceTimersByTimeAsync(200);
+        expect(document.querySelector('.post-history-list-loading')).toBeNull();
+        expect(screen.getByRole('button', { name: 'さらに古い検索結果を表示' })).toBeTruthy();
+        view.unmount();
+    });
+
+    it('200ms超の初回ローカル読込だけspinnerを表示し、完了後に解除する', async () => {
+        vi.useFakeTimers();
+        const deferredPosts = createDeferred<ReturnType<typeof createRecord>[]>();
+        repositoryMock.getLatestVisibleChunk.mockReturnValue(deferredPosts.promise);
+
+        const view = render(PostHistoryDialog, {
+            props: { show: true, onClose: vi.fn(), pubkeyHex: PUBKEY_HEX },
+        });
+
+        await vi.advanceTimersByTimeAsync(200);
+        expect(document.querySelector('.post-history-list-loading')).not.toBeNull();
+        expect(getHistoryContainer().getAttribute('aria-busy')).toBe('true');
+
+        deferredPosts.resolve([]);
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.runAllTicks();
+        expect(screen.getByText('投稿履歴はありません')).toBeTruthy();
+        expect(document.querySelector('.post-history-list-loading')).toBeNull();
+        expect(getHistoryContainer().getAttribute('aria-busy')).toBe('false');
+
+        view.unmount();
+        vi.clearAllTimers();
+    });
+
     it('インポート後は読み込み済み検索範囲を先頭から再構築する', async () => {
         const existingPosts = Array.from({ length: 51 }, (_, index) =>
             createRecord({


### PR DESCRIPTION
## 概要

初回のローカル投稿履歴読込中に、実際にはデータがあるにもかかわらず「投稿履歴はありません」と一瞬表示される問題を修正します。

- 初回ローカル読込と検索に成功・進行中・失敗の状態を追加
- 現在の読込／検索が成功して0件の場合のみ空状態を表示
- 200msを超える読込だけ控えめなspinnerを表示し、リストに `aria-busy` を付与
- debounce、stale結果、close、pubkey変更、失敗時に誤った空状態を出さない

段階描画は、production build上の同条件比較を実証できなかったため採用していません。既存の50件取得・timeline・relay・repair・scroll契約は維持しています。

## 検証

- `npx vitest run src/test/unit/postHistoryDialog.test.ts` (86 passed)
- `npm run check`
- `npm test` (306 files / 3342 tests)
- `npx playwright test src/test/e2e/postHistoryDialog.spec.ts --project=desktop-chromium --project=mobile-chromium` (20 passed, 10 expected skips)
- `npm run build`
- `git diff --check`