### PR TITLE
fix: validate parent response kind

### DIFF
--- a/src/lib/parentClientAuthService.ts
+++ b/src/lib/parentClientAuthService.ts
@@ -570,6 +570,19 @@ export class ParentClientAuthService {
         const pending = this.pendingRequests.get(requestId);
         if (!pending) return;
 
+        const responseFamily =
+            message.type === "auth.result" || message.type === "auth.error"
+                ? 'auth'
+                : message.type === "rpc.result" || message.type === "rpc.error"
+                    ? 'rpc'
+                    : null;
+        if (responseFamily && responseFamily !== pending.kind) {
+            globalThis.clearTimeout(pending.timeoutId);
+            this.pendingRequests.delete(requestId);
+            pending.reject(new Error("parent_client_invalid_response"));
+            return;
+        }
+
         globalThis.clearTimeout(pending.timeoutId);
         this.pendingRequests.delete(requestId);
 

--- a/src/test/unit/parentClientAuthService.test.ts
+++ b/src/test/unit/parentClientAuthService.test.ts
@@ -9,6 +9,26 @@ import { createMockConsole, type MockConsole, MockStorage } from '../helpers';
 import { EMBED_MESSAGE_NAMESPACE } from '../../lib/embedProtocol';
 import { createMockWindow } from '../embedWindowTestUtils';
 
+function dispatchParentMessage(
+    listeners: Map<string, (event: MessageEvent) => void>,
+    parent: { postMessage: ReturnType<typeof vi.fn> },
+    type: string,
+    requestId: string,
+    payload: unknown,
+): void {
+    listeners.get('message')?.({
+        data: {
+            namespace: EMBED_MESSAGE_NAMESPACE,
+            version: 1,
+            type,
+            requestId,
+            payload,
+        },
+        origin: 'https://parent.example.com',
+        source: parent,
+    } as unknown as MessageEvent);
+}
+
 describe('ParentClientAuthService', () => {
     let mockConsole: MockConsole;
 
@@ -99,6 +119,156 @@ describe('ParentClientAuthService', () => {
             id: 'signed-event',
             sig: 'signature',
         });
+    });
+
+    it('auth pending への rpc.result は protocol error で reject し、後続の auth.result を無視する', async () => {
+        const { windowObj, parent, listeners } = createMockWindow();
+        const service = new ParentClientAuthService(windowObj, mockConsole);
+
+        const connectPromise = service.connect({ capabilities: ['signEvent'] });
+        const authRequest = vi.mocked(parent.postMessage).mock.calls[1][0] as any;
+        dispatchParentMessage(listeners, parent, 'rpc.result', authRequest.requestId, {
+            result: {
+                id: 'wrong-family-result',
+                sig: 'wrong-family-signature',
+            },
+        });
+
+        await expect(connectPromise).rejects.toThrow('parent_client_invalid_response');
+        expect(service.isConnected()).toBe(false);
+
+        dispatchParentMessage(listeners, parent, 'auth.result', authRequest.requestId, {
+            pubkeyHex: 'ab'.repeat(32),
+            capabilities: ['signEvent'],
+        });
+
+        expect(service.isConnected()).toBe(false);
+    });
+
+    it('auth pending への rpc.error は error code/message を伝播せず cleanup する', async () => {
+        const { windowObj, parent, listeners } = createMockWindow();
+        const service = new ParentClientAuthService(windowObj, mockConsole);
+
+        const connectPromise = service.connect({ capabilities: ['signEvent'] });
+        const authRequest = vi.mocked(parent.postMessage).mock.calls[1][0] as any;
+        dispatchParentMessage(listeners, parent, 'rpc.error', authRequest.requestId, {
+            code: 'wrong_rpc_code',
+            message: 'wrong rpc message',
+        });
+
+        await expect(connectPromise).rejects.toThrow('parent_client_invalid_response');
+        expect(service.isConnected()).toBe(false);
+
+        dispatchParentMessage(listeners, parent, 'auth.result', authRequest.requestId, {
+            pubkeyHex: 'cd'.repeat(32),
+            capabilities: ['signEvent'],
+        });
+
+        expect(service.isConnected()).toBe(false);
+    });
+
+    it('rpc pending への auth.result は protocol error で reject し、後続の rpc.result を無視する', async () => {
+        const { windowObj, parent, listeners } = createMockWindow();
+        const service = new ParentClientAuthService(windowObj, mockConsole);
+
+        const connectPromise = service.connect({ capabilities: ['signEvent'] });
+        const authRequest = vi.mocked(parent.postMessage).mock.calls[1][0] as any;
+        dispatchParentMessage(listeners, parent, 'auth.result', authRequest.requestId, {
+            pubkeyHex: 'ef'.repeat(32),
+            capabilities: ['signEvent'],
+        });
+        await connectPromise;
+        const sessionBeforeRpc = service.getSessionData();
+
+        const rpcPromise = service.signEvent({ kind: 1, content: 'hello', tags: [] });
+        const rpcRequest = vi.mocked(parent.postMessage).mock.calls[2][0] as any;
+        dispatchParentMessage(listeners, parent, 'auth.result', rpcRequest.requestId, {
+            pubkeyHex: '12'.repeat(32),
+            capabilities: ['signEvent'],
+        });
+
+        await expect(rpcPromise).rejects.toThrow('parent_client_invalid_response');
+        expect(service.getSessionData()).toEqual(sessionBeforeRpc);
+
+        dispatchParentMessage(listeners, parent, 'rpc.result', rpcRequest.requestId, {
+            result: {
+                id: 'late-result',
+                sig: 'late-signature',
+            },
+        });
+
+        expect(service.getSessionData()).toEqual(sessionBeforeRpc);
+    });
+
+    it('rpc pending への auth.error は error code/message を伝播せず cleanup する', async () => {
+        const { windowObj, parent, listeners } = createMockWindow();
+        const service = new ParentClientAuthService(windowObj, mockConsole);
+
+        const connectPromise = service.connect({ capabilities: ['signEvent'] });
+        const authRequest = vi.mocked(parent.postMessage).mock.calls[1][0] as any;
+        dispatchParentMessage(listeners, parent, 'auth.result', authRequest.requestId, {
+            pubkeyHex: '34'.repeat(32),
+            capabilities: ['signEvent'],
+        });
+        await connectPromise;
+
+        const rpcPromise = service.signEvent({ kind: 1, content: 'hello', tags: [] });
+        const rpcRequest = vi.mocked(parent.postMessage).mock.calls[2][0] as any;
+        dispatchParentMessage(listeners, parent, 'auth.error', rpcRequest.requestId, {
+            code: 'wrong_auth_code',
+            message: 'wrong auth message',
+        });
+
+        await expect(rpcPromise).rejects.toThrow('parent_client_invalid_response');
+        expect(service.isConnected()).toBe(true);
+
+        dispatchParentMessage(listeners, parent, 'rpc.result', rpcRequest.requestId, {
+            result: {
+                id: 'late-result',
+                sig: 'late-signature',
+            },
+        });
+
+        expect(service.isConnected()).toBe(true);
+    });
+
+    it('rpc.error は同familyの error code/message を維持する', async () => {
+        const { windowObj, parent, listeners } = createMockWindow();
+        const service = new ParentClientAuthService(windowObj, mockConsole);
+
+        const connectPromise = service.connect({ capabilities: ['signEvent'] });
+        const authRequest = vi.mocked(parent.postMessage).mock.calls[1][0] as any;
+        dispatchParentMessage(listeners, parent, 'auth.result', authRequest.requestId, {
+            pubkeyHex: '56'.repeat(32),
+            capabilities: ['signEvent'],
+        });
+        await connectPromise;
+
+        const rpcPromise = service.signEvent({ kind: 1, content: 'hello', tags: [] });
+        const rpcRequest = vi.mocked(parent.postMessage).mock.calls[2][0] as any;
+        dispatchParentMessage(listeners, parent, 'rpc.error', rpcRequest.requestId, {
+            code: 'rpc_failed',
+            message: 'rpc failed',
+        });
+
+        await expect(rpcPromise).rejects.toThrow('rpc failed');
+    });
+
+    it('response 未着時は通常どおり timeout で reject する', async () => {
+        vi.useFakeTimers();
+        try {
+            const { windowObj } = createMockWindow();
+            const service = new ParentClientAuthService(windowObj, mockConsole);
+            const connectPromise = service.connect({ timeoutMs: 100 });
+            const timeoutExpectation = expect(connectPromise).rejects.toThrow('parent_client_timeout');
+
+            await vi.advanceTimersByTimeAsync(100);
+
+            await timeoutExpectation;
+            expect(service.isConnected()).toBe(false);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('capabilities 未指定時は signEvent のみを既定要求する', () => {


### PR DESCRIPTION
## Summary

Parent-client response handling now validates the response family against the pending request kind before family-specific payload processing.

## Root cause

A pending request was removed and its timeout cleared before checking whether the response belonged to the same request family. A response with the same request ID from the other family could therefore enter auth or RPC payload/error handling.

## Changes

- Auth pending requests accept only `auth.result` and `auth.error`.
- RPC pending requests accept only `rpc.result` and `rpc.error`.
- Wrong-family responses reject with `parent_client_invalid_response`, clear the timeout, and remove the pending entry before returning.
- Wrong-family result values and error code/message values are not propagated.
- Existing namespace/version, source, origin, request ID, envelope, session, signer, restore, account, storage, and NIP-46 behavior is unchanged.
- `auth.login` and `auth.logout` remote-event handling remains unchanged.

## Tests

Added regression coverage for both directions of wrong-family result/error responses, cleanup and duplicate/late-response ignoring, normal `rpc.error` behavior, and normal timeout behavior.

- `npm run test -- src/test/unit/parentClientAuthService.test.ts`: 17 passed
- Related parent-client/restore/account/signer tests: 191 passed across 5 files
- `npm run check`: passed with 0 errors and 0 warnings
- `npm test`: 310 files, 3,488 tests passed
- `git diff --check`: passed

Build was not run because the production change is limited to TypeScript message routing and unit tests; it does not affect Vite, PWA, service worker, assets, bundling, or WASM boundaries.

Playwright and real-iframe verification were not run because source/origin/browser API behavior was unchanged and the protocol branching is covered by deterministic unit tests.