### PR TITLE
chore: update DOMPurify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "blurhash": "^2.0.5",
         "browser-image-compression": "^2.0.2",
         "dexie": "^4.4.2",
-        "dompurify": "^3.3.3",
+        "dompurify": "^3.4.12",
         "ipaddr.js": "^2.3.0",
         "mediabunny": "^1.24.2",
         "nip07-awaiter": "^1.1.0",
@@ -4774,9 +4774,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "blurhash": "^2.0.5",
     "browser-image-compression": "^2.0.2",
     "dexie": "^4.4.2",
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.12",
     "ipaddr.js": "^2.3.0",
     "mediabunny": "^1.24.2",
     "nip07-awaiter": "^1.1.0",


### PR DESCRIPTION
## Summary

- Update `dompurify` from `^3.3.3` to `^3.4.12`.
- Resolve DOMPurify to `3.4.12` without changing application sanitization code or tests.

## Details

- Changed files: `package.json`, `package-lock.json`.
- The lockfile diff is limited to the root DOMPurify metadata and the DOMPurify package entry; no unrelated dependency versions, overrides, or line-ending changes were introduced.
- Existing DOMPurify usage and sanitization settings were preserved.

## Audit and dependency tree

- Before: `npm audit` reported 7 vulnerabilities: 1 low, 1 moderate, and 5 high. The moderate finding was DOMPurify-related; the other affected packages were `@babel/core`, `brace-expansion`, `fast-uri`, `postcss`, `vite`, and `ws`.
- After: `npm audit` reports 6 vulnerabilities: 1 low and 5 high. The DOMPurify audit finding is no longer present. Remaining findings are in `@babel/core`, `brace-expansion`, `fast-uri`, `postcss`, `vite`, and `ws`; they are outside this PR and were not changed.
- Before and after `npm ls --all`: exit code 1 due to the existing `svelte-check` dependency-tree issue (`picomatch@2.3.2` invalid for `^3 || ^4`). No new invalid or extraneous dependency was introduced.
- `npm ls dompurify --all` after update: `dompurify@3.4.12`.

## Verification

- `npm ci`: passed.
- Targeted sanitization tests (`domSanitizer.test.ts`, `draftHtmlSanitizer.test.ts`, `htmlSanitizer.test.ts`, `channelContextPreview.test.ts`): 4 files, 16 tests passed.
- `npm run check`: passed with 0 errors and 0 warnings.
- `npm test`: passed, 308 files and 3422 tests.
- `npm run build`: passed, including legacy bridge verification; existing chunk-size warning remains.
- `git diff --check`: passed.

Manual real-browser verification was not run because this PR only changes the DOMPurify dependency and preserves all application sanitization code and configuration.
