### PR TITLE
Refresh inline spinner styling

### DIFF
--- a/src/components/LoadingPlaceholder.svelte
+++ b/src/components/LoadingPlaceholder.svelte
@@ -137,14 +137,50 @@
     }
 
     .inline-spinner {
+        --spinner-stroke: clamp(2px, calc(var(--loader-size) * 0.09), 3.5px);
+        position: relative;
         display: block;
+        flex: 0 0 var(--loader-size);
         width: var(--loader-size);
         height: var(--loader-size);
-        border: max(2px, calc(var(--loader-size) * 0.1)) solid currentColor;
-        border-right-color: transparent;
         border-radius: 50%;
-        animation: inline-spinner-rotate 0.8s linear infinite;
         box-sizing: border-box;
+        color: currentColor;
+        animation: inline-spinner-rotate 1.1s linear infinite;
+    }
+
+    .inline-spinner::before,
+    .inline-spinner::after {
+        position: absolute;
+        inset: 0;
+        display: block;
+        border-radius: inherit;
+        content: "";
+    }
+
+    .inline-spinner::before {
+        border: var(--spinner-stroke) solid currentColor;
+        opacity: 0.24;
+    }
+
+    .inline-spinner::after {
+        background: conic-gradient(
+            from -28deg,
+            transparent 0deg,
+            color-mix(in srgb, currentColor 28%, transparent) 26deg,
+            currentColor 88deg,
+            transparent 116deg
+        );
+        mask: radial-gradient(
+            farthest-side,
+            transparent calc(100% - var(--spinner-stroke)),
+            #000 calc(100% - var(--spinner-stroke) + 0.5px)
+        );
+        -webkit-mask: radial-gradient(
+            farthest-side,
+            transparent calc(100% - var(--spinner-stroke)),
+            #000 calc(100% - var(--spinner-stroke) + 0.5px)
+        );
     }
 
     @keyframes inline-spinner-rotate {

--- a/src/components/LoadingPlaceholder.svelte
+++ b/src/components/LoadingPlaceholder.svelte
@@ -137,50 +137,78 @@
     }
 
     .inline-spinner {
-        --spinner-stroke: clamp(2px, calc(var(--loader-size) * 0.09), 3.5px);
+        --spinner-width: clamp(
+            3.5px,
+            calc(var(--loader-size) * 0.16),
+            6px
+        );
+        --spinner-track-opacity: 0.12;
+        --spinner-arc-opacity: 0.64;
+
         position: relative;
         display: block;
-        flex: 0 0 var(--loader-size);
         width: var(--loader-size);
         height: var(--loader-size);
+        flex: 0 0 auto;
+        color: currentColor;
         border-radius: 50%;
         box-sizing: border-box;
-        color: currentColor;
-        animation: inline-spinner-rotate 1.1s linear infinite;
-    }
-
-    .inline-spinner::before,
-    .inline-spinner::after {
-        position: absolute;
-        inset: 0;
-        display: block;
-        border-radius: inherit;
-        content: "";
     }
 
     .inline-spinner::before {
-        border: var(--spinner-stroke) solid currentColor;
-        opacity: 0.24;
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        border: var(--spinner-width) solid currentColor;
+        opacity: var(--spinner-track-opacity);
+        box-sizing: border-box;
     }
 
     .inline-spinner::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
         background: conic-gradient(
-            from -28deg,
+            from -80deg,
             transparent 0deg,
-            color-mix(in srgb, currentColor 28%, transparent) 26deg,
-            currentColor 88deg,
-            transparent 116deg
-        );
-        mask: radial-gradient(
-            farthest-side,
-            transparent calc(100% - var(--spinner-stroke)),
-            #000 calc(100% - var(--spinner-stroke) + 0.5px)
+            transparent 210deg,
+            currentColor 300deg,
+            currentColor 360deg
         );
         -webkit-mask: radial-gradient(
             farthest-side,
-            transparent calc(100% - var(--spinner-stroke)),
-            #000 calc(100% - var(--spinner-stroke) + 0.5px)
+            transparent calc(100% - var(--spinner-width)),
+            #000 calc(100% - var(--spinner-width) + 0.5px)
         );
+        mask: radial-gradient(
+            farthest-side,
+            transparent calc(100% - var(--spinner-width)),
+            #000 calc(100% - var(--spinner-width) + 0.5px)
+        );
+        opacity: var(--spinner-arc-opacity);
+        animation: inline-spinner-rotate
+            900ms
+            cubic-bezier(0.55, 0.15, 0.45, 0.85)
+            infinite;
+        transform-origin: center;
+    }
+
+    :global(:root.dark) .inline-spinner {
+        --spinner-track-opacity: 0.14;
+        --spinner-arc-opacity: 0.72;
+    }
+
+    :global(html body :where(.primary, .danger)) .inline-spinner {
+        --spinner-track-opacity: 0.18;
+        --spinner-arc-opacity: 0.82;
+    }
+
+    :global(html body :where(.secondary, .warning)) .inline-spinner,
+    :global(:root.light body :where(.header)) .inline-spinner {
+        --spinner-track-opacity: 0.12;
+        --spinner-arc-opacity: 0.64;
     }
 
     @keyframes inline-spinner-rotate {
@@ -276,8 +304,9 @@
             transform: translate(-25%, -25%) scale(1) rotate(0deg);
         }
 
-        .inline-spinner {
+        .inline-spinner::after {
             animation: none;
+            transform: rotate(35deg);
         }
     }
 </style>


### PR DESCRIPTION
## 変更概要
`LoadingPlaceholder.svelte` の `variant="spinner"` をCSSのみで刷新し、背景に応じてトラックと円弧の濃度を調整しました。

## デザインとCSS実装
- `.inline-spinner` 本体と既存の疑似要素だけを使用
- `::before` に静止トラック、`::after` に短い円弧を実装
- 指定の`conic-gradient`、`radial-gradient`マスク、900msの自然な回転を使用
- 標準`mask`と`-webkit-mask`の両方を設定
- `currentColor`を維持し、線幅を`--loader-size`に応じて`clamp()`で調整
- 通常背景、darkテーマ、primary/danger、secondary/warning・light headerで不透明度のみを上書き
- reduced motionでは回転を停止し、35度の静止状態を維持

## 維持した既存挙動
- JavaScript/TypeScript、Svelteテンプレート、公開API、ARIA属性を変更していません
- `--loader-size`、number/string指定、`.inline-spinner`、表示条件を維持しています
- デフォルトの四角形ローダーとローディングテキストは変更していません
- 表示領域の幅・高さを指定サイズに固定し、周囲のレイアウトを維持しています

## 検証
- `vitest run src/test/unit/loadingPlaceholder.test.ts` — 2 tests passed
- `npm run check` — 0 errors, 0 warnings
- `npm test` — 306 files / 3351 tests passed
- 実ブラウザ（Viteハーネス、Chromium）で計算値を確認: 通常`0.12/0.64`、dark`0.14/0.72`、primary`0.18/0.82`、secondary`0.12/0.64`
- 実ブラウザで24pxのレイアウトサイズ維持を確認

## 未実行の検証
- iOS Safari/Android Chromeの実端末確認は、この環境から実端末へ接続できないため未実行です。