### PR TITLE
fix: safely migrate legacy nsec credentials

### DIFF
--- a/.agents/skills/ehagaki-nostr/references/implementation-map.md
+++ b/.agents/skills/ehagaki-nostr/references/implementation-map.md
@@ -109,6 +109,15 @@
 - 関連テスト: `src/test/unit/customEmoji.test.ts`、`src/test/unit/editorDocumentUtils.test.ts`、`src/test/unit/postManager.test.ts`、`src/test/unit/ehagakiDb.test.ts`
 - 注意点: shortcodeだけで同名画像を潰さず、選択したURLと必要なset addressを保持する。network testはmockする。
 
+## legacy nsec credential migration
+
+- 機能: 旧single-accountの`nostr-secret-key`を、nsec自身から導出したpubkeyのcredential、`nsec` account record、activation policyに沿うactive pointerへ安全に移行する。
+- 関連NIP: nsecのdecode/identity導出はNIP-19。migrationはrelay eventを生成・取得しない。
+- 主な実装ファイル: `src/lib/legacyNsecMigration.ts`、`src/lib/authService.ts`、`src/lib/keyManager.svelte.ts`、`src/lib/accountManager.ts`。
+- 主な関数または責務: `captureLegacyNsecMigrationSnapshot`がaccount listとactive pointerをstrictに取得し、`migrateLegacyNsec`がcredential readback、account record readback、activation policy、legacy削除を順に所有する。`AuthService.initializeAuth`はsnapshot後にNIP-07/NIP-46の旧single-account移行を必要時だけ実行し、nsec migrationの後に既存managed restoreへ進む。
+- 関連テスト: `src/test/unit/legacyNsecMigration.test.ts`、`src/test/unit/keyManager.test.ts`、`src/test/unit/accountManager.test.ts`、`src/test/unit/authService.initialize.test.ts`。
+- 注意点: profile/relay storage keyのsuffixをidentity根拠に使わない。legacy credentialはすべての永続条件をreadbackで確認するまで削除しない。既存の有効なactive pointerはtypeにかかわらずmigration中に維持し、Parent clientは起動時managed restore候補へ追加しない。
+
 ## NIP-07
 
 - 機能: browser extensionを待機し、公開鍵取得とevent署名を行う。

--- a/src/lib/accountManager.ts
+++ b/src/lib/accountManager.ts
@@ -112,27 +112,14 @@ export class AccountManager {
     }
 
     /**
-     * 旧形式（シングルアカウント）からマルチアカウント形式へのマイグレーション。
-     * nostr-accounts キーが存在しない場合のみ実行。
+     * 旧形式（シングルアカウント）からマルチアカウント形式へのNIP-07/NIP-46移行。
+     * legacy nsec は自身からidentityを導出する専用migrationが扱う。
      */
     migrateFromSingleAccount(): void {
         if (this.localStorage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS) !== null) return;
 
         const accounts: StoredAccount[] = [];
         let activePubkey: string | null = null;
-
-        // nsec認証のマイグレーション
-        const legacyNsec = this.localStorage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY);
-        if (legacyNsec) {
-            // nsecからpubkeyHexを特定するため、既存のprofileデータを探す
-            const nsecPubkey = this.findPubkeyForLegacyNsec();
-            if (nsecPubkey) {
-                this.localStorage.setItem(getNsecStorageKey(nsecPubkey), legacyNsec);
-                accounts.push({ pubkeyHex: nsecPubkey, type: 'nsec', addedAt: Date.now() });
-                activePubkey = nsecPubkey;
-            }
-            this.localStorage.removeItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY);
-        }
 
         // NIP-07認証のマイグレーション
         const nip07Pubkey = this.localStorage.getItem(STORAGE_KEYS.NOSTR_NIP07_PUBKEY);
@@ -162,37 +149,14 @@ export class AccountManager {
             this.localStorage.removeItem(STORAGE_KEYS.NOSTR_NIP46_SESSION_LEGACY);
         }
 
