### PR TITLE
test: isolate Playwright worktree ports

### DIFF
--- a/.agents/skills/ehagaki-browser-debug/references/browser-debug-map.md
+++ b/.agents/skills/ehagaki-browser-debug/references/browser-debug-map.md
@@ -182,11 +182,11 @@
 - **主な実装ファイル:** `playwright.config.ts`、`src/test/e2e/composerTargetDialog.spec.ts`、`src/test/e2e/ComposerTargetDialogHarness.svelte`、`src/test/e2e/composerTargetDialogHarnessEntry.ts`、`src/test/e2e/postHistoryDialog.spec.ts`、`src/test/e2e/PostHistoryDialogHarness.svelte`、`src/test/e2e/postHistoryDialogHarnessEntry.ts`、`composer-target-dialog-playwright.html`、`post-history-dialog-playwright.html`。
 - **主な関数、store、hook、controller:** Playwright標準`test` fixtureの`page`と`isMobile`、各`gotoHarness()`、window上の`__COMPOSER_TARGET_HARNESS__`/`__POST_HISTORY_HARNESS__` ready state。独立したcustom fixture moduleは現checkoutにない。
 - **Event source:** page navigation、role/label locator操作、keyboard/tap/click、route mock、viewport resize、popup/history、DOM evaluation。
-- **StateまたはCSS変数:** config `baseURL=http://127.0.0.1:4173/ehagaki/`、`locale=ja-JP`、trace `on-first-retry`、workers `1`、harness-injected deterministic data。
+- **StateまたはCSS変数:** config `locale=ja-JP`、trace `on-first-retry`、workers `1`、harness-injected deterministic data。`EHAGAKI_E2E_PORT`を指定した場合はそのportを使用し、未指定時はworktree rootを正規化して決定的に算出する。
 - **Cleanup所有者:** Playwright runnerがpage/contextを破棄し、route/popupはtestがcloseする。temporary artifactは調査完了時に削除する。
 - **関連テスト:** `src/test/e2e/composerTargetDialog.spec.ts`と`src/test/e2e/postHistoryDialog.spec.ts`。unit/component mock基盤は`src/test/setup.ts`と`src/test/mocks/`。
 - **Playwrightまたは実端末確認が必要になる条件:** config上の全projectは実browser engineでDOMを描画するが、IME/browser chrome/PWA standalone/WebViewは実端末確認を別途行う。
-- **注意点:** `desktop-chromium`は`Desktop Chrome` descriptor。`mobile-chromium`は`iPhone 13` descriptorをChromiumのdefault engineで実行する。`mobile-webkit`だけが`browserName: 'webkit'`を明示し、`composerTargetDialog.spec.ts`だけに限定される。`webServer`はVite dev serverを4173で起動し、post-history harness URLをready checkに使う。
+- **注意点:** `desktop-chromium`は`Desktop Chrome` descriptor。`mobile-chromium`は`iPhone 13` descriptorをChromiumのdefault engineで実行する。`mobile-webkit`だけが`browserName: 'webkit'`を明示し、`composerTargetDialog.spec.ts`だけに限定される。base URL、Vite command、post-history harness ready URLは同じresolved portを使用し、Vite commandは`--strictPort`で自動移動を禁止する。worktree rootごとにportが異なるため、通常の複数worktreeが固定`4173`を共有しない。`reuseExistingServer: false`で古いserverを再利用せず、常に現在checkoutのViteを起動する。
 
 ## 関連テストの選択
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,16 @@
 import { defineConfig, devices } from '@playwright/test';
