### PR TITLE
fix: await per-account cleanup before logout

### DIFF
--- a/src/lib/accountManager.ts
+++ b/src/lib/accountManager.ts
@@ -178,17 +178,41 @@ export class AccountManager {
     /**
      * 指定アカウントの per-user データ（認証情報、リレー、プロフィール）を全て削除する。
      */
-    cleanupAccountData(pubkeyHex: string): void {
-        try {
-            this.localStorage.removeItem(getNsecStorageKey(pubkeyHex));
-            this.localStorage.removeItem(getNip46SessionStorageKey(pubkeyHex));
-            this.localStorage.removeItem(getParentClientSessionStorageKey(pubkeyHex));
-            this.localStorage.removeItem(STORAGE_KEYS.NOSTR_RELAYS + pubkeyHex);
-            this.localStorage.removeItem(STORAGE_KEYS.NOSTR_PROFILE + pubkeyHex);
-            void profilesRepository.delete(pubkeyHex);
-            void relayConfigsRepository.delete(pubkeyHex);
-        } catch (error) {
-            this.console.error('アカウントデータ削除エラー:', error);
+    async cleanupAccountData(pubkeyHex: string): Promise<void> {
+        const localStorageKeys = [
+            { key: getNsecStorageKey(pubkeyHex), target: 'nsec' },
+            { key: getNip46SessionStorageKey(pubkeyHex), target: 'nip46-session' },
+            { key: getParentClientSessionStorageKey(pubkeyHex), target: 'parent-client-session' },
+            { key: STORAGE_KEYS.NOSTR_RELAYS + pubkeyHex, target: 'relay-config' },
+            { key: STORAGE_KEYS.NOSTR_PROFILE + pubkeyHex, target: 'profile' },
+        ] as const;
+
+        for (const { key, target } of localStorageKeys) {
+            try {
+                this.localStorage.removeItem(key);
+            } catch {
+                this.console.error('アカウントデータ削除に失敗しました', {
+                    stage: 'local-storage',
+                    target,
+                    reason: 'unexpected',
+                });
+            }
         }
+
+        const repositoryResults = await Promise.allSettled([
+            Promise.resolve().then(() => profilesRepository.delete(pubkeyHex)),
+            Promise.resolve().then(() => relayConfigsRepository.delete(pubkeyHex)),
+        ]);
+
+        const repositoryTargets = ['profile-repository', 'relay-config-repository'] as const;
+        repositoryResults.forEach((result, index) => {
+            if (result.status === 'rejected') {
+                this.console.error('アカウントデータ削除に失敗しました', {
+                    stage: 'indexeddb',
+                    target: repositoryTargets[index],
+                    reason: 'rejected',
+                });
+            }
+        });
     }
 }

--- a/src/lib/appAccountSessionController.ts
+++ b/src/lib/appAccountSessionController.ts
@@ -81,7 +81,7 @@ export interface AppAccountSessionControllerDependencies {
     logoutAccountFromAuthService(
         pubkeyHex: string,
         options: { notifyParentClient?: boolean },
-    ): string | null | undefined;
+    ): Promise<string | null | undefined>;
     resolveLogoutAccountAction(nextPubkey: string | null | undefined): LogoutActionResult;
     clearAuthState(): void;
     setGuestProfile(profile: ProfileGuestSnapshot): void;
@@ -277,10 +277,11 @@ export function createAppAccountSessionController(
         try {
             deps.resetUploadDisplayState();
 
+            const nextPubkey = await deps.logoutAccountFromAuthService(pubkeyHex, {
+                notifyParentClient: options.notifyParentClient,
+            });
             const nextAction = deps.resolveLogoutAccountAction(
-                deps.logoutAccountFromAuthService(pubkeyHex, {
-                    notifyParentClient: options.notifyParentClient,
-                }),
+                nextPubkey,
             );
 
             if (nextAction.kind === 'switch') {

--- a/src/lib/authService.ts
+++ b/src/lib/authService.ts
@@ -186,7 +186,15 @@ export class AuthService {
             const accountType = this.accountManager?.getAccountType(pubkeyHex);
             if (accountType === 'parentClient' || isRuntimeParentClientAccount) {
                 this.runtime.parentClientSvc.disconnect(options.notifyParentClient ?? true);
-                ParentClientAuthService.clearSession(this.runtime.localStorage, pubkeyHex);
+                try {
+                    ParentClientAuthService.clearSession(this.runtime.localStorage, pubkeyHex);
+                } catch {
+                    this.runtime.console.error('アカウントデータ削除に失敗しました', {
+                        stage: 'local-storage',
+                        target: 'parent-client-session',
+                        reason: 'unexpected',
+                    });
+                }
             } else if (accountType === 'nip46') {
                 try {
                     await this.runtime.nip46Svc.disconnect();

--- a/src/lib/authService.ts
+++ b/src/lib/authService.ts
@@ -173,10 +173,10 @@ export class AuthService {
      * 指定アカウントをログアウトする。
      * @returns 次のアクティブアカウントのpubkeyHex。アカウントが残っていない場合はnull。
      */
-    logoutAccount(
+    async logoutAccount(
         pubkeyHex: string,
         options: { notifyParentClient?: boolean } = {},
-    ): string | null | undefined {
+    ): Promise<string | null | undefined> {
         try {
             const isRuntimeParentClientAccount =
                 this.runtime.parentClientSvc.isConnected()
@@ -188,16 +188,18 @@ export class AuthService {
                 this.runtime.parentClientSvc.disconnect(options.notifyParentClient ?? true);
                 ParentClientAuthService.clearSession(this.runtime.localStorage, pubkeyHex);
             } else if (accountType === 'nip46') {
-                this.runtime.nip46Svc.disconnect().catch(e => {
+                try {
+                    await this.runtime.nip46Svc.disconnect();
+                } catch {
                     this.runtime.console.error('NIP-46切断エラー', {
                         stage: 'disconnect',
                         reason: 'unexpected',
                     });
-                });
+                }
             }
 
             // per-accountデータを削除
-            this.accountManager?.cleanupAccountData(pubkeyHex);
+            await this.accountManager?.cleanupAccountData(pubkeyHex);
 
             // アカウントリストから削除
             const nextPubkey = this.accountManager?.removeAccount(pubkeyHex);

--- a/src/test/unit/accountManager.test.ts
+++ b/src/test/unit/accountManager.test.ts
@@ -1,6 +1,25 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const repositoryMocks = vi.hoisted(() => ({
+    profileDelete: vi.fn(),
+    relayConfigDelete: vi.fn(),
+}));
+
+vi.mock('../../lib/storage/profilesRepository', () => ({
+    profilesRepository: {
+        delete: repositoryMocks.profileDelete,
+    },
+}));
+
+vi.mock('../../lib/storage/relayConfigsRepository', () => ({
+    relayConfigsRepository: {
+        delete: repositoryMocks.relayConfigDelete,
+    },
+}));
+
 import { AccountManager } from '../../lib/accountManager';
 import { STORAGE_KEYS } from '../../lib/constants';
+import { getNsecStorageKey } from '../../lib/authStorageKeys';
 import { createMockConsole, type MockConsole, MockStorage } from '../helpers';
 
 describe('AccountManager', () => {
@@ -13,6 +32,8 @@ describe('AccountManager', () => {
         mockConsole = createMockConsole();
         manager = new AccountManager({ localStorage: storage, console: mockConsole });
         vi.clearAllMocks();
+        repositoryMocks.profileDelete.mockReset().mockResolvedValue(undefined);
+        repositoryMocks.relayConfigDelete.mockReset().mockResolvedValue(undefined);
     });
 
     describe('getAccounts', () => {
@@ -145,34 +166,132 @@ describe('AccountManager', () => {
     });
 
     describe('cleanupAccountData', () => {
-        it('指定アカウントの全データを削除する', () => {
+        it('指定アカウントの全データを削除する', async () => {
             const pubkey = 'abc123';
             storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_PREFIX + pubkey, 'nsec1...');
             storage.setItem(STORAGE_KEYS.NOSTR_NIP46_SESSION_PREFIX + pubkey, '{}');
+            storage.setItem(STORAGE_KEYS.NOSTR_PARENT_CLIENT_SESSION_PREFIX + pubkey, '{}');
             storage.setItem(STORAGE_KEYS.NOSTR_RELAYS + pubkey, '[]');
             storage.setItem(STORAGE_KEYS.NOSTR_PROFILE + pubkey, '{}');
 
-            manager.cleanupAccountData(pubkey);
+            await manager.cleanupAccountData(pubkey);
 
             expect(storage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_PREFIX + pubkey)).toBeNull();
             expect(storage.getItem(STORAGE_KEYS.NOSTR_NIP46_SESSION_PREFIX + pubkey)).toBeNull();
+            expect(storage.getItem(STORAGE_KEYS.NOSTR_PARENT_CLIENT_SESSION_PREFIX + pubkey)).toBeNull();
             expect(storage.getItem(STORAGE_KEYS.NOSTR_RELAYS + pubkey)).toBeNull();
             expect(storage.getItem(STORAGE_KEYS.NOSTR_PROFILE + pubkey)).toBeNull();
+            expect(repositoryMocks.profileDelete).toHaveBeenCalledWith(pubkey);
+            expect(repositoryMocks.relayConfigDelete).toHaveBeenCalledWith(pubkey);
         });
 
-        it('localStorage.removeItemが例外を投げた場合にエラーログを出力する', () => {
+        it('repository削除がsettleするまでresolveせず、rejectしても他方を待つ', async () => {
+            let resolveProfile!: () => void;
+            let resolveRelayConfig!: () => void;
+            const profileDeletion = new Promise<void>((resolve) => {
+                resolveProfile = resolve;
+            });
+            const relayConfigDeletion = new Promise<void>((resolve) => {
+                resolveRelayConfig = resolve;
+            });
+            repositoryMocks.profileDelete.mockReturnValue(profileDeletion);
+            repositoryMocks.relayConfigDelete.mockReturnValue(relayConfigDeletion);
+
+            let cleanupSettled = false;
+            const cleanupPromise = manager.cleanupAccountData('abc123').then(() => {
+                cleanupSettled = true;
+            });
+
+            await Promise.resolve();
+            expect(repositoryMocks.profileDelete).toHaveBeenCalledWith('abc123');
+            expect(repositoryMocks.relayConfigDelete).toHaveBeenCalledWith('abc123');
+            expect(cleanupSettled).toBe(false);
+
+            resolveProfile();
+            await Promise.resolve();
+            expect(cleanupSettled).toBe(false);
+
+            resolveRelayConfig();
+            await cleanupPromise;
+            expect(cleanupSettled).toBe(true);
+        });
+
+        it('profile削除がrejectしてもrelay削除を待ち、安全なmetadataをログへ残す', async () => {
+            let resolveRelayConfig!: () => void;
+            repositoryMocks.profileDelete.mockRejectedValue(new Error('profile failure'));
+            repositoryMocks.relayConfigDelete.mockReturnValue(new Promise<void>((resolve) => {
+                resolveRelayConfig = resolve;
+            }));
+
+            const cleanupPromise = manager.cleanupAccountData('abc123');
+            await Promise.resolve();
+
+            expect(repositoryMocks.relayConfigDelete).toHaveBeenCalledWith('abc123');
+            resolveRelayConfig();
+            await expect(cleanupPromise).resolves.toBeUndefined();
+            expect(mockConsole.error).toHaveBeenCalledWith(
+                'アカウントデータ削除に失敗しました',
+                { stage: 'indexeddb', target: 'profile-repository', reason: 'rejected' },
+            );
+        });
+
+        it('relay削除がrejectしてもprofile削除を待ち、安全なmetadataをログへ残す', async () => {
+            let resolveProfile!: () => void;
+            repositoryMocks.relayConfigDelete.mockRejectedValue(new Error('relay failure'));
+            repositoryMocks.profileDelete.mockReturnValue(new Promise<void>((resolve) => {
+                resolveProfile = resolve;
+            }));
+
+            const cleanupPromise = manager.cleanupAccountData('abc123');
+            await Promise.resolve();
+
+            expect(repositoryMocks.profileDelete).toHaveBeenCalledWith('abc123');
+            resolveProfile();
+            await expect(cleanupPromise).resolves.toBeUndefined();
+            expect(mockConsole.error).toHaveBeenCalledWith(
+                'アカウントデータ削除に失敗しました',
+                { stage: 'indexeddb', target: 'relay-config-repository', reason: 'rejected' },
+            );
+        });
+
+        it('localStorageの一部が例外でも残りのkeyとrepository削除を試行する', async () => {
             const throwingStorage = new MockStorage();
-            throwingStorage.removeItem = vi.fn().mockImplementation(() => {
-                throw new Error('Storage error');
+            const originalRemoveItem = throwingStorage.removeItem.bind(throwingStorage);
+            throwingStorage.removeItem = vi.fn().mockImplementation((key: string) => {
+                if (key === getNsecStorageKey('abc123')) {
+                    throw new Error('Storage error');
+                }
+                originalRemoveItem(key);
             });
             const errorManager = new AccountManager({ localStorage: throwingStorage, console: mockConsole });
 
-            errorManager.cleanupAccountData('abc123');
+            await errorManager.cleanupAccountData('abc123');
 
+            expect(throwingStorage.removeItem).toHaveBeenCalledTimes(5);
+            expect(repositoryMocks.profileDelete).toHaveBeenCalledWith('abc123');
+            expect(repositoryMocks.relayConfigDelete).toHaveBeenCalledWith('abc123');
             expect(mockConsole.error).toHaveBeenCalledWith(
-                'アカウントデータ削除エラー:',
-                expect.any(Error)
+                'アカウントデータ削除に失敗しました',
+                { stage: 'local-storage', target: 'nsec', reason: 'unexpected' },
             );
+        });
+
+        it('対象外アカウントのlocalStorageとrepository dataへ触れない', async () => {
+            const targetPubkey = 'target';
+            const otherPubkey = 'other';
+            storage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_PREFIX + otherPubkey, 'other-secret');
+            storage.setItem(STORAGE_KEYS.NOSTR_PROFILE + otherPubkey, 'other-profile');
+            storage.setItem(STORAGE_KEYS.NOSTR_RELAYS + otherPubkey, 'other-relays');
+
+            await manager.cleanupAccountData(targetPubkey);
+
+            expect(storage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_PREFIX + otherPubkey)).toBe('other-secret');
+            expect(storage.getItem(STORAGE_KEYS.NOSTR_PROFILE + otherPubkey)).toBe('other-profile');
+            expect(storage.getItem(STORAGE_KEYS.NOSTR_RELAYS + otherPubkey)).toBe('other-relays');
+            expect(repositoryMocks.profileDelete).toHaveBeenCalledWith(targetPubkey);
+            expect(repositoryMocks.profileDelete).not.toHaveBeenCalledWith(otherPubkey);
+            expect(repositoryMocks.relayConfigDelete).toHaveBeenCalledWith(targetPubkey);
+            expect(repositoryMocks.relayConfigDelete).not.toHaveBeenCalledWith(otherPubkey);
         });
     });
 

--- a/src/test/unit/appAccountSessionController.test.ts
+++ b/src/test/unit/appAccountSessionController.test.ts
@@ -29,6 +29,7 @@ function createController(overrides: Record<string, unknown> = {}) {
         [OTHER_PUBKEY, 'nsec'],
     ]);
     const switchingAccountStateHistory: boolean[] = [];
+    const loggingOutStateHistory: boolean[] = [];
 
     const accountManager = {
         getAccountType: vi.fn((pubkeyHex: string) => accounts.get(pubkeyHex) ?? null),
@@ -58,9 +59,10 @@ function createController(overrides: Record<string, unknown> = {}) {
             switchingAccountStateHistory.push(next);
         }),
         getIsLoggingOut: () => isLoggingOut,
-        setIsLoggingOut: (next: boolean) => {
+        setIsLoggingOut: vi.fn((next: boolean) => {
             isLoggingOut = next;
-        },
+            loggingOutStateHistory.push(next);
+        }),
         setProfileLoading: vi.fn(),
         getAuthStateSnapshot: () => authSnapshot,
         getCurrentRxNostr: () => currentRxNostr,
@@ -82,7 +84,7 @@ function createController(overrides: Record<string, unknown> = {}) {
         })),
         handlePostAuth: vi.fn(async () => undefined),
         resetUploadDisplayState: vi.fn(),
-        logoutAccountFromAuthService: vi.fn(() => null),
+        logoutAccountFromAuthService: vi.fn(async () => null),
         resolveLogoutAccountAction: vi.fn((nextPubkey: string | null | undefined) => {
             if (typeof nextPubkey === 'string') {
                 return { kind: 'switch', pubkeyHex: nextPubkey };
@@ -111,6 +113,7 @@ function createController(overrides: Record<string, unknown> = {}) {
         deps,
         controller: createAppAccountSessionController(deps as never),
         switchingAccountStateHistory,
+        loggingOutStateHistory,
         getActivePubkey: () => activePubkey,
         setActivePubkey: (next: string | null) => {
             activePubkey = next;
@@ -424,7 +427,7 @@ describe('createAppAccountSessionController', () => {
 
     it('logoutAccount guest 分岐では認証情報を初期化する', async () => {
         const { deps, controller } = createController({
-            logoutAccountFromAuthService: vi.fn(() => null),
+            logoutAccountFromAuthService: vi.fn(async () => null),
         });
 
         await controller.logoutAccount(CURRENT_PUBKEY);
@@ -432,6 +435,53 @@ describe('createAppAccountSessionController', () => {
         expect(deps.resetUploadDisplayState).toHaveBeenCalledOnce();
         expect(deps.clearAuthState).toHaveBeenCalledOnce();
         expect(deps.setGuestProfile).toHaveBeenCalledOnce();
+        expect(deps.initializeNostr).toHaveBeenCalledOnce();
+        expect(deps.refreshAccountList).toHaveBeenCalledOnce();
+        expect(deps.closeLogoutDialog).toHaveBeenCalledOnce();
+    });
+
+    it('cleanup完了までlogout actionとreloadを実行せず、isLoggingOutを維持する', async () => {
+        let resolveLogout: ((value: string) => void) | undefined;
+        const { deps, controller, loggingOutStateHistory } = createController({
+            logoutAccountFromAuthService: vi.fn(() => new Promise<string>((resolve) => {
+                resolveLogout = resolve;
+            })),
+        });
+
+        const logoutPromise = controller.logoutAccount(CURRENT_PUBKEY);
+        await Promise.resolve();
+
+        expect(deps.resolveLogoutAccountAction).not.toHaveBeenCalled();
+        expect(deps.reloadWindow).not.toHaveBeenCalled();
+        expect(loggingOutStateHistory).toEqual([true]);
+
+        resolveLogout?.(TARGET_PUBKEY);
+        await logoutPromise;
+
+        expect(deps.resolveLogoutAccountAction).toHaveBeenCalledWith(TARGET_PUBKEY);
+        expect(deps.reloadWindow).toHaveBeenCalledOnce();
+        expect(loggingOutStateHistory).toEqual([true, false]);
+    });
+
+    it('cleanup完了後にguest遷移、refresh、dialog closeを実行する', async () => {
+        let resolveLogout: ((value: null) => void) | undefined;
+        const { deps, controller } = createController({
+            logoutAccountFromAuthService: vi.fn(() => new Promise<null>((resolve) => {
+                resolveLogout = resolve;
+            })),
+        });
+
+        const logoutPromise = controller.logoutAccount(CURRENT_PUBKEY);
+        await Promise.resolve();
+
+        expect(deps.resolveLogoutAccountAction).not.toHaveBeenCalled();
+        expect(deps.initializeNostr).not.toHaveBeenCalled();
+        expect(deps.refreshAccountList).not.toHaveBeenCalled();
+        expect(deps.closeLogoutDialog).not.toHaveBeenCalled();
+
+        resolveLogout?.(null);
+        await logoutPromise;
+
         expect(deps.initializeNostr).toHaveBeenCalledOnce();
         expect(deps.refreshAccountList).toHaveBeenCalledOnce();
         expect(deps.closeLogoutDialog).toHaveBeenCalledOnce();
@@ -460,7 +510,7 @@ describe('createAppAccountSessionController', () => {
 
     it('logoutAccount のswitch分岐では再読み込みする', async () => {
         const { deps, controller } = createController({
-            logoutAccountFromAuthService: vi.fn(() => TARGET_PUBKEY),
+            logoutAccountFromAuthService: vi.fn(async () => TARGET_PUBKEY),
         });
 
         await controller.logoutAccount(CURRENT_PUBKEY);
@@ -468,5 +518,45 @@ describe('createAppAccountSessionController', () => {
         expect(deps.reloadWindow).toHaveBeenCalledOnce();
         expect(deps.restoreManagedAccountSession).not.toHaveBeenCalled();
         expect(deps.closeLogoutDialog).not.toHaveBeenCalled();
+    });
+
+    it('remote Parent client logoutもcleanup await後に完了する', async () => {
+        let resolveLogout: ((value: null) => void) | undefined;
+        const { deps, controller } = createController({
+            logoutAccountFromAuthService: vi.fn(() => new Promise<null>((resolve) => {
+                resolveLogout = resolve;
+            })),
+        });
+
+        const logoutPromise = controller.handleRemoteParentClientLogout(CURRENT_PUBKEY);
+        await Promise.resolve();
+
+        expect(deps.resolveLogoutAccountAction).not.toHaveBeenCalled();
+        expect(deps.refreshAccountList).not.toHaveBeenCalled();
+
+        resolveLogout?.(null);
+        await logoutPromise;
+
+        expect(deps.logoutAccountFromAuthService).toHaveBeenCalledWith(
+            CURRENT_PUBKEY,
+            { notifyParentClient: false },
+        );
+        expect(deps.refreshAccountList).toHaveBeenCalledOnce();
+    });
+
+    it('logoutの予期しないreject時にerrorを記録してisLoggingOutを解除する', async () => {
+        const { deps, controller, loggingOutStateHistory } = createController({
+            logoutAccountFromAuthService: vi.fn(async () => {
+                throw new Error('logout failed');
+            }),
+        });
+
+        await controller.logoutAccount(CURRENT_PUBKEY);
+
+        expect(deps.logger.error).toHaveBeenCalledWith('ログアウト処理中にエラー', {
+            stage: 'logout-account',
+            reason: 'unexpected',
+        });
+        expect(loggingOutStateHistory).toEqual([true, false]);
     });
 });

--- a/src/test/unit/authService.logout.test.ts
+++ b/src/test/unit/authService.logout.test.ts
@@ -9,7 +9,10 @@ vi.mock('../../lib/accountDataReset', () => ({
 import { AuthService } from '../../lib/authService';
 import { resetManagedAccountData } from '../../lib/accountDataReset';
 import { nip46Service } from '../../lib/nip46Service';
-import { parentClientAuthService } from '../../lib/parentClientAuthService';
+import {
+    parentClientAuthService,
+    ParentClientAuthService,
+} from '../../lib/parentClientAuthService';
 import { createMockAccountManager, createMockDependencies } from './authServiceTestUtils';
 
 describe('AuthService.logoutAccount', () => {
@@ -22,6 +25,7 @@ describe('AuthService.logoutAccount', () => {
         vi.mocked(parentClientAuthService.disconnect).mockReset();
         vi.mocked(parentClientAuthService.isConnected).mockReset().mockReturnValue(false);
         vi.mocked(parentClientAuthService.getUserPubkey).mockReset().mockReturnValue(null);
+        vi.mocked(ParentClientAuthService.clearSession).mockReset();
         mockDependencies = createMockDependencies();
         authService = new AuthService(mockDependencies);
         mockAccountManager = createMockAccountManager({
@@ -97,6 +101,53 @@ describe('AuthService.logoutAccount', () => {
 
         expect(parentClientAuthService.disconnect).toHaveBeenCalledWith(false);
     });
+
+    it.each([true, false])(
+        'Parent client session削除失敗後もcleanupとregistry削除を継続する（notify=%s）',
+        async (notifyParentClient) => {
+            const events: string[] = [];
+            mockAccountManager.getAccountType.mockReturnValue('parentClient');
+            vi.mocked(parentClientAuthService.disconnect).mockImplementation((notify) => {
+                events.push(`disconnect:${notify}`);
+            });
+            vi.mocked(ParentClientAuthService.clearSession).mockImplementation(() => {
+                events.push('clearSession');
+                throw new Error('session deletion failed');
+            });
+            mockAccountManager.cleanupAccountData.mockImplementation(async () => {
+                events.push('cleanup');
+            });
+            mockAccountManager.removeAccount.mockImplementation(() => {
+                events.push('removeAccount');
+                return 'next-pubkey';
+            });
+
+            await expect(authService.logoutAccount('pubkey1', { notifyParentClient }))
+                .resolves.toBe('next-pubkey');
+
+            expect(events).toEqual([
+                `disconnect:${notifyParentClient}`,
+                'clearSession',
+                'cleanup',
+                'removeAccount',
+            ]);
+            expect(parentClientAuthService.disconnect).toHaveBeenCalledWith(notifyParentClient);
+            expect(mockAccountManager.cleanupAccountData).toHaveBeenCalledWith('pubkey1');
+            expect(mockAccountManager.removeAccount).toHaveBeenCalledWith('pubkey1');
+            expect(mockDependencies.console?.error).toHaveBeenCalledWith(
+                'アカウントデータ削除に失敗しました',
+                {
+                    stage: 'local-storage',
+                    target: 'parent-client-session',
+                    reason: 'unexpected',
+                },
+            );
+            expect(mockDependencies.console?.error).not.toHaveBeenCalledWith(
+                expect.anything(),
+                expect.any(Error),
+            );
+        },
+    );
 
     it('NIP-46 disconnect errorでもlogoutを完了する', async () => {
         const { nip46Service } = await import('../../lib/nip46Service');

--- a/src/test/unit/authService.logout.test.ts
+++ b/src/test/unit/authService.logout.test.ts
@@ -8,6 +8,8 @@ vi.mock('../../lib/accountDataReset', () => ({
 
 import { AuthService } from '../../lib/authService';
 import { resetManagedAccountData } from '../../lib/accountDataReset';
+import { nip46Service } from '../../lib/nip46Service';
+import { parentClientAuthService } from '../../lib/parentClientAuthService';
 import { createMockAccountManager, createMockDependencies } from './authServiceTestUtils';
 
 describe('AuthService.logoutAccount', () => {
@@ -16,6 +18,10 @@ describe('AuthService.logoutAccount', () => {
     let mockAccountManager: ReturnType<typeof createMockAccountManager>;
 
     beforeEach(() => {
+        vi.mocked(nip46Service.disconnect).mockReset().mockResolvedValue(undefined);
+        vi.mocked(parentClientAuthService.disconnect).mockReset();
+        vi.mocked(parentClientAuthService.isConnected).mockReset().mockReturnValue(false);
+        vi.mocked(parentClientAuthService.getUserPubkey).mockReset().mockReturnValue(null);
         mockDependencies = createMockDependencies();
         authService = new AuthService(mockDependencies);
         mockAccountManager = createMockAccountManager({
@@ -29,21 +35,36 @@ describe('AuthService.logoutAccount', () => {
         vi.clearAllMocks();
     });
 
-    it('nsecアカウントのログアウト → cleanupAccountData + removeAccount', () => {
+    it('nsecアカウントのログアウト → cleanupAccountData + removeAccount', async () => {
         mockAccountManager.getAccountType.mockReturnValue('nsec');
 
-        const result = authService.logoutAccount('pubkey1');
+        const result = await authService.logoutAccount('pubkey1');
 
         expect(mockAccountManager.cleanupAccountData).toHaveBeenCalledWith('pubkey1');
         expect(mockAccountManager.removeAccount).toHaveBeenCalledWith('pubkey1');
         expect(result).toBe('next-pubkey');
     });
 
+    it('cleanup完了後にaccount registryから削除する', async () => {
+        let resolveCleanup!: () => void;
+        mockAccountManager.cleanupAccountData.mockReturnValue(new Promise<void>((resolve) => {
+            resolveCleanup = resolve;
+        }));
+
+        const logoutPromise = authService.logoutAccount('pubkey1');
+        await Promise.resolve();
+
+        expect(mockAccountManager.removeAccount).not.toHaveBeenCalled();
+        resolveCleanup();
+        await expect(logoutPromise).resolves.toBe('next-pubkey');
+        expect(mockAccountManager.removeAccount).toHaveBeenCalledWith('pubkey1');
+    });
+
     it('nip46アカウントのログアウト → nip46Service.disconnect呼出', async () => {
         const { nip46Service } = await import('../../lib/nip46Service');
         mockAccountManager.getAccountType.mockReturnValue('nip46');
 
-        authService.logoutAccount('pubkey1');
+        await authService.logoutAccount('pubkey1');
 
         expect(nip46Service.disconnect).toHaveBeenCalled();
     });
@@ -52,7 +73,7 @@ describe('AuthService.logoutAccount', () => {
         const { parentClientAuthService } = await import('../../lib/parentClientAuthService');
         mockAccountManager.getAccountType.mockReturnValue('parentClient');
 
-        authService.logoutAccount('pubkey1');
+        await authService.logoutAccount('pubkey1');
 
         expect(parentClientAuthService.disconnect).toHaveBeenCalledWith(true);
     });
@@ -61,7 +82,7 @@ describe('AuthService.logoutAccount', () => {
         const { parentClientAuthService } = await import('../../lib/parentClientAuthService');
         mockAccountManager.getAccountType.mockReturnValue('parentClient');
 
-        authService.logoutAccount('pubkey1', { notifyParentClient: false });
+        await authService.logoutAccount('pubkey1', { notifyParentClient: false });
 
         expect(parentClientAuthService.disconnect).toHaveBeenCalledWith(false);
     });
@@ -72,26 +93,41 @@ describe('AuthService.logoutAccount', () => {
         vi.mocked(parentClientAuthService.isConnected).mockReturnValue(true);
         vi.mocked(parentClientAuthService.getUserPubkey).mockReturnValue('pubkey1');
 
-        authService.logoutAccount('pubkey1', { notifyParentClient: false });
+        await authService.logoutAccount('pubkey1', { notifyParentClient: false });
 
         expect(parentClientAuthService.disconnect).toHaveBeenCalledWith(false);
     });
 
-    it('次のアクティブアカウント返却', () => {
+    it('NIP-46 disconnect errorでもlogoutを完了する', async () => {
+        const { nip46Service } = await import('../../lib/nip46Service');
+        mockAccountManager.getAccountType.mockReturnValue('nip46');
+        vi.mocked(nip46Service.disconnect).mockRejectedValue(new Error('disconnect failed'));
+
+        await expect(authService.logoutAccount('pubkey1')).resolves.toBe('next-pubkey');
+
+        expect(mockAccountManager.cleanupAccountData).toHaveBeenCalledWith('pubkey1');
+        expect(mockAccountManager.removeAccount).toHaveBeenCalledWith('pubkey1');
+        expect(mockDependencies.console?.error).toHaveBeenCalledWith('NIP-46切断エラー', {
+            stage: 'disconnect',
+            reason: 'unexpected',
+        });
+    });
+
+    it('次のアクティブアカウント返却', async () => {
         mockAccountManager.removeAccount.mockReturnValue('next-active');
-        const result = authService.logoutAccount('pubkey1');
+        const result = await authService.logoutAccount('pubkey1');
         expect(result).toBe('next-active');
     });
 
-    it('最後のアカウント削除でnull返却', () => {
+    it('最後のアカウント削除でnull返却', async () => {
         mockAccountManager.removeAccount.mockReturnValue(null);
-        const result = authService.logoutAccount('pubkey1');
+        const result = await authService.logoutAccount('pubkey1');
         expect(result).toBeNull();
     });
 
-    it('accountManager未設定時もエラーにならない', () => {
+    it('accountManager未設定時もエラーにならない', async () => {
         const service = new AuthService(mockDependencies);
-        expect(() => service.logoutAccount('pubkey1')).not.toThrow();
+        await expect(service.logoutAccount('pubkey1')).resolves.toBeUndefined();
     });
 
     it('最後のアカウントログアウトは await 可能な全体リセットを呼ぶ', async () => {

--- a/src/test/unit/authServiceTestUtils.ts
+++ b/src/test/unit/authServiceTestUtils.ts
@@ -85,7 +85,7 @@ export function createMockAccountManager(overrides: Record<string, unknown> = {}
         addAccount: vi.fn(),
         getAccountType: vi.fn(),
         removeAccount: vi.fn(),
-        cleanupAccountData: vi.fn(),
+        cleanupAccountData: vi.fn().mockResolvedValue(undefined),
         cleanupNostrLoginData: vi.fn(),
         getActiveAccountPubkey: vi.fn().mockReturnValue(null),
         getAccounts: vi.fn().mockReturnValue([]),


### PR DESCRIPTION
## Summary

Account logout waits for all per-account cleanup to settle before removing the account registry entry or proceeding to reload/guest transitions.

## Root cause

The original logout path started `profilesRepository.delete()` and `relayConfigsRepository.delete()` with `void`, so logout could continue before IndexedDB cleanup settled. A follow-up issue remained: `ParentClientAuthService.clearSession()` directly called `localStorage.removeItem()` before `AccountManager.cleanupAccountData()`. If that deletion threw, the outer logout catch returned `null` and left the stored account and active pointer behind.

## Changes

- Made `AccountManager.cleanupAccountData()` async.
- Kept per-account nsec, NIP-46 session, Parent client session, relay config, and profile localStorage cleanup best-effort per key.
- Started profile and relay repository deletion together, awaited both with `Promise.allSettled`, and logged only safe stage/target/reason metadata on rejection.
- Made `AuthService.logoutAccount()` return `Promise<string | null | undefined>` and await cleanup before `removeAccount()`.
- Wrapped Parent client session deletion in local error handling so failure logs safe metadata and still proceeds through cleanup and registry removal.
- Preserved Parent client notify true/false behavior, runtime Parent client detection, and NIP-46 disconnect failure handling.
- Made the session controller await auth-service logout before switch reload, guest initialization, account-list refresh, dialog close, and logging-out state release.
- Preserved the separate last-account `resetManagedAccountData()` full-reset path unchanged.

## Tests

- Targeted tests (`authService.logout.test.ts`, `accountManager.test.ts`, `appAccountSessionController.test.ts`): 71 passed.
- `npm run check`: passed with 0 errors and 0 warnings.
- `npm test`: passed, 310 files / 3,500 tests.
- `git diff --check`: passed.
- Build not run: changes are limited to auth error handling and unit tests; Vite/PWA/service-worker/asset/bundling boundaries were not changed.
- Playwright not run: deterministic unit tests cover the failure ordering, and no UI/browser API/service-worker protocol changed.
- Storage schema, repository schema, dependencies, and lockfiles were not changed.