-        // アカウントリストを保存
-        this.saveAccounts(accounts);
-        if (activePubkey) {
-            this.saveActiveAccountPubkey(activePubkey);
-        }
-    }
-
-    /**
-     * レガシーnsecに対応するpubkeyHexを見つける。
-     * localStorageの nostr-profile-{pubkey} キーを走査して特定。
-     */
-    private findPubkeyForLegacyNsec(): string | null {
-        try {
-            return (
-                this.findFirstStorageKeySuffix(STORAGE_KEYS.NOSTR_PROFILE)
-                ?? this.findFirstStorageKeySuffix(STORAGE_KEYS.NOSTR_RELAYS)
-            );
-        } catch {
-            // localStorageアクセスエラー
-        }
-        return null;
-    }
-
-    private findFirstStorageKeySuffix(prefix: string): string | null {
-        for (let i = 0; i < this.localStorage.length; i++) {
-            const key = this.localStorage.key(i);
-            if (key?.startsWith(prefix)) {
-                return key.substring(prefix.length);
+        // legacy nsecしかない場合は、nsec専用migrationが安全な保存を完了するまで
+        // nostr-accounts を作らない。
+        if (accounts.length > 0) {
+            this.saveAccounts(accounts);
+            if (activePubkey) {
+                this.saveActiveAccountPubkey(activePubkey);
             }
         }
-        return null;
     }
 
     /**

--- a/src/lib/authRestoreUtils.ts
+++ b/src/lib/authRestoreUtils.ts
@@ -48,10 +48,8 @@ interface NsecRestoreDependencies {
     publicKeyState: PublicKeyState;
     keyManager: {
         derivePublicKey(secretKey: string): PublicKeyData;
-        saveToStorage(secretKey: string): unknown;
     };
     setNsecAuthFn: SetAuthFn;
-    accountManager?: AccountMigrationTarget | null;
 }
 
 interface LegacyNsecDependencies extends NsecRestoreDependencies {
@@ -134,28 +132,18 @@ export function applyPublicKeyAuth(
 export function restoreNsecFromStoredKey(
     secretKey: string,
     dependencies: NsecRestoreDependencies,
-    options: { clearLegacyKeyOnFailure?: boolean; migrateLegacyAccount?: boolean } = {},
 ): RestoreResult {
     dependencies.publicKeyState.setNsec(secretKey);
 
     try {
         const derived = dependencies.keyManager.derivePublicKey(secretKey);
         if (!derived.hex) {
-            if (options.clearLegacyKeyOnFailure) {
-                dependencies.keyManager.saveToStorage('');
-            }
             return { hasAuth: false };
         }
 
         dependencies.setNsecAuthFn(derived.hex, derived.npub, derived.nprofile);
-        if (options.migrateLegacyAccount) {
-            dependencies.accountManager?.addAccount(derived.hex, 'nsec');
-        }
         return { hasAuth: true, pubkeyHex: derived.hex };
     } catch {
-        if (options.clearLegacyKeyOnFailure) {
-            dependencies.keyManager.saveToStorage('');
-        }
         return { hasAuth: false };
     }
 }
@@ -354,10 +342,7 @@ export async function checkLegacyNsecAuth(
     const storedKey = dependencies.keyManager.loadFromStorage();
     if (!storedKey) return { hasAuth: false };
 
-    return restoreNsecFromStoredKey(storedKey, dependencies, {
-        clearLegacyKeyOnFailure: true,
-        migrateLegacyAccount: true,
-    });
+    return restoreNsecFromStoredKey(storedKey, dependencies);
 }
 
 export async function checkLegacyNip07Auth(

--- a/src/lib/authService.ts
+++ b/src/lib/authService.ts
@@ -14,6 +14,10 @@ import { createAuthServiceRuntime, type AuthServiceRuntime } from './authService
 import { ParentClientAuthService, type ParentClientConnectOptions } from './parentClientAuthService';
 import { resetManagedAccountData } from './accountDataReset';
 import type { Nip46PendingNostrConnectSession } from './nip46Service';
+import {
+    captureLegacyNsecMigrationSnapshot,
+    migrateLegacyNsec,
+} from './legacyNsecMigration';
 
 type ParentClientAuthOptions = Pick<ParentClientConnectOptions, 'silent' | 'timeoutMs'>;
 
@@ -224,8 +228,20 @@ export class AuthService {
     async initializeAuth(): Promise<RestoreResult> {
         try {
             if (this.accountManager) {
+                const snapshotResult = captureLegacyNsecMigrationSnapshot(this.runtime.localStorage);
+                if (snapshotResult.status === 'failed') {
+                    return { hasAuth: false };
+                }
+
                 this.accountManager.cleanupNostrLoginData();
-                this.accountManager.migrateFromSingleAccount();
+                if (!snapshotResult.snapshot.accountListExisted) {
+                    this.accountManager.migrateFromSingleAccount();
+                }
+                migrateLegacyNsec({
+                    localStorage: this.runtime.localStorage,
+                    keyManager: this.runtime.keyManager,
+                    snapshot: snapshotResult.snapshot,
+                });
                 return await runManagedAuthRestore({
                     accountManager: this.accountManager,
                     restoreAccount: (pubkeyHex, type) => this.restoreAccount(pubkeyHex, type),

--- a/src/lib/authServiceRuntime.ts
+++ b/src/lib/authServiceRuntime.ts
@@ -12,9 +12,15 @@ interface AuthServiceKeyManager {
     derivePublicKey(secretKey: string): PublicKeyData;
     saveToStorage(secretKey: string, pubkeyHex?: string): unknown;
     loadFromStorage(pubkeyHex?: string): string | null;
-    readStoredKey(pubkeyHex: string):
+    readStoredKey(pubkeyHex?: string):
         | { status: 'found'; secretKey: string }
         | { status: 'missing' }
+        | { status: 'error' };
+    writeStoredKeyForMigration(pubkeyHex: string, secretKey: string):
+        | { status: 'saved' }
+        | { status: 'error' };
+    removeStoredKeyForMigration(pubkeyHex?: string):
+        | { status: 'removed' }
         | { status: 'error' };
     setCurrentSecretKey(secretKey: string | null): void;
 }
@@ -30,6 +36,8 @@ function isAuthServiceKeyManager(
         && typeof candidate.saveToStorage === 'function'
         && typeof candidate.loadFromStorage === 'function'
         && typeof candidate.readStoredKey === 'function'
+        && typeof candidate.writeStoredKeyForMigration === 'function'
+        && typeof candidate.removeStoredKeyForMigration === 'function'
         && typeof candidate.setCurrentSecretKey === 'function';
 }
 

--- a/src/lib/keyManager.svelte.ts
+++ b/src/lib/keyManager.svelte.ts
@@ -74,7 +74,7 @@ export class KeyStorage {
         }
     }
 
-    readStoredKey(pubkeyHex: string):
+    readStoredKey(pubkeyHex?: string):
         | { status: 'found'; secretKey: string }
         | { status: 'missing' }
         | { status: 'error' } {
@@ -83,6 +83,41 @@ export class KeyStorage {
             return secretKey
                 ? { status: 'found', secretKey }
                 : { status: 'missing' };
+        } catch {
+            return { status: 'error' };
+        }
+    }
+
+    /**
+     * Legacy migration only: persist a per-account key without changing the
+     * runtime secret-key store, and confirm the stored value immediately.
+     */
+    writeStoredKeyForMigration(pubkeyHex: string, secretKey: string):
+        | { status: 'saved' }
+        | { status: 'error' } {
+        try {
+            this.localStorage.setItem(getNsecStorageKey(pubkeyHex), secretKey);
+            return this.localStorage.getItem(getNsecStorageKey(pubkeyHex)) === secretKey
+                ? { status: 'saved' }
+                : { status: 'error' };
+        } catch {
+            return { status: 'error' };
+        }
+    }
+
+    /**
+     * Legacy migration only: remove a stored key without changing the runtime
+     * secret-key store, and confirm that the key is absent immediately.
+     */
+    removeStoredKeyForMigration(pubkeyHex?: string):
+        | { status: 'removed' }
+        | { status: 'error' } {
+        try {
+            const storageKey = getNsecStorageKey(pubkeyHex);
+            this.localStorage.removeItem(storageKey);
+            return this.localStorage.getItem(storageKey) === null
+                ? { status: 'removed' }
+                : { status: 'error' };
         } catch {
             return { status: 'error' };
         }
@@ -256,11 +291,23 @@ export class KeyManager {
         return this.storage.loadFromStorage(pubkeyHex);
     }
 
-    readStoredKey(pubkeyHex: string):
+    readStoredKey(pubkeyHex?: string):
         | { status: 'found'; secretKey: string }
         | { status: 'missing' }
         | { status: 'error' } {
         return this.storage.readStoredKey(pubkeyHex);
+    }
+
+    writeStoredKeyForMigration(pubkeyHex: string, secretKey: string):
+        | { status: 'saved' }
+        | { status: 'error' } {
+        return this.storage.writeStoredKeyForMigration(pubkeyHex, secretKey);
+    }
+
+    removeStoredKeyForMigration(pubkeyHex?: string):
+        | { status: 'removed' }
+        | { status: 'error' } {
+        return this.storage.removeStoredKeyForMigration(pubkeyHex);
     }
 
     setCurrentSecretKey(secretKey: string | null): void {

--- a/src/lib/legacyNsecMigration.ts
+++ b/src/lib/legacyNsecMigration.ts
@@ -1,0 +1,284 @@
+import { STORAGE_KEYS } from './constants';
+import type { PublicKeyData, StoredAccount } from './types';
+
+type StoredKeyReadResult =
+    | { status: 'found'; secretKey: string }
+    | { status: 'missing' }
+    | { status: 'error' };
+type StoredKeyWriteResult = { status: 'saved' } | { status: 'error' };
+type StoredKeyRemoveResult = { status: 'removed' } | { status: 'error' };
+
+export type LegacyNsecMigrationResult =
+    | { status: 'legacy-credential-missing' }
+    | { status: 'legacy-credential-read-failed' }
+    | { status: 'credential-invalid' }
+    | { status: 'identity-derivation-failed' }
+    | { status: 'destination-credential-read-failed' }
+    | { status: 'destination-credential-conflict' }
+    | { status: 'destination-credential-save-failed' }
+    | { status: 'account-record-read-failed' }
+    | { status: 'account-record-invalid' }
+    | { status: 'account-record-save-failed' }
+    | { status: 'active-pointer-read-failed' }
+    | { status: 'active-pointer-save-failed' }
+    | { status: 'legacy-credential-delete-failed' }
+    | { status: 'migrated' }
+    | { status: 'already-migrated' };
+
+export type LegacyNsecMigrationSnapshot = {
+    accountListExisted: boolean;
+    accounts: StoredAccount[];
+    activePubkey: string | null;
+    activePointerIsValid: boolean;
+};
+
+export type LegacyNsecMigrationSnapshotResult =
+    | { status: 'ready'; snapshot: LegacyNsecMigrationSnapshot }
+    | {
+        status: 'failed';
+        reason: 'account-record-read-failed' | 'account-record-invalid' | 'active-pointer-read-failed';
+    };
+
+export interface LegacyNsecMigrationKeyManager {
+    isValidNsec(secretKey: string): boolean;
+    derivePublicKey(secretKey: string): PublicKeyData;
+    readStoredKey(pubkeyHex?: string): StoredKeyReadResult;
+    writeStoredKeyForMigration(pubkeyHex: string, secretKey: string): StoredKeyWriteResult;
+    removeStoredKeyForMigration(pubkeyHex?: string): StoredKeyRemoveResult;
+}
+
+interface LegacyNsecMigrationDependencies {
+    localStorage: Storage;
+    keyManager: LegacyNsecMigrationKeyManager;
+    snapshot: LegacyNsecMigrationSnapshot;
+    now?: () => number;
+}
+
+type StrictAccountsResult =
+    | { status: 'ok'; accounts: StoredAccount[]; accountListExisted: boolean }
+    | { status: 'read-failed' }
+    | { status: 'invalid' };
+
+const ACCOUNT_TYPES: readonly StoredAccount['type'][] = [
+    'nsec',
+    'nip07',
+    'nip46',
+    'parentClient',
+];
+
+function isStoredAccount(value: unknown): value is StoredAccount {
+    if (!value || typeof value !== 'object') return false;
+
+    const candidate = value as Partial<StoredAccount>;
+    return typeof candidate.pubkeyHex === 'string'
+        && candidate.pubkeyHex.length > 0
+        && typeof candidate.addedAt === 'number'
+        && Number.isFinite(candidate.addedAt)
+        && typeof candidate.type === 'string'
+        && ACCOUNT_TYPES.includes(candidate.type as StoredAccount['type']);
+}
+
+function readAccountsStrict(localStorage: Storage): StrictAccountsResult {
+    let raw: string | null;
+    try {
+        raw = localStorage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS);
+    } catch {
+        return { status: 'read-failed' };
+    }
+
+    if (raw === null) {
+        return { status: 'ok', accounts: [], accountListExisted: false };
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (!Array.isArray(parsed) || !parsed.every(isStoredAccount)) {
+            return { status: 'invalid' };
+        }
+
+        const pubkeys = new Set<string>();
+        for (const account of parsed) {
+            if (pubkeys.has(account.pubkeyHex)) {
+                return { status: 'invalid' };
+            }
+            pubkeys.add(account.pubkeyHex);
+        }
+
+        return {
+            status: 'ok',
+            accounts: parsed.map((account) => ({ ...account })),
+            accountListExisted: true,
+        };
+    } catch {
+        return { status: 'invalid' };
+    }
+}
+
+function readActivePubkey(localStorage: Storage):
+    | { status: 'ok'; activePubkey: string | null }
+    | { status: 'error' } {
+    try {
+        return {
+            status: 'ok',
+            activePubkey: localStorage.getItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT),
+        };
+    } catch {
+        return { status: 'error' };
+    }
+}
+
+function writeAccountsWithReadback(
+    localStorage: Storage,
+    accounts: StoredAccount[],
+    pubkeyHex: string,
+): boolean {
+    try {
+        localStorage.setItem(STORAGE_KEYS.NOSTR_ACCOUNTS, JSON.stringify(accounts));
+    } catch {
+        return false;
+    }
+
+    const readback = readAccountsStrict(localStorage);
+    return readback.status === 'ok'
+        && readback.accounts.some((account) => account.pubkeyHex === pubkeyHex && account.type === 'nsec');
+}
+
+function setActivePubkeyWithReadback(localStorage: Storage, pubkeyHex: string): boolean {
+    try {
+        localStorage.setItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT, pubkeyHex);
+    } catch {
+        return false;
+    }
+
+    const readback = readActivePubkey(localStorage);
+    return readback.status === 'ok' && readback.activePubkey === pubkeyHex;
+}
+
+/**
+ * Captures the migration policy inputs before any legacy single-account write.
+ * Callers must not start legacy migration if this returns a failure.
+ */
+export function captureLegacyNsecMigrationSnapshot(
+    localStorage: Storage,
+): LegacyNsecMigrationSnapshotResult {
+    const accountsResult = readAccountsStrict(localStorage);
+    if (accountsResult.status === 'read-failed') {
+        return { status: 'failed', reason: 'account-record-read-failed' };
+    }
+    if (accountsResult.status === 'invalid') {
+        return { status: 'failed', reason: 'account-record-invalid' };
+    }
+
+    const activeResult = readActivePubkey(localStorage);
+    if (activeResult.status === 'error') {
+        return { status: 'failed', reason: 'active-pointer-read-failed' };
+    }
+
+    return {
+        status: 'ready',
+        snapshot: {
+            accountListExisted: accountsResult.accountListExisted,
+            accounts: accountsResult.accounts,
+            activePubkey: activeResult.activePubkey,
+            activePointerIsValid: activeResult.activePubkey !== null
+                && accountsResult.accounts.some((account) => account.pubkeyHex === activeResult.activePubkey),
+        },
+    };
+}
+
+/**
+ * Migrates only persistent legacy nsec data. It deliberately does not update
+ * auth state, the in-memory key store, or any non-nsec runtime.
+ */
+export function migrateLegacyNsec({
+    localStorage,
+    keyManager,
+    snapshot,
+    now = Date.now,
+}: LegacyNsecMigrationDependencies): LegacyNsecMigrationResult {
+    const legacyResult = keyManager.readStoredKey();
+    if (legacyResult.status === 'missing') {
+        return { status: 'legacy-credential-missing' };
+    }
+    if (legacyResult.status === 'error') {
+        return { status: 'legacy-credential-read-failed' };
+    }
+
+    const legacyCredential = legacyResult.secretKey;
+    if (!keyManager.isValidNsec(legacyCredential)) {
+        return { status: 'credential-invalid' };
+    }
+
+    let derived: PublicKeyData;
+    try {
+        derived = keyManager.derivePublicKey(legacyCredential);
+    } catch {
+        return { status: 'identity-derivation-failed' };
+    }
+    if (!derived.hex) {
+        return { status: 'identity-derivation-failed' };
+    }
+
+    let changed = false;
+    const destinationResult = keyManager.readStoredKey(derived.hex);
+    if (destinationResult.status === 'error') {
+        return { status: 'destination-credential-read-failed' };
+    }
+    if (destinationResult.status === 'found' && destinationResult.secretKey !== legacyCredential) {
+        return { status: 'destination-credential-conflict' };
+    }
+    if (destinationResult.status === 'missing') {
+        if (keyManager.writeStoredKeyForMigration(derived.hex, legacyCredential).status !== 'saved') {
+            return { status: 'destination-credential-save-failed' };
+        }
+        changed = true;
+    }
+
+    const accountsResult = readAccountsStrict(localStorage);
+    if (accountsResult.status === 'read-failed') {
+        return { status: 'account-record-read-failed' };
+    }
+    if (accountsResult.status === 'invalid') {
+        return { status: 'account-record-invalid' };
+    }
+
+    const existingAccount = accountsResult.accounts.find((account) => account.pubkeyHex === derived.hex);
+    const nextAccounts = existingAccount
+        ? accountsResult.accounts.map((account) => account.pubkeyHex === derived.hex
+            ? { ...account, type: 'nsec' as const }
+            : account)
+        : [...accountsResult.accounts, { pubkeyHex: derived.hex, type: 'nsec' as const, addedAt: now() }];
+    const needsAccountWrite = !existingAccount || existingAccount.type !== 'nsec';
+
+    if (needsAccountWrite) {
+        if (!writeAccountsWithReadback(localStorage, nextAccounts, derived.hex)) {
+            return { status: 'account-record-save-failed' };
+        }
+        changed = true;
+    } else if (!accountsResult.accounts.some((account) => account.pubkeyHex === derived.hex && account.type === 'nsec')) {
+        return { status: 'account-record-save-failed' };
+    }
+
+    const activeResult = readActivePubkey(localStorage);
+    if (activeResult.status === 'error') {
+        return { status: 'active-pointer-read-failed' };
+    }
+
+    const shouldActivateDerived = !snapshot.accountListExisted || !snapshot.activePointerIsValid;
+    if (shouldActivateDerived) {
+        if (activeResult.activePubkey !== derived.hex) {
+            if (!setActivePubkeyWithReadback(localStorage, derived.hex)) {
+                return { status: 'active-pointer-save-failed' };
+            }
+            changed = true;
+        }
+    } else if (activeResult.activePubkey !== snapshot.activePubkey) {
+        return { status: 'active-pointer-save-failed' };
+    }
+
+    if (keyManager.removeStoredKeyForMigration().status !== 'removed') {
+        return { status: 'legacy-credential-delete-failed' };
+    }
+
+    return { status: changed ? 'migrated' : 'already-migrated' };
+}

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -79,9 +79,11 @@ export class MockKeyManager implements KeyManagerInterface {
 
     getFromStore = vi.fn(() => this.storedKey);
     loadFromStorage = vi.fn(() => this.storageKey);
-    readStoredKey = vi.fn<(pubkeyHex: string) => StoredKeyReadResult>(() => this.storageKey
+    readStoredKey = vi.fn<(pubkeyHex?: string) => StoredKeyReadResult>(() => this.storageKey
         ? { status: 'found' as const, secretKey: this.storageKey }
         : { status: 'missing' as const });
+    writeStoredKeyForMigration = vi.fn(() => ({ status: 'saved' as const }));
+    removeStoredKeyForMigration = vi.fn(() => ({ status: 'removed' as const }));
     setCurrentSecretKey = vi.fn((secretKey: string | null) => {
         this.storedKey = secretKey;
     });

--- a/src/test/unit/accountManager.test.ts
+++ b/src/test/unit/accountManager.test.ts
@@ -179,29 +179,23 @@ describe('AccountManager', () => {
     describe('migrateFromSingleAccount', () => {
         it('nostr-accountsが存在する場合はスキップ', () => {
             storage.setItem(STORAGE_KEYS.NOSTR_ACCOUNTS, '[]');
-            storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, 'nsec1...');
+            storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, 'legacy-value');
 
             manager.migrateFromSingleAccount();
 
-            // nsecがそのまま残る（マイグレーションされない）
-            expect(storage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)).toBe('nsec1...');
+            expect(storage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)).toBe('legacy-value');
         });
 
-        it('nsec認証をマイグレーション（profileキーからpubkey特定）', () => {
-            const pubkey = 'abc123';
-            storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, 'nsec1testkey');
-            storage.setItem(STORAGE_KEYS.NOSTR_PROFILE + pubkey, JSON.stringify({ name: 'Test' }));
+        it('legacy nsecとprofileまたはrelay keyを変更せず専用migrationへ残す', () => {
+            storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, 'legacy-value');
+            storage.setItem(STORAGE_KEYS.NOSTR_PROFILE + 'profile-pubkey', JSON.stringify({ name: 'Test' }));
+            storage.setItem(STORAGE_KEYS.NOSTR_RELAYS + 'relay-pubkey', JSON.stringify(['wss://relay.example']));
 
             manager.migrateFromSingleAccount();
 
-            expect(storage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_PREFIX + pubkey)).toBe('nsec1testkey');
-            expect(storage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)).toBeNull();
-
-            const accounts = manager.getAccounts();
-            expect(accounts).toHaveLength(1);
-            expect(accounts[0].pubkeyHex).toBe(pubkey);
-            expect(accounts[0].type).toBe('nsec');
-            expect(manager.getActiveAccountPubkey()).toBe(pubkey);
+            expect(storage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)).toBe('legacy-value');
+            expect(storage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS)).toBeNull();
+            expect(manager.getActiveAccountPubkey()).toBeNull();
         });
 
         it('NIP-07認証をマイグレーション', () => {
@@ -234,21 +228,20 @@ describe('AccountManager', () => {
             expect(accounts[0].type).toBe('nip46');
         });
 
-        it('複数認証タイプの同時マイグレーション', () => {
-            const nsecPub = 'nsecpub';
+        it('複数の非nsec認証タイプを同時にマイグレーション', () => {
             const nip07Pub = 'nip07pub';
-            storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, 'nsec1key');
-            storage.setItem(STORAGE_KEYS.NOSTR_PROFILE + nsecPub, '{}');
             storage.setItem(STORAGE_KEYS.NOSTR_NIP07_PUBKEY, nip07Pub);
+            const nip46Pub = 'nip46pub';
+            const session = JSON.stringify({ userPubkey: nip46Pub, relayUrl: 'wss://relay' });
+            storage.setItem(STORAGE_KEYS.NOSTR_NIP46_SESSION_LEGACY, session);
 
             manager.migrateFromSingleAccount();
 
             const accounts = manager.getAccounts();
             expect(accounts).toHaveLength(2);
-            expect(accounts.find(a => a.pubkeyHex === nsecPub)?.type).toBe('nsec');
             expect(accounts.find(a => a.pubkeyHex === nip07Pub)?.type).toBe('nip07');
-            // 最初に見つかったnsecがアクティブ
-            expect(manager.getActiveAccountPubkey()).toBe(nsecPub);
+            expect(accounts.find(a => a.pubkeyHex === nip46Pub)?.type).toBe('nip46');
+            expect(manager.getActiveAccountPubkey()).toBe(nip07Pub);
         });
     });
 

--- a/src/test/unit/authService.initialize.test.ts
+++ b/src/test/unit/authService.initialize.test.ts
@@ -5,6 +5,9 @@ import './authServiceModuleMocks';
 
 import { AuthService } from '../../lib/authService';
 import { MANAGED_NIP07_IDENTITY_READ_TIMEOUT_MS } from '../../lib/authRestoreUtils';
+import { AccountManager } from '../../lib/accountManager';
+import { getNsecStorageKey } from '../../lib/authStorageKeys';
+import { STORAGE_KEYS } from '../../lib/constants';
 import {
     createMockAccountManager,
     createMockDependencies,
@@ -61,7 +64,7 @@ describe('AuthService.initializeAuth', () => {
             { pubkeyHex: FALLBACK_PUBKEY, type: 'nsec', addedAt: 2000 },
         ]);
 
-        mockKeyManager.readStoredKey.mockImplementation((pubkey: string) => {
+        mockKeyManager.readStoredKey.mockImplementation((pubkey?: string) => {
             if (pubkey === FALLBACK_PUBKEY) return { status: 'found', secretKey: 'fallback-nsec' };
             return { status: 'missing' };
         });
@@ -112,7 +115,7 @@ describe('AuthService.initializeAuth', () => {
             { pubkeyHex: FALLBACK_PUBKEY, type: 'nsec', addedAt: 2000 },
         ]);
 
-        mockKeyManager.readStoredKey.mockImplementation((pubkey: string) => {
+        mockKeyManager.readStoredKey.mockImplementation((pubkey?: string) => {
             if (pubkey === FALLBACK_PUBKEY) return { status: 'found', secretKey: 'fallback-nsec' };
             return { status: 'missing' };
         });
@@ -148,7 +151,7 @@ describe('AuthService.initializeAuth', () => {
             { pubkeyHex: NIP07_PUBKEY, type: 'nip07', addedAt: 1000 },
             { pubkeyHex: FALLBACK_PUBKEY, type: 'nsec', addedAt: 2000 },
         ]);
-        mockKeyManager.readStoredKey.mockImplementation((pubkey: string) =>
+        mockKeyManager.readStoredKey.mockImplementation((pubkey?: string) =>
             pubkey === FALLBACK_PUBKEY
                 ? { status: 'found', secretKey: 'fallback-nsec' }
                 : { status: 'missing' },
@@ -179,6 +182,72 @@ describe('AuthService.initializeAuth', () => {
         });
         expect(mockDependencies.setNip07Auth).not.toHaveBeenCalled();
         expect(mockAccountManager.setActiveAccount).toHaveBeenCalledWith(FALLBACK_PUBKEY);
+    });
+
+    it('account listがない場合はlegacy NIP-07移行後にderived nsecをactiveとしてmanaged restoreする', async () => {
+        const storage = new MockStorage();
+        const derivedPubkey = 'ef'.repeat(32);
+        storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, 'legacy-credential');
+        storage.setItem(STORAGE_KEYS.NOSTR_NIP07_PUBKEY, 'ab'.repeat(32));
+
+        const keyManager = {
+            isValidNsec: vi.fn(() => true),
+            derivePublicKey: vi.fn(() => ({
+                hex: derivedPubkey,
+                npub: 'npub1derived',
+                nprofile: 'nprofile1derived',
+            })),
+            saveToStorage: vi.fn(),
+            loadFromStorage: vi.fn(() => storage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)),
+            readStoredKey: vi.fn((pubkeyHex?: string) => {
+                const secretKey = storage.getItem(getNsecStorageKey(pubkeyHex));
+                return secretKey ? { status: 'found' as const, secretKey } : { status: 'missing' as const };
+            }),
+            writeStoredKeyForMigration: vi.fn((pubkeyHex: string, secretKey: string) => {
+                storage.setItem(getNsecStorageKey(pubkeyHex), secretKey);
+                return storage.getItem(getNsecStorageKey(pubkeyHex)) === secretKey
+                    ? { status: 'saved' as const }
+                    : { status: 'error' as const };
+            }),
+            removeStoredKeyForMigration: vi.fn((pubkeyHex?: string) => {
+                storage.removeItem(getNsecStorageKey(pubkeyHex));
+                return storage.getItem(getNsecStorageKey(pubkeyHex)) === null
+                    ? { status: 'removed' as const }
+                    : { status: 'error' as const };
+            }),
+            setCurrentSecretKey: vi.fn(),
+        };
+        const service = new AuthService({
+            ...createMockDependencies(),
+            localStorage: storage,
+            keyManager: keyManager as any,
+        });
+        const accountManager = new AccountManager({ localStorage: storage });
+        service.setAccountManager(accountManager);
+
+        await expect(service.initializeAuth()).resolves.toEqual({ hasAuth: true, pubkeyHex: derivedPubkey });
+        expect(accountManager.getActiveAccountPubkey()).toBe(derivedPubkey);
+        expect(accountManager.getAccounts()).toEqual([
+            expect.objectContaining({ pubkeyHex: 'ab'.repeat(32), type: 'nip07' }),
+            expect.objectContaining({ pubkeyHex: derivedPubkey, type: 'nsec' }),
+        ]);
+        expect(storage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)).toBeNull();
+        expect(keyManager.setCurrentSecretKey).toHaveBeenCalledTimes(1);
+    });
+
+    it('migration snapshot失敗時はlegacy migrationとmanaged restoreを開始しない', async () => {
+        const storage = new MockStorage();
+        storage.getItem = vi.fn(() => {
+            throw new Error('storage unavailable');
+        });
+        mockDependencies.localStorage = storage;
+        const service = new AuthService(mockDependencies);
+        service.setAccountManager(mockAccountManager as any);
+
+        await expect(service.initializeAuth()).resolves.toEqual({ hasAuth: false });
+        expect(mockAccountManager.cleanupNostrLoginData).not.toHaveBeenCalled();
+        expect(mockAccountManager.migrateFromSingleAccount).not.toHaveBeenCalled();
+        expect(mockDependencies.setNsecAuth).not.toHaveBeenCalled();
     });
 
     it('アカウントなし→レガシーnsec検出', async () => {

--- a/src/test/unit/keyManager.test.ts
+++ b/src/test/unit/keyManager.test.ts
@@ -209,6 +209,40 @@ describe('KeyStorage', () => {
         });
     });
 
+    describe('legacy migration storage operations', () => {
+        it('pubkey別credentialをin-memory stateへ反映せずに保存し、readbackを確認する', () => {
+            const result = storage.writeStoredKeyForMigration('migration-pubkey', 'migration-value');
+
+            expect(result).toEqual({ status: 'saved' });
+            expect(mockLocalStorage.getItem('nostr-secret-key-migration-pubkey')).toBe('migration-value');
+            expect(mockSecretKeyStore.set).not.toHaveBeenCalled();
+        });
+
+        it('silent write failureを成功扱いしない', () => {
+            mockLocalStorage.setItem = vi.fn();
+
+            expect(storage.writeStoredKeyForMigration('migration-pubkey', 'migration-value'))
+                .toEqual({ status: 'error' });
+            expect(mockSecretKeyStore.set).not.toHaveBeenCalled();
+        });
+
+        it('legacy credentialの削除をin-memory stateへ反映せずに確認する', () => {
+            mockLocalStorage.setItem('nostr-secret-key', 'migration-value');
+
+            expect(storage.removeStoredKeyForMigration()).toEqual({ status: 'removed' });
+            expect(mockLocalStorage.getItem('nostr-secret-key')).toBeNull();
+            expect(mockSecretKeyStore.set).not.toHaveBeenCalled();
+        });
+
+        it('silent remove failureを成功扱いしない', () => {
+            mockLocalStorage.setItem('nostr-secret-key', 'migration-value');
+            mockLocalStorage.removeItem = vi.fn();
+
+            expect(storage.removeStoredKeyForMigration()).toEqual({ status: 'error' });
+            expect(mockSecretKeyStore.set).not.toHaveBeenCalled();
+        });
+    });
+
     it('setCurrentSecretKeyは保存済みキーを変更せずにin-memory stateだけを更新する', () => {
         storage.setCurrentSecretKey('runtime-key');
 

--- a/src/test/unit/legacyNsecMigration.test.ts
+++ b/src/test/unit/legacyNsecMigration.test.ts
@@ -1,0 +1,428 @@
+import { describe, expect, it, vi } from 'vitest';
+import { nip19 } from 'nostr-tools';
+
+vi.mock('../../lib/keyManager.svelte', async () => {
+    const actual = await import('../../lib/keyManager.svelte');
+    return {
+        KeyManager: actual.KeyManager,
+        KeyStorage: actual.KeyStorage,
+        ExternalAuthChecker: actual.ExternalAuthChecker,
+        PublicKeyState: actual.PublicKeyState,
+        KeyValidator: actual.KeyValidator,
+    };
+});
+
+import { KeyManager } from '../../lib/keyManager.svelte';
+import {
+    captureLegacyNsecMigrationSnapshot,
+    migrateLegacyNsec,
+} from '../../lib/legacyNsecMigration';
+import { buildManagedRestoreCandidates } from '../../lib/authManagedRestoreUtils';
+import { getNip46SessionStorageKey, getParentClientSessionStorageKey, getNsecStorageKey } from '../../lib/authStorageKeys';
+import { STORAGE_KEYS } from '../../lib/constants';
+import type { StoredAccount } from '../../lib/types';
+import { MockStorage, createMockConsole } from '../helpers';
+
+class FaultStorage extends MockStorage {
+    readonly failingGetKeys = new Set<string>();
+    readonly failingSetKeys = new Set<string>();
+    readonly ignoredSetKeys = new Set<string>();
+    readonly failingRemoveKeys = new Set<string>();
+    readonly ignoredRemoveKeys = new Set<string>();
+    mutateActiveAfterAccountsWrite: string | null = null;
+
+    override getItem(key: string): string | null {
+        if (this.failingGetKeys.has(key)) throw new Error('storage read failed');
+        return super.getItem(key);
+    }
+
+    override setItem(key: string, value: string): void {
+        if (this.failingSetKeys.has(key)) throw new Error('storage write failed');
+        if (this.ignoredSetKeys.has(key)) return;
+        super.setItem(key, value);
+        if (key === STORAGE_KEYS.NOSTR_ACCOUNTS && this.mutateActiveAfterAccountsWrite !== null) {
+            super.setItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT, this.mutateActiveAfterAccountsWrite);
+        }
+    }
+
+    override removeItem(key: string): void {
+        if (this.failingRemoveKeys.has(key)) throw new Error('storage remove failed');
+        if (this.ignoredRemoveKeys.has(key)) return;
+        super.removeItem(key);
+    }
+}
+
+function createCredential(seed: number): string {
+    return nip19.nsecEncode(Uint8Array.from({ length: 32 }, () => seed));
+}
+
+function createKeyManager(storage: Storage): KeyManager {
+    return new KeyManager({
+        localStorage: storage,
+        console: createMockConsole(),
+        secretKeyStore: { value: null, set: () => undefined },
+    });
+}
+
+function account(pubkeyHex: string, type: StoredAccount['type'], addedAt = 100): StoredAccount {
+    return { pubkeyHex, type, addedAt };
+}
+
+function getSnapshot(storage: Storage) {
+    const result = captureLegacyNsecMigrationSnapshot(storage);
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') throw new Error('snapshot unavailable');
+    return result.snapshot;
+}
+
+function migrate(storage: FaultStorage, keyManager = createKeyManager(storage)) {
+    return migrateLegacyNsec({
+        localStorage: storage,
+        keyManager,
+        snapshot: getSnapshot(storage),
+        now: () => 500,
+    });
+}
+
+describe('legacy nsec migration', () => {
+    it('credential自身からidentityを導出し、profileまたはrelay suffixを参照しない', () => {
+        const storage = new FaultStorage();
+        const keyManager = createKeyManager(storage);
+        const credential = createCredential(1);
+        const derivedPubkey = keyManager.derivePublicKey(credential).hex;
+        storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, credential);
+        storage.setItem(STORAGE_KEYS.NOSTR_PROFILE + 'f'.repeat(64), '{}');
+        storage.setItem(STORAGE_KEYS.NOSTR_RELAYS + 'e'.repeat(64), '[]');
+
+        expect(migrate(storage, keyManager)).toEqual({ status: 'migrated' });
+        expect(storage.getItem(getNsecStorageKey(derivedPubkey)) === credential).toBe(true);
+        expect(storage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)).toBeNull();
+        expect(storage.getItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT)).toBe(derivedPubkey);
+        expect(JSON.parse(storage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS) ?? '[]')).toEqual([
+            account(derivedPubkey, 'nsec', 500),
+        ]);
+
+        const secondSnapshot = getSnapshot(storage);
+        expect(migrateLegacyNsec({ localStorage: storage, keyManager, snapshot: secondSnapshot, now: () => 500 }))
+            .toEqual({ status: 'legacy-credential-missing' });
+        expect(JSON.parse(storage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS) ?? '[]')).toHaveLength(1);
+    });
+
+    it('account listがない旧single-account状態ではderived nsecをactiveにする', () => {
+        const storage = new FaultStorage();
+        const keyManager = createKeyManager(storage);
+        const credential = createCredential(2);
+        const derivedPubkey = keyManager.derivePublicKey(credential).hex;
+        storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, credential);
+
+        expect(migrate(storage, keyManager)).toEqual({ status: 'migrated' });
+        expect(storage.getItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT)).toBe(derivedPubkey);
+    });
+
+    it('正常な空account listではderived nsecを追加してactiveにする', () => {
+        const storage = new FaultStorage();
+        const keyManager = createKeyManager(storage);
+        const credential = createCredential(3);
+        const derivedPubkey = keyManager.derivePublicKey(credential).hex;
+        storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, credential);
+        storage.setItem(STORAGE_KEYS.NOSTR_ACCOUNTS, '[]');
+
+        expect(migrate(storage, keyManager)).toEqual({ status: 'migrated' });
+        expect(storage.getItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT)).toBe(derivedPubkey);
+        expect(JSON.parse(storage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS) ?? '[]')).toEqual([
+            account(derivedPubkey, 'nsec', 500),
+        ]);
+    });
+
+    for (const type of ['nsec', 'nip07', 'nip46'] as const) {
+        it(`有効な${type} active pointerを維持し、次回managed restoreの先頭候補に残す`, () => {
+            const storage = new FaultStorage();
+            const keyManager = createKeyManager(storage);
+            const credential = createCredential(type === 'nsec' ? 4 : type === 'nip07' ? 5 : 6);
+            const derivedPubkey = keyManager.derivePublicKey(credential).hex;
+            const activePubkey = 'b'.repeat(64);
+            storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, credential);
+            storage.setItem(STORAGE_KEYS.NOSTR_ACCOUNTS, JSON.stringify([account(activePubkey, type)]));
+            storage.setItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT, activePubkey);
+
+            expect(migrate(storage, keyManager)).toEqual({ status: 'migrated' });
+            expect(storage.getItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT)).toBe(activePubkey);
+
+            const accounts = JSON.parse(storage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS) ?? '[]') as StoredAccount[];
+            expect(accounts).toEqual([
+                account(activePubkey, type),
+                account(derivedPubkey, 'nsec', 500),
+            ]);
+            expect(buildManagedRestoreCandidates({
+                activePubkey,
+                activeType: type,
+                accounts,
+            })[0]).toMatchObject({ pubkeyHex: activePubkey, type });
+        });
+    }
+
+    it('Parent client active pointerを維持し、sessionとmanaged candidate規則へ触れない', () => {
+        const storage = new FaultStorage();
+        const keyManager = createKeyManager(storage);
+        const credential = createCredential(7);
+        const derivedPubkey = keyManager.derivePublicKey(credential).hex;
+        const activePubkey = 'c'.repeat(64);
+        storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, credential);
+        storage.setItem(STORAGE_KEYS.NOSTR_ACCOUNTS, JSON.stringify([account(activePubkey, 'parentClient')]));
+        storage.setItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT, activePubkey);
+        storage.setItem(getParentClientSessionStorageKey(activePubkey), 'parent-session');
+
+        expect(migrate(storage, keyManager)).toEqual({ status: 'migrated' });
+        expect(storage.getItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT)).toBe(activePubkey);
+        expect(storage.getItem(getParentClientSessionStorageKey(activePubkey))).toBe('parent-session');
+        expect(storage.getItem(getNsecStorageKey(derivedPubkey)) === credential).toBe(true);
+
+        const accounts = JSON.parse(storage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS) ?? '[]') as StoredAccount[];
+        expect(buildManagedRestoreCandidates({
+            activePubkey,
+            activeType: 'parentClient',
+            accounts,
+        }).some((candidate) => candidate.pubkeyHex === activePubkey)).toBe(false);
+    });
+
+    it('missingまたは不正なactive pointerだけをderived nsecへ置き換える', () => {
+        for (const activePubkey of [null, 'd'.repeat(64)]) {
+            const storage = new FaultStorage();
+            const keyManager = createKeyManager(storage);
+            const credential = createCredential(activePubkey === null ? 8 : 9);
+            const derivedPubkey = keyManager.derivePublicKey(credential).hex;
+            storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, credential);
+            storage.setItem(STORAGE_KEYS.NOSTR_ACCOUNTS, JSON.stringify([account('e'.repeat(64), 'nip07')]));
+            if (activePubkey) storage.setItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT, activePubkey);
+
+            expect(migrate(storage, keyManager)).toEqual({ status: 'migrated' });
+            expect(storage.getItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT)).toBe(derivedPubkey);
+        }
+    });
+
+    it('derived nsecが既にactiveならpointerを書き換えない', () => {
+        const storage = new FaultStorage();
+        const keyManager = createKeyManager(storage);
+        const credential = createCredential(10);
+        const derivedPubkey = keyManager.derivePublicKey(credential).hex;
+        storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, credential);
+        storage.setItem(getNsecStorageKey(derivedPubkey), credential);
+        storage.setItem(STORAGE_KEYS.NOSTR_ACCOUNTS, JSON.stringify([account(derivedPubkey, 'nsec')]));
+        storage.setItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT, derivedPubkey);
+        const originalSetItem = storage.setItem.bind(storage);
+        let activePointerWrites = 0;
+        storage.setItem = (key, value) => {
+            if (key === STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT) activePointerWrites += 1;
+            originalSetItem(key, value);
+        };
+
+        expect(migrate(storage, keyManager)).toEqual({ status: 'already-migrated' });
+        expect(activePointerWrites).toBe(0);
+        expect(storage.getItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT)).toBe(derivedPubkey);
+    });
+
+    it('destination credential conflictでは既存の永続データを変更しない', () => {
+        const storage = new FaultStorage();
+        const keyManager = createKeyManager(storage);
+        const credential = createCredential(11);
+        const derivedPubkey = keyManager.derivePublicKey(credential).hex;
+        const conflictingCredential = createCredential(12);
+        storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, credential);
+        storage.setItem(getNsecStorageKey(derivedPubkey), conflictingCredential);
+
+        expect(migrate(storage, keyManager)).toEqual({ status: 'destination-credential-conflict' });
+        expect(storage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY) === credential).toBe(true);
+        expect(storage.getItem(getNsecStorageKey(derivedPubkey)) === conflictingCredential).toBe(true);
+        expect(storage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS)).toBeNull();
+        expect(storage.getItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT)).toBeNull();
+    });
+
+    it('同じpubkeyの別方式recordをnsecへ更新し、addedAtを維持する', () => {
+        const storage = new FaultStorage();
+        const keyManager = createKeyManager(storage);
+        const credential = createCredential(15);
+        const derivedPubkey = keyManager.derivePublicKey(credential).hex;
+        storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, credential);
+        storage.setItem(STORAGE_KEYS.NOSTR_ACCOUNTS, JSON.stringify([
+            account(derivedPubkey, 'nip07', 123),
+        ]));
+        storage.setItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT, derivedPubkey);
+
+        expect(migrate(storage, keyManager)).toEqual({ status: 'migrated' });
+        expect(JSON.parse(storage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS) ?? '[]')).toEqual([
+            account(derivedPubkey, 'nsec', 123),
+        ]);
+        expect(storage.getItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT)).toBe(derivedPubkey);
+    });
+
+    it('invalid credentialまたはidentity導出失敗ではlegacyを保持し永続状態を変更しない', () => {
+        const invalidStorage = new FaultStorage();
+        const invalidKeyManager = createKeyManager(invalidStorage);
+        invalidStorage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, 'invalid-value');
+        expect(migrate(invalidStorage, invalidKeyManager)).toEqual({ status: 'credential-invalid' });
+        expect(invalidStorage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)).toBe('invalid-value');
+        expect(invalidStorage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS)).toBeNull();
+
+        const derivationStorage = new FaultStorage();
+        derivationStorage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, 'opaque-value');
+        const derivationSnapshot = getSnapshot(derivationStorage);
+        const failingKeyManager = {
+            isValidNsec: () => true,
+            derivePublicKey: () => {
+                throw new Error('derivation failed');
+            },
+            readStoredKey: (pubkeyHex?: string) => {
+                const value = derivationStorage.getItem(getNsecStorageKey(pubkeyHex));
+                return value ? { status: 'found' as const, secretKey: value } : { status: 'missing' as const };
+            },
+            writeStoredKeyForMigration: () => ({ status: 'error' as const }),
+            removeStoredKeyForMigration: () => ({ status: 'error' as const }),
+        };
+        expect(migrateLegacyNsec({
+            localStorage: derivationStorage,
+            keyManager: failingKeyManager,
+            snapshot: derivationSnapshot,
+        })).toEqual({ status: 'identity-derivation-failed' });
+        expect(derivationStorage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)).toBe('opaque-value');
+        expect(derivationStorage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS)).toBeNull();
+    });
+
+    it('壊れたaccount listまたはactive pointer読出し失敗ではsnapshotが永続migrationを止める', () => {
+        const invalidListStorage = new FaultStorage();
+        invalidListStorage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, createCredential(13));
+        invalidListStorage.setItem(STORAGE_KEYS.NOSTR_ACCOUNTS, '{invalid');
+        expect(captureLegacyNsecMigrationSnapshot(invalidListStorage))
+            .toEqual({ status: 'failed', reason: 'account-record-invalid' });
+        expect(invalidListStorage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)).not.toBeNull();
+
+        const pointerFailureStorage = new FaultStorage();
+        pointerFailureStorage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, createCredential(14));
+        pointerFailureStorage.failingGetKeys.add(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT);
+        expect(captureLegacyNsecMigrationSnapshot(pointerFailureStorage))
+            .toEqual({ status: 'failed', reason: 'active-pointer-read-failed' });
+        pointerFailureStorage.failingGetKeys.delete(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT);
+        expect(pointerFailureStorage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)).not.toBeNull();
+        expect(pointerFailureStorage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS)).toBeNull();
+    });
+
+    it('legacy、destination、account listの読出し失敗を個別に区別し、legacyを維持する', () => {
+        const legacyReadFailure = new FaultStorage();
+        const legacyReadKeyManager = createKeyManager(legacyReadFailure);
+        legacyReadFailure.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, createCredential(14));
+        const legacyReadSnapshot = getSnapshot(legacyReadFailure);
+        legacyReadFailure.failingGetKeys.add(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY);
+        expect(migrateLegacyNsec({
+            localStorage: legacyReadFailure,
+            keyManager: legacyReadKeyManager,
+            snapshot: legacyReadSnapshot,
+        })).toEqual({ status: 'legacy-credential-read-failed' });
+        legacyReadFailure.failingGetKeys.delete(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY);
+        expect(legacyReadFailure.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)).not.toBeNull();
+
+        const destinationReadFailure = new FaultStorage();
+        const destinationReadKeyManager = createKeyManager(destinationReadFailure);
+        const destinationCredential = createCredential(15);
+        const destinationPubkey = destinationReadKeyManager.derivePublicKey(destinationCredential).hex;
+        destinationReadFailure.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, destinationCredential);
+        const destinationSnapshot = getSnapshot(destinationReadFailure);
+        destinationReadFailure.failingGetKeys.add(getNsecStorageKey(destinationPubkey));
+        expect(migrateLegacyNsec({
+            localStorage: destinationReadFailure,
+            keyManager: destinationReadKeyManager,
+            snapshot: destinationSnapshot,
+        })).toEqual({ status: 'destination-credential-read-failed' });
+        destinationReadFailure.failingGetKeys.delete(getNsecStorageKey(destinationPubkey));
+        expect(destinationReadFailure.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)).not.toBeNull();
+
+        const accountReadFailure = new FaultStorage();
+        const accountReadKeyManager = createKeyManager(accountReadFailure);
+        accountReadFailure.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, createCredential(16));
+        const accountSnapshot = getSnapshot(accountReadFailure);
+        accountReadFailure.failingGetKeys.add(STORAGE_KEYS.NOSTR_ACCOUNTS);
+        expect(migrateLegacyNsec({
+            localStorage: accountReadFailure,
+            keyManager: accountReadKeyManager,
+            snapshot: accountSnapshot,
+        })).toEqual({ status: 'account-record-read-failed' });
+        accountReadFailure.failingGetKeys.delete(STORAGE_KEYS.NOSTR_ACCOUNTS);
+        expect(accountReadFailure.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)).not.toBeNull();
+    });
+
+    it('destination、account record、active pointer、legacy removeの各失敗でlegacyを維持する', () => {
+        const failures: Array<{
+            setup(storage: FaultStorage, derivedPubkey: string): void;
+            expected: string;
+        }> = [
+            {
+                setup: (storage, derivedPubkey) => storage.failingSetKeys.add(getNsecStorageKey(derivedPubkey)),
+                expected: 'destination-credential-save-failed',
+            },
+            {
+                setup: (storage, derivedPubkey) => storage.ignoredSetKeys.add(getNsecStorageKey(derivedPubkey)),
+                expected: 'destination-credential-save-failed',
+            },
+            {
+                setup: (storage) => storage.failingSetKeys.add(STORAGE_KEYS.NOSTR_ACCOUNTS),
+                expected: 'account-record-save-failed',
+            },
+            {
+                setup: (storage) => storage.ignoredSetKeys.add(STORAGE_KEYS.NOSTR_ACCOUNTS),
+                expected: 'account-record-save-failed',
+            },
+            {
+                setup: (storage) => storage.failingSetKeys.add(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT),
+                expected: 'active-pointer-save-failed',
+            },
+            {
+                setup: (storage) => storage.ignoredSetKeys.add(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT),
+                expected: 'active-pointer-save-failed',
+            },
+            {
+                setup: (storage) => storage.failingRemoveKeys.add(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY),
+                expected: 'legacy-credential-delete-failed',
+            },
+            {
+                setup: (storage) => storage.ignoredRemoveKeys.add(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY),
+                expected: 'legacy-credential-delete-failed',
+            },
+        ];
+
+        failures.forEach(({ setup, expected }, index) => {
+            const storage = new FaultStorage();
+            const keyManager = createKeyManager(storage);
+            const credential = createCredential(24 + index);
+            const derivedPubkey = keyManager.derivePublicKey(credential).hex;
+            storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, credential);
+            setup(storage, derivedPubkey);
+
+            expect(migrate(storage, keyManager)).toEqual({ status: expected });
+            expect(storage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY) === credential).toBe(true);
+        });
+    });
+
+    it('維持すべきactive pointerが途中で変化した場合はlegacyを削除しない', () => {
+        const storage = new FaultStorage();
+        const keyManager = createKeyManager(storage);
+        const credential = createCredential(18);
+        const activePubkey = 'f'.repeat(64);
+        storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, credential);
+        storage.setItem(STORAGE_KEYS.NOSTR_ACCOUNTS, JSON.stringify([account(activePubkey, 'nip46')]));
+        storage.setItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT, activePubkey);
+        storage.mutateActiveAfterAccountsWrite = 'a'.repeat(64);
+
+        expect(migrate(storage, keyManager)).toEqual({ status: 'active-pointer-save-failed' });
+        expect(storage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY) === credential).toBe(true);
+    });
+
+    it('NIP-46 sessionなどunrelated credentialを変更しない', () => {
+        const storage = new FaultStorage();
+        const keyManager = createKeyManager(storage);
+        const credential = createCredential(19);
+        const sessionPubkey = 'a'.repeat(64);
+        storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, credential);
+        storage.setItem(getNip46SessionStorageKey(sessionPubkey), 'session-value');
+
+        expect(migrate(storage, keyManager)).toEqual({ status: 'migrated' });
+        expect(storage.getItem(getNip46SessionStorageKey(sessionPubkey))).toBe('session-value');
+    });
+});


