### PR TITLE
fix: redact sensitive NIP-46 logs

### DIFF
--- a/src/lib/appAccountSessionController.ts
+++ b/src/lib/appAccountSessionController.ts
@@ -199,7 +199,10 @@ export function createAppAccountSessionController(
                 : null;
 
             if (!targetAccountType) {
-                deps.logger.error('アカウントタイプが見つかりません:', pubkeyHex);
+                deps.logger.error('アカウントタイプが見つかりません', {
+                    stage: 'switch-account',
+                    reason: 'account-not-found',
+                });
                 return false;
             }
 
@@ -251,8 +254,11 @@ export function createAppAccountSessionController(
             }
             await convergeToGuest();
             return false;
-        } catch (error) {
-            deps.logger.error('アカウント切替中にエラー:', error);
+        } catch {
+            deps.logger.error('アカウント切替中にエラー', {
+                stage: 'switch-account',
+                reason: 'unexpected',
+            });
             if (transactionStarted) {
                 await convergeToGuest();
             }
@@ -306,8 +312,11 @@ export function createAppAccountSessionController(
             if (options.closeDialog !== false && nextAction.kind !== 'keep-current') {
                 deps.closeLogoutDialog();
             }
-        } catch (error) {
-            deps.logger.error('ログアウト処理中にエラー:', error);
+        } catch {
+            deps.logger.error('ログアウト処理中にエラー', {
+                stage: 'logout-account',
+                reason: 'unexpected',
+            });
         } finally {
             deps.setIsLoggingOut(false);
         }

--- a/src/lib/appAuthUtils.ts
+++ b/src/lib/appAuthUtils.ts
@@ -86,7 +86,10 @@ export async function runNip07Login(
 
         const result = await deps.authenticateWithNip07();
         if (!result.success) {
-            deps.console.error('NIP-07認証失敗:', result.error);
+            deps.console.error('NIP-07認証失敗', {
+                stage: 'result',
+                reason: 'unexpected',
+            });
             return result.error ?? 'nip07_auth_error';
         }
 
@@ -100,7 +103,10 @@ export async function runNip07Login(
         await handleSuccessfulAuthResult(result, deps.handlePostAuth);
         return undefined;
     } catch (error) {
-        deps.console.error('NIP-07ログインでエラー:', error);
+        deps.console.error('NIP-07ログインでエラー', {
+            stage: 'request',
+            reason: 'unexpected',
+        });
         return error instanceof Error ? error.message : 'nip07_auth_error';
     } finally {
         deps.setLoading(false);
@@ -116,14 +122,20 @@ export async function runNip46Login(
     try {
         const result = await deps.authenticateWithNip46(bunkerUrl);
         if (!result.success) {
-            deps.console.error('NIP-46認証失敗:', result.error);
+            deps.console.error('NIP-46認証失敗', {
+                stage: 'result',
+                reason: 'unexpected',
+            });
             return result.error ?? 'NIP-46 authentication failed';
         }
 
         await handleSuccessfulAuthResult(result, deps.handlePostAuth);
         return undefined;
     } catch (error) {
-        deps.console.error('NIP-46ログインでエラー:', error);
+        deps.console.error('NIP-46ログインでエラー', {
+            stage: 'request',
+            reason: 'unexpected',
+        });
         return error instanceof Error ? error.message : 'NIP-46 login failed';
     } finally {
         deps.setLoading(false);

--- a/src/lib/authRestoreUtils.ts
+++ b/src/lib/authRestoreUtils.ts
@@ -363,7 +363,10 @@ export async function checkLegacyNip07Auth(
         dependencies.localStorage.removeItem(LEGACY_NIP07_STORAGE_KEY);
         return result;
     } catch (error) {
-        dependencies.console.error('NIP-07セッション復元エラー:', error);
+        dependencies.console.error('NIP-07セッション復元エラー', {
+            stage: 'legacy-restore',
+            reason: 'unexpected',
+        });
         dependencies.localStorage.removeItem(LEGACY_NIP07_STORAGE_KEY);
         return { hasAuth: false };
     }
@@ -384,7 +387,10 @@ export async function checkLegacyNip46Auth(
         Nip46Storage.clearSession(dependencies.localStorage);
         return result;
     } catch (error) {
-        dependencies.console.error('NIP-46セッション復元エラー:', error);
+        dependencies.console.error('NIP-46セッション復元エラー', {
+            stage: 'legacy-restore',
+            reason: 'unexpected',
+        });
         return { hasAuth: false };
     }
 }

--- a/src/lib/authService.ts
+++ b/src/lib/authService.ts
@@ -66,8 +66,11 @@ export class AuthService {
             this.runtime.setNsecAuthFn(derived.hex, derived.npub, derived.nprofile);
             this.accountManager?.addAccount(derived.hex, 'nsec');
             return { success: true, pubkeyHex: derived.hex };
-        } catch (error) {
-            this.runtime.console.error('nsec認証処理中にエラー:', error);
+        } catch {
+            this.runtime.console.error('nsec認証処理中にエラー', {
+                stage: 'nsec-authentication',
+                reason: 'unexpected',
+            });
             return { success: false, error: 'authentication_error' };
         }
     }
@@ -101,7 +104,10 @@ export class AuthService {
             const pubkeyHex = await this.runtime.nip46Svc.connect(bunkerUrl);
             return this.finalizeNip46Authentication(pubkeyHex);
         } catch (error) {
-            this.runtime.console.error('NIP-46認証エラー:', error);
+            this.runtime.console.error('NIP-46認証エラー', {
+                stage: 'bunker-connect',
+                reason: 'unexpected',
+            });
             const msg = error instanceof Error ? error.message : 'nip46_connection_failed';
             return { success: false, error: msg };
         }
@@ -152,7 +158,10 @@ export class AuthService {
         } catch (error) {
             const msg = error instanceof Error ? error.message : 'parent_client_auth_error';
             if (!options.silent) {
-                this.runtime.console.error('親クライアント連携認証エラー:', error);
+                this.runtime.console.error('親クライアント連携認証エラー', {
+                    stage: 'parent-client-connect',
+                    reason: 'unexpected',
+                });
             }
             return { success: false, error: msg };
         }
@@ -180,7 +189,10 @@ export class AuthService {
                 ParentClientAuthService.clearSession(this.runtime.localStorage, pubkeyHex);
             } else if (accountType === 'nip46') {
                 this.runtime.nip46Svc.disconnect().catch(e => {
-                    this.runtime.console.error('NIP-46切断エラー:', e);
+                    this.runtime.console.error('NIP-46切断エラー', {
+                        stage: 'disconnect',
+                        reason: 'unexpected',
+                    });
                 });
             }
 
@@ -194,8 +206,11 @@ export class AuthService {
 
             // string: 次のアクティブアカウント, null: アカウント残なし, undefined: 非アクティブ削除
             return nextPubkey;
-        } catch (error) {
-            this.runtime.console.error('ログアウト処理中に予期しないエラー:', error);
+        } catch {
+            this.runtime.console.error('ログアウト処理中に予期しないエラー', {
+                stage: 'logout',
+                reason: 'unexpected',
+            });
             return null;
         }
     }
@@ -250,7 +265,10 @@ export class AuthService {
 
             return await this.initializeLegacyAuth();
         } catch (error) {
-            this.runtime.console.error('認証初期化失敗:', error);
+            this.runtime.console.error('認証初期化失敗', {
+                stage: 'restore',
+                reason: 'unexpected',
+            });
             return { hasAuth: false };
         }
     }
@@ -275,7 +293,10 @@ export class AuthService {
             const pubkeyHex = await pending.completion;
             return { success: true, pubkeyHex };
         } catch (error) {
-            this.runtime.console.error('NIP-46 nostrconnect認証エラー:', error);
+            this.runtime.console.error('NIP-46 nostrconnect認証エラー', {
+                stage: 'nostrconnect-completion',
+                reason: 'unexpected',
+            });
             return {
                 success: false,
                 error: error instanceof Error
@@ -336,7 +357,10 @@ export class AuthService {
                 if (event.data.success) {
                     this.runtime.console.log('プロフィール画像キャッシュをクリアしました');
                 } else {
-                    this.runtime.console.error('プロフィール画像キャッシュクリア失敗:', event.data.error);
+                    this.runtime.console.error('プロフィール画像キャッシュクリア失敗', {
+                        stage: 'profile-image-cache',
+                        reason: 'unexpected',
+                    });
                 }
             };
 
@@ -344,8 +368,11 @@ export class AuthService {
                 { action: 'clearProfileCache' },
                 [messageChannel.port2]
             );
-        } catch (error) {
-            this.runtime.console.error('プロフィール画像キャッシュクリア中にエラー:', error);
+        } catch {
+            this.runtime.console.error('プロフィール画像キャッシュクリア中にエラー', {
+                stage: 'profile-image-cache',
+                reason: 'unexpected',
+            });
         }
     }
 

--- a/src/lib/bootstrap/appInitializationBootstrap.ts
+++ b/src/lib/bootstrap/appInitializationBootstrap.ts
@@ -88,8 +88,11 @@ export async function runAppInitializationBootstrap({
         if (resolveAuthenticatedSession) {
             try {
                 authResult = await resolveAuthenticatedSession(authResult);
-            } catch (error) {
-                console.error('親クライアント連携自動認証中にエラー:', error);
+            } catch {
+                console.error('親クライアント連携自動認証中にエラー', {
+                    stage: 'resolve-session',
+                    reason: 'unexpected',
+                });
             }
         }
 
@@ -101,8 +104,11 @@ export async function runAppInitializationBootstrap({
         }
 
         refreshAccountList();
-    } catch (error) {
-        console.error("認証初期化中にエラー:", error);
+    } catch {
+        console.error("認証初期化中にエラー", {
+            stage: 'initialize-auth',
+            reason: 'unexpected',
+        });
         await initializeGuestSession();
         stopProfileLoading();
     } finally {
@@ -145,9 +151,7 @@ export function registerNip46VisibilityHandler({
             && nip46Service.hasRecoverableSession()
             && !nip46Service.isManualCheckInProgress()
         ) {
-            console.debug?.("NIP-46 visibility auto recovery started", {
-                hiddenDuration,
-            });
+            console.debug?.("NIP-46 visibility auto recovery started");
             nip46Service.ensureConnection()
                 .then((recovered) => {
                     if (recovered) {
@@ -156,8 +160,11 @@ export function registerNip46VisibilityHandler({
                         console.warn?.("NIP-46 visibility auto recovery failed");
                     }
                 })
-                .catch((error) => {
-                    console.error("NIP-46 visibility auto recovery threw unexpectedly:", error);
+                .catch(() => {
+                    console.error("NIP-46 visibility auto recovery threw unexpectedly", {
+                        stage: 'visibility-recovery',
+                        reason: 'unexpected',
+                    });
                 });
         }
     }

--- a/src/lib/fileUploadManager.ts
+++ b/src/lib/fileUploadManager.ts
@@ -90,8 +90,11 @@ export class FileUploadManager implements FileUploadManagerInterface {
         file,
         mimeType: file.type || undefined,
       });
-    } catch (error) {
-      console.warn('post_media_cache_persist_failed', error);
+    } catch {
+      console.warn('post_media_cache_persist_failed', {
+        stage: 'media-cache',
+        reason: 'unexpected',
+      });
     }
   }
 
@@ -272,7 +275,10 @@ export class FileUploadManager implements FileUploadManagerInterface {
       }
 
       if (devMode) {
-        console.error("[dev] Upload error:", error);
+        console.error("[dev] Upload error", {
+          stage: 'upload',
+          reason: 'unexpected',
+        });
       }
       const errorMessage = error instanceof Error ? error.message : String(error);
 
@@ -440,8 +446,11 @@ export class FileUploadManager implements FileUploadManagerInterface {
       );
 
       return await promise;
-    } catch (error) {
-      console.error('Service Workerからの共有メディア取得に失敗:', error);
+    } catch {
+      console.error('Service Workerからの共有メディア取得に失敗', {
+        stage: 'shared-media',
+        reason: 'unexpected',
+      });
       return null;
     }
   }
@@ -479,5 +488,4 @@ export class FileUploadManager implements FileUploadManagerInterface {
     }
   }
 }
-
 

--- a/src/lib/nip46AuthFlowCoordinator.ts
+++ b/src/lib/nip46AuthFlowCoordinator.ts
@@ -177,7 +177,10 @@ export function createNip46AuthFlowController(
         return undefined;
       }
 
-      deps.console.error("NIP-46 nostrconnectログインでエラー:", error);
+      deps.console.error("NIP-46 nostrconnectログインでエラー", {
+        stage: 'start',
+        reason: 'unexpected',
+      });
       resetPendingState({ preserveError: true });
       const message = error instanceof Error ? error.message : "NIP-46 login failed";
       deps.state.setErrorMessage(message);

--- a/src/lib/nip46Service.ts
+++ b/src/lib/nip46Service.ts
@@ -55,6 +55,18 @@ const NIP46_FINAL_LOCAL_RELAY_UNREACHABLE_MESSAGE =
 const NIP46_FINAL_RELAY_VERIFICATION_FAILED_MESSAGE =
     'Communication could not be verified on the relay selected by the remote signer';
 
+type Nip46LogFailureReason =
+    | 'unexpected'
+    | 'identity-invalid'
+    | 'identity-mismatch'
+    | 'permission-denied'
+    | 'timeout'
+    | 'auth-challenge'
+    | 'relay-unreachable'
+    | 'relay-negotiation-invalid'
+    | 'cancelled'
+    | 'method-unsupported';
+
 type RelayConnectionLogMessages = {
     connecting: string;
     connected: string;
@@ -320,28 +332,29 @@ export class Nip46SignerAdapter {
         };
         const startedAt = Date.now();
         console.debug('[NIP-46] sign_event start', {
+            method: 'sign_event',
+            stage: 'start',
             kind: template.kind,
-            created_at: template.created_at,
-            tagsLength: template.tags.length,
-            contentLength: template.content.length,
-            hasPubkey: typeof effectivePubkey === 'string' && effectivePubkey.length > 0,
         });
 
         try {
             const signedEvent = await this.bunkerSigner.signEvent(template);
             const durationMs = Date.now() - startedAt;
             console.debug('[NIP-46] sign_event resolved', {
+                method: 'sign_event',
+                stage: 'success',
+                kind: template.kind,
                 durationMs,
-                eventId: typeof signedEvent?.id === 'string' ? signedEvent.id : '(missing)',
-                pubkey: typeof signedEvent?.pubkey === 'string' ? signedEvent.pubkey : '(missing)',
-                kind: typeof signedEvent?.kind === 'number' ? signedEvent.kind : '(missing)',
             });
             return signedEvent;
         } catch (error) {
             const durationMs = Date.now() - startedAt;
             console.error('[NIP-46] sign_event failed', {
+                method: 'sign_event',
+                stage: 'failure',
+                kind: template.kind,
                 durationMs,
-                error,
+                reason: 'unexpected' satisfies Nip46LogFailureReason,
             });
             throw error;
         }
@@ -362,19 +375,20 @@ export class Nip46SignerAdapter {
 class Nip46WebSocket extends WebSocket {
     constructor(url: string | URL, protocols?: string | string[]) {
         super(url, protocols);
-        const wsUrl = url.toString();
         this.addEventListener('open', () => {
-            console.debug('[NIP-46 WS] connected:', wsUrl);
+            console.debug('[NIP-46 WS] open', { direction: 'transport' });
         });
-        this.addEventListener('message', (ev: MessageEvent) => {
-            const data = typeof ev.data === 'string' ? ev.data : '[binary]';
-            console.debug('[NIP-46 WS] ←', data.length > 300 ? data.substring(0, 300) + '…' : data);
+        this.addEventListener('message', () => {
+            console.debug('[NIP-46 WS] receive', { direction: 'inbound' });
         });
         this.addEventListener('close', (ev: CloseEvent) => {
-            console.debug('[NIP-46 WS] closed:', wsUrl, ev.code, ev.reason);
+            console.debug('[NIP-46 WS] close', {
+                direction: 'transport',
+                closeCode: ev.code,
+            });
         });
         this.addEventListener('error', () => {
-            console.debug('[NIP-46 WS] error:', wsUrl);
+            console.debug('[NIP-46 WS] error', { direction: 'transport' });
         });
     }
     send(data: string | Blob | BufferSource): void {
@@ -398,8 +412,7 @@ class Nip46WebSocket extends WebSocket {
                 }
             } catch { /* not JSON, send as-is */ }
         }
-        const msg = typeof outData === 'string' ? outData : '[binary]';
-        console.debug('[NIP-46 WS] →', msg.length > 300 ? msg.substring(0, 300) + '…' : msg);
+        console.debug('[NIP-46 WS] send', { direction: 'outbound' });
         super.send(outData);
     }
 }
@@ -420,17 +433,28 @@ async function createConnectedPool(
     const connectedRelays: string[] = [];
     const connectionErrors: string[] = [];
 
-    for (const relay of [...new Set(relays)]) {
+    const uniqueRelays = [...new Set(relays)];
+    for (const [index, relay] of uniqueRelays.entries()) {
         try {
-            console.debug('[NIP-46] connecting to relay:', relay);
+            console.debug('[NIP-46] relay connection attempt', {
+                attempt: index + 1,
+                total: uniqueRelays.length,
+            });
             await pool.ensureRelay(relay, {
                 connectionTimeout: RELAY_CONNECT_TIMEOUT_MS,
             });
-            console.debug('[NIP-46] relay connected:', relay);
+            console.debug('[NIP-46] relay connection succeeded', {
+                connected: connectedRelays.length + 1,
+                total: uniqueRelays.length,
+            });
             connectedRelays.push(relay);
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            console.warn('[NIP-46] relay connection failed:', relay, msg);
+            console.warn('[NIP-46] relay connection failed', {
+                reason: 'relay-unreachable' satisfies Nip46LogFailureReason,
+                failed: connectionErrors.length + 1,
+                total: uniqueRelays.length,
+            });
             connectionErrors.push(`${relay}: ${msg}`);
         }
     }
@@ -449,10 +473,10 @@ async function createConnectedPool(
     }
 
     if (connectionErrors.length > 0) {
-        console.warn(
-            '[NIP-46] continuing with reachable relays only:',
-            connectedRelays,
-        );
+        console.warn('[NIP-46] continuing with reachable relays only', {
+            connected: connectedRelays.length,
+            failed: connectionErrors.length,
+        });
     }
 
     return { pool, connectedRelays };
@@ -516,19 +540,29 @@ async function createConnectedPoolReadyOnFirstReachable(
         rejectAllFailed = null;
     };
 
-    const connectionAttempts = uniqueRelays.map(async (relay) => {
+    const connectionAttempts = uniqueRelays.map(async (relay, index) => {
         try {
-            console.debug(logMessages.connecting, relay);
+            console.debug(logMessages.connecting, {
+                attempt: index + 1,
+                total: uniqueRelays.length,
+            });
             await pool.ensureRelay(relay, {
                 connectionTimeout: RELAY_CONNECT_TIMEOUT_MS,
             });
-            console.debug(logMessages.connected, relay);
+            console.debug(logMessages.connected, {
+                connected: connectedRelays.length + 1,
+                total: uniqueRelays.length,
+            });
             connectedRelaySet.add(relay);
             connectedRelays.push(relay);
             settleFirstReachable();
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            console.warn(logMessages.failed, relay, msg);
+            console.warn(logMessages.failed, {
+                reason: 'relay-unreachable' satisfies Nip46LogFailureReason,
+                failed: connectionErrors.length + 1,
+                total: uniqueRelays.length,
+            });
             connectionErrors.push(`${relay}: ${msg}`);
         } finally {
             remainingAttempts -= 1;
@@ -574,7 +608,10 @@ async function createConnectedPoolReadyOnFirstReachable(
     );
 
     if (connectionErrors.length > 0) {
-        console.warn(logMessages.partial, finalizedConnectedRelays);
+        console.warn(logMessages.partial, {
+            connected: finalizedConnectedRelays.length,
+            failed: connectionErrors.length,
+        });
     }
 
     return {
@@ -597,17 +634,27 @@ async function createConnectedPoolForReachableRelays(
     const connectionErrors: string[] = [];
 
     await Promise.all(
-        uniqueRelays.map(async (relay) => {
+        uniqueRelays.map(async (relay, index) => {
             try {
-                console.debug(logMessages.connecting, relay);
+                console.debug(logMessages.connecting, {
+                    attempt: index + 1,
+                    total: uniqueRelays.length,
+                });
                 await pool.ensureRelay(relay, {
                     connectionTimeout: RELAY_CONNECT_TIMEOUT_MS,
                 });
-                console.debug(logMessages.connected, relay);
+                console.debug(logMessages.connected, {
+                    connected: connectedRelaySet.size + 1,
+                    total: uniqueRelays.length,
+                });
                 connectedRelaySet.add(relay);
             } catch (err) {
                 const msg = err instanceof Error ? err.message : String(err);
-                console.warn(logMessages.failed, relay, msg);
+                console.warn(logMessages.failed, {
+                    reason: 'relay-unreachable' satisfies Nip46LogFailureReason,
+                    failed: connectionErrors.length + 1,
+                    total: uniqueRelays.length,
+                });
                 connectionErrors.push(`${relay}: ${msg}`);
             }
         }),
@@ -631,7 +678,10 @@ async function createConnectedPoolForReachableRelays(
     }
 
     if (connectionErrors.length > 0) {
-        console.warn(logMessages.partial, finalizedConnectedRelays);
+        console.warn(logMessages.partial, {
+            connected: finalizedConnectedRelays.length,
+            failed: connectionErrors.length,
+        });
     }
 
     return {
@@ -795,28 +845,10 @@ export function sanitizeNip46NostrConnectRelays(relays: string[]): string[] {
     return sanitized;
 }
 
-function sanitizeRelayForLog(relay: string): string {
-    const trimmed = relay.trim();
-    if (!trimmed) {
-        return '[empty relay]';
-    }
-
-    try {
-        const relayUrl = new URL(trimmed);
-        if (relayUrl.username || relayUrl.password) {
-            relayUrl.username = '';
-            relayUrl.password = '';
-        }
-        return relayUrl.toString();
-    } catch {
-        return '[invalid relay string]';
-    }
-}
-
 function parseDeterministicRelayList(value: string): {
-    parsedRelays: string[];
     supportedRelays: string[];
-    unsupportedRelays: string[];
+    parsedCount: number;
+    unsupportedCount: number;
 } {
     let parsed: unknown;
 
@@ -838,9 +870,8 @@ function parseDeterministicRelayList(value: string): {
         throw new Error(NIP46_FINAL_RELAY_LIST_MISSING_MESSAGE);
     }
 
-    const parsedRelays: string[] = [];
     const supportedRelays: string[] = [];
-    const unsupportedRelays: string[] = [];
+    let unsupportedCount = 0;
     const seen = new Set<string>();
 
     for (const relay of parsed) {
@@ -852,11 +883,9 @@ function parseDeterministicRelayList(value: string): {
             throw new Error(NIP46_FINAL_RELAY_LIST_INVALID_MESSAGE);
         }
 
-        parsedRelays.push(sanitizeRelayForLog(relay));
-
         const normalizedRelay = normalizeSupportedNip46FinalRelay(relay);
         if (!normalizedRelay) {
-            unsupportedRelays.push(sanitizeRelayForLog(relay));
+            unsupportedCount += 1;
             continue;
         }
 
@@ -869,9 +898,9 @@ function parseDeterministicRelayList(value: string): {
     }
 
     return {
-        parsedRelays,
         supportedRelays,
-        unsupportedRelays,
+        parsedCount: parsed.length,
+        unsupportedCount,
     };
 }
 
@@ -998,7 +1027,11 @@ async function resolveNostrConnectRelayResolution(
 
     if (reconciliationResult.type === 'error') {
         if (isUnsupportedSwitchRelaysError(reconciliationResult.error)) {
-            console.warn('[NIP-46] switch_relays not supported by signer; using client initial relays:', reconciliationResult.error);
+            console.warn('[NIP-46] switch_relays not supported by signer', {
+                method: 'switch_relays',
+                outcome: 'method-unsupported',
+                reason: 'method-unsupported' satisfies Nip46LogFailureReason,
+            });
             return {
                 kind: 'method-unsupported',
                 finalRelays: [...fallbackRelays],
@@ -1021,15 +1054,12 @@ async function resolveNostrConnectRelayResolution(
     const relayList = parseDeterministicRelayList(
         reconciliationResult.value,
     );
-    console.debug('[NIP-46] switch_relays returned relays:', relayList.parsedRelays);
-    console.debug(
-        '[NIP-46] supported final relay candidates:',
-        relayList.supportedRelays,
-    );
-    console.debug(
-        '[NIP-46] unsupported final relays:',
-        relayList.unsupportedRelays,
-    );
+    console.debug('[NIP-46] switch_relays response classified', {
+        method: 'switch_relays',
+        parsed: relayList.parsedCount,
+        supported: relayList.supportedRelays.length,
+        unsupported: relayList.unsupportedCount,
+    });
 
     if (relayList.supportedRelays.length === 0) {
         throw new Error(NIP46_FINAL_RELAY_NO_USABLE_MESSAGE);
@@ -1408,7 +1438,7 @@ export class Nip46Service {
             await this.closeRuntimeSnapshot(runtime);
             console.debug('[NIP-46] rebuildConnection: pool + BunkerSigner rebuilt');
             return true;
-        } catch (error) {
+        } catch {
             await failCandidate();
             console.warn('[NIP-46] rebuildConnection candidate verification failed');
             return false;
@@ -1478,12 +1508,17 @@ export class Nip46Service {
     }
 
     async connect(bunkerUrl: string, timeoutMs: number = 30000): Promise<string> {
-        console.debug('[NIP-46] connect: parsing bunker URL...');
+        console.debug('[NIP-46] bunker connect parsing', {
+            stage: 'start',
+        });
         const bp = await parseBunkerInput(bunkerUrl);
         if (!bp) {
             throw new Error('Invalid bunker URL');
         }
-        console.debug('[NIP-46] connect: parsed bp =', { pubkey: bp.pubkey, relays: bp.relays, secret: bp.secret ? '***' : null });
+        console.debug('[NIP-46] bunker connect input parsed', {
+            stage: 'parsed',
+            relays: bp.relays.length,
+        });
 
         if (bp.relays.length === 0) {
             throw new Error('No relays specified in bunker URL');
@@ -1837,8 +1872,10 @@ export class Nip46Service {
 
                     if (verifiedUserPubkey !== expectedUserPubkey) {
                         console.warn(
-                            '[NIP-46] negotiated final relay returned unexpected public key:',
-                            selectedRelay,
+                            '[NIP-46] negotiated final relay identity mismatch',
+                            {
+                                reason: 'identity-mismatch' satisfies Nip46LogFailureReason,
+                            },
                         );
                         throw new Error(NIP46_FINAL_RELAY_VERIFICATION_FAILED_MESSAGE);
                     }
@@ -1854,10 +1891,9 @@ export class Nip46Service {
                         throw createNostrConnectCancellationError();
                     }
 
-                    console.warn(
-                        '[NIP-46] negotiated final relay verification failed',
-                        selectedRelay,
-                    );
+                    console.warn('[NIP-46] negotiated final relay verification failed', {
+                        reason: 'relay-negotiation-invalid' satisfies Nip46LogFailureReason,
+                    });
 
                     await closeNostrConnectTemporarySigner(finalSignerCandidate);
                     finalSignerCandidate = null;
@@ -1998,7 +2034,9 @@ export class Nip46Service {
                             console.debug('[NIP-46] EOSE received on handshake subscription; subscription remains open awaiting signer response');
                         },
                         onevent: async (event: { id?: string; content: string; pubkey: string }) => {
-                            console.debug('[NIP-46] EVENT received', event.id ?? '(no id)', 'from', event.pubkey);
+                            console.debug('[NIP-46] handshake response received', {
+                                stage: 'response-received',
+                            });
 
                             if (settled) {
                                 console.debug('[NIP-46] EVENT ignored: already settled');
@@ -2008,7 +2046,9 @@ export class Nip46Service {
                             settleHandshakeStartedSuccess();
 
                             try {
-                                console.debug('[NIP-46] decrypt start', 'pubkey:', event.pubkey);
+                                console.debug('[NIP-46] handshake decrypt started', {
+                                    stage: 'decrypt-start',
+                                });
                                 const temporaryConversationKey = nip44.getConversationKey(
                                     clientSecretKey,
                                     event.pubkey,
@@ -2019,9 +2059,14 @@ export class Nip46Service {
                                         event.content,
                                         temporaryConversationKey,
                                     );
-                                    console.debug('[NIP-46] decrypt ok');
+                                    console.debug('[NIP-46] handshake decrypt succeeded', {
+                                        stage: 'decrypt-success',
+                                    });
                                 } catch (decryptErr) {
-                                    console.debug('[NIP-46] decrypt fail', decryptErr);
+                                    console.debug('[NIP-46] handshake decrypt failed', {
+                                        stage: 'decrypt-failure',
+                                        reason: 'unexpected' satisfies Nip46LogFailureReason,
+                                    });
                                     throw decryptErr;
                                 }
                                 const response = JSON.parse(decrypted) as {
@@ -2031,29 +2076,25 @@ export class Nip46Service {
                                     error?: string;
                                 };
                                 const resultValue = response.result;
-                                const resultType = typeof resultValue;
                                 const isKnownAck = resultValue === 'ack';
-                                console.debug('[NIP-46] parsed payload detail:', {
-                                    keys: Object.keys(response),
-                                    id: response.id ?? 'none',
-                                    method: response.method ?? 'none',
-                                    resultType,
-                                    resultIsKnown: isKnownAck ? 'ack' : undefined,
-                                    resultLength: resultType === 'string' ? (resultValue as string).length : 'n/a',
-                                    expectedLength: sharedSecret.length,
-                                    error: response.error ?? 'none',
-                                });
 
                                 const isSecretMatch = resultValue === sharedSecret;
                                 if (!isSecretMatch && !isKnownAck) {
-                                    console.debug('[NIP-46] result mismatch; ignoring event');
+                                    console.debug('[NIP-46] handshake response rejected', {
+                                        stage: 'response-rejected',
+                                        reason: 'unexpected' satisfies Nip46LogFailureReason,
+                                    });
                                     return;
                                 }
                                 if (isKnownAck && !isSecretMatch) {
-                                    console.warn('[NIP-46] remote signer responded with "ack" instead of the secret — accepting for compatibility (secret validation skipped)');
+                                    console.warn('[NIP-46] handshake accepted compatibility acknowledgement', {
+                                        stage: 'compatibility-ack',
+                                    });
                                 }
 
-                                console.debug('[NIP-46] handshake accepted; isSecretMatch:', isSecretMatch, 'isAck:', isKnownAck);
+                                console.debug('[NIP-46] handshake accepted', {
+                                    stage: 'accepted',
+                                });
                                 handshakeAccepted = true;
                                 handshakeSubscription?.close();
                                 handshakeSubscription = null;
@@ -2190,8 +2231,10 @@ export class Nip46Service {
                                 rejectCompletion?.(error);
                             }
                         },
-                        onclose: async (reasons?: string[]) => {
-                            console.debug('[NIP-46] handshake subscription closed; settled:', settled, 'handshakeAccepted:', handshakeAccepted, 'reasons:', reasons);
+                        onclose: async () => {
+                            console.debug('[NIP-46] handshake subscription closed', {
+                                stage: 'closed',
+                            });
                             if (settled || handshakeAccepted) {
                                 return;
                             }
@@ -2414,11 +2457,11 @@ export class Nip46Service {
         if (pendingOperationPromise) {
             try {
                 pendingOperationSucceeded = await pendingOperationPromise;
-            } catch (error) {
+            } catch {
                 pendingOperationSucceeded = false;
-                console.warn('[NIP-46] signer request: pending operation failed unexpectedly', {
+                console.warn('[NIP-46] signer request: pending operation failed', {
                     operationKind: pendingOperationKind,
-                    message: error instanceof Error ? error.message : 'Unknown error',
+                    reason: 'unexpected' satisfies Nip46LogFailureReason,
                 });
             }
         }
@@ -2445,17 +2488,15 @@ export class Nip46Service {
 
         console.debug('[NIP-46] signer request: starting limited reconnect', {
             operationKind: pendingOperationKind,
-            hasRecoverableSession: this.hasRecoverableSession(),
-            hasRuntimeSigner: this.signerAdapter !== null,
         });
 
         let recovered: boolean;
         try {
             recovered = await this.ensureConnection();
-        } catch (error) {
+        } catch {
             console.error('[NIP-46] signer request: reconnect threw unexpectedly', {
                 operationKind: pendingOperationKind,
-                message: error instanceof Error ? error.message : 'Unknown error',
+                reason: 'unexpected' satisfies Nip46LogFailureReason,
             });
             return null;
         }

--- a/src/lib/nostrAuthService.ts
+++ b/src/lib/nostrAuthService.ts
@@ -251,18 +251,25 @@ export function createNip42Authenticator(sessionPubkey: string): (boundRelayUrl:
                 const authEvent = makeAuthEvent(relayUrl, challenge);
 
                 try {
-                    console.debug('nip42_auth_sign_requested', { relay: relayUrl });
+                    console.debug('nip42_auth_sign_requested', {
+                        method: 'sign_event:22242',
+                        stage: 'start',
+                    });
                     const signer = await authService.getEventSigner(sessionPubkey);
                     assertCurrentSession(sessionPubkey);
                     const signed = await signer.signEvent(authEvent);
                     assertCurrentSession(sessionPubkey);
                     validateAuthEvent(signed, relayUrl, challenge, sessionPubkey);
-                    console.debug('nip42_auth_sign_succeeded', { relay: relayUrl });
+                    console.debug('nip42_auth_sign_succeeded', {
+                        method: 'sign_event:22242',
+                        stage: 'success',
+                    });
                     return signed as any;
                 } catch (error) {
                     console.warn('nip42_auth_sign_failed', {
-                        relay: relayUrl,
-                        message: error instanceof Error ? error.message : 'Unknown error',
+                        method: 'sign_event:22242',
+                        stage: 'failure',
+                        reason: 'unexpected',
                     });
                     throw error;
                 }

--- a/src/lib/postDeletionService.ts
+++ b/src/lib/postDeletionService.ts
@@ -190,8 +190,11 @@ export class PostDeletionService {
                 ) {
                     return { success: false, error: "nip46_signer_not_available" };
                 }
-            } catch (error) {
-                this.deps.console.error("post_deletion_nip46_signer_failed", error);
+            } catch {
+                this.deps.console.error("post_deletion_nip46_signer_failed", {
+                    stage: 'resolve-signer',
+                    reason: 'unexpected',
+                });
                 return { success: false, error: "post_error" };
             }
         }
@@ -209,8 +212,11 @@ export class PostDeletionService {
         let signedEvent: any;
         try {
             signedEvent = await signerResolution.signEvent!(deletionEvent);
-        } catch (error) {
-            this.deps.console.error("post_deletion_sign_failed", error);
+        } catch {
+            this.deps.console.error("post_deletion_sign_failed", {
+                stage: 'sign-event',
+                reason: 'unexpected',
+            });
             return { success: false, error: "post_error" };
         }
 
@@ -228,8 +234,11 @@ export class PostDeletionService {
                     includeDefaultWriteRelays: true,
                 },
             );
-        } catch (error) {
-            this.deps.console.error("post_deletion_send_failed", error);
+        } catch {
+            this.deps.console.error("post_deletion_send_failed", {
+                stage: 'publish',
+                reason: 'unexpected',
+            });
             return { success: false, error: "post_error" };
         }
 
@@ -250,8 +259,11 @@ export class PostDeletionService {
                 deletionEventId,
                 deletedAt,
             );
-        } catch (error) {
-            this.deps.console.warn("post_history_mark_deleted_failed", error);
+        } catch {
+            this.deps.console.warn("post_history_mark_deleted_failed", {
+                stage: 'post-history',
+                reason: 'unexpected',
+            });
         }
 
         return {

--- a/src/lib/postEventBuilder.ts
+++ b/src/lib/postEventBuilder.ts
@@ -228,7 +228,10 @@ export class PostEventSender {
 
             const observer = {
                 next: (packet: any) => {
-                    this.console.log(`リレー ${packet.from} への送信結果:`, packet.ok ? "成功" : "失敗", packet.notice ? `(${packet.notice})` : "");
+                    this.console.log('リレー送信結果', {
+                        stage: 'publish',
+                        outcome: packet.ok ? 'success' : 'failure',
+                    });
                     const relay = typeof packet.from === "string" ? packet.from : "";
                     if (!relay) return;
                     resultEventId = packet.event?.id || packet.eventId || resultEventId;
@@ -264,8 +267,11 @@ export class PostEventSender {
                         }
                     }
                 },
-                error: (error: any) => {
-                    this.console.error("送信エラー:", error);
+                error: () => {
+                    this.console.error("送信エラー", {
+                        stage: 'publish',
+                        reason: 'unexpected',
+                    });
                     safeResolve({ success: false, error: "post_network_error" });
                 },
                 complete: () => {

--- a/src/lib/postManager.ts
+++ b/src/lib/postManager.ts
@@ -115,8 +115,11 @@ export class PostManager {
     return { success: false, error };
   }
 
-  private handleSubmissionError(logMessage: string, error: unknown): PostResult {
-    this.deps.console?.error(logMessage, error);
+  private handleSubmissionError(logMessage: string): PostResult {
+    this.deps.console?.error(logMessage, {
+      stage: 'submission',
+      reason: 'unexpected',
+    });
     return this.notifyPostFailure('post_error');
   }
 
@@ -154,8 +157,11 @@ export class PostManager {
     rqNotifyOptions?: ReplyQuoteNotifyOptions,
   ): PostResult {
     if (result.success) {
-      void Promise.resolve(this.deps.saveHashtagsToHistoryFn?.(hashtags)).catch((error) => {
-        this.deps.console?.warn?.("hashtag_history_save_failed", error);
+      void Promise.resolve(this.deps.saveHashtagsToHistoryFn?.(hashtags)).catch(() => {
+        this.deps.console?.warn?.("hashtag_history_save_failed", {
+          stage: 'post-success',
+          reason: 'unexpected',
+        });
       });
       this.clearReplyQuoteAfterSuccess();
       this.deps.iframeMessageService?.notifyPostSuccess({
@@ -191,8 +197,11 @@ export class PostManager {
         acceptedRelays,
         relayHints,
       });
-    } catch (error) {
-      this.deps.console?.warn?.("post_history_save_failed", error);
+    } catch {
+      this.deps.console?.warn?.("post_history_save_failed", {
+        stage: 'post-history',
+        reason: 'unexpected',
+      });
     }
   }
 
@@ -206,13 +215,7 @@ export class PostManager {
     logSignedEvent?: boolean;
   }): Promise<PostResult> {
     this.deps.console?.debug?.('[PostManager] sendPreparedEvent start', {
-      hasSigner: Boolean(params.signer),
-      hasSignEventFn: Boolean(params.signEvent),
       eventKind: params.event?.kind,
-      eventCreatedAt: params.event?.created_at,
-      tagsLength: Array.isArray(params.event?.tags) ? params.event.tags.length : 0,
-      contentLength: typeof params.event?.content === 'string' ? params.event.content.length : 0,
-      additionalWriteRelaysCount: params.additionalWriteRelays?.length ?? 0,
     });
 
     const signEvent = params.signEvent
@@ -228,20 +231,20 @@ export class PostManager {
       : params.event;
 
     this.deps.console?.debug?.('[PostManager] sendPreparedEvent signed', {
-      eventId: eventToSend?.id ?? '(missing)',
       eventKind: eventToSend?.kind ?? '(missing)',
-      eventPubkey: eventToSend?.pubkey ?? '(missing)',
     });
 
     if (signEvent && params.logSignedEvent) {
-      this.deps.console?.log('署名済みイベント:', eventToSend);
+      this.deps.console?.debug?.('[PostManager] signed event ready');
     }
 
     const result = await this.eventSender!.sendEvent(eventToSend, {
       targetRelays: params.additionalWriteRelays,
       includeDefaultWriteRelays: true,
     });
-    this.deps.console?.debug?.('[PostManager] sendPreparedEvent publish result', result);
+    this.deps.console?.debug?.('[PostManager] sendPreparedEvent publish completed', {
+      success: result.success,
+    });
     const resultWithEvent: PostResult = result.success
       ? {
         ...result,
@@ -453,7 +456,7 @@ export class PostManager {
             additionalWriteRelays,
           });
         } catch (err) {
-          return this.handleSubmissionError('window.nostrでの投稿エラー:', err);
+          return this.handleSubmissionError('window.nostrでの投稿エラー:');
         }
       }
 
@@ -497,7 +500,7 @@ export class PostManager {
             additionalWriteRelays,
           });
         } catch (err) {
-          return this.handleSubmissionError('NIP-46での投稿エラー:', err);
+          return this.handleSubmissionError('NIP-46での投稿エラー:');
         }
       }
 
@@ -535,7 +538,7 @@ export class PostManager {
             additionalWriteRelays,
           });
         } catch (err) {
-          return this.handleSubmissionError('親クライアント連携での投稿エラー:', err);
+          return this.handleSubmissionError('親クライアント連携での投稿エラー:');
         }
       }
 
@@ -569,7 +572,7 @@ export class PostManager {
       });
 
     } catch (err) {
-      return this.handleSubmissionError('投稿エラー:', err);
+      return this.handleSubmissionError('投稿エラー:');
     }
   }
 

--- a/src/lib/uploadHelper.ts
+++ b/src/lib/uploadHelper.ts
@@ -180,7 +180,10 @@ async function uploadValidFiles(
     } catch (error) {
         if (devMode) {
             const modeLabel = import.meta.env.MODE === "development" ? "[dev]" : "[preview]";
-            console.error(`${modeLabel} [uploadHelper] Upload error:`, error);
+            console.error(`${modeLabel} [uploadHelper] Upload error`, {
+                stage: 'upload',
+                reason: 'unexpected',
+            });
         }
         throw error;
     }
@@ -506,8 +509,11 @@ export async function uploadHelper({
                 imageXMap,
                 dependencies,
             });
-        } catch (e) {
-            console.warn(`${modeLabel} [dev] imetaタグ生成失敗`, e);
+        } catch {
+            console.warn(`${modeLabel} [dev] imetaタグ生成失敗`, {
+                stage: 'imeta-tag',
+                reason: 'unexpected',
+            });
         }
     }
 

--- a/src/stores/authStore.svelte.ts
+++ b/src/stores/authStore.svelte.ts
@@ -32,7 +32,6 @@ export function updateAuthState(newState: Partial<AuthState>): void {
         type: updated.type,
         isAuthenticated: updated.isAuthenticated,
         isValid: updated.isValid,
-        pubkey: updated.pubkey ? updated.pubkey.substring(0, 8) + '...' : 'empty'
     });
 }
 

--- a/src/test/logAssertions.ts
+++ b/src/test/logAssertions.ts
@@ -1,0 +1,59 @@
+import { expect } from 'vitest';
+
+type ConsoleSpy = {
+    mock: {
+        calls: unknown[][];
+    };
+};
+
+function collectValueStrings(
+    value: unknown,
+    seen: WeakSet<object>,
+    result: string[],
+): void {
+    if (typeof value === 'string') {
+        result.push(value);
+        return;
+    }
+
+    if (
+        value === null
+        || typeof value === 'number'
+        || typeof value === 'boolean'
+        || typeof value === 'bigint'
+    ) {
+        result.push(String(value));
+        return;
+    }
+
+    if (typeof value !== 'object' || seen.has(value)) {
+        return;
+    }
+    seen.add(value);
+
+    for (const key of Reflect.ownKeys(value)) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
+        if (descriptor && 'value' in descriptor) {
+            collectValueStrings(descriptor.value, seen, result);
+        }
+    }
+}
+
+export function expectConsoleCallsNotToContain(
+    spies: readonly ConsoleSpy[],
+    forbiddenValues: readonly string[],
+): void {
+    const values: string[] = [];
+    const seen = new WeakSet<object>();
+    for (const spy of spies) {
+        for (const call of spy.mock.calls) {
+            for (const argument of call) {
+                collectValueStrings(argument, seen, values);
+            }
+        }
+    }
+
+    for (const forbiddenValue of forbiddenValues) {
+        expect(values.some((value) => value.includes(forbiddenValue))).toBe(false);
+    }
+}

--- a/src/test/unit/appAuthUtils.test.ts
+++ b/src/test/unit/appAuthUtils.test.ts
@@ -218,7 +218,10 @@ describe('runNip07Login', () => {
             console: { error: consoleError },
         })).resolves.toBe('nip07_auth_error');
 
-        expect(consoleError).toHaveBeenCalledWith('NIP-07認証失敗:', 'nip07_auth_error');
+        expect(consoleError).toHaveBeenCalledWith(
+            'NIP-07認証失敗',
+            { stage: 'result', reason: 'unexpected' },
+        );
     });
 });
 

--- a/src/test/unit/appInitializationBootstrap.test.ts
+++ b/src/test/unit/appInitializationBootstrap.test.ts
@@ -141,7 +141,10 @@ describe('runAppInitializationBootstrap', () => {
 
         await runAppInitializationBootstrap(params as never);
 
-        expect(params.console.error).toHaveBeenCalledWith('親クライアント連携自動認証中にエラー:', error);
+        expect(params.console.error).toHaveBeenCalledWith(
+            '親クライアント連携自動認証中にエラー',
+            { stage: 'resolve-session', reason: 'unexpected' },
+        );
         expect(params.handleAuthenticated).toHaveBeenCalledWith('restored-pubkey');
     });
 
@@ -153,7 +156,10 @@ describe('runAppInitializationBootstrap', () => {
 
         await runAppInitializationBootstrap(params as never);
 
-        expect(params.console.error).toHaveBeenCalledWith('認証初期化中にエラー:', error);
+        expect(params.console.error).toHaveBeenCalledWith(
+            '認証初期化中にエラー',
+            { stage: 'initialize-auth', reason: 'unexpected' },
+        );
         expect(params.initializeGuestSession).toHaveBeenCalledOnce();
         expect(params.stopProfileLoading).toHaveBeenCalledOnce();
         expect(params.refreshAccountList).not.toHaveBeenCalled();
@@ -270,8 +276,8 @@ describe('registerNip46VisibilityHandler', () => {
         await Promise.resolve();
 
         expect(recoveryConsole.error).toHaveBeenCalledWith(
-            'NIP-46 visibility auto recovery threw unexpectedly:',
-            error,
+            'NIP-46 visibility auto recovery threw unexpectedly',
+            { stage: 'visibility-recovery', reason: 'unexpected' },
         );
     });
 

--- a/src/test/unit/authService.authenticate.test.ts
+++ b/src/test/unit/authService.authenticate.test.ts
@@ -5,6 +5,7 @@ import './authServiceModuleMocks';
 
 import { AuthService } from '../../lib/authService';
 import { createMockAccountManager, createMockDependencies, createMockNip07Dependencies, createMockParentClientSession } from './authServiceTestUtils';
+import { expectConsoleCallsNotToContain } from '../logAssertions';
 
 describe('AuthService.authenticateWithNsec', () => {
     let authService: AuthService;
@@ -81,7 +82,10 @@ describe('AuthService.authenticateWithNsec', () => {
 
         expect(result.success).toBe(false);
         expect(result.error).toBe('authentication_error');
-        expect(mockConsole.error).toHaveBeenCalledWith('nsec認証処理中にエラー:', expect.any(Error));
+        expect(mockConsole.error).toHaveBeenCalledWith(
+            'nsec認証処理中にエラー',
+            { stage: 'nsec-authentication', reason: 'unexpected' },
+        );
     });
 
     it('短すぎるNsecが拒否される', async () => {
@@ -232,13 +236,20 @@ describe('AuthService.authenticateWithNip46', () => {
 
     it('接続失敗でエラーを返す', async () => {
         const { nip46Service } = await import('../../lib/nip46Service');
-        vi.mocked(nip46Service.connect).mockRejectedValue(new Error('Connection timeout'));
+        const sentinel = 'Connection timeout with bunker secret';
+        const error = new Error(sentinel);
+        error.stack = `stack:${sentinel}`;
+        error.cause = { nested: sentinel };
+        (error as { customPayload?: unknown }).customPayload = { sentinel };
+        (error as { cycle?: unknown }).cycle = error;
+        vi.mocked(nip46Service.connect).mockRejectedValue(error);
 
         const service = new AuthService(mockDependencies);
         const result = await service.authenticateWithNip46('bunker://invalid');
 
         expect(result.success).toBe(false);
-        expect(result.error).toBe('Connection timeout');
+        expect(result.error).toBe(sentinel);
+        expectConsoleCallsNotToContain([mockDependencies.console!.error as never], [sentinel]);
     });
 
     it('nostrconnect 待機成功は pubkey を返し、認証状態はまだ確定しない', async () => {

--- a/src/test/unit/nip46Service.test.ts
+++ b/src/test/unit/nip46Service.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../../lib/nip46Service';
 import { createDeferred } from '../deferredTestUtils';
 import { MockStorage } from '../helpers';
+import { expectConsoleCallsNotToContain } from '../logAssertions';
 
 const TEST_USER_PUBKEY = 'b'.repeat(64);
 const TEST_RECONNECT_PUBKEY = 'c'.repeat(64);
@@ -147,6 +148,42 @@ describe('Nip46SignerAdapter', () => {
 
         expect(pubkey).toBe('user-pubkey');
         expect(mockBunkerSigner.getPublicKey).toHaveBeenCalled();
+    });
+
+    it('signEvent失敗時は元のErrorをthrowするが、Errorの詳細やイベント内容をログへ渡さない', async () => {
+        const eventSecret = 'event-content-secret';
+        const errorSecret = 'signer-error-secret';
+        const cause = new Error(`${errorSecret}: cause`);
+        Object.defineProperty(cause, 'customPayload', {
+            value: eventSecret,
+            enumerable: true,
+        });
+        const error = new Error(errorSecret);
+        error.stack = `stack:${errorSecret}`;
+        error.cause = cause;
+        Object.defineProperty(error, 'customPayload', {
+            value: { nested: eventSecret },
+            enumerable: true,
+        });
+        (error as { cycle?: unknown }).cycle = error;
+        mockBunkerSigner.signEvent.mockRejectedValueOnce(error);
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+
+        try {
+            await expect(adapter.signEvent({
+                kind: 1,
+                content: eventSecret,
+                tags: [['p', eventSecret]],
+                pubkey: eventSecret,
+            })).rejects.toBe(error);
+            expectConsoleCallsNotToContain([errorSpy], [
+                eventSecret,
+                errorSecret,
+                `stack:${errorSecret}`,
+            ]);
+        } finally {
+            errorSpy.mockRestore();
+        }
     });
 });
 
@@ -795,6 +832,38 @@ describe('Nip46Service', () => {
 
             await expect(pendingFlow.pending.handshakeStarted).resolves.toBeUndefined();
             await expect(pendingFlow.pending.completion).resolves.toBe(TEST_USER_PUBKEY);
+        });
+
+        it('handshakeのイベント本文・応答payload・pubkey・Error詳細をログへ渡さない', async () => {
+            const frameSecret = 'handshake-frame-secret';
+            const payloadSecret = 'handshake-payload-secret';
+            const error = new Error(payloadSecret);
+            error.stack = `stack:${payloadSecret}`;
+            error.cause = { frameSecret };
+            (error as { cycle?: unknown }).cycle = error;
+            const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => { });
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+            const pendingFlow = await createPendingFallbackNostrConnect();
+            const { nip44 } = await import('nostr-tools');
+            vi.mocked(nip44.decrypt).mockImplementation(() => {
+                throw error;
+            });
+
+            try {
+                await pendingFlow.handlers.onevent({
+                    content: frameSecret,
+                    pubkey: pendingFlow.remoteSignerPubkey,
+                });
+                await pendingFlow.pending.cancel();
+                expectConsoleCallsNotToContain([debugSpy, warnSpy], [
+                    frameSecret,
+                    payloadSecret,
+                    `stack:${payloadSecret}`,
+                ]);
+            } finally {
+                debugSpy.mockRestore();
+                warnSpy.mockRestore();
+            }
         });
 
         it('最初の ready 後 1500ms の収集猶予時間内に ready になった initial relay だけを URI に含める', async () => {
@@ -1514,34 +1583,26 @@ describe('Nip46Service', () => {
                 await pendingFlow.pending.completion;
 
                 expect(debugSpy).toHaveBeenCalledWith(
-                    '[NIP-46] switch_relays returned relays:',
-                    [
-                        'ws://127.0.0.1:4869/',
-                        'wss://relay.final.example.com/',
-                        'ws://relay.example.com/',
-                    ],
-                );
-                expect(debugSpy).toHaveBeenCalledWith(
-                    '[NIP-46] supported final relay candidates:',
-                    ['ws://127.0.0.1:4869/', 'wss://relay.final.example.com'],
-                );
-                expect(debugSpy).toHaveBeenCalledWith(
-                    '[NIP-46] unsupported final relays:',
-                    ['ws://relay.example.com/'],
+                    '[NIP-46] switch_relays response classified',
+                    {
+                        method: 'switch_relays',
+                        parsed: 3,
+                        supported: 2,
+                        unsupported: 1,
+                    },
                 );
                 expect(warnSpy).toHaveBeenCalledWith(
                     '[NIP-46] negotiated final relay connection failed:',
-                    'ws://127.0.0.1:4869/',
-                    'connection refused',
+                    expect.objectContaining({
+                        reason: 'relay-unreachable',
+                    }),
                 );
-
-                const loggedText = [...debugSpy.mock.calls, ...warnSpy.mock.calls]
-                    .flat()
-                    .map((value) =>
-                        typeof value === 'string' ? value : JSON.stringify(value),
-                    )
-                    .join(' ');
-                expect(loggedText).not.toContain('ab'.repeat(32));
+                expectConsoleCallsNotToContain([debugSpy, warnSpy], [
+                    'wss://relay.final.example.com',
+                    'ws://relay.example.com',
+                    'connection refused',
+                    'ab'.repeat(32),
+                ]);
             } finally {
                 debugSpy.mockRestore();
                 warnSpy.mockRestore();

--- a/src/test/unit/nip46WebSocketLog.test.ts
+++ b/src/test/unit/nip46WebSocketLog.test.ts
@@ -1,0 +1,132 @@
+import { beforeAll, afterAll, describe, expect, it, vi } from 'vitest';
+
+import { expectConsoleCallsNotToContain } from '../logAssertions';
+
+const mockPool = {
+    ensureRelay: vi.fn().mockResolvedValue({}),
+    destroy: vi.fn(),
+};
+const mockUseWebSocketImplementation = vi.fn();
+const mockParseBunkerInput = vi.fn();
+const mockSigner = {
+    sendRequest: vi.fn().mockResolvedValue('ok'),
+    getPublicKey: vi.fn().mockResolvedValue('b'.repeat(64)),
+    close: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('nostr-tools', () => ({
+    kinds: { NostrConnect: 24133 },
+    nip44: {
+        getConversationKey: vi.fn(() => new Uint8Array([1])),
+        decrypt: vi.fn(),
+    },
+}));
+
+vi.mock('nostr-tools/nip46', () => ({
+    BunkerSigner: {
+        fromBunker: vi.fn(() => mockSigner),
+    },
+    BUNKER_REGEX: /^bunker:\/\//,
+    createNostrConnectURI: vi.fn(),
+    parseBunkerInput: mockParseBunkerInput,
+}));
+
+vi.mock('nostr-tools/pool', () => ({
+    SimplePool: vi.fn(function () {
+        return mockPool;
+    }),
+    useWebSocketImplementation: mockUseWebSocketImplementation,
+}));
+
+vi.mock('nostr-tools/utils', () => ({
+    bytesToHex: vi.fn(() => 'a'.repeat(64)),
+    hexToBytes: vi.fn(() => new Uint8Array(32)),
+}));
+
+vi.mock('nostr-tools/pure', () => ({
+    generateSecretKey: vi.fn(() => new Uint8Array(32)),
+    getPublicKey: vi.fn(() => 'c'.repeat(64)),
+}));
+
+class FakeWebSocket extends EventTarget {
+    readonly sent: unknown[] = [];
+
+    constructor(
+        readonly url: string | URL,
+        readonly protocols?: string | string[],
+    ) {
+        super();
+    }
+
+    send(data: unknown): void {
+        this.sent.push(data);
+    }
+}
+
+describe('NIP-46 WebSocket logging', () => {
+    let Nip46Service: typeof import('../../lib/nip46Service').Nip46Service;
+    let webSocketImplementation: new (
+        url: string | URL,
+        protocols?: string | string[],
+    ) => FakeWebSocket;
+
+    beforeAll(async () => {
+        vi.stubGlobal('WebSocket', FakeWebSocket);
+        ({ Nip46Service } = await import('../../lib/nip46Service'));
+    });
+
+    afterAll(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('受信本文・送信本文・close reason・URLをログへ渡さない', async () => {
+        mockParseBunkerInput.mockResolvedValueOnce({
+            pubkey: 'd'.repeat(64),
+            relays: ['wss://relay.example.com'],
+            secret: 'bunker-secret',
+        });
+        mockSigner.sendRequest.mockImplementation((method: string) =>
+            method === 'get_public_key' ? 'b'.repeat(64) : 'ok');
+        const service = new Nip46Service();
+        await service.connect('bunker://ignored');
+
+        webSocketImplementation = mockUseWebSocketImplementation.mock.calls
+            .map(([implementation]) => implementation)
+            .find((implementation) => implementation?.name === 'Nip46WebSocket');
+        expect(webSocketImplementation).toBeDefined();
+
+        const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => { });
+        const socket = new webSocketImplementation('wss://secret-relay.example.com');
+        const sentinel = 'encrypted-nip46-frame-secret';
+        socket.dispatchEvent(new Event('message'));
+        const closeEvent = new Event('close');
+        Object.defineProperties(closeEvent, {
+            code: { value: 4001 },
+            reason: { value: sentinel },
+        });
+        socket.dispatchEvent(closeEvent);
+        socket.send(JSON.stringify({ secret: sentinel, content: sentinel }));
+
+        try {
+            expect(debugSpy).toHaveBeenCalledWith(
+                '[NIP-46 WS] receive',
+                { direction: 'inbound' },
+            );
+            expect(debugSpy).toHaveBeenCalledWith(
+                '[NIP-46 WS] close',
+                { direction: 'transport', closeCode: 4001 },
+            );
+            expect(debugSpy).toHaveBeenCalledWith(
+                '[NIP-46 WS] send',
+                { direction: 'outbound' },
+            );
+            expectConsoleCallsNotToContain([debugSpy], [
+                sentinel,
+                'secret-relay.example.com',
+            ]);
+        } finally {
+            debugSpy.mockRestore();
+            await service.disconnect();
+        }
+    });
+});

--- a/src/test/unit/postManager.test.ts
+++ b/src/test/unit/postManager.test.ts
@@ -1050,7 +1050,10 @@ describe('PostEventSender', () => {
 
         expect(result.success).toBe(false);
         expect(result.error).toBe('post_network_error');
-        expect(mockConsole.error).toHaveBeenCalledWith('送信エラー:', expect.any(Error));
+        expect(mockConsole.error).toHaveBeenCalledWith(
+            '送信エラー',
+            { stage: 'publish', reason: 'unexpected' },
+        );
     });
 
     it('応答なしタイムアウトを適切に処理する', async () => {


### PR DESCRIPTION
## Summary

- Redact NIP-46, Nostr Connect, NIP-42, WebSocket, authentication, restore, signer-consumer, post, deletion, and upload logs.
- Keep only safe stage/method/outcome/count metadata and explicit failure reasons; remove URLs, payloads, event fields, pubkeys, and raw Error objects/details.
- Preserve thrown Error identity, return values, cleanup/retry/fallback, and auth/session behavior.
- Add recursive sentinel coverage for Error fields/cycles, handshake payloads, and WebSocket frames/close reasons.

## Validation

- `npm test` — 308 files, 3422 tests passed
- `npm run check` — passed with 0 diagnostics
- `npm run build` — passed; existing chunk-size warning remains
- `git diff --check` — passed
- Targeted static console-argument audit — no sensitive arguments found