+import { fileURLToPath, URL as NodeURL } from 'node:url';
+import {
+    buildPlaywrightEndpoints,
+    buildPlaywrightViteCommand,
+    resolvePlaywrightPort,
+} from './scripts/playwrightWorktreePort';
+
+const worktreeRoot = import.meta.url.startsWith('file://')
+    ? fileURLToPath(new NodeURL('.', import.meta.url))
+    : process.cwd();
+const resolvedPort = resolvePlaywrightPort({ rootPath: worktreeRoot });
+const endpoints = buildPlaywrightEndpoints(resolvedPort);
 
 export default defineConfig({
     testDir: './src/test/e2e',
@@ -9,14 +21,14 @@ export default defineConfig({
     fullyParallel: false,
     workers: 1,
     use: {
-        baseURL: 'http://127.0.0.1:4173/ehagaki/',
+        baseURL: endpoints.appBaseURL,
         locale: 'ja-JP',
         trace: 'on-first-retry',
     },
     webServer: {
-        command: 'npx vite --host 127.0.0.1 --port 4173',
-        url: 'http://127.0.0.1:4173/ehagaki/post-history-dialog-playwright.html',
-        reuseExistingServer: true,
+        command: buildPlaywrightViteCommand(resolvedPort),
+        url: endpoints.readyURL,
+        reuseExistingServer: false,
         timeout: 120_000,
     },
     projects: [

--- a/scripts/playwrightWorktreePort.ts
+++ b/scripts/playwrightWorktreePort.ts
@@ -1,0 +1,109 @@
+import path from 'node:path';
+
+export const PLAYWRIGHT_HOST = '127.0.0.1';
+export const PLAYWRIGHT_APP_BASE_PATH = '/ehagaki/';
+export const PLAYWRIGHT_READY_PATH =
+    '/ehagaki/post-history-dialog-playwright.html';
+export const PLAYWRIGHT_PORT_ENV = 'EHAGAKI_E2E_PORT';
+export const MIN_PLAYWRIGHT_PORT = 1_024;
+export const MAX_PLAYWRIGHT_PORT = 65_535;
+
+const AUTO_PORT_MIN = 45_000;
+const AUTO_PORT_SPAN = 10_000;
+
+export function parsePlaywrightPort(value: string): number {
+    const trimmed = value.trim();
+
+    if (!/^[0-9]+$/.test(trimmed)) {
+        throw new Error(
+            `${PLAYWRIGHT_PORT_ENV} must be a decimal integer from ${MIN_PLAYWRIGHT_PORT} to ${MAX_PLAYWRIGHT_PORT}.`,
+        );
+    }
+
+    const port = Number(trimmed);
+    if (
+        !Number.isSafeInteger(port) ||
+        port < MIN_PLAYWRIGHT_PORT ||
+        port > MAX_PLAYWRIGHT_PORT
+    ) {
+        throw new Error(
+            `${PLAYWRIGHT_PORT_ENV} must be a decimal integer from ${MIN_PLAYWRIGHT_PORT} to ${MAX_PLAYWRIGHT_PORT}.`,
+        );
+    }
+
+    return port;
+}
+
+export function normalizeWorktreeRoot(
+    rootPath: string,
+    platform: NodeJS.Platform = process.platform,
+): string {
+    if (!rootPath.trim()) {
+        throw new Error('Playwright worktree root path must not be empty.');
+    }
+
+    const pathApi = platform === 'win32' ? path.win32 : path.posix;
+    const normalized = pathApi.normalize(pathApi.resolve(rootPath));
+    const root = pathApi.parse(normalized).root;
+    const withoutTrailingSeparator =
+        normalized.length > root.length
+            ? normalized.replace(/[\\/]+$/, '')
+            : normalized;
+
+    return platform === 'win32'
+        ? withoutTrailingSeparator.toLowerCase()
+        : withoutTrailingSeparator;
+}
+
+export function hashWorktreeRoot(normalizedRoot: string): number {
+    let hash = 2_166_136_261;
+
+    for (let index = 0; index < normalizedRoot.length; index += 1) {
+        hash ^= normalizedRoot.charCodeAt(index);
+        hash = Math.imul(hash, 16_777_619);
+    }
+
+    return hash >>> 0;
+}
+
+export function derivePlaywrightPort(normalizedRoot: string): number {
+    return AUTO_PORT_MIN + (hashWorktreeRoot(normalizedRoot) % AUTO_PORT_SPAN);
+}
+
+export interface ResolvePlaywrightPortOptions {
+    rootPath: string;
+    envPort?: string;
+    platform?: NodeJS.Platform;
+}
+
+export function resolvePlaywrightPort({
+    rootPath,
+    envPort = process.env[PLAYWRIGHT_PORT_ENV],
+    platform = process.platform,
+}: ResolvePlaywrightPortOptions): number {
+    if (envPort !== undefined) {
+        return parsePlaywrightPort(envPort);
+    }
+
+    return derivePlaywrightPort(normalizeWorktreeRoot(rootPath, platform));
+}
+
+export interface PlaywrightEndpoints {
+    origin: string;
+    appBaseURL: string;
+    readyURL: string;
+}
+
+export function buildPlaywrightEndpoints(port: number): PlaywrightEndpoints {
+    const origin = `http://${PLAYWRIGHT_HOST}:${port}`;
+
+    return {
+        origin,
+        appBaseURL: `${origin}${PLAYWRIGHT_APP_BASE_PATH}`,
+        readyURL: `${origin}${PLAYWRIGHT_READY_PATH}`,
+    };
+}
+
+export function buildPlaywrightViteCommand(port: number): string {
+    return `npx vite --host ${PLAYWRIGHT_HOST} --port ${port} --strictPort`;
+}

--- a/src/test/unit/playwrightWorktreePort.test.ts
+++ b/src/test/unit/playwrightWorktreePort.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildPlaywrightEndpoints,
+    buildPlaywrightViteCommand,
+    derivePlaywrightPort,
+    normalizeWorktreeRoot,
+    parsePlaywrightPort,
+    resolvePlaywrightPort,
+} from '../../../scripts/playwrightWorktreePort';
+
+describe('playwright worktree port resolver', () => {
+    it('uses a valid explicit port and trims surrounding whitespace', () => {
+        expect(parsePlaywrightPort('4173')).toBe(4173);
+        expect(
+            resolvePlaywrightPort({
+                rootPath: 'C:/worktrees/ehagaki',
+                envPort: '  51234  ',
+                platform: 'win32',
+            }),
+        ).toBe(51234);
+    });
+
+    it.each(['', '0', '1023', '65536', '-1', '12abc', '4173.5', '  '])(
+        'rejects invalid explicit port %j',
+        (value) => {
+            expect(() => parsePlaywrightPort(value)).toThrow(
+                /EHAGAKI_E2E_PORT.*1024.*65535/,
+            );
+        },
+    );
+
+    it('accepts the safe non-privileged port boundaries', () => {
+        expect(parsePlaywrightPort('1024')).toBe(1024);
+        expect(parsePlaywrightPort('65535')).toBe(65535);
+    });
+
+    it('normalizes Windows separators, case, dot segments, and trailing separators', () => {
+        const slashPath = normalizeWorktreeRoot(
+            'C:/Users/Example/ehagaki/./test/../',
+            'win32',
+        );
+        const backslashPath = normalizeWorktreeRoot(
+            'c:\\users\\example\\ehagaki\\',
+            'win32',
+        );
+
+        expect(slashPath).toBe('c:\\users\\example\\ehagaki');
+        expect(backslashPath).toBe(slashPath);
+    });
+
+    it('derives a stable port for the same root and distinct ports for representative roots', () => {
+        const firstRoot = normalizeWorktreeRoot(
+            'C:/Users/Example/.codex/worktrees/first/ehagaki',
+            'win32',
+        );
+        const secondRoot = normalizeWorktreeRoot(
+            'C:/Users/Example/.codex/worktrees/second/ehagaki',
+            'win32',
+        );
+
+        const firstPort = derivePlaywrightPort(firstRoot);
+        expect(resolvePlaywrightPort({
+            rootPath: 'c:\\users\\example\\.codex\\worktrees\\first\\ehagaki\\',
+            platform: 'win32',
+        })).toBe(firstPort);
+        expect(firstPort).not.toBe(derivePlaywrightPort(secondRoot));
+        expect(firstPort).toBeGreaterThanOrEqual(1024);
+        expect(firstPort).toBeLessThanOrEqual(65535);
+    });
+
+    it('is independent of time, process id, and randomness', () => {
+        const root = normalizeWorktreeRoot('C:/worktrees/ehagaki', 'win32');
+
+        expect([
+            derivePlaywrightPort(root),
+            derivePlaywrightPort(root),
+            derivePlaywrightPort(root),
+        ]).toEqual([expect.any(Number), expect.any(Number), expect.any(Number)]);
+        expect(derivePlaywrightPort(root)).toBe(derivePlaywrightPort(root));
+    });
+});
+
+describe('Playwright config connection values', () => {
+    it('uses one host and port for the app, server command, and ready URL', async () => {
+        const { default: config } = await import('../../../playwright.config');
+        const baseURL = config.use?.baseURL;
+        const webServer = config.webServer as {
+            command: string;
+            reuseExistingServer?: boolean;
+            url: string;
+        };
+        const baseUrl = new URL(baseURL as string);
+        const readyUrl = new URL(webServer.url);
+
+        expect(baseUrl.hostname).toBe('127.0.0.1');
+        expect(readyUrl.hostname).toBe('127.0.0.1');
+        expect(baseUrl.port).toBe(readyUrl.port);
+        expect(baseUrl.pathname).toBe('/ehagaki/');
+        expect(readyUrl.pathname).toBe(
+            '/ehagaki/post-history-dialog-playwright.html',
+        );
+        expect(webServer.command).toContain(`--host 127.0.0.1`);
+        expect(webServer.command).toContain(`--port ${baseUrl.port}`);
+        expect(webServer.command).toContain('--strictPort');
+        expect(webServer.reuseExistingServer).toBe(false);
+        expect(config.projects?.map((project) => project.name)).toEqual([
+            'desktop-chromium',
+            'mobile-chromium',
+            'mobile-webkit',
+        ]);
+        expect(config.projects?.[2]?.testMatch).toBe(
+            '**/composerTargetDialog.spec.ts',
+        );
+    });
+
+    it('builds all connection values from a supplied port', () => {
+        const endpoints = buildPlaywrightEndpoints(54321);
+
+        expect(endpoints).toEqual({
+            origin: 'http://127.0.0.1:54321',
+            appBaseURL: 'http://127.0.0.1:54321/ehagaki/',
+            readyURL:
+                'http://127.0.0.1:54321/ehagaki/post-history-dialog-playwright.html',
+        });
+        expect(buildPlaywrightViteCommand(54321)).toBe(
+            'npx vite --host 127.0.0.1 --port 54321 --strictPort',
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Playwright E2E now uses a deterministic port per checkout/worktree so a server from another worktree cannot be mistaken for the current test target.

## Root cause

The configuration shared fixed port `4173` across checkouts and reused an existing server. A Vite server started from another worktree could therefore satisfy the ready check while serving different code.

## Changes

- Added `scripts/playwrightWorktreePort.ts` for Playwright-only pure helpers.
- `EHAGAKI_E2E_PORT` accepts trimmed decimal integers from `1024` through `65535`; invalid values fail during config loading without echoing the supplied value.
- Without an override, the config directory is normalized as the worktree root:
  - absolute path resolution
  - separator and dot-segment normalization
  - trailing separator removal
  - Windows case folding
- The normalized root is hashed deterministically and mapped to `45000-54999`.
- One resolved port builds the origin, `/ehagaki/` base URL, ready URL, and Vite command.
- Vite uses `--strictPort`, and `reuseExistingServer: false` always starts the current checkout's server. This avoids stale or cross-worktree server reuse; the existing manual-server convenience is intentionally traded for deterministic test isolation.
- Existing projects, devices, testMatch, harness paths, and E2E assertions are unchanged.
- Added resolver and config-integrity unit tests.
- Updated the browser-debug map.

## Verification

- Port/config unit test: 15 passed.
- Invalid config override (`4173.5`): rejected at config load with exit 1.
- Default E2E server: `http://127.0.0.1:51261/ehagaki/`; ready check used `/ehagaki/post-history-dialog-playwright.html` and `--strictPort`. The unrelated legacy listener on `4173` was left running.
- Explicit override: `EHAGAKI_E2E_PORT=54321`; Vite served `http://127.0.0.1:54321/ehagaki/` and the ready check returned 200.
- Desktop Chromium Post History representative: passed.
- Mobile Chromium Composer Target representative: passed.
- Mobile WebKit Composer Target representative: passed.
- Full `npm run test:e2e`: 67 passed, 10 skipped.
- `npm run check`: 0 errors, 0 warnings.
- `npm test`: 311 files / 3515 tests passed.
- `git diff --check`: passed.
- package.json and package-lock.json: unchanged.

The first two local full-suite attempts exposed an existing intermittent desktop Chromium focus assertion in the image-viewer test; the isolated test passed and the final full suite passed without changing that unrelated E2E assertion.

Build was not run because this change is limited to Playwright config, Node/test-only utilities, tests, and browser-debug documentation; application runtime and production bundling are unchanged.

A simultaneous two-worktree browser run was not performed. The deterministic resolver unit tests cover representative distinct roots and path normalization, and real Playwright runs verified the selected default and override ports. No temporary worktree was created; all temporary Vite servers were terminated by Playwright, and no test artifacts were staged.