### PR DESCRIPTION
## 変更概要
- legacy nsec の永続migrationを局所モジュールへ集約しました。
- profile／relay storage key のsuffixによるidentity推測を廃止しました。

## legacy nsec identity導出
- legacy credentialを副作用なしで読み、nsec自身からderived pubkeyを決定します。
- credential conflict、壊れたaccount list、storage読出し失敗ではlegacy値とunrelated dataを保持します。

## 永続書込みとlegacy削除順序
1. destination credentialの完全一致readback
2. nsec account recordのreadback
3. activation policyに沿うactive pointerのreadback
4. legacy credentialの削除と不存在確認

## activation policy
- account listがなかった旧single-account状態ではderived nsecをactiveにします。
- 既存account listの有効active pointerはtypeにかかわらずmigration中に維持し、欠落または不正なpointerだけderived nsecへ設定します。

## Parent client active時の扱い
- Parent clientのactive pointer、session、runtime、credentialをmigrationは変更しません。
- 起動時managed restore候補への追加や候補順の変更は行いません。

## 部分失敗と再試行
- localStorage transactionは導入せず、legacy credentialを最後に削除します。
- 書込み例外とsilent no-opをreadbackで失敗扱いにし、部分的なdestination credential/account recordは削除せず次回起動で再試行します。

## 検証
- `npm test` — 307 files / 3411 tests passed
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — passed
- `git diff --check` — passed

## 未実行の検証
- Playwright、実relay、実extension、実remote signerは実行していません。今回の受入条件は決定的なStorage相当fakeによるunit/integration testです。