### PR TITLE
fix: verify managed account restore identities

### DIFF
--- a/src/lib/authManagedSessionRestoreUtils.ts
+++ b/src/lib/authManagedSessionRestoreUtils.ts
@@ -1,28 +1,70 @@
-import type { RestoreResult } from './authRestoreUtils';
+import type {
+    ManagedRestoreFailureReason,
+    ManagedRestoreResult,
+} from './authRestoreUtils';
 
 export async function restoreManagedSessionAccount<TSession>({
     pubkeyHex,
     loadSession,
+    validateStoredIdentity,
     reconnect,
-    applyAuth,
+    isExpectedAccount,
+    finalize,
+    cleanupRuntime,
     onError,
 }: {
     pubkeyHex: string;
     loadSession: (pubkeyHex: string) => TSession | null;
-    reconnect: (session: TSession) => Promise<unknown>;
-    applyAuth: (pubkeyHex: string) => RestoreResult;
-    onError: (error: unknown) => void;
-}): Promise<RestoreResult> {
+    validateStoredIdentity: (session: TSession, pubkeyHex: string) => boolean;
+    reconnect: (session: TSession) => Promise<string>;
+    isExpectedAccount: () => boolean;
+    finalize: (pubkeyHex: string) => Promise<ManagedRestoreResult> | ManagedRestoreResult;
+    cleanupRuntime: () => Promise<void> | void;
+    onError: (reason: ManagedRestoreFailureReason) => void;
+}): Promise<ManagedRestoreResult> {
     const session = loadSession(pubkeyHex);
     if (!session) {
-        return { hasAuth: false };
+        return { hasAuth: false, reason: 'session-unavailable' };
     }
 
+    if (!validateStoredIdentity(session, pubkeyHex)) {
+        return { hasAuth: false, reason: 'identity-mismatch' };
+    }
+
+    let cleanupStarted = false;
+    const cleanupOnce = async (): Promise<void> => {
+        if (cleanupStarted) return;
+        cleanupStarted = true;
+        try {
+            await cleanupRuntime();
+        } catch {
+            // The caller's transaction cleanup remains the final safety net.
+        }
+    };
+
     try {
-        await reconnect(session);
-        return applyAuth(pubkeyHex);
-    } catch (error) {
-        onError(error);
-        return { hasAuth: false };
+        const reconnectedPubkey = await reconnect(session);
+        if (reconnectedPubkey !== pubkeyHex) {
+            await cleanupOnce();
+            return { hasAuth: false, reason: 'identity-mismatch' };
+        }
+
+        if (!isExpectedAccount()) {
+            await cleanupOnce();
+            return { hasAuth: false, reason: 'account-record-mismatch' };
+        }
+
+        const result = await finalize(reconnectedPubkey);
+        if (!result.hasAuth) {
+            await cleanupOnce();
+            return result;
+        }
+
+        return { hasAuth: true, pubkeyHex };
+    } catch {
+        const reason: ManagedRestoreFailureReason = 'reconnect-failed';
+        onError(reason);
+        await cleanupOnce();
+        return { hasAuth: false, reason };
     }
 }

--- a/src/lib/authRestoreUtils.ts
+++ b/src/lib/authRestoreUtils.ts
@@ -12,6 +12,26 @@ import type { ParentClientAuthService } from './parentClientAuthService';
 const LEGACY_NIP07_STORAGE_KEY = 'nostr-nip07-pubkey';
 
 export type RestoreResult = { hasAuth: boolean; pubkeyHex?: string };
+export type ManagedRestoreFailureReason =
+    | 'invalid-requested-pubkey'
+    | 'account-record-mismatch'
+    | 'credential-missing'
+    | 'credential-read-failed'
+    | 'credential-invalid'
+    | 'identity-source-unavailable'
+    | 'identity-read-failed'
+    | 'identity-mismatch'
+    | 'session-unavailable'
+    | 'reconnect-failed'
+    | 'persistence-failed'
+    | 'runtime-commit-failed'
+    | 'unsupported-account-type';
+export type ManagedRestoreResult =
+    | { hasAuth: true; pubkeyHex: string }
+    | { hasAuth: false; reason: ManagedRestoreFailureReason };
+
+export const MANAGED_NIP07_EXTENSION_DISCOVERY_TIMEOUT_MS = 1_000;
+export const MANAGED_NIP07_IDENTITY_READ_TIMEOUT_MS = 3_000;
 
 type AccountAuthType = StoredAccount['type'];
 type PublicKeyAuthType = 'nip07' | 'nip46' | 'parentClient';
@@ -42,13 +62,18 @@ interface LegacyNsecDependencies extends NsecRestoreDependencies {
 
 export interface ManagedAuthRestoreDependencies extends NsecRestoreDependencies, PublicKeyAuthDependencies {
     localStorage: Storage;
-    nip07Service: Pick<Nip07AuthService, 'waitForExtension'>;
-    nip46Svc: Pick<Nip46Service, 'reconnect' | 'bindSessionPersistence'>;
-    parentClientSvc: Pick<ParentClientAuthService, 'reconnect'>;
-    accountManager?: AccountMigrationTarget | null;
+    nip07Service: Pick<Nip07AuthService, 'waitForExtension' | 'authenticate'>;
+    nip46Svc: Pick<Nip46Service, 'reconnect' | 'bindSessionPersistence' | 'disconnect'>;
+    parentClientSvc: Pick<ParentClientAuthService, 'reconnect' | 'getSessionData' | 'disconnect'>;
+    isExpectedAccount(pubkeyHex: string, type: AccountAuthType): boolean;
     console: Console;
     keyManager: NsecRestoreDependencies['keyManager'] & {
-        loadFromStorage(pubkeyHex?: string): string | null;
+        isValidNsec(secretKey: string): boolean;
+        readStoredKey(pubkeyHex: string):
+            | { status: 'found'; secretKey: string }
+            | { status: 'missing' }
+            | { status: 'error' };
+        setCurrentSecretKey(secretKey: string | null): void;
     };
 }
 
@@ -138,68 +163,163 @@ export function restoreNsecFromStoredKey(
 export async function restoreManagedNsecAccount(
     pubkeyHex: string,
     dependencies: ManagedAuthRestoreDependencies,
-): Promise<RestoreResult> {
-    const storedKey = dependencies.keyManager.loadFromStorage(pubkeyHex);
-    if (!storedKey) return { hasAuth: false };
+): Promise<ManagedRestoreResult> {
+    const storedKeyResult = dependencies.keyManager.readStoredKey(pubkeyHex);
+    if (storedKeyResult.status === 'missing') {
+        return { hasAuth: false, reason: 'credential-missing' };
+    }
+    if (storedKeyResult.status === 'error') {
+        return { hasAuth: false, reason: 'credential-read-failed' };
+    }
 
-    return restoreNsecFromStoredKey(storedKey, dependencies);
+    const { secretKey } = storedKeyResult;
+    if (!dependencies.keyManager.isValidNsec(secretKey)) {
+        return { hasAuth: false, reason: 'credential-invalid' };
+    }
+
+    let derived: PublicKeyData;
+    try {
+        derived = dependencies.keyManager.derivePublicKey(secretKey);
+    } catch {
+        return { hasAuth: false, reason: 'identity-read-failed' };
+    }
+
+    if (!derived.hex) {
+        return { hasAuth: false, reason: 'identity-read-failed' };
+    }
+    if (derived.hex !== pubkeyHex) {
+        return { hasAuth: false, reason: 'identity-mismatch' };
+    }
+    if (!dependencies.isExpectedAccount(pubkeyHex, 'nsec')) {
+        return { hasAuth: false, reason: 'account-record-mismatch' };
+    }
+
+    try {
+        dependencies.keyManager.setCurrentSecretKey(secretKey);
+        dependencies.publicKeyState.setNsec(secretKey);
+        dependencies.setNsecAuthFn(derived.hex, derived.npub, derived.nprofile);
+        return { hasAuth: true, pubkeyHex };
+    } catch {
+        dependencies.keyManager.setCurrentSecretKey(null);
+        dependencies.publicKeyState.clear();
+        return { hasAuth: false, reason: 'runtime-commit-failed' };
+    }
 }
 
 export async function restoreManagedNip07Account(
     pubkeyHex: string,
     dependencies: ManagedAuthRestoreDependencies,
-): Promise<RestoreResult> {
-    const available = await dependencies.nip07Service.waitForExtension(1000);
-    if (!available) return { hasAuth: false };
+): Promise<ManagedRestoreResult> {
+    const available = await dependencies.nip07Service.waitForExtension(
+        MANAGED_NIP07_EXTENSION_DISCOVERY_TIMEOUT_MS,
+    );
+    if (!available) {
+        return { hasAuth: false, reason: 'identity-source-unavailable' };
+    }
+
+    const result = await dependencies.nip07Service.authenticate({
+        timeoutMs: MANAGED_NIP07_IDENTITY_READ_TIMEOUT_MS,
+    });
+    if (!result.success || !result.pubkeyHex || !result.pubkeyData) {
+        return { hasAuth: false, reason: 'identity-read-failed' };
+    }
+    if (result.pubkeyHex !== result.pubkeyData.hex) {
+        return { hasAuth: false, reason: 'identity-read-failed' };
+    }
+    if (result.pubkeyHex !== pubkeyHex) {
+        return { hasAuth: false, reason: 'identity-mismatch' };
+    }
+    if (!dependencies.isExpectedAccount(pubkeyHex, 'nip07')) {
+        return { hasAuth: false, reason: 'account-record-mismatch' };
+    }
 
     try {
-        return applyPublicKeyAuth('nip07', pubkeyHex, dependencies);
-    } catch (error) {
-        dependencies.console.error('NIP-07アカウント復元エラー:', error);
-        return { hasAuth: false };
+        dependencies.setNip07AuthFn(
+            result.pubkeyData.hex,
+            result.pubkeyData.npub,
+            result.pubkeyData.nprofile,
+        );
+        return { hasAuth: true, pubkeyHex };
+    } catch {
+        return { hasAuth: false, reason: 'runtime-commit-failed' };
     }
 }
 
 export async function restoreManagedNip46Account(
     pubkeyHex: string,
     dependencies: ManagedAuthRestoreDependencies,
-): Promise<RestoreResult> {
+): Promise<ManagedRestoreResult> {
     return restoreManagedSessionAccount({
         pubkeyHex,
         loadSession: (targetPubkeyHex) =>
             Nip46Storage.loadSession(dependencies.localStorage, targetPubkeyHex),
-        reconnect: async (session) => {
-            const restoredPubkey = await dependencies.nip46Svc.reconnect(session);
-            dependencies.nip46Svc.bindSessionPersistence(
-                dependencies.localStorage,
-                pubkeyHex,
-            );
-            return restoredPubkey;
+        validateStoredIdentity: (session, targetPubkeyHex) =>
+            session.userPubkey === targetPubkeyHex,
+        // NIP-46 reconnect returns the saved session user pubkey. This only
+        // checks the service contract; it does not verify a live signer identity.
+        reconnect: (session) => dependencies.nip46Svc.reconnect(session),
+        isExpectedAccount: () => dependencies.isExpectedAccount(pubkeyHex, 'nip46'),
+        finalize: (targetPubkeyHex) => {
+            try {
+                dependencies.nip46Svc.bindSessionPersistence(
+                    dependencies.localStorage,
+                    targetPubkeyHex,
+                );
+            } catch {
+                return { hasAuth: false, reason: 'persistence-failed' };
+            }
+
+            try {
+                applyPublicKeyAuth('nip46', targetPubkeyHex, dependencies);
+                return { hasAuth: true, pubkeyHex: targetPubkeyHex };
+            } catch {
+                return { hasAuth: false, reason: 'runtime-commit-failed' };
+            }
         },
-        applyAuth: (targetPubkeyHex) =>
-            applyPublicKeyAuth('nip46', targetPubkeyHex, dependencies),
-        onError: (error) => dependencies.console.error('NIP-46アカウント復元エラー:', error),
+        cleanupRuntime: () => dependencies.nip46Svc.disconnect(),
+        onError: () => dependencies.console.error('NIP-46アカウント復元に失敗しました'),
     });
 }
 
 export async function restoreManagedParentClientAccount(
     pubkeyHex: string,
     dependencies: ManagedAuthRestoreDependencies,
-): Promise<RestoreResult> {
+): Promise<ManagedRestoreResult> {
     return restoreManagedSessionAccount({
         pubkeyHex,
         loadSession: (targetPubkeyHex) =>
             ParentClientStorage.loadSession(dependencies.localStorage, targetPubkeyHex),
+        validateStoredIdentity: (session, targetPubkeyHex) =>
+            session.pubkeyHex === targetPubkeyHex,
         reconnect: (session) => dependencies.parentClientSvc.reconnect(session),
-        applyAuth: (targetPubkeyHex) =>
-            applyPublicKeyAuth('parentClient', targetPubkeyHex, dependencies),
-        onError: (error) => dependencies.console.error('親クライアント連携アカウント復元エラー:', error),
+        isExpectedAccount: () => dependencies.isExpectedAccount(pubkeyHex, 'parentClient'),
+        finalize: (targetPubkeyHex) => {
+            const activeSession = dependencies.parentClientSvc.getSessionData();
+            if (!activeSession || activeSession.pubkeyHex !== targetPubkeyHex) {
+                return { hasAuth: false, reason: 'identity-mismatch' };
+            }
+
+            try {
+                ParentClientStorage.saveSession(dependencies.localStorage, activeSession);
+            } catch {
+                return { hasAuth: false, reason: 'persistence-failed' };
+            }
+
+            try {
+                applyPublicKeyAuth('parentClient', targetPubkeyHex, dependencies);
+                return { hasAuth: true, pubkeyHex: targetPubkeyHex };
+            } catch {
+                return { hasAuth: false, reason: 'runtime-commit-failed' };
+            }
+        },
+        cleanupRuntime: () => dependencies.parentClientSvc.disconnect(false),
+        onError: () => dependencies.console.error('親クライアント連携アカウント復元に失敗しました'),
     });
 }
 
 const managedRestoreStrategies: Record<
     AccountAuthType,
-    (pubkeyHex: string, dependencies: ManagedAuthRestoreDependencies) => Promise<RestoreResult>
+    (pubkeyHex: string, dependencies: ManagedAuthRestoreDependencies) => Promise<ManagedRestoreResult>
 > = {
     nsec: restoreManagedNsecAccount,
     nip07: restoreManagedNip07Account,
@@ -210,19 +330,22 @@ const managedRestoreStrategies: Record<
 export function createManagedAuthRestoreDependencies(
     source: ManagedAuthRestoreDependencies,
 ): ManagedAuthRestoreDependencies {
-    return {
-        ...source,
-        accountManager: source.accountManager ?? null,
-    };
+    return source;
 }
 
 export async function restoreManagedAccount(
     pubkeyHex: string,
     type: AccountAuthType,
     dependencies: ManagedAuthRestoreDependencies,
-): Promise<RestoreResult> {
+): Promise<ManagedRestoreResult> {
+    if (!/^[0-9a-fA-F]{64}$/.test(pubkeyHex)) {
+        return { hasAuth: false, reason: 'invalid-requested-pubkey' };
+    }
+
     const strategy = managedRestoreStrategies[type];
-    return strategy ? strategy(pubkeyHex, dependencies) : { hasAuth: false };
+    return strategy
+        ? strategy(pubkeyHex, dependencies)
+        : { hasAuth: false, reason: 'unsupported-account-type' };
 }
 
 export async function checkLegacyNsecAuth(

--- a/src/lib/authService.ts
+++ b/src/lib/authService.ts
@@ -6,6 +6,7 @@ import {
     createManagedAuthRestoreDependencies,
     restoreManagedAccount,
     runManagedAuthRestore,
+    type ManagedRestoreResult,
     runLegacyAuthChecks,
     type RestoreResult,
 } from './authRestoreUtils';
@@ -271,11 +272,26 @@ export class AuthService {
     /**
      * 指定アカウントの認証を復元する。
      */
-    async restoreAccount(pubkeyHex: string, type: 'nsec' | 'nip07' | 'nip46' | 'parentClient'): Promise<RestoreResult> {
+    async restoreAccount(
+        pubkeyHex: string,
+        type: 'nsec' | 'nip07' | 'nip46' | 'parentClient',
+    ): Promise<ManagedRestoreResult> {
+        if (!/^[0-9a-fA-F]{64}$/.test(pubkeyHex)) {
+            return { hasAuth: false, reason: 'invalid-requested-pubkey' };
+        }
+
+        if (!this.accountManager || this.accountManager.getAccountType(pubkeyHex) !== type) {
+            return { hasAuth: false, reason: 'account-record-mismatch' };
+        }
+
         return restoreManagedAccount(
             pubkeyHex,
             type,
-            createManagedAuthRestoreDependencies(this.createRestoreDependencies()),
+            createManagedAuthRestoreDependencies({
+                ...this.createRestoreDependencies(),
+                isExpectedAccount: (targetPubkeyHex, expectedType) =>
+                    this.accountManager?.getAccountType(targetPubkeyHex) === expectedType,
+            }),
         );
     }
 

--- a/src/lib/authServiceRuntime.ts
+++ b/src/lib/authServiceRuntime.ts
@@ -12,6 +12,11 @@ interface AuthServiceKeyManager {
     derivePublicKey(secretKey: string): PublicKeyData;
     saveToStorage(secretKey: string, pubkeyHex?: string): unknown;
     loadFromStorage(pubkeyHex?: string): string | null;
+    readStoredKey(pubkeyHex: string):
+        | { status: 'found'; secretKey: string }
+        | { status: 'missing' }
+        | { status: 'error' };
+    setCurrentSecretKey(secretKey: string | null): void;
 }
 
 function isAuthServiceKeyManager(
@@ -23,7 +28,9 @@ function isAuthServiceKeyManager(
         && typeof candidate.isValidNsec === 'function'
         && typeof candidate.derivePublicKey === 'function'
         && typeof candidate.saveToStorage === 'function'
-        && typeof candidate.loadFromStorage === 'function';
+        && typeof candidate.loadFromStorage === 'function'
+        && typeof candidate.readStoredKey === 'function'
+        && typeof candidate.setCurrentSecretKey === 'function';
 }
 
 export interface AuthServiceRuntime {

--- a/src/lib/keyManager.svelte.ts
+++ b/src/lib/keyManager.svelte.ts
@@ -74,6 +74,24 @@ export class KeyStorage {
         }
     }
 
+    readStoredKey(pubkeyHex: string):
+        | { status: 'found'; secretKey: string }
+        | { status: 'missing' }
+        | { status: 'error' } {
+        try {
+            const secretKey = this.localStorage.getItem(getNsecStorageKey(pubkeyHex));
+            return secretKey
+                ? { status: 'found', secretKey }
+                : { status: 'missing' };
+        } catch {
+            return { status: 'error' };
+        }
+    }
+
+    setCurrentSecretKey(secretKey: string | null): void {
+        this.secretKeyStore.set(secretKey);
+    }
+
     getFromStore(): string | null {
         return this.secretKeyStore.value;
     }
@@ -236,6 +254,17 @@ export class KeyManager {
 
     loadFromStorage(pubkeyHex?: string): string | null {
         return this.storage.loadFromStorage(pubkeyHex);
+    }
+
+    readStoredKey(pubkeyHex: string):
+        | { status: 'found'; secretKey: string }
+        | { status: 'missing' }
+        | { status: 'error' } {
+        return this.storage.readStoredKey(pubkeyHex);
+    }
+
+    setCurrentSecretKey(secretKey: string | null): void {
+        this.storage.setCurrentSecretKey(secretKey);
     }
 
     getFromStore(): string | null {

--- a/src/lib/nip07AuthService.ts
+++ b/src/lib/nip07AuthService.ts
@@ -68,13 +68,30 @@ export class Nip07AuthService {
     /**
      * NIP-07拡張機能から公開鍵を取得し、npub/nprofileを導出
      */
-    async authenticate(): Promise<AuthResult & { pubkeyData?: PublicKeyData }> {
+    async authenticate(
+        options: { timeoutMs?: number } = {},
+    ): Promise<AuthResult & { pubkeyData?: PublicKeyData }> {
         if (!this.isAvailable()) {
             return { success: false, error: 'nip07_not_available' };
         }
 
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
         try {
-            const pubkeyHex: string = await this.capturedNostr.getPublicKey();
+            const readPromise = Promise.resolve().then(
+                () => this.capturedNostr.getPublicKey(),
+            );
+            const timeoutMs = options.timeoutMs;
+            const pubkeyHex: string = typeof timeoutMs === 'number' && timeoutMs > 0
+                ? await Promise.race([
+                    readPromise,
+                    new Promise<never>((_, reject) => {
+                        timeoutId = setTimeout(() => {
+                            reject(new Error('nip07_identity_read_timeout'));
+                        }, timeoutMs);
+                    }),
+                ])
+                : await readPromise;
 
             if (!pubkeyHex) {
                 return { success: false, error: 'nip07_no_pubkey' };
@@ -89,8 +106,14 @@ export class Nip07AuthService {
                 pubkeyData: { hex: pubkeyHex, npub, nprofile },
             };
         } catch (error) {
-            this.console.error('NIP-07認証エラー:', error);
+            if (typeof options.timeoutMs !== 'number' || options.timeoutMs <= 0) {
+                this.console.error('NIP-07認証エラー:', error);
+            }
             return { success: false, error: 'nip07_auth_error' };
+        } finally {
+            if (timeoutId !== undefined) {
+                clearTimeout(timeoutId);
+            }
         }
     }
 

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -4,6 +4,11 @@ import { vi } from 'vitest';
 import type { RxNostr } from 'rx-nostr';
 import type { KeyManagerInterface } from '../lib/types';
 
+type StoredKeyReadResult =
+    | { status: 'found'; secretKey: string }
+    | { status: 'missing' }
+    | { status: 'error' };
+
 export type MockConsole = Console & {
     log: ReturnType<typeof vi.fn>;
     debug: ReturnType<typeof vi.fn>;
@@ -74,6 +79,12 @@ export class MockKeyManager implements KeyManagerInterface {
 
     getFromStore = vi.fn(() => this.storedKey);
     loadFromStorage = vi.fn(() => this.storageKey);
+    readStoredKey = vi.fn<(pubkeyHex: string) => StoredKeyReadResult>(() => this.storageKey
+        ? { status: 'found' as const, secretKey: this.storageKey }
+        : { status: 'missing' as const });
+    setCurrentSecretKey = vi.fn((secretKey: string | null) => {
+        this.storedKey = secretKey;
+    });
     isWindowNostrAvailable = vi.fn(() => this.windowNostrAvailable);
 
     // Additional methods for authService tests

--- a/src/test/unit/appAccountSessionController.test.ts
+++ b/src/test/unit/appAccountSessionController.test.ts
@@ -324,6 +324,26 @@ describe('createAppAccountSessionController', () => {
         expect(getActivePubkey()).toBe(CURRENT_PUBKEY);
     });
 
+    it('NIP-07 targetのidentity read失敗後はcurrent accountを一度だけrollbackする', async () => {
+        const { deps, controller, getActivePubkey } = createController({
+            restoreManagedAccountSession,
+        });
+        deps.restoreAccount.mockImplementation(async (pubkeyHex: string) =>
+            pubkeyHex === TARGET_PUBKEY
+                ? { hasAuth: false, reason: 'identity-read-failed' }
+                : { hasAuth: true, pubkeyHex },
+        );
+
+        await expect(controller.switchAccount(TARGET_PUBKEY)).resolves.toBe(true);
+
+        expect(deps.restoreAccount).toHaveBeenCalledTimes(2);
+        expect(deps.restoreAccount).toHaveBeenNthCalledWith(1, TARGET_PUBKEY, 'nip07');
+        expect(deps.restoreAccount).toHaveBeenNthCalledWith(2, CURRENT_PUBKEY, 'parentClient');
+        expect(deps.handlePostAuth).toHaveBeenCalledTimes(1);
+        expect(deps.handlePostAuth).toHaveBeenCalledWith(CURRENT_PUBKEY);
+        expect(getActivePubkey()).toBe(CURRENT_PUBKEY);
+    });
+
     it('rollback mismatch後は再rollbackせずguestへ収束する', async () => {
         const { deps, controller, getActivePubkey } = createController();
         deps.restoreManagedAccountSession

--- a/src/test/unit/authService.initialize.test.ts
+++ b/src/test/unit/authService.initialize.test.ts
@@ -1,15 +1,20 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import type { AuthServiceDependencies } from '../../lib/types';
 import { MockStorage, type MockKeyManager } from '../helpers';
 import './authServiceModuleMocks';
 
 import { AuthService } from '../../lib/authService';
+import { MANAGED_NIP07_IDENTITY_READ_TIMEOUT_MS } from '../../lib/authRestoreUtils';
 import {
     createMockAccountManager,
     createMockDependencies,
     createMockNip07Dependencies,
     createMockNip46Session,
 } from './authServiceTestUtils';
+
+const ACTIVE_PUBKEY = 'aa'.repeat(32);
+const FALLBACK_PUBKEY = 'bb'.repeat(32);
+const NIP07_PUBKEY = 'cc'.repeat(32);
 
 describe('AuthService.initializeAuth', () => {
     let mockDependencies: AuthServiceDependencies;
@@ -23,13 +28,18 @@ describe('AuthService.initializeAuth', () => {
         vi.clearAllMocks();
     });
 
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it('マルチアカウント: アクティブアカウント復元成功', async () => {
-        mockAccountManager.getActiveAccountPubkey.mockReturnValue('active-pub');
+        mockAccountManager.getActiveAccountPubkey.mockReturnValue(ACTIVE_PUBKEY);
         mockAccountManager.getAccountType.mockReturnValue('nsec');
 
-        mockKeyManager.loadFromStorage.mockReturnValue('valid-nsec');
+        mockKeyManager.readStoredKey.mockReturnValue({ status: 'found', secretKey: 'valid-nsec' });
+        mockKeyManager.isValidNsec.mockReturnValue(true);
         mockKeyManager.derivePublicKey.mockReturnValue({
-            hex: 'active-pub',
+            hex: ACTIVE_PUBKEY,
             npub: 'npub1active',
             nprofile: 'nprofile1active',
         });
@@ -40,23 +50,24 @@ describe('AuthService.initializeAuth', () => {
         const result = await service.initializeAuth();
 
         expect(result.hasAuth).toBe(true);
-        expect(result.pubkeyHex).toBe('active-pub');
+        expect(result.pubkeyHex).toBe(ACTIVE_PUBKEY);
     });
 
     it('マルチアカウント: アクティブ失敗→他アカウントフォールバック成功', async () => {
-        mockAccountManager.getActiveAccountPubkey.mockReturnValue('active-pub');
+        mockAccountManager.getActiveAccountPubkey.mockReturnValue(ACTIVE_PUBKEY);
         mockAccountManager.getAccountType.mockReturnValue('nsec');
         mockAccountManager.getAccounts.mockReturnValue([
-            { pubkeyHex: 'active-pub', type: 'nsec', addedAt: 1000 },
-            { pubkeyHex: 'fallback-pub', type: 'nsec', addedAt: 2000 },
+            { pubkeyHex: ACTIVE_PUBKEY, type: 'nsec', addedAt: 1000 },
+            { pubkeyHex: FALLBACK_PUBKEY, type: 'nsec', addedAt: 2000 },
         ]);
 
-        mockKeyManager.loadFromStorage.mockImplementation((pubkey?: string) => {
-            if (pubkey === 'fallback-pub') return 'fallback-nsec';
-            return null;
+        mockKeyManager.readStoredKey.mockImplementation((pubkey: string) => {
+            if (pubkey === FALLBACK_PUBKEY) return { status: 'found', secretKey: 'fallback-nsec' };
+            return { status: 'missing' };
         });
+        mockKeyManager.isValidNsec.mockReturnValue(true);
         mockKeyManager.derivePublicKey.mockReturnValue({
-            hex: 'fallback-pub',
+            hex: FALLBACK_PUBKEY,
             npub: 'npub1fallback',
             nprofile: 'nprofile1fallback',
         });
@@ -67,18 +78,18 @@ describe('AuthService.initializeAuth', () => {
         const result = await service.initializeAuth();
 
         expect(result.hasAuth).toBe(true);
-        expect(result.pubkeyHex).toBe('fallback-pub');
-        expect(mockAccountManager.setActiveAccount).toHaveBeenCalledWith('fallback-pub');
+        expect(result.pubkeyHex).toBe(FALLBACK_PUBKEY);
+        expect(mockAccountManager.setActiveAccount).toHaveBeenCalledWith(FALLBACK_PUBKEY);
     });
 
     it('マルチアカウント: 全アカウント復元失敗', async () => {
-        mockAccountManager.getActiveAccountPubkey.mockReturnValue('active-pub');
+        mockAccountManager.getActiveAccountPubkey.mockReturnValue(ACTIVE_PUBKEY);
         mockAccountManager.getAccountType.mockReturnValue('nsec');
         mockAccountManager.getAccounts.mockReturnValue([
-            { pubkeyHex: 'active-pub', type: 'nsec', addedAt: 1000 },
+            { pubkeyHex: ACTIVE_PUBKEY, type: 'nsec', addedAt: 1000 },
         ]);
 
-        mockKeyManager.loadFromStorage.mockReturnValue(null);
+        mockKeyManager.readStoredKey.mockReturnValue({ status: 'missing' });
 
         const service = new AuthService(mockDependencies);
         service.setAccountManager(mockAccountManager as any);
@@ -89,23 +100,25 @@ describe('AuthService.initializeAuth', () => {
     });
 
     it('マルチアカウント: parentClient は起動時自動復元せず他アカウントへフォールバックする', async () => {
-        mockAccountManager.getActiveAccountPubkey.mockReturnValue('parent-pub');
+        const parentPubkey = 'dd'.repeat(32);
+        mockAccountManager.getActiveAccountPubkey.mockReturnValue(parentPubkey);
         mockAccountManager.getAccountType.mockImplementation((pubkeyHex: string) => {
-            if (pubkeyHex === 'parent-pub') return 'parentClient';
-            if (pubkeyHex === 'fallback-pub') return 'nsec';
+            if (pubkeyHex === parentPubkey) return 'parentClient';
+            if (pubkeyHex === FALLBACK_PUBKEY) return 'nsec';
             return null;
         });
         mockAccountManager.getAccounts.mockReturnValue([
-            { pubkeyHex: 'parent-pub', type: 'parentClient', addedAt: 1000 },
-            { pubkeyHex: 'fallback-pub', type: 'nsec', addedAt: 2000 },
+            { pubkeyHex: parentPubkey, type: 'parentClient', addedAt: 1000 },
+            { pubkeyHex: FALLBACK_PUBKEY, type: 'nsec', addedAt: 2000 },
         ]);
 
-        mockKeyManager.loadFromStorage.mockImplementation((pubkey?: string) => {
-            if (pubkey === 'fallback-pub') return 'fallback-nsec';
-            return null;
+        mockKeyManager.readStoredKey.mockImplementation((pubkey: string) => {
+            if (pubkey === FALLBACK_PUBKEY) return { status: 'found', secretKey: 'fallback-nsec' };
+            return { status: 'missing' };
         });
+        mockKeyManager.isValidNsec.mockReturnValue(true);
         mockKeyManager.derivePublicKey.mockReturnValue({
-            hex: 'fallback-pub',
+            hex: FALLBACK_PUBKEY,
             npub: 'npub1fallback',
             nprofile: 'nprofile1fallback',
         });
@@ -118,9 +131,54 @@ describe('AuthService.initializeAuth', () => {
         const result = await service.initializeAuth();
 
         expect(result.hasAuth).toBe(true);
-        expect(result.pubkeyHex).toBe('fallback-pub');
+        expect(result.pubkeyHex).toBe(FALLBACK_PUBKEY);
         expect(parentClientAuthService.reconnect).not.toHaveBeenCalled();
-        expect(mockAccountManager.setActiveAccount).toHaveBeenCalledWith('fallback-pub');
+        expect(mockAccountManager.setActiveAccount).toHaveBeenCalledWith(FALLBACK_PUBKEY);
+    });
+
+    it('NIP-07 identity read timeout後に次のmanaged candidateを試す', async () => {
+        vi.useFakeTimers();
+        mockAccountManager.getActiveAccountPubkey.mockReturnValue(NIP07_PUBKEY);
+        mockAccountManager.getAccountType.mockImplementation((pubkeyHex: string) => {
+            if (pubkeyHex === NIP07_PUBKEY) return 'nip07';
+            if (pubkeyHex === FALLBACK_PUBKEY) return 'nsec';
+            return null;
+        });
+        mockAccountManager.getAccounts.mockReturnValue([
+            { pubkeyHex: NIP07_PUBKEY, type: 'nip07', addedAt: 1000 },
+            { pubkeyHex: FALLBACK_PUBKEY, type: 'nsec', addedAt: 2000 },
+        ]);
+        mockKeyManager.readStoredKey.mockImplementation((pubkey: string) =>
+            pubkey === FALLBACK_PUBKEY
+                ? { status: 'found', secretKey: 'fallback-nsec' }
+                : { status: 'missing' },
+        );
+        mockKeyManager.isValidNsec.mockReturnValue(true);
+        mockKeyManager.derivePublicKey.mockReturnValue({
+            hex: FALLBACK_PUBKEY,
+            npub: 'npub1fallback',
+            nprofile: 'nprofile1fallback',
+        });
+
+        const deferred = new Promise<string>(() => undefined);
+        mockDependencies.window = {
+            nostr: {
+                getPublicKey: vi.fn(() => deferred),
+                signEvent: vi.fn(),
+            },
+        } as unknown as Window;
+        const service = new AuthService(mockDependencies);
+        service.setAccountManager(mockAccountManager as any);
+
+        const initialize = service.initializeAuth();
+        await vi.advanceTimersByTimeAsync(MANAGED_NIP07_IDENTITY_READ_TIMEOUT_MS);
+
+        await expect(initialize).resolves.toMatchObject({
+            hasAuth: true,
+            pubkeyHex: FALLBACK_PUBKEY,
+        });
+        expect(mockDependencies.setNip07Auth).not.toHaveBeenCalled();
+        expect(mockAccountManager.setActiveAccount).toHaveBeenCalledWith(FALLBACK_PUBKEY);
     });
 
     it('アカウントなし→レガシーnsec検出', async () => {

--- a/src/test/unit/authService.restore.test.ts
+++ b/src/test/unit/authService.restore.test.ts
@@ -1,15 +1,38 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { AuthServiceDependencies } from '../../lib/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthServiceDependencies, StoredAccount } from '../../lib/types';
 import type { MockKeyManager } from '../helpers';
 import './authServiceModuleMocks';
 
 import { AuthService } from '../../lib/authService';
 import {
+    MANAGED_NIP07_IDENTITY_READ_TIMEOUT_MS,
+} from '../../lib/authRestoreUtils';
+import {
+    createMockAccountManager,
     createMockDependencies,
     createMockNip07Dependencies,
     createMockNip46Session,
     createMockParentClientSession,
 } from './authServiceTestUtils';
+
+const NSEC_PUBKEY = 'aa'.repeat(32);
+const NIP07_PUBKEY = 'bb'.repeat(32);
+const NIP46_PUBKEY = 'cc'.repeat(32);
+const PARENT_PUBKEY = 'dd'.repeat(32);
+
+function createManagedService(
+    dependencies: AuthServiceDependencies,
+    pubkeyHex: string,
+    type: StoredAccount['type'],
+    getAccountType: (pubkey: string) => StoredAccount['type'] | null =
+        (pubkey) => pubkey === pubkeyHex ? type : null,
+): AuthService {
+    const service = new AuthService(dependencies);
+    service.setAccountManager(createMockAccountManager({
+        getAccountType: vi.fn(getAccountType),
+    }) as any);
+    return service;
+}
 
 describe('AuthService.restoreAccount', () => {
     let mockDependencies: AuthServiceDependencies;
@@ -17,141 +40,382 @@ describe('AuthService.restoreAccount', () => {
 
     beforeEach(() => {
         mockDependencies = createMockDependencies();
-        mockKeyManager = mockDependencies.keyManager as any;
+        mockKeyManager = mockDependencies.keyManager as MockKeyManager;
         vi.clearAllMocks();
     });
 
-    it('restoreNsecAccount: 秘密鍵存在→公開鍵導出→認証復元', async () => {
-        mockKeyManager.loadFromStorage.mockReturnValue('stored-nsec');
-        mockKeyManager.derivePublicKey.mockReturnValue({
-            hex: 'restored-pubkey',
-            npub: 'npub1restored',
-            nprofile: 'nprofile1restored',
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('保存account recordがない場合は方式固有restoreを開始しない', async () => {
+        const service = new AuthService(mockDependencies);
+
+        await expect(service.restoreAccount(NSEC_PUBKEY, 'nsec')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'account-record-mismatch',
         });
-
-        const service = new AuthService(mockDependencies);
-        const result = await service.restoreAccount('restored-pubkey', 'nsec');
-
-        expect(result.hasAuth).toBe(true);
-        expect(result.pubkeyHex).toBe('restored-pubkey');
-        expect(mockDependencies.setNsecAuth).toHaveBeenCalledWith('restored-pubkey', 'npub1restored', 'nprofile1restored');
+        expect(mockKeyManager.readStoredKey).not.toHaveBeenCalled();
     });
 
-    it('restoreNsecAccount: 秘密鍵なし→失敗', async () => {
-        mockKeyManager.loadFromStorage.mockReturnValue(null);
+    it('nsec: 導出identity一致後だけsecret stateとauth stateを反映する', async () => {
+        mockKeyManager.readStoredKey.mockReturnValue({ status: 'found', secretKey: 'stored-nsec' });
+        mockKeyManager.isValidNsec.mockReturnValue(true);
+        mockKeyManager.derivePublicKey.mockReturnValue({
+            hex: NSEC_PUBKEY,
+            npub: 'npub1nsec',
+            nprofile: 'nprofile1nsec',
+        });
+        const service = createManagedService(mockDependencies, NSEC_PUBKEY, 'nsec');
 
-        const service = new AuthService(mockDependencies);
-        const result = await service.restoreAccount('some-pubkey', 'nsec');
+        const result = await service.restoreAccount(NSEC_PUBKEY, 'nsec');
 
-        expect(result.hasAuth).toBe(false);
+        expect(result).toEqual({ hasAuth: true, pubkeyHex: NSEC_PUBKEY });
+        expect(mockKeyManager.setCurrentSecretKey).toHaveBeenCalledWith('stored-nsec');
+        expect(mockDependencies.setNsecAuth).toHaveBeenCalledWith(
+            NSEC_PUBKEY,
+            'npub1nsec',
+            'nprofile1nsec',
+        );
     });
 
-    it('restoreNip07Account: 拡張機能待機→認証成功', async () => {
-        const validPubkey = 'ef'.repeat(32);
-        const nip07Deps = createMockNip07Dependencies(validPubkey);
+    it('nsec: mismatchではsecret stateとauth stateを変更しない', async () => {
+        mockKeyManager.readStoredKey.mockReturnValue({ status: 'found', secretKey: 'stored-nsec' });
+        mockKeyManager.isValidNsec.mockReturnValue(true);
+        mockKeyManager.derivePublicKey.mockReturnValue({
+            hex: NIP07_PUBKEY,
+            npub: 'npub1other',
+            nprofile: 'nprofile1other',
+        });
+        const service = createManagedService(mockDependencies, NSEC_PUBKEY, 'nsec');
 
-        const service = new AuthService(nip07Deps);
-        const result = await service.restoreAccount(validPubkey, 'nip07');
+        await expect(service.restoreAccount(NSEC_PUBKEY, 'nsec')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'identity-mismatch',
+        });
+        expect(mockKeyManager.setCurrentSecretKey).not.toHaveBeenCalled();
+        expect(mockDependencies.setNsecAuth).not.toHaveBeenCalled();
+    });
 
-        expect(result.hasAuth).toBe(true);
-        expect(result.pubkeyHex).toBe(validPubkey);
+    it.each([
+        [{ status: 'missing' }, 'credential-missing'],
+        [{ status: 'error' }, 'credential-read-failed'],
+    ] as const)('nsec: storage結果 %o を失敗として返す', async (storedKeyResult, reason) => {
+        mockKeyManager.readStoredKey.mockReturnValue(storedKeyResult);
+        const service = createManagedService(mockDependencies, NSEC_PUBKEY, 'nsec');
+
+        await expect(service.restoreAccount(NSEC_PUBKEY, 'nsec')).resolves.toEqual({
+            hasAuth: false,
+            reason,
+        });
+        expect(mockDependencies.setNsecAuth).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['invalid nsec', () => {
+            mockKeyManager.readStoredKey.mockReturnValue({ status: 'found', secretKey: 'not-an-nsec' });
+            mockKeyManager.isValidNsec.mockReturnValue(false);
+        }, 'credential-invalid'],
+        ['derive exception', () => {
+            mockKeyManager.readStoredKey.mockReturnValue({ status: 'found', secretKey: 'stored-nsec' });
+            mockKeyManager.isValidNsec.mockReturnValue(true);
+            mockKeyManager.derivePublicKey.mockImplementation(() => {
+                throw new Error('derive failed');
+            });
+        }, 'identity-read-failed'],
+        ['empty derived pubkey', () => {
+            mockKeyManager.readStoredKey.mockReturnValue({ status: 'found', secretKey: 'stored-nsec' });
+            mockKeyManager.isValidNsec.mockReturnValue(true);
+            mockKeyManager.derivePublicKey.mockReturnValue({ hex: '', npub: '', nprofile: '' });
+        }, 'identity-read-failed'],
+    ] as const)('nsec: %sではstateを反映しない', async (_caseName, prepare, reason) => {
+        prepare();
+        const service = createManagedService(mockDependencies, NSEC_PUBKEY, 'nsec');
+
+        await expect(service.restoreAccount(NSEC_PUBKEY, 'nsec')).resolves.toEqual({
+            hasAuth: false,
+            reason,
+        });
+        expect(mockKeyManager.setCurrentSecretKey).not.toHaveBeenCalled();
+        expect(mockDependencies.setNsecAuth).not.toHaveBeenCalled();
+        expect(mockKeyManager.saveToStorage).not.toHaveBeenCalled();
+    });
+
+    it('nsec: late account record不一致ではstateを反映しない', async () => {
+        mockKeyManager.readStoredKey.mockReturnValue({ status: 'found', secretKey: 'stored-nsec' });
+        mockKeyManager.isValidNsec.mockReturnValue(true);
+        mockKeyManager.derivePublicKey.mockReturnValue({
+            hex: NSEC_PUBKEY,
+            npub: 'npub1nsec',
+            nprofile: 'nprofile1nsec',
+        });
+        let checks = 0;
+        const service = createManagedService(
+            mockDependencies,
+            NSEC_PUBKEY,
+            'nsec',
+            () => (++checks === 1 ? 'nsec' : null),
+        );
+
+        await expect(service.restoreAccount(NSEC_PUBKEY, 'nsec')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'account-record-mismatch',
+        });
+        expect(mockKeyManager.setCurrentSecretKey).not.toHaveBeenCalled();
+        expect(mockDependencies.setNsecAuth).not.toHaveBeenCalled();
+    });
+
+    it('NIP-07: extension返却identity一致後だけauth stateを反映する', async () => {
+        const nip07Deps = createMockNip07Dependencies(NIP07_PUBKEY, mockDependencies);
+        const service = createManagedService(nip07Deps, NIP07_PUBKEY, 'nip07');
+
+        await expect(service.restoreAccount(NIP07_PUBKEY, 'nip07')).resolves.toEqual({
+            hasAuth: true,
+            pubkeyHex: NIP07_PUBKEY,
+        });
         expect(nip07Deps.setNip07Auth).toHaveBeenCalled();
     });
 
-    it('restoreNip07Account: 拡張機能なし→失敗', async () => {
-        const service = new AuthService(mockDependencies);
-        const result = await service.restoreAccount('some-pubkey', 'nip07');
+    it('NIP-07: extension identity mismatchではauth stateを反映しない', async () => {
+        const nip07Deps = createMockNip07Dependencies(NSEC_PUBKEY, mockDependencies);
+        const service = createManagedService(nip07Deps, NIP07_PUBKEY, 'nip07');
 
-        expect(result.hasAuth).toBe(false);
+        await expect(service.restoreAccount(NIP07_PUBKEY, 'nip07')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'identity-mismatch',
+        });
+        expect(nip07Deps.setNip07Auth).not.toHaveBeenCalled();
     });
 
-    it('restoreNip46Account: セッション復元→再接続成功', async () => {
-        const validPubkey = 'ab'.repeat(32);
+    it('NIP-07: pubkey dataの内部不一致はauth stateを反映しない', async () => {
+        const nip07Deps = createMockNip07Dependencies(NIP07_PUBKEY, mockDependencies);
+        const service = createManagedService(nip07Deps, NIP07_PUBKEY, 'nip07');
+        const runtime = (service as unknown as {
+            runtime: { nip07Service: { authenticate: ReturnType<typeof vi.fn> } };
+        }).runtime;
+        runtime.nip07Service.authenticate = vi.fn().mockResolvedValue({
+            success: true,
+            pubkeyHex: NIP07_PUBKEY,
+            pubkeyData: { hex: NSEC_PUBKEY, npub: 'npub1other', nprofile: 'nprofile1other' },
+        });
+
+        await expect(service.restoreAccount(NIP07_PUBKEY, 'nip07')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'identity-read-failed',
+        });
+        expect(nip07Deps.setNip07Auth).not.toHaveBeenCalled();
+    });
+
+    it('NIP-07: identity read timeoutはauth stateと他方式runtimeを変更しない', async () => {
+        vi.useFakeTimers();
+        let resolvePublicKey: ((value: string) => void) | undefined;
+        const nip07Deps = createMockNip07Dependencies(NIP07_PUBKEY, mockDependencies);
+        (nip07Deps.window as any).nostr.getPublicKey.mockImplementation(
+            () => new Promise<string>((resolve) => { resolvePublicKey = resolve; }),
+        );
+        const service = createManagedService(nip07Deps, NIP07_PUBKEY, 'nip07');
+
+        const restore = service.restoreAccount(NIP07_PUBKEY, 'nip07');
+        await vi.advanceTimersByTimeAsync(MANAGED_NIP07_IDENTITY_READ_TIMEOUT_MS);
+
+        await expect(restore).resolves.toEqual({
+            hasAuth: false,
+            reason: 'identity-read-failed',
+        });
+        expect(nip07Deps.setNip07Auth).not.toHaveBeenCalled();
+
+        resolvePublicKey?.(NIP07_PUBKEY);
+        await Promise.resolve();
+        expect(nip07Deps.setNip07Auth).not.toHaveBeenCalled();
+        const { nip46Service } = await import('../../lib/nip46Service');
+        const { parentClientAuthService } = await import('../../lib/parentClientAuthService');
+        expect(nip46Service.reconnect).not.toHaveBeenCalled();
+        expect(parentClientAuthService.reconnect).not.toHaveBeenCalled();
+    });
+
+    it('NIP-46: 保存session identity mismatchではreconnectを開始しない', async () => {
         const { nip46Service, Nip46Service: Nip46ServiceClass } = await import('../../lib/nip46Service');
-        const session = createMockNip46Session(validPubkey, { pingVerified: true });
+        vi.mocked(Nip46ServiceClass.loadSession).mockReturnValue(
+            createMockNip46Session(NIP07_PUBKEY),
+        );
+        const service = createManagedService(mockDependencies, NIP46_PUBKEY, 'nip46');
+
+        await expect(service.restoreAccount(NIP46_PUBKEY, 'nip46')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'identity-mismatch',
+        });
+        expect(nip46Service.reconnect).not.toHaveBeenCalled();
+        expect(mockDependencies.setNip46Auth).not.toHaveBeenCalled();
+    });
+
+    it('NIP-46: reconnect失敗ではpartial runtimeをcleanupする', async () => {
+        const { nip46Service, Nip46Service: Nip46ServiceClass } = await import('../../lib/nip46Service');
+        vi.mocked(Nip46ServiceClass.loadSession).mockReturnValue(createMockNip46Session(NIP46_PUBKEY));
+        vi.mocked(nip46Service.reconnect).mockRejectedValue(new Error('reconnect failed'));
+        const service = createManagedService(mockDependencies, NIP46_PUBKEY, 'nip46');
+
+        await expect(service.restoreAccount(NIP46_PUBKEY, 'nip46')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'reconnect-failed',
+        });
+        expect(nip46Service.disconnect).toHaveBeenCalledOnce();
+        expect(mockDependencies.setNip46Auth).not.toHaveBeenCalled();
+    });
+
+    it('NIP-46: reconnect戻り値の契約不一致ではpartial runtimeをcleanupする', async () => {
+        const { nip46Service, Nip46Service: Nip46ServiceClass } = await import('../../lib/nip46Service');
+        vi.mocked(Nip46ServiceClass.loadSession).mockReturnValue(createMockNip46Session(NIP46_PUBKEY));
+        vi.mocked(nip46Service.reconnect).mockResolvedValue(NIP07_PUBKEY);
+        const service = createManagedService(mockDependencies, NIP46_PUBKEY, 'nip46');
+
+        await expect(service.restoreAccount(NIP46_PUBKEY, 'nip46')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'identity-mismatch',
+        });
+        expect(nip46Service.disconnect).toHaveBeenCalledOnce();
+        expect(nip46Service.bindSessionPersistence).not.toHaveBeenCalled();
+        expect(mockDependencies.setNip46Auth).not.toHaveBeenCalled();
+    });
+
+    it('NIP-46: late account record不一致ではpartial runtimeをcleanupする', async () => {
+        const { nip46Service, Nip46Service: Nip46ServiceClass } = await import('../../lib/nip46Service');
+        vi.mocked(Nip46ServiceClass.loadSession).mockReturnValue(createMockNip46Session(NIP46_PUBKEY));
+        vi.mocked(nip46Service.reconnect).mockResolvedValue(NIP46_PUBKEY);
+        let checks = 0;
+        const service = createManagedService(
+            mockDependencies,
+            NIP46_PUBKEY,
+            'nip46',
+            () => (++checks === 1 ? 'nip46' : null),
+        );
+
+        await expect(service.restoreAccount(NIP46_PUBKEY, 'nip46')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'account-record-mismatch',
+        });
+        expect(nip46Service.disconnect).toHaveBeenCalledOnce();
+        expect(mockDependencies.setNip46Auth).not.toHaveBeenCalled();
+    });
+
+    it('NIP-46: 保存整合性とreconnect契約一致後だけbindとauth stateを反映する', async () => {
+        const { nip46Service, Nip46Service: Nip46ServiceClass } = await import('../../lib/nip46Service');
+        const session = createMockNip46Session(NIP46_PUBKEY, { pingVerified: true });
         vi.mocked(Nip46ServiceClass.loadSession).mockReturnValue(session);
-        vi.mocked(nip46Service.reconnect).mockResolvedValue(validPubkey);
+        vi.mocked(nip46Service.reconnect).mockResolvedValue(NIP46_PUBKEY);
+        const service = createManagedService(mockDependencies, NIP46_PUBKEY, 'nip46');
 
-        const service = new AuthService(mockDependencies);
-        const result = await service.restoreAccount(validPubkey, 'nip46');
-
-        expect(result.hasAuth).toBe(true);
-        expect(result.pubkeyHex).toBe(validPubkey);
-        expect(nip46Service.reconnect).toHaveBeenCalledWith(session);
+        await expect(service.restoreAccount(NIP46_PUBKEY, 'nip46')).resolves.toEqual({
+            hasAuth: true,
+            pubkeyHex: NIP46_PUBKEY,
+        });
         expect(nip46Service.bindSessionPersistence).toHaveBeenCalledWith(
             mockDependencies.localStorage,
-            validPubkey,
+            NIP46_PUBKEY,
         );
         expect(mockDependencies.setNip46Auth).toHaveBeenCalled();
     });
 
-    it('restoreNip46Account: セッションなし→失敗', async () => {
-        const validPubkey = 'cd'.repeat(32);
-        const { Nip46Service: Nip46ServiceClass } = await import('../../lib/nip46Service');
-        vi.mocked(Nip46ServiceClass.loadSession).mockReturnValue(null);
-
-        const service = new AuthService(mockDependencies);
-        const result = await service.restoreAccount(validPubkey, 'nip46');
-
-        expect(result.hasAuth).toBe(false);
-    });
-
-    it('restoreNip46Account: 再接続失敗→失敗', async () => {
-        const validPubkey = 'cd'.repeat(32);
+    it('NIP-46: persistence失敗ではpartial runtimeをcleanupしauth stateを反映しない', async () => {
         const { nip46Service, Nip46Service: Nip46ServiceClass } = await import('../../lib/nip46Service');
-        const session = createMockNip46Session(validPubkey);
-        vi.mocked(Nip46ServiceClass.loadSession).mockReturnValue(session);
-        vi.mocked(nip46Service.reconnect).mockRejectedValue(new Error('reconnect failed'));
+        vi.mocked(Nip46ServiceClass.loadSession).mockReturnValue(createMockNip46Session(NIP46_PUBKEY));
+        vi.mocked(nip46Service.reconnect).mockResolvedValue(NIP46_PUBKEY);
+        vi.mocked(nip46Service.bindSessionPersistence).mockImplementation(() => {
+            throw new Error('persistence failed');
+        });
+        const service = createManagedService(mockDependencies, NIP46_PUBKEY, 'nip46');
 
-        const service = new AuthService(mockDependencies);
-        const result = await service.restoreAccount(validPubkey, 'nip46');
-
-        expect(result.hasAuth).toBe(false);
+        await expect(service.restoreAccount(NIP46_PUBKEY, 'nip46')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'persistence-failed',
+        });
+        expect(nip46Service.disconnect).toHaveBeenCalledOnce();
+        expect(mockDependencies.setNip46Auth).not.toHaveBeenCalled();
     });
 
-    it('restoreParentClientAccount: セッション復元→再接続成功', async () => {
-        const validPubkey = 'ef'.repeat(32);
+    it('Parent client: 保存sessionまたは再認証identity mismatchでは通知なしでcleanupする', async () => {
         const { parentClientAuthService, ParentClientAuthService: ParentClientAuthServiceClass } = await import('../../lib/parentClientAuthService');
-        const session = createMockParentClientSession(validPubkey);
+        const session = createMockParentClientSession(PARENT_PUBKEY);
         vi.mocked(ParentClientAuthServiceClass.loadSession).mockReturnValue(session);
-        vi.mocked(parentClientAuthService.reconnect).mockResolvedValue(validPubkey);
+        vi.mocked(parentClientAuthService.reconnect).mockResolvedValue(NIP07_PUBKEY);
+        const service = createManagedService(mockDependencies, PARENT_PUBKEY, 'parentClient');
 
-        const service = new AuthService(mockDependencies);
-        const result = await service.restoreAccount(validPubkey, 'parentClient');
+        await expect(service.restoreAccount(PARENT_PUBKEY, 'parentClient')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'identity-mismatch',
+        });
+        expect(parentClientAuthService.disconnect).toHaveBeenCalledWith(false);
+        expect(ParentClientAuthServiceClass.saveSession).not.toHaveBeenCalled();
+        expect(mockDependencies.setParentClientAuth).not.toHaveBeenCalled();
+    });
 
-        expect(result.hasAuth).toBe(true);
-        expect(result.pubkeyHex).toBe(validPubkey);
+    it('Parent client: 再認証結果とactive session一致後だけ保存してauth stateを反映する', async () => {
+        const { parentClientAuthService, ParentClientAuthService: ParentClientAuthServiceClass } = await import('../../lib/parentClientAuthService');
+        const session = createMockParentClientSession(PARENT_PUBKEY);
+        const refreshedSession = createMockParentClientSession(PARENT_PUBKEY, { connectedAt: 456 });
+        vi.mocked(ParentClientAuthServiceClass.loadSession).mockReturnValue(session);
+        vi.mocked(parentClientAuthService.reconnect).mockResolvedValue(PARENT_PUBKEY);
+        vi.mocked(parentClientAuthService.getSessionData).mockReturnValue(refreshedSession);
+        const service = createManagedService(mockDependencies, PARENT_PUBKEY, 'parentClient');
+
+        await expect(service.restoreAccount(PARENT_PUBKEY, 'parentClient')).resolves.toEqual({
+            hasAuth: true,
+            pubkeyHex: PARENT_PUBKEY,
+        });
+        expect(ParentClientAuthServiceClass.saveSession).toHaveBeenCalledWith(
+            mockDependencies.localStorage,
+            refreshedSession,
+        );
         expect(mockDependencies.setParentClientAuth).toHaveBeenCalled();
     });
 
-    it('restoreParentClientAccount: セッションなし→失敗', async () => {
-        const validPubkey = '12'.repeat(32);
-        const { ParentClientAuthService: ParentClientAuthServiceClass } = await import('../../lib/parentClientAuthService');
-        vi.mocked(ParentClientAuthServiceClass.loadSession).mockReturnValue(null);
-
-        const service = new AuthService(mockDependencies);
-        const result = await service.restoreAccount(validPubkey, 'parentClient');
-
-        expect(result.hasAuth).toBe(false);
-    });
-
-    it('restoreParentClientAccount: 再接続失敗→失敗', async () => {
-        const validPubkey = '56'.repeat(32);
+    it('Parent client: reconnect後のactive session identity不一致は通知なしでcleanupする', async () => {
         const { parentClientAuthService, ParentClientAuthService: ParentClientAuthServiceClass } = await import('../../lib/parentClientAuthService');
-        const session = createMockParentClientSession(validPubkey);
-        vi.mocked(ParentClientAuthServiceClass.loadSession).mockReturnValue(session);
-        vi.mocked(parentClientAuthService.reconnect).mockRejectedValue(new Error('parent reconnect failed'));
+        vi.mocked(ParentClientAuthServiceClass.loadSession).mockReturnValue(
+            createMockParentClientSession(PARENT_PUBKEY),
+        );
+        vi.mocked(parentClientAuthService.reconnect).mockResolvedValue(PARENT_PUBKEY);
+        vi.mocked(parentClientAuthService.getSessionData).mockReturnValue(
+            createMockParentClientSession(NIP07_PUBKEY),
+        );
+        const service = createManagedService(mockDependencies, PARENT_PUBKEY, 'parentClient');
 
-        const service = new AuthService(mockDependencies);
-        const result = await service.restoreAccount(validPubkey, 'parentClient');
-
-        expect(result.hasAuth).toBe(false);
+        await expect(service.restoreAccount(PARENT_PUBKEY, 'parentClient')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'identity-mismatch',
+        });
+        expect(parentClientAuthService.disconnect).toHaveBeenCalledWith(false);
+        expect(mockDependencies.setParentClientAuth).not.toHaveBeenCalled();
     });
 
-    it('不明なタイプ→失敗', async () => {
-        const service = new AuthService(mockDependencies);
-        const result = await service.restoreAccount('some-pubkey', 'unknown' as any);
+    it('Parent client: late account type不一致は通知なしでcleanupする', async () => {
+        const { parentClientAuthService, ParentClientAuthService: ParentClientAuthServiceClass } = await import('../../lib/parentClientAuthService');
+        const session = createMockParentClientSession(PARENT_PUBKEY);
+        vi.mocked(ParentClientAuthServiceClass.loadSession).mockReturnValue(session);
+        vi.mocked(parentClientAuthService.reconnect).mockResolvedValue(PARENT_PUBKEY);
+        vi.mocked(parentClientAuthService.getSessionData).mockReturnValue(session);
+        let checks = 0;
+        const service = createManagedService(
+            mockDependencies,
+            PARENT_PUBKEY,
+            'parentClient',
+            () => (++checks === 1 ? 'parentClient' : 'nip07'),
+        );
 
-        expect(result.hasAuth).toBe(false);
+        await expect(service.restoreAccount(PARENT_PUBKEY, 'parentClient')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'account-record-mismatch',
+        });
+        expect(parentClientAuthService.disconnect).toHaveBeenCalledWith(false);
+        expect(ParentClientAuthServiceClass.saveSession).not.toHaveBeenCalled();
+        expect(mockDependencies.setParentClientAuth).not.toHaveBeenCalled();
+    });
+
+    it('不正な要求pubkeyはrestoreを開始しない', async () => {
+        const service = createManagedService(mockDependencies, 'not-a-pubkey', 'nsec');
+
+        await expect(service.restoreAccount('not-a-pubkey', 'nsec')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'invalid-requested-pubkey',
+        });
     });
 });

--- a/src/test/unit/keyManager.test.ts
+++ b/src/test/unit/keyManager.test.ts
@@ -185,6 +185,37 @@ describe('KeyStorage', () => {
         });
     });
 
+    describe('readStoredKey', () => {
+        it('指定アカウントの保存済みキーを秘密鍵ストアへ反映せずに読む', () => {
+            mockLocalStorage.setItem('nostr-secret-key-test-pubkey', 'stored-key');
+
+            const result = storage.readStoredKey('test-pubkey');
+
+            expect(result).toEqual({ status: 'found', secretKey: 'stored-key' });
+            expect(mockSecretKeyStore.set).not.toHaveBeenCalled();
+        });
+
+        it('キーがない場合はmissingを返す', () => {
+            expect(storage.readStoredKey('missing-pubkey')).toEqual({ status: 'missing' });
+        });
+
+        it('ストレージ読出し例外はerrorを返し、秘密鍵ストアを変更しない', () => {
+            mockLocalStorage.getItem = vi.fn(() => {
+                throw new Error('Storage access error');
+            });
+
+            expect(storage.readStoredKey('test-pubkey')).toEqual({ status: 'error' });
+            expect(mockSecretKeyStore.set).not.toHaveBeenCalled();
+        });
+    });
+
+    it('setCurrentSecretKeyは保存済みキーを変更せずにin-memory stateだけを更新する', () => {
+        storage.setCurrentSecretKey('runtime-key');
+
+        expect(mockSecretKeyStore.set).toHaveBeenCalledWith('runtime-key');
+        expect(mockLocalStorage.getItem('nostr-secret-key')).toBeNull();
+    });
+
     describe('hasStoredKey', () => {
         it('キーが存在する場合はtrueを返す', () => {
             mockLocalStorage.setItem('nostr-secret-key', 'some-key');

--- a/src/test/unit/nip07AuthService.test.ts
+++ b/src/test/unit/nip07AuthService.test.ts
@@ -22,6 +22,10 @@ describe('Nip07AuthService', () => {
         mockConsole = createMockConsole();
     });
 
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     describe('isAvailable', () => {
         it('window.nostrが存在しない場合はfalseを返す', () => {
             const service = new Nip07AuthService(createMockWindow(), mockConsole);
@@ -170,6 +174,61 @@ describe('Nip07AuthService', () => {
 
             expect(result.success).toBe(false);
             expect(result.error).toBe('nip07_no_pubkey');
+        });
+
+        it('timeout指定時はidentity readを有限時間で失敗させ、詳細をログ出力しない', async () => {
+            vi.useFakeTimers();
+            let resolvePublicKey: ((value: string) => void) | undefined;
+            const service = new Nip07AuthService(
+                createMockWindow({
+                    getPublicKey: vi.fn(() => new Promise<string>((resolve) => {
+                        resolvePublicKey = resolve;
+                    })),
+                    signEvent: vi.fn(),
+                }),
+                mockConsole,
+            );
+
+            const resultPromise = service.authenticate({ timeoutMs: 3_000 });
+            await vi.advanceTimersByTimeAsync(3_000);
+
+            await expect(resultPromise).resolves.toEqual({
+                success: false,
+                error: 'nip07_auth_error',
+            });
+            expect(mockConsole.error).not.toHaveBeenCalled();
+
+            resolvePublicKey?.('a'.repeat(64));
+            await Promise.resolve();
+            expect(mockConsole.error).not.toHaveBeenCalled();
+        });
+
+        it('timeout未指定の明示認証は遅延identity readを待ち続ける', async () => {
+            vi.useFakeTimers();
+            let resolvePublicKey: ((value: string) => void) | undefined;
+            const service = new Nip07AuthService(
+                createMockWindow({
+                    getPublicKey: vi.fn(() => new Promise<string>((resolve) => {
+                        resolvePublicKey = resolve;
+                    })),
+                    signEvent: vi.fn(),
+                }),
+                mockConsole,
+            );
+
+            let settled = false;
+            const resultPromise = service.authenticate().then((result) => {
+                settled = true;
+                return result;
+            });
+            await vi.advanceTimersByTimeAsync(3_001);
+            expect(settled).toBe(false);
+
+            resolvePublicKey?.('a'.repeat(64));
+            await expect(resultPromise).resolves.toMatchObject({
+                success: true,
+                pubkeyHex: 'a'.repeat(64),
+            });
         });
     });
 


### PR DESCRIPTION
## 変更概要

保存済みアカウントの managed restore で、要求 pubkey と方式ごとの取得・導出・再認証 identity を global auth state 反映前に照合します。

## 方式別 identity 検証

- nsec: pubkey 別に副作用なしで保存キーを読み、nsec 形式・導出 pubkey・保存 account record/type を検証してから secret/PublicKey/auth state を反映します。
- NIP-07: extension discovery を 1 秒、identity read を 3 秒で区切り、現在の extension が返す pubkey を完全一致で照合します。明示ログインは timeout 未指定のままです。
- Parent client: 保存 session、silent reconnect 結果、active session を照合し、session 保存後に auth state を反映します。
- NIP-46: pubkey 別 session の `userPubkey` と reconnect の service 契約を照合します。reconnect 戻り値を live signer identity の証明としては扱いません。

## Cleanup と既存責務

reconnect 後の失敗は方式別 runtime cleanup を一度だけ実行します（Parent client は `disconnect(false)`、NIP-46 は `disconnect()`）。PR #50 の one-shot helper、post-auth 後 active pointer commit、非再帰 rollback、guest fallback は変更していません。

## 検証

- 認証・アカウント切替の近接 unit tests: 118 passed
- `src/test/unit/parentClientAuthService.test.ts`: 11 passed
- `src/test/unit/nip46Service.test.ts`: 97 passed
- `npm test`: 306 files / 3,388 tests passed
- `npm run check`: 0 errors / 0 warnings
- `npm run build`: passed
- `git diff --check`: passed

## 未実行の検証

Playwright と実 extension / remote signer 接続は、今回の受入条件が dependency-injected service と決定的 unit test であるため実行していません。