### PR TITLE
Fix failed account switch rollback

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -681,8 +681,8 @@
       rxNostr = next;
     },
     disposeNostrSession,
-    clearNip46RuntimeForAuthChange,
     nip46Service,
+    parentClientService: parentClientAuthService,
     accountManager,
     restoreManagedAccountSession,
     restoreAccount: (pubkeyHex, type) =>

--- a/src/lib/accountManager.ts
+++ b/src/lib/accountManager.ts
@@ -55,6 +55,10 @@ export class AccountManager {
         this.saveActiveAccountPubkey(pubkeyHex);
     }
 
+    clearActiveAccount(): void {
+        this.clearActiveAccountPubkey();
+    }
+
     addAccount(pubkeyHex: string, type: StoredAccount['type']): void {
         const accounts = this.getAccounts();
         const existing = accounts.find(a => a.pubkeyHex === pubkeyHex);

--- a/src/lib/appAccountSessionController.ts
+++ b/src/lib/appAccountSessionController.ts
@@ -22,7 +22,9 @@ interface ParentClientRuntimeController {
 
 interface AccountManagerLike {
     getAccountType: (pubkeyHex: string) => ManagedAccountType | null;
+    hasAccount: (pubkeyHex: string) => boolean;
     setActiveAccount: (pubkeyHex: string) => void;
+    getActiveAccountPubkey: () => string | null;
     clearActiveAccount: () => void;
 }
 
@@ -162,8 +164,13 @@ export function createAppAccountSessionController(
 
     function commitActiveAccount(pubkeyHex: string): boolean {
         try {
+            if (!deps.accountManager.hasAccount(pubkeyHex)) {
+                return false;
+            }
+
             deps.accountManager.setActiveAccount(pubkeyHex);
-            return true;
+            return deps.accountManager.hasAccount(pubkeyHex)
+                && deps.accountManager.getActiveAccountPubkey() === pubkeyHex;
         } catch {
             deps.logger.error('アクティブアカウントの保存に失敗しました');
             return false;

--- a/src/lib/appAccountSessionController.ts
+++ b/src/lib/appAccountSessionController.ts
@@ -1,3 +1,5 @@
+import type { ManagedAccountSessionRestoreResult } from './appAuthUtils';
+
 type ManagedAccountType = 'nsec' | 'nip07' | 'nip46' | 'parentClient';
 
 type LogoutAccountOptions = {
@@ -14,9 +16,14 @@ interface Nip46RuntimeController {
     disconnect: () => Promise<void>;
 }
 
+interface ParentClientRuntimeController {
+    disconnect: (notifyParent?: boolean) => void;
+}
+
 interface AccountManagerLike {
     getAccountType: (pubkeyHex: string) => ManagedAccountType | null;
     setActiveAccount: (pubkeyHex: string) => void;
+    clearActiveAccount: () => void;
 }
 
 interface ProfileGuestSnapshot {
@@ -32,6 +39,15 @@ interface AuthStateSnapshot {
     pubkey?: string;
 }
 
+function isManagedAccountType(
+    type: string | undefined,
+): type is ManagedAccountType {
+    return type === 'nsec'
+        || type === 'nip07'
+        || type === 'nip46'
+        || type === 'parentClient';
+}
+
 export interface AppAccountSessionControllerDependencies {
     getIsSwitchingAccount(): boolean;
     setIsSwitchingAccount(next: boolean): void;
@@ -42,26 +58,18 @@ export interface AppAccountSessionControllerDependencies {
     getCurrentRxNostr(): unknown;
     setCurrentRxNostr(next: undefined): void;
     disposeNostrSession(session: unknown): undefined;
-    clearNip46RuntimeForAuthChange(params: {
-        currentAuthType?: string;
-        currentPubkeyHex?: string | null;
-        nextAuthType: ManagedAccountType;
-        nextPubkeyHex?: string | null;
-        nip46Service: Nip46RuntimeController;
-    }): Promise<void>;
     nip46Service: Nip46RuntimeController;
+    parentClientService: ParentClientRuntimeController;
     accountManager: AccountManagerLike;
     restoreManagedAccountSession(params: {
-        pubkeyHex: string;
-        accountManager: AccountManagerLike;
+        requestedPubkeyHex: string;
+        accountType: ManagedAccountType;
         restoreAccount: (
             pubkeyHex: string,
             type: ManagedAccountType,
         ) => Promise<{ hasAuth: boolean; pubkeyHex?: string }>;
         handlePostAuth: (pubkeyHex: string) => Promise<void>;
-        onMissingAccountType: () => void;
-        onRestoreFailure: () => void;
-    }): Promise<boolean>;
+    }): Promise<ManagedAccountSessionRestoreResult>;
     restoreAccount(
         pubkeyHex: string,
         type: ManagedAccountType,
@@ -94,6 +102,74 @@ export interface AppAccountSessionController {
 export function createAppAccountSessionController(
     deps: AppAccountSessionControllerDependencies,
 ): AppAccountSessionController {
+    async function runCleanupStep(action: () => void | Promise<void>): Promise<void> {
+        try {
+            await action();
+        } catch {
+            deps.logger.error('アカウント切替のruntime cleanupに失敗しました');
+        }
+    }
+
+    async function disposeSession(session: unknown): Promise<void> {
+        try {
+            await deps.disposeNostrSession(session);
+        } catch {
+            deps.logger.error('アカウント切替のNostr runtime cleanupに失敗しました');
+        } finally {
+            deps.setCurrentRxNostr(undefined);
+        }
+    }
+
+    async function cleanupRuntime(
+        authType: string | undefined,
+        session: unknown,
+    ): Promise<void> {
+        if (authType === 'nip46') {
+            await runCleanupStep(() => deps.nip46Service.disconnect());
+        } else if (authType === 'parentClient') {
+            await runCleanupStep(() => deps.parentClientService.disconnect(false));
+        }
+
+        await disposeSession(session);
+        await runCleanupStep(() => deps.clearAuthState());
+    }
+
+    async function convergeToGuest(): Promise<void> {
+        await cleanupRuntime(
+            deps.getAuthStateSnapshot()?.type,
+            deps.getCurrentRxNostr(),
+        );
+        await runCleanupStep(() => deps.accountManager.clearActiveAccount());
+        deps.setGuestProfile({
+            name: '',
+            displayName: '',
+            picture: '',
+            npub: '',
+            nprofile: '',
+        });
+        deps.setProfileLoaded(false);
+
+        try {
+            await deps.initializeNostr();
+        } catch {
+            deps.logger.error('ゲストruntimeの初期化に失敗しました');
+            await disposeSession(deps.getCurrentRxNostr());
+        } finally {
+            deps.setSecretKey('');
+            deps.setErrorMessage('');
+        }
+    }
+
+    function commitActiveAccount(pubkeyHex: string): boolean {
+        try {
+            deps.accountManager.setActiveAccount(pubkeyHex);
+            return true;
+        } catch {
+            deps.logger.error('アクティブアカウントの保存に失敗しました');
+            return false;
+        }
+    }
+
     async function switchAccount(pubkeyHex: string): Promise<boolean> {
         if (deps.getIsSwitchingAccount()) {
             return false;
@@ -101,37 +177,78 @@ export function createAppAccountSessionController(
 
         deps.setIsSwitchingAccount(true);
         deps.setProfileLoading(false);
+        let transactionStarted = false;
 
         try {
             const currentAuth = deps.getAuthStateSnapshot();
-            const nextAccountType = deps.accountManager.getAccountType(pubkeyHex);
+            const currentRuntime = deps.getCurrentRxNostr();
+            const targetAccountType = deps.accountManager.getAccountType(pubkeyHex);
+            const rollbackPubkeyHex = isManagedAccountType(currentAuth?.type)
+                && currentAuth?.pubkey
+                ? currentAuth.pubkey
+                : null;
+            const rollbackAccountType = rollbackPubkeyHex
+                ? deps.accountManager.getAccountType(rollbackPubkeyHex)
+                : null;
 
-            if (nextAccountType) {
-                await deps.clearNip46RuntimeForAuthChange({
-                    currentAuthType: currentAuth?.type,
-                    currentPubkeyHex: currentAuth?.pubkey,
-                    nextAuthType: nextAccountType,
-                    nextPubkeyHex: pubkeyHex,
-                    nip46Service: deps.nip46Service,
-                });
+            if (!targetAccountType) {
+                deps.logger.error('アカウントタイプが見つかりません:', pubkeyHex);
+                return false;
             }
 
-            deps.setCurrentRxNostr(deps.disposeNostrSession(deps.getCurrentRxNostr()));
+            transactionStarted = true;
+            await cleanupRuntime(currentAuth?.type, currentRuntime);
 
-            return await deps.restoreManagedAccountSession({
-                pubkeyHex,
-                accountManager: deps.accountManager,
+            const targetRestore = await deps.restoreManagedAccountSession({
+                requestedPubkeyHex: pubkeyHex,
+                accountType: targetAccountType,
                 restoreAccount: deps.restoreAccount,
                 handlePostAuth: deps.handlePostAuth,
-                onMissingAccountType: () => {
-                    deps.logger.error('アカウントタイプが見つかりません:', pubkeyHex);
-                },
-                onRestoreFailure: () => {
-                    deps.logger.error('アカウント復元に失敗:', pubkeyHex);
-                },
             });
+
+            if (targetRestore.success && commitActiveAccount(targetRestore.pubkeyHex)) {
+                return true;
+            }
+
+            deps.logger.error(
+                'アカウント復元に失敗:',
+                targetRestore.success ? 'active-pointer-commit-failed' : targetRestore.reason,
+            );
+            await cleanupRuntime(targetAccountType, deps.getCurrentRxNostr());
+
+            let rollbackAttempted = false;
+            if (rollbackPubkeyHex && rollbackAccountType) {
+                rollbackAttempted = true;
+                const rollbackRestore = await deps.restoreManagedAccountSession({
+                    requestedPubkeyHex: rollbackPubkeyHex,
+                    accountType: rollbackAccountType,
+                    restoreAccount: deps.restoreAccount,
+                    handlePostAuth: deps.handlePostAuth,
+                });
+
+                if (rollbackRestore.success && commitActiveAccount(rollbackRestore.pubkeyHex)) {
+                    return true;
+                }
+
+                deps.logger.error(
+                    'アカウントrollbackに失敗:',
+                    rollbackRestore.success
+                        ? 'active-pointer-commit-failed'
+                        : rollbackRestore.reason,
+                );
+                await cleanupRuntime(rollbackAccountType, deps.getCurrentRxNostr());
+            }
+
+            if (!rollbackAttempted) {
+                deps.logger.error('アカウントrollbackの対象がありません');
+            }
+            await convergeToGuest();
+            return false;
         } catch (error) {
             deps.logger.error('アカウント切替中にエラー:', error);
+            if (transactionStarted) {
+                await convergeToGuest();
+            }
             return false;
         } finally {
             deps.setIsSwitchingAccount(false);

--- a/src/lib/appAuthUtils.ts
+++ b/src/lib/appAuthUtils.ts
@@ -7,11 +7,6 @@ type DisposableSession = {
 
 type ManagedAccountType = 'nsec' | 'nip07' | 'nip46' | 'parentClient';
 
-interface ManagedAccountController {
-    setActiveAccount: (pubkeyHex: string) => void;
-    getAccountType: (pubkeyHex: string) => ManagedAccountType | null;
-}
-
 interface Nip46RuntimeController {
     disconnect: () => Promise<void>;
 }
@@ -150,31 +145,49 @@ export function resolveLogoutAccountAction(nextPubkey: string | null | undefined
     return { kind: 'keep-current' };
 }
 
+export type ManagedAccountSessionRestoreResult =
+    | { success: true; pubkeyHex: string }
+    | {
+        success: false;
+        reason: 'restore-failed' | 'missing-pubkey' | 'pubkey-mismatch' | 'post-auth-failed';
+    };
+
 export async function restoreManagedAccountSession(params: {
-    pubkeyHex: string;
-    accountManager: ManagedAccountController;
+    requestedPubkeyHex: string;
+    accountType: ManagedAccountType;
     restoreAccount: (
         pubkeyHex: string,
         type: ManagedAccountType,
     ) => Promise<RestoreResult>;
     handlePostAuth: (pubkeyHex: string) => Promise<void>;
-    onMissingAccountType?: () => void;
-    onRestoreFailure?: () => void;
-}): Promise<boolean> {
-    params.accountManager.setActiveAccount(params.pubkeyHex);
-    const accountType = params.accountManager.getAccountType(params.pubkeyHex);
-
-    if (!accountType) {
-        params.onMissingAccountType?.();
-        return false;
+}): Promise<ManagedAccountSessionRestoreResult> {
+    let result: RestoreResult;
+    try {
+        result = await params.restoreAccount(
+            params.requestedPubkeyHex,
+            params.accountType,
+        );
+    } catch {
+        return { success: false, reason: 'restore-failed' };
     }
 
-    const result = await params.restoreAccount(params.pubkeyHex, accountType);
-    if (result.hasAuth && result.pubkeyHex) {
+    if (!result.hasAuth) {
+        return { success: false, reason: 'restore-failed' };
+    }
+
+    if (!result.pubkeyHex) {
+        return { success: false, reason: 'missing-pubkey' };
+    }
+
+    if (result.pubkeyHex !== params.requestedPubkeyHex) {
+        return { success: false, reason: 'pubkey-mismatch' };
+    }
+
+    try {
         await params.handlePostAuth(result.pubkeyHex);
-        return true;
+    } catch {
+        return { success: false, reason: 'post-auth-failed' };
     }
 
-    params.onRestoreFailure?.();
-    return false;
+    return { success: true, pubkeyHex: result.pubkeyHex };
 }

--- a/src/test/unit/accountManager.test.ts
+++ b/src/test/unit/accountManager.test.ts
@@ -110,6 +110,16 @@ describe('AccountManager', () => {
             manager.setActiveAccount('unknown');
             expect(manager.getActiveAccountPubkey()).toBe('pubkey1');
         });
+
+        it('active pointerをclearしても保存アカウントは削除しない', () => {
+            manager.addAccount('pubkey1', 'nsec');
+            manager.clearActiveAccount();
+
+            expect(manager.getActiveAccountPubkey()).toBeNull();
+            expect(manager.getAccounts()).toEqual([
+                expect.objectContaining({ pubkeyHex: 'pubkey1', type: 'nsec' }),
+            ]);
+        });
     });
 
     describe('hasAccount', () => {

--- a/src/test/unit/appAccountSessionController.test.ts
+++ b/src/test/unit/appAccountSessionController.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { createAppAccountSessionController } from '../../lib/appAccountSessionController';
+import { restoreManagedAccountSession } from '../../lib/appAuthUtils';
 
 const CURRENT_PUBKEY = 'aa'.repeat(32);
 const TARGET_PUBKEY = 'bb'.repeat(32);
@@ -31,11 +32,13 @@ function createController(overrides: Record<string, unknown> = {}) {
 
     const accountManager = {
         getAccountType: vi.fn((pubkeyHex: string) => accounts.get(pubkeyHex) ?? null),
+        hasAccount: vi.fn((pubkeyHex: string) => accounts.has(pubkeyHex)),
         setActiveAccount: vi.fn((pubkeyHex: string) => {
             if (accounts.has(pubkeyHex)) {
                 activePubkey = pubkeyHex;
             }
         }),
+        getActiveAccountPubkey: vi.fn(() => activePubkey),
         clearActiveAccount: vi.fn(() => {
             activePubkey = null;
         }),
@@ -46,6 +49,8 @@ function createController(overrides: Record<string, unknown> = {}) {
         success: true,
         pubkeyHex: params.requestedPubkeyHex,
     }));
+    const accountManagerOverride = overrides.accountManager as Partial<typeof accountManager> | undefined;
+    const { accountManager: _ignoredAccountManager, ...otherOverrides } = overrides;
     const deps = {
         getIsSwitchingAccount: () => isSwitchingAccount,
         setIsSwitchingAccount: vi.fn((next: boolean) => {
@@ -69,9 +74,12 @@ function createController(overrides: Record<string, unknown> = {}) {
         parentClientService: {
             disconnect: vi.fn(),
         },
-        accountManager,
+        accountManager: { ...accountManager, ...accountManagerOverride },
         restoreManagedAccountSession,
-        restoreAccount: vi.fn(async () => ({ hasAuth: true, pubkeyHex: TARGET_PUBKEY })),
+        restoreAccount: vi.fn(async (pubkeyHex: string): Promise<{ hasAuth: boolean; pubkeyHex?: string }> => ({
+            hasAuth: true,
+            pubkeyHex,
+        })),
         handlePostAuth: vi.fn(async () => undefined),
         resetUploadDisplayState: vi.fn(),
         logoutAccountFromAuthService: vi.fn(() => null),
@@ -96,7 +104,7 @@ function createController(overrides: Record<string, unknown> = {}) {
         reloadWindow: vi.fn(),
         closeLogoutDialog: vi.fn(),
         logger: { error: vi.fn() },
-        ...overrides,
+        ...otherOverrides,
     };
 
     return {
@@ -149,7 +157,7 @@ describe('createAppAccountSessionController', () => {
         await controller.switchAccount(TARGET_PUBKEY);
 
         expect(order.indexOf(`type:${TARGET_PUBKEY}`)).toBeLessThan(order.indexOf('parent-disconnect'));
-        expect(deps.disposeNostrSession).toHaveBeenCalledOnce();
+        expect(deps.disposeNostrSession).toHaveBeenCalled();
     });
 
     it('target type欠落ではruntime、auth state、active pointerへ触れない', async () => {
@@ -216,9 +224,70 @@ describe('createAppAccountSessionController', () => {
             accountType: 'nip07',
         }));
         expect(deps.accountManager.setActiveAccount).toHaveBeenCalledWith(TARGET_PUBKEY);
+        expect(deps.accountManager.getActiveAccountPubkey).toHaveBeenCalled();
         expect(getActivePubkey()).toBe(TARGET_PUBKEY);
         expect(deps.disposeNostrSession).toHaveBeenCalledOnce();
         expect(switchingAccountStateHistory).toEqual([true, false]);
+    });
+
+    it('target commit時に対象アカウントが消えた場合は失敗扱いにしてrollbackする', async () => {
+        const {
+            deps,
+            controller,
+            accounts,
+            getActivePubkey,
+            setCurrentRuntime,
+        } = createController({
+            restoreManagedAccountSession,
+        });
+        const targetPartialRuntime = { dispose: vi.fn() };
+        deps.restoreAccount.mockImplementation(async (pubkeyHex: string): Promise<{ hasAuth: boolean; pubkeyHex?: string }> => {
+            if (pubkeyHex === TARGET_PUBKEY) {
+                accounts.delete(TARGET_PUBKEY);
+                setCurrentRuntime(targetPartialRuntime);
+            }
+            return { hasAuth: true, pubkeyHex };
+        });
+
+        await expect(controller.switchAccount(TARGET_PUBKEY)).resolves.toBe(true);
+
+        expect(deps.handlePostAuth).toHaveBeenNthCalledWith(1, TARGET_PUBKEY);
+        expect(deps.handlePostAuth).toHaveBeenNthCalledWith(2, CURRENT_PUBKEY);
+        expect(deps.accountManager.setActiveAccount).toHaveBeenCalledTimes(1);
+        expect(deps.accountManager.setActiveAccount).toHaveBeenCalledWith(CURRENT_PUBKEY);
+        expect(deps.disposeNostrSession).toHaveBeenCalledWith(targetPartialRuntime);
+        expect(getActivePubkey()).toBe(CURRENT_PUBKEY);
+    });
+
+    it('rollback commit時にcurrent accountが消えた場合はguestへ収束する', async () => {
+        const {
+            deps,
+            controller,
+            accounts,
+            getActivePubkey,
+            setCurrentRuntime,
+        } = createController({
+            restoreManagedAccountSession,
+        });
+        const rollbackPartialRuntime = { dispose: vi.fn() };
+        deps.restoreAccount.mockImplementation(async (pubkeyHex: string): Promise<{ hasAuth: boolean; pubkeyHex?: string }> => {
+            if (pubkeyHex === CURRENT_PUBKEY) {
+                accounts.delete(CURRENT_PUBKEY);
+                setCurrentRuntime(rollbackPartialRuntime);
+                return { hasAuth: true, pubkeyHex };
+            }
+            return { hasAuth: false };
+        });
+
+        await expect(controller.switchAccount(TARGET_PUBKEY)).resolves.toBe(false);
+
+        expect(deps.handlePostAuth).toHaveBeenCalledWith(CURRENT_PUBKEY);
+        expect(deps.accountManager.setActiveAccount).not.toHaveBeenCalled();
+        expect(deps.disposeNostrSession).toHaveBeenCalledWith(rollbackPartialRuntime);
+        expect(deps.accountManager.clearActiveAccount).toHaveBeenCalledOnce();
+        expect(getActivePubkey()).toBeNull();
+        expect(accounts.has(OTHER_PUBKEY)).toBe(true);
+        expect(deps.restoreAccount).toHaveBeenCalledTimes(2);
     });
 
     it('target mismatchをcleanupしてcurrent authenticated accountを一度だけrollbackする', async () => {

--- a/src/test/unit/appAccountSessionController.test.ts
+++ b/src/test/unit/appAccountSessionController.test.ts
@@ -2,12 +2,50 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { createAppAccountSessionController } from '../../lib/appAccountSessionController';
 
+const CURRENT_PUBKEY = 'aa'.repeat(32);
+const TARGET_PUBKEY = 'bb'.repeat(32);
+const OTHER_PUBKEY = 'cc'.repeat(32);
+
+type ManagedSessionRestoreResult =
+    | { success: true; pubkeyHex: string }
+    | {
+        success: false;
+        reason: 'restore-failed' | 'missing-pubkey' | 'pubkey-mismatch' | 'post-auth-failed';
+    };
+
 function createController(overrides: Record<string, unknown> = {}) {
     let isSwitchingAccount = false;
     let isLoggingOut = false;
     let currentRxNostr: unknown = { dispose: vi.fn() };
+    let activePubkey: string | null = CURRENT_PUBKEY;
+    let authSnapshot: { type?: string; pubkey?: string } = {
+        type: 'parentClient',
+        pubkey: CURRENT_PUBKEY,
+    };
+    const accounts = new Map<string, 'nsec' | 'nip07' | 'nip46' | 'parentClient'>([
+        [CURRENT_PUBKEY, 'parentClient'],
+        [TARGET_PUBKEY, 'nip07'],
+        [OTHER_PUBKEY, 'nsec'],
+    ]);
     const switchingAccountStateHistory: boolean[] = [];
 
+    const accountManager = {
+        getAccountType: vi.fn((pubkeyHex: string) => accounts.get(pubkeyHex) ?? null),
+        setActiveAccount: vi.fn((pubkeyHex: string) => {
+            if (accounts.has(pubkeyHex)) {
+                activePubkey = pubkeyHex;
+            }
+        }),
+        clearActiveAccount: vi.fn(() => {
+            activePubkey = null;
+        }),
+    };
+    const restoreManagedAccountSession = vi.fn(async (params: {
+        requestedPubkeyHex: string;
+    }): Promise<ManagedSessionRestoreResult> => ({
+        success: true,
+        pubkeyHex: params.requestedPubkeyHex,
+    }));
     const deps = {
         getIsSwitchingAccount: () => isSwitchingAccount,
         setIsSwitchingAccount: vi.fn((next: boolean) => {
@@ -18,26 +56,22 @@ function createController(overrides: Record<string, unknown> = {}) {
         setIsLoggingOut: (next: boolean) => {
             isLoggingOut = next;
         },
-            setProfileLoading: vi.fn(),
-        getAuthStateSnapshot: () => ({
-            type: 'parentClient',
-            pubkey: 'aa'.repeat(32),
-        }),
+        setProfileLoading: vi.fn(),
+        getAuthStateSnapshot: () => authSnapshot,
         getCurrentRxNostr: () => currentRxNostr,
-        setCurrentRxNostr: (next: undefined) => {
+        setCurrentRxNostr: vi.fn((next: undefined) => {
             currentRxNostr = next;
-        },
+        }),
         disposeNostrSession: vi.fn(() => undefined),
-        clearNip46RuntimeForAuthChange: vi.fn(async () => undefined),
         nip46Service: {
             disconnect: vi.fn(async () => undefined),
         },
-        accountManager: {
-            getAccountType: vi.fn(() => 'nsec'),
-            setActiveAccount: vi.fn(),
+        parentClientService: {
+            disconnect: vi.fn(),
         },
-        restoreManagedAccountSession: vi.fn(async () => true),
-        restoreAccount: vi.fn(async () => ({ hasAuth: true, pubkeyHex: 'bb'.repeat(32) })),
+        accountManager,
+        restoreManagedAccountSession,
+        restoreAccount: vi.fn(async () => ({ hasAuth: true, pubkeyHex: TARGET_PUBKEY })),
         handlePostAuth: vi.fn(async () => undefined),
         resetUploadDisplayState: vi.fn(),
         logoutAccountFromAuthService: vi.fn(() => null),
@@ -50,7 +84,9 @@ function createController(overrides: Record<string, unknown> = {}) {
             }
             return { kind: 'keep-current' };
         }),
-        clearAuthState: vi.fn(),
+        clearAuthState: vi.fn(() => {
+            authSnapshot = { type: 'none', pubkey: '' };
+        }),
         setGuestProfile: vi.fn(),
         setProfileLoaded: vi.fn(),
         initializeNostr: vi.fn(async () => undefined),
@@ -67,71 +103,234 @@ function createController(overrides: Record<string, unknown> = {}) {
         deps,
         controller: createAppAccountSessionController(deps as never),
         switchingAccountStateHistory,
+        getActivePubkey: () => activePubkey,
+        setActivePubkey: (next: string | null) => {
+            activePubkey = next;
+        },
+        setCurrentRuntime: (next: unknown) => {
+            currentRxNostr = next;
+        },
+        setAuthSnapshot: (next: { type?: string; pubkey?: string }) => {
+            authSnapshot = next;
+        },
+        accounts,
     };
 }
 
 describe('createAppAccountSessionController', () => {
-    it('switchAccount は restoreManagedAccountSession を実行する', async () => {
+    it('switching中の再入を拒否する', async () => {
+        let resolveRestore: ((value: { success: true; pubkeyHex: string }) => void) | undefined;
+        const restoreManagedAccountSession = vi.fn(() => new Promise<{ success: true; pubkeyHex: string }>((resolve) => {
+            resolveRestore = resolve;
+        }));
+        const { controller } = createController({ restoreManagedAccountSession });
+
+        const first = controller.switchAccount(TARGET_PUBKEY);
+        await expect(controller.switchAccount(OTHER_PUBKEY)).resolves.toBe(false);
+        resolveRestore?.({ success: true, pubkeyHex: TARGET_PUBKEY });
+        await expect(first).resolves.toBe(true);
+        expect(restoreManagedAccountSession).toHaveBeenCalledOnce();
+    });
+
+    it('target type確認をcurrent runtime cleanupより先に行う', async () => {
+        const order: string[] = [];
+        const { deps, controller } = createController({
+            accountManager: {
+                getAccountType: vi.fn((pubkeyHex: string) => {
+                    order.push(`type:${pubkeyHex}`);
+                    return pubkeyHex === TARGET_PUBKEY ? 'nip07' : 'parentClient';
+                }),
+                setActiveAccount: vi.fn(),
+                clearActiveAccount: vi.fn(),
+            },
+            parentClientService: { disconnect: vi.fn(() => order.push('parent-disconnect')) },
+        });
+
+        await controller.switchAccount(TARGET_PUBKEY);
+
+        expect(order.indexOf(`type:${TARGET_PUBKEY}`)).toBeLessThan(order.indexOf('parent-disconnect'));
+        expect(deps.disposeNostrSession).toHaveBeenCalledOnce();
+    });
+
+    it('target type欠落ではruntime、auth state、active pointerへ触れない', async () => {
+        const { deps, controller, getActivePubkey } = createController({
+            accountManager: {
+                getAccountType: vi.fn(() => null),
+                setActiveAccount: vi.fn(),
+                clearActiveAccount: vi.fn(),
+            },
+        });
+
+        await expect(controller.switchAccount(TARGET_PUBKEY)).resolves.toBe(false);
+
+        expect(deps.disposeNostrSession).not.toHaveBeenCalled();
+        expect(deps.clearAuthState).not.toHaveBeenCalled();
+        expect(deps.accountManager.setActiveAccount).not.toHaveBeenCalled();
+        expect(deps.accountManager.clearActiveAccount).not.toHaveBeenCalled();
+        expect(getActivePubkey()).toBe(CURRENT_PUBKEY);
+    });
+
+    it('current parent client runtimeを通知なしでcleanupする', async () => {
+        const { deps, controller } = createController();
+
+        await controller.switchAccount(TARGET_PUBKEY);
+
+        expect(deps.parentClientService.disconnect).toHaveBeenCalledWith(false);
+        expect(deps.nip46Service.disconnect).not.toHaveBeenCalled();
+    });
+
+    it('current NIP-46 runtimeをcleanupする', async () => {
+        const { deps, controller, setAuthSnapshot, accounts } = createController();
+        accounts.set(CURRENT_PUBKEY, 'nip46');
+        setAuthSnapshot({ type: 'nip46', pubkey: CURRENT_PUBKEY });
+
+        await controller.switchAccount(TARGET_PUBKEY);
+
+        expect(deps.nip46Service.disconnect).toHaveBeenCalledOnce();
+        expect(deps.parentClientService.disconnect).not.toHaveBeenCalled();
+    });
+
+    it.each(['nsec', 'nip07'] as const)('current %sではremote signer cleanupを行わない', async (type) => {
+        const { deps, controller, setAuthSnapshot, accounts } = createController();
+        accounts.set(CURRENT_PUBKEY, type);
+        setAuthSnapshot({ type, pubkey: CURRENT_PUBKEY });
+
+        await controller.switchAccount(TARGET_PUBKEY);
+
+        expect(deps.nip46Service.disconnect).not.toHaveBeenCalled();
+        expect(deps.parentClientService.disconnect).not.toHaveBeenCalled();
+    });
+
+    it('正常targetではrestore、post-auth完了後の結果、active pointerが同じpubkeyになる', async () => {
         const {
             deps,
             controller,
+            getActivePubkey,
             switchingAccountStateHistory,
         } = createController();
 
-        await expect(controller.switchAccount('bb'.repeat(32))).resolves.toBe(true);
+        await expect(controller.switchAccount(TARGET_PUBKEY)).resolves.toBe(true);
 
+        expect(deps.restoreManagedAccountSession).toHaveBeenCalledWith(expect.objectContaining({
+            requestedPubkeyHex: TARGET_PUBKEY,
+            accountType: 'nip07',
+        }));
+        expect(deps.accountManager.setActiveAccount).toHaveBeenCalledWith(TARGET_PUBKEY);
+        expect(getActivePubkey()).toBe(TARGET_PUBKEY);
+        expect(deps.disposeNostrSession).toHaveBeenCalledOnce();
         expect(switchingAccountStateHistory).toEqual([true, false]);
-        expect(deps.setProfileLoading).toHaveBeenCalledWith(false);
-        expect(deps.clearNip46RuntimeForAuthChange).toHaveBeenCalledTimes(1);
-        expect(deps.disposeNostrSession).toHaveBeenCalledTimes(1);
-        expect(deps.restoreManagedAccountSession).toHaveBeenCalledTimes(1);
     });
 
-    it('switchAccount は非同期処理の開始前に切替状態を有効化する', async () => {
-        let resolveRestore: ((result: boolean) => void) | undefined;
-        let resolveRestoreStarted: (() => void) | undefined;
-        const restoreStarted = new Promise<void>((resolve) => {
-            resolveRestoreStarted = resolve;
+    it('target mismatchをcleanupしてcurrent authenticated accountを一度だけrollbackする', async () => {
+        const events: string[] = [];
+        const {
+            deps,
+            controller,
+            getActivePubkey,
+            setActivePubkey,
+            setCurrentRuntime,
+        } = createController();
+        setActivePubkey(OTHER_PUBKEY);
+        deps.disposeNostrSession.mockImplementation(() => {
+            events.push('dispose');
+            return undefined;
         });
-        const restoreManagedAccountSession = vi.fn(() => {
-            resolveRestoreStarted?.();
-            return new Promise<boolean>((resolve) => {
-                resolveRestore = resolve;
+        deps.restoreManagedAccountSession
+            .mockImplementationOnce(async () => {
+                events.push('target');
+                setCurrentRuntime({ dispose: vi.fn() });
+                return { success: false, reason: 'pubkey-mismatch' } as const;
+            })
+            .mockImplementationOnce(async () => {
+                events.push('rollback');
+                return { success: true, pubkeyHex: CURRENT_PUBKEY } as const;
             });
-        });
-        const { controller, switchingAccountStateHistory } = createController({
-            restoreManagedAccountSession,
-        });
 
-        const switchPromise = controller.switchAccount('bb'.repeat(32));
+        await expect(controller.switchAccount(TARGET_PUBKEY)).resolves.toBe(true);
 
-        await restoreStarted;
-        expect(switchingAccountStateHistory).toEqual([true]);
-        resolveRestore?.(true);
-        await expect(switchPromise).resolves.toBe(true);
-        expect(switchingAccountStateHistory).toEqual([true, false]);
+        expect(deps.restoreManagedAccountSession).toHaveBeenNthCalledWith(1, expect.objectContaining({ requestedPubkeyHex: TARGET_PUBKEY }));
+        expect(deps.restoreManagedAccountSession).toHaveBeenNthCalledWith(2, expect.objectContaining({ requestedPubkeyHex: CURRENT_PUBKEY }));
+        expect(events.indexOf('dispose', 1)).toBeLessThan(events.indexOf('rollback'));
+        expect(deps.accountManager.setActiveAccount).toHaveBeenCalledTimes(1);
+        expect(getActivePubkey()).toBe(CURRENT_PUBKEY);
     });
 
-    it('switchAccount は復元失敗時も切替状態を解除する', async () => {
-        const { controller, switchingAccountStateHistory } = createController({
-            restoreManagedAccountSession: vi.fn(async () => false),
-        });
+    it('rollback mismatch後は再rollbackせずguestへ収束する', async () => {
+        const { deps, controller, getActivePubkey } = createController();
+        deps.restoreManagedAccountSession
+            .mockResolvedValueOnce({ success: false, reason: 'pubkey-mismatch' })
+            .mockResolvedValueOnce({ success: false, reason: 'pubkey-mismatch' });
 
-        await expect(controller.switchAccount('bb'.repeat(32))).resolves.toBe(false);
+        await expect(controller.switchAccount(TARGET_PUBKEY)).resolves.toBe(false);
 
-        expect(switchingAccountStateHistory).toEqual([true, false]);
+        expect(deps.restoreManagedAccountSession).toHaveBeenCalledTimes(2);
+        expect(deps.restoreManagedAccountSession).toHaveBeenNthCalledWith(2, expect.objectContaining({ requestedPubkeyHex: CURRENT_PUBKEY }));
+        expect(deps.accountManager.setActiveAccount).not.toHaveBeenCalled();
+        expect(deps.accountManager.clearActiveAccount).toHaveBeenCalledOnce();
+        expect(getActivePubkey()).toBeNull();
+        expect(deps.initializeNostr).toHaveBeenCalledOnce();
     });
 
-    it('switchAccount は例外時も切替状態を解除する', async () => {
-        const { controller, switchingAccountStateHistory } = createController({
-            restoreManagedAccountSession: vi.fn(async () => {
-                throw new Error('restore failed');
-            }),
+    it('rollback不能時はguestへ収束する', async () => {
+        const { deps, controller, setAuthSnapshot, accounts } = createController();
+        accounts.delete(CURRENT_PUBKEY);
+        setAuthSnapshot({ type: 'parentClient', pubkey: CURRENT_PUBKEY });
+        deps.restoreManagedAccountSession.mockResolvedValueOnce({ success: false, reason: 'restore-failed' });
+
+        await expect(controller.switchAccount(TARGET_PUBKEY)).resolves.toBe(false);
+
+        expect(deps.restoreManagedAccountSession).toHaveBeenCalledOnce();
+        expect(deps.accountManager.clearActiveAccount).toHaveBeenCalledOnce();
+        expect(deps.initializeNostr).toHaveBeenCalledOnce();
+    });
+
+    it('guest開始時は保存active pointerがあってもaccount rollbackを行わない', async () => {
+        const { deps, controller, setAuthSnapshot } = createController();
+        setAuthSnapshot({ type: 'none', pubkey: CURRENT_PUBKEY });
+        deps.restoreManagedAccountSession.mockResolvedValueOnce({ success: false, reason: 'restore-failed' });
+
+        await expect(controller.switchAccount(TARGET_PUBKEY)).resolves.toBe(false);
+
+        expect(deps.restoreManagedAccountSession).toHaveBeenCalledOnce();
+        expect(deps.accountManager.clearActiveAccount).toHaveBeenCalledOnce();
+    });
+
+    it('guest初期化が失敗した場合もpartial runtimeを破棄する', async () => {
+        const { deps, controller, setAuthSnapshot, setCurrentRuntime } = createController();
+        const guestRuntime = { dispose: vi.fn() };
+        setAuthSnapshot({ type: 'none', pubkey: '' });
+        deps.restoreManagedAccountSession.mockResolvedValueOnce({ success: false, reason: 'restore-failed' });
+        deps.initializeNostr.mockImplementation(async () => {
+            setCurrentRuntime(guestRuntime);
+            throw new Error('guest initialization failed');
         });
 
-        await expect(controller.switchAccount('bb'.repeat(32))).resolves.toBe(false);
+        await expect(controller.switchAccount(TARGET_PUBKEY)).resolves.toBe(false);
 
-        expect(switchingAccountStateHistory).toEqual([true, false]);
+        expect(deps.disposeNostrSession).toHaveBeenLastCalledWith(guestRuntime);
+        expect(deps.setSecretKey).toHaveBeenCalledWith('');
+        expect(deps.setErrorMessage).toHaveBeenCalledWith('');
+    });
+
+    it('cleanup失敗後も残りcleanupを続け、再帰せずguestへ収束する', async () => {
+        const { deps, controller, getActivePubkey } = createController({
+            parentClientService: {
+                disconnect: vi.fn(() => {
+                    throw new Error('disconnect failed');
+                }),
+            },
+        });
+        deps.restoreManagedAccountSession.mockResolvedValueOnce({ success: false, reason: 'restore-failed' });
+        deps.accountManager.getAccountType.mockImplementation((pubkeyHex: string) =>
+            pubkeyHex === TARGET_PUBKEY ? 'nip07' : null,
+        );
+
+        await expect(controller.switchAccount(TARGET_PUBKEY)).resolves.toBe(false);
+
+        expect(deps.clearAuthState).toHaveBeenCalled();
+        expect(deps.accountManager.clearActiveAccount).toHaveBeenCalledOnce();
+        expect(getActivePubkey()).toBeNull();
+        expect(deps.restoreManagedAccountSession).toHaveBeenCalledOnce();
     });
 
     it('logoutAccount guest 分岐では認証情報を初期化する', async () => {
@@ -139,59 +338,45 @@ describe('createAppAccountSessionController', () => {
             logoutAccountFromAuthService: vi.fn(() => null),
         });
 
-        await controller.logoutAccount('aa'.repeat(32));
+        await controller.logoutAccount(CURRENT_PUBKEY);
 
-        expect(deps.resetUploadDisplayState).toHaveBeenCalledTimes(1);
-        expect(deps.clearAuthState).toHaveBeenCalledTimes(1);
-        expect(deps.setGuestProfile).toHaveBeenCalledTimes(1);
-        expect(deps.initializeNostr).toHaveBeenCalledTimes(1);
-        expect(deps.refreshAccountList).toHaveBeenCalledTimes(1);
-        expect(deps.closeLogoutDialog).toHaveBeenCalledTimes(1);
+        expect(deps.resetUploadDisplayState).toHaveBeenCalledOnce();
+        expect(deps.clearAuthState).toHaveBeenCalledOnce();
+        expect(deps.setGuestProfile).toHaveBeenCalledOnce();
+        expect(deps.initializeNostr).toHaveBeenCalledOnce();
+        expect(deps.refreshAccountList).toHaveBeenCalledOnce();
+        expect(deps.closeLogoutDialog).toHaveBeenCalledOnce();
     });
 
-    it('handleRemoteParentClientLogout は non-parentClient auth を無視する', async () => {
-        const { deps, controller } = createController({
-            getAuthStateSnapshot: () => ({
-                type: 'nip07',
-                pubkey: 'aa'.repeat(32),
-            }),
-        });
+    it('handleRemoteParentClientLogout はnon-parentClient authを無視する', async () => {
+        const { deps, controller, setAuthSnapshot } = createController();
+        setAuthSnapshot({ type: 'nip07', pubkey: CURRENT_PUBKEY });
 
-        await controller.handleRemoteParentClientLogout('aa'.repeat(32));
+        await controller.handleRemoteParentClientLogout(CURRENT_PUBKEY);
 
         expect(deps.logoutAccountFromAuthService).not.toHaveBeenCalled();
         expect(deps.restoreManagedAccountSession).not.toHaveBeenCalled();
     });
 
-    it('handleRemoteParentClientLogout は復帰成功時に logout せず refresh する', async () => {
-        const restoreManagedAccountSession = vi.fn(async () => true);
-        const { deps, controller } = createController({
-            accountManager: {
-                getAccountType: vi.fn(() => 'nsec'),
-                setActiveAccount: vi.fn(),
-            },
-            restoreManagedAccountSession,
-        });
+    it('handleRemoteParentClientLogout は復帰成功時にlogoutせずrefreshする', async () => {
+        const { deps, controller, accounts } = createController();
+        accounts.set(CURRENT_PUBKEY, 'nsec');
 
-        await controller.handleRemoteParentClientLogout('aa'.repeat(32));
+        await controller.handleRemoteParentClientLogout(CURRENT_PUBKEY);
 
-        expect(restoreManagedAccountSession).toHaveBeenCalledTimes(1);
+        expect(deps.restoreManagedAccountSession).toHaveBeenCalledOnce();
         expect(deps.logoutAccountFromAuthService).not.toHaveBeenCalled();
-        expect(deps.refreshAccountList).toHaveBeenCalledTimes(1);
+        expect(deps.refreshAccountList).toHaveBeenCalledOnce();
     });
 
-    it('logoutAccount の switch 分岐では再読み込みする', async () => {
+    it('logoutAccount のswitch分岐では再読み込みする', async () => {
         const { deps, controller } = createController({
-            accountManager: {
-                getAccountType: vi.fn(() => 'nsec'),
-                setActiveAccount: vi.fn(),
-            },
-            logoutAccountFromAuthService: vi.fn(() => 'bb'.repeat(32)),
+            logoutAccountFromAuthService: vi.fn(() => TARGET_PUBKEY),
         });
 
-        await controller.logoutAccount('aa'.repeat(32));
+        await controller.logoutAccount(CURRENT_PUBKEY);
 
-        expect(deps.reloadWindow).toHaveBeenCalledTimes(1);
+        expect(deps.reloadWindow).toHaveBeenCalledOnce();
         expect(deps.restoreManagedAccountSession).not.toHaveBeenCalled();
         expect(deps.closeLogoutDialog).not.toHaveBeenCalled();
     });

--- a/src/test/unit/appAuthUtils.test.ts
+++ b/src/test/unit/appAuthUtils.test.ts
@@ -102,56 +102,70 @@ describe('resolveLogoutAccountAction', () => {
 });
 
 describe('restoreManagedAccountSession', () => {
-    it('account type があって restore に成功すれば post auth を呼ぶ', async () => {
+    it('要求pubkeyとrestore結果が一致すればpost-auth後に同じpubkeyを返す', async () => {
         const handlePostAuth = vi.fn(async () => undefined);
-        const accountManager = {
-            setActiveAccount: vi.fn(),
-            getAccountType: vi.fn(() => 'nip07' as const),
-        };
 
         await expect(restoreManagedAccountSession({
-            pubkeyHex: 'pubkey-1',
-            accountManager,
+            requestedPubkeyHex: 'pubkey-1',
+            accountType: 'nip07',
             restoreAccount: vi.fn(async () => ({ hasAuth: true, pubkeyHex: 'pubkey-1' })),
             handlePostAuth,
-        })).resolves.toBe(true);
+        })).resolves.toEqual({ success: true, pubkeyHex: 'pubkey-1' });
 
-        expect(accountManager.setActiveAccount).toHaveBeenCalledWith('pubkey-1');
         expect(handlePostAuth).toHaveBeenCalledWith('pubkey-1');
     });
 
-    it('account type がなければ missing callback を呼ぶ', async () => {
-        const onMissingAccountType = vi.fn();
+    it('restore失敗ではpost-authを呼ばない', async () => {
+        const handlePostAuth = vi.fn(async () => undefined);
 
         await expect(restoreManagedAccountSession({
-            pubkeyHex: 'pubkey-1',
-            accountManager: {
-                setActiveAccount: vi.fn(),
-                getAccountType: vi.fn(() => null),
-            },
-            restoreAccount: vi.fn(),
-            handlePostAuth: vi.fn(async () => undefined),
-            onMissingAccountType,
-        })).resolves.toBe(false);
+            requestedPubkeyHex: 'pubkey-1',
+            accountType: 'nsec',
+            restoreAccount: vi.fn(async () => ({ hasAuth: false })),
+            handlePostAuth,
+        })).resolves.toEqual({ success: false, reason: 'restore-failed' });
 
-        expect(onMissingAccountType).toHaveBeenCalledOnce();
+        expect(handlePostAuth).not.toHaveBeenCalled();
     });
 
-    it('restore に失敗すれば failure callback を呼ぶ', async () => {
-        const onRestoreFailure = vi.fn();
+    it('結果pubkeyがなければpost-authを呼ばない', async () => {
+        const handlePostAuth = vi.fn(async () => undefined);
 
         await expect(restoreManagedAccountSession({
-            pubkeyHex: 'pubkey-1',
-            accountManager: {
-                setActiveAccount: vi.fn(),
-                getAccountType: vi.fn(() => 'nsec' as const),
-            },
-            restoreAccount: vi.fn(async () => ({ hasAuth: false })),
-            handlePostAuth: vi.fn(async () => undefined),
-            onRestoreFailure,
-        })).resolves.toBe(false);
+            requestedPubkeyHex: 'pubkey-1',
+            accountType: 'nsec',
+            restoreAccount: vi.fn(async () => ({ hasAuth: true })),
+            handlePostAuth,
+        })).resolves.toEqual({ success: false, reason: 'missing-pubkey' });
 
-        expect(onRestoreFailure).toHaveBeenCalledOnce();
+        expect(handlePostAuth).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['未登録の結果pubkey', 'pubkey-unregistered'],
+        ['別の登録済み結果pubkey', 'pubkey-2'],
+    ])('%sでも一致しなければpost-authを呼ばない', async (_label, resultPubkeyHex) => {
+        const handlePostAuth = vi.fn(async () => undefined);
+
+        await expect(restoreManagedAccountSession({
+            requestedPubkeyHex: 'pubkey-1',
+            accountType: 'nip07',
+            restoreAccount: vi.fn(async () => ({ hasAuth: true, pubkeyHex: resultPubkeyHex })),
+            handlePostAuth,
+        })).resolves.toEqual({ success: false, reason: 'pubkey-mismatch' });
+
+        expect(handlePostAuth).not.toHaveBeenCalled();
+    });
+
+    it('post-auth失敗を成功扱いしない', async () => {
+        await expect(restoreManagedAccountSession({
+            requestedPubkeyHex: 'pubkey-1',
+            accountType: 'nip07',
+            restoreAccount: vi.fn(async () => ({ hasAuth: true, pubkeyHex: 'pubkey-1' })),
+            handlePostAuth: vi.fn(async () => {
+                throw new Error('post-auth failed');
+            }),
+        })).resolves.toEqual({ success: false, reason: 'post-auth-failed' });
     });
 });
 


### PR DESCRIPTION
## Summary

- Make `switchAccount()` own the account-switch transaction and restore the prior authenticated account once when the target attempt fails.
- Convert `restoreManagedAccountSession()` to a one-shot restore/post-auth helper with a requested-pubkey/result-pubkey boundary check.
- Add guest convergence and active-pointer clearing without deleting saved accounts or credentials.

## Transaction and rollback

- Validate the target account type before tearing down the current runtime.
- Clean up NIP-46 or parent-client runtime with the existing APIs, dispose rx-nostr, and clear auth state before each restore attempt.
- Clean up partial target or rollback runtime on failure; rollback never re-enters `switchAccount()`.
- On rollback failure or no authenticated rollback candidate, clear the active pointer and initialize the existing guest path.

## Pubkey mismatch behavior

A restore result whose pubkey is missing or differs from the requested pubkey is a failure. It does not run post-auth or commit the active pointer. The target then attempts the original authenticated account once; a rollback mismatch converges to guest.

## Validation

- `npm run test -- src/test/unit/appAuthUtils.test.ts src/test/unit/appAccountSessionController.test.ts src/test/unit/accountManager.test.ts`
- `npm run check`
- `npm test` — 306 files, 3365 tests passed
- `npm run build`
- `git diff --check`

## Not run

- Playwright was not run: the acceptance criteria are covered by deterministic dependency-injected unit tests.