### PR TITLE
refactor: share iframe message trust gate

### DIFF
--- a/.agents/skills/ehagaki-browser-debug/references/browser-debug-map.md
+++ b/.agents/skills/ehagaki-browser-debug/references/browser-debug-map.md
@@ -108,13 +108,13 @@
 
 - **主な症状または責務:** trusted parent origin、message envelope、requestId、remote auth/settings/composer context、親委譲storage/IndexedDBを扱う。
 - **主な実装ファイル:** `src/lib/embedProtocol.ts`、`src/lib/iframeMessageService.ts`、`src/lib/parentClientAuthService.ts`、`src/lib/embedComposerContextService.ts`、`src/lib/embedSettingsService.ts`、`src/lib/embedStorageService.ts`、`src/lib/embedIndexedDbService.ts`、`src/lib/appEmbedController.ts`、`src/lib/appRuntimeBindings.ts`、`public/embed-parent-client-example.js`。
-- **主な関数、store、hook、controller:** `getParentOriginFromSearch()`、`isEmbedMessageEnvelope()`、各serviceの`initialize()`/`handleMessage`、`createAppEmbedController()`、`setupAppRuntimeBindings()`。
+- **主な関数、store、hook、controller:** `getParentOriginFromSearch()`、`isEmbedMessageEnvelope()`、`getTrustedParentEmbedMessage()`、各serviceの`initialize()`/`handleMessage`、`createAppEmbedController()`、`setupAppRuntimeBindings()`。
 - **Event source:** `window.message`、`window.parent.postMessage()`、request timeout、remote login/logout/settings/context event。
 - **StateまたはCSS変数:** `trustedParentOrigin`、`pendingRequests`、listener Set、controller pending action、namespace/version/requestId/capability payload。
 - **Cleanup所有者:** `setupAppRuntimeBindings()` cleanupがremote listener subscriptionを解除する。request timeoutは各serviceがclearする。service singletonのwindow `message` listenerは一度登録して存続する現行設計。
 - **関連テスト:** `src/test/integration/app-parent-client.integration.test.ts`、`src/test/unit/iframeMessageService.test.ts`、`src/test/unit/parentClientAuthService.test.ts`、`src/test/unit/appEmbedController.test.ts`、`src/test/unit/embedComposerContextService.test.ts`、`src/test/unit/embedSettingsService.test.ts`、`src/test/unit/embedStorageService.test.ts`、`src/test/unit/embedIndexedDbService.test.ts`。
 - **Playwrightまたは実端末確認が必要になる条件:** real iframe source/origin、sandbox/Permissions Policy、storage partitioning、parent navigation、focus境界はbrowser harnessが必要。
-- **注意点:** `event.source`と`event.origin`の検証を弱めない。親sample、protocol、parser/bootstrap、testsを同じcontract surfaceとして確認する。
+- **注意点:** composer context、settings、storage、IndexedDBは共通の受信 trust gate で envelope・exact parent source・exact trusted origin だけを判定し、routing、requestId、payload、pending map、lifecycleは各serviceが所有する。Parent clientはこのhelper対象外であり、queryで確立したparent origin契約も維持する。`event.source`と`event.origin`の検証を弱めない。親sample、protocol、parser/bootstrap、testsを同じcontract surfaceとして確認する。
 
 ## URL queryと外部入力
 

--- a/iframe-message-gate-child-playwright.html
+++ b/iframe-message-gate-child-playwright.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Iframe Message Gate Child Harness</title>
+</head>
+<body>
+    <output id="child-ready" aria-label="Child ready">false</output>
+    <output id="composer-count" aria-label="Composer count">0</output>
+    <output id="settings-count" aria-label="Settings count">0</output>
+    <button id="storage-request" type="button">Request storage</button>
+    <output id="storage-result" aria-label="Storage result"></output>
+    <script type="module" src="/src/test/e2e/iframeMessageGateChildHarnessEntry.ts"></script>
+</body>
+</html>

--- a/iframe-message-gate-playwright.html
+++ b/iframe-message-gate-playwright.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Iframe Message Gate Playwright Harness</title>
+</head>
+<body>
+    <output id="harness-ready" aria-label="Harness ready">false</output>
+    <output id="storage-request-id" aria-label="Storage request ID"></output>
+    <output id="sibling-send-status" aria-label="Sibling send status"></output>
+    <div id="frames"></div>
+    <script type="module" src="/src/test/e2e/iframeMessageGateHarnessEntry.ts"></script>
+</body>
+</html>

--- a/iframe-message-gate-sender-playwright.html
+++ b/iframe-message-gate-sender-playwright.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8" />
+    <title>Iframe Message Gate Sender Harness</title>
+</head>
+<body>
+    <script type="module" src="/src/test/e2e/iframeMessageGateSenderHarnessEntry.ts"></script>
+</body>
+</html>

--- a/src/lib/embedComposerContextService.ts
+++ b/src/lib/embedComposerContextService.ts
@@ -2,8 +2,8 @@ import {
     embedMessageRequiresRequestId,
     getParentOriginFromSearch,
     isValidEmbedRequestId,
-    isEmbedMessageEnvelope,
 } from "./embedProtocol";
+import { getTrustedParentEmbedMessage } from "./embedMessageTrustGate";
 
 type RemoteComposerSetContextListener = (
     payload: unknown,
@@ -44,14 +44,12 @@ export class EmbedComposerContextService {
     }
 
     private handleMessage = (event: MessageEvent): void => {
-        if (!this.windowObj) return;
-        if (!isEmbedMessageEnvelope(event.data)) return;
-        if (event.source !== this.windowObj.parent) return;
-        if (this.trustedParentOrigin && event.origin !== this.trustedParentOrigin) {
-            return;
-        }
-
-        const message = event.data;
+        const message = getTrustedParentEmbedMessage(
+            event,
+            this.windowObj,
+            this.trustedParentOrigin,
+        );
+        if (!message) return;
 
         if (message.type === "composer.setContext") {
             if (

--- a/src/lib/embedIndexedDbService.ts
+++ b/src/lib/embedIndexedDbService.ts
@@ -3,7 +3,6 @@ import {
     EMBED_MESSAGE_VERSION,
     embedMessageRequiresRequestId,
     getParentOriginFromSearch,
-    isEmbedMessageEnvelope,
     isValidEmbedRequestId,
     type EmbedIndexedDbErrorPayload,
     type EmbedIndexedDbGetSnapshotPayload,
@@ -11,6 +10,7 @@ import {
     type EmbedIndexedDbSetSnapshotPayload,
     type EmbedIndexedDbStoreName,
 } from "./embedProtocol";
+import { getTrustedParentEmbedMessage } from "./embedMessageTrustGate";
 import type { UploadDestinationRecord } from "./storage/ehagakiDb";
 import {
     UPLOAD_DESTINATION_GLOBAL_SCOPE,
@@ -266,12 +266,12 @@ export class EmbedIndexedDbService {
     }
 
     private handleMessage = (event: MessageEvent): void => {
-        if (!this.windowObj) return;
-        if (!isEmbedMessageEnvelope(event.data)) return;
-        if (event.source !== this.windowObj.parent) return;
-        if (this.trustedParentOrigin && event.origin !== this.trustedParentOrigin) return;
-
-        const message = event.data;
+        const message = getTrustedParentEmbedMessage(
+            event,
+            this.windowObj,
+            this.trustedParentOrigin,
+        );
+        if (!message) return;
         if (message.type !== "idb.result" && message.type !== "idb.error") {
             return;
         }

--- a/src/lib/embedMessageTrustGate.ts
+++ b/src/lib/embedMessageTrustGate.ts
@@ -1,0 +1,21 @@
+import {
+    isEmbedMessageEnvelope,
+    type EmbedMessageEnvelope,
+} from "./embedProtocol";
+
+/**
+ * Returns an embed message only when it came from this iframe's trusted parent.
+ * Routing and message-specific validation remain owned by each receiving service.
+ */
+export function getTrustedParentEmbedMessage(
+    event: MessageEvent,
+    windowObj: Window | undefined,
+    trustedParentOrigin: string | null,
+): EmbedMessageEnvelope | null {
+    if (!windowObj) return null;
+    if (!isEmbedMessageEnvelope(event.data)) return null;
+    if (event.source !== windowObj.parent) return null;
+    if (trustedParentOrigin && event.origin !== trustedParentOrigin) return null;
+
+    return event.data;
+}

--- a/src/lib/embedSettingsService.ts
+++ b/src/lib/embedSettingsService.ts
@@ -1,10 +1,10 @@
 import {
     embedMessageRequiresRequestId,
     getParentOriginFromSearch,
-    isEmbedMessageEnvelope,
     isValidEmbedRequestId,
     type EmbedSettingsSetPayload,
 } from "./embedProtocol";
+import { getTrustedParentEmbedMessage } from "./embedMessageTrustGate";
 
 type RemoteSettingsSetListener = (
     payload: EmbedSettingsSetPayload,
@@ -133,14 +133,12 @@ export class EmbedSettingsService {
     }
 
     private handleMessage = (event: MessageEvent): void => {
-        if (!this.windowObj) return;
-        if (!isEmbedMessageEnvelope(event.data)) return;
-        if (event.source !== this.windowObj.parent) return;
-        if (this.trustedParentOrigin && event.origin !== this.trustedParentOrigin) {
-            return;
-        }
-
-        const message = event.data;
+        const message = getTrustedParentEmbedMessage(
+            event,
+            this.windowObj,
+            this.trustedParentOrigin,
+        );
+        if (!message) return;
 
         if (message.type !== "settings.set") {
             return;

--- a/src/lib/embedStorageService.ts
+++ b/src/lib/embedStorageService.ts
@@ -3,7 +3,6 @@ import {
     EMBED_MESSAGE_VERSION,
     embedMessageRequiresRequestId,
     getParentOriginFromSearch,
-    isEmbedMessageEnvelope,
     isValidEmbedRequestId,
     type EmbedStorageErrorPayload,
     type EmbedStorageGetPayload,
@@ -11,6 +10,7 @@ import {
     type EmbedStorageResultPayload,
     type EmbedStorageSetPayload,
 } from "./embedProtocol";
+import { getTrustedParentEmbedMessage } from "./embedMessageTrustGate";
 import {
     EMBED_STORAGE_KEYS,
     filterAllowedEmbedStorageKeys,
@@ -248,12 +248,12 @@ export class EmbedStorageService {
     }
 
     private handleMessage = (event: MessageEvent): void => {
-        if (!this.windowObj) return;
-        if (!isEmbedMessageEnvelope(event.data)) return;
-        if (event.source !== this.windowObj.parent) return;
-        if (this.trustedParentOrigin && event.origin !== this.trustedParentOrigin) return;
-
-        const message = event.data;
+        const message = getTrustedParentEmbedMessage(
+            event,
+            this.windowObj,
+            this.trustedParentOrigin,
+        );
+        if (!message) return;
         if (message.type !== "storage.result" && message.type !== "storage.error") {
             return;
         }

--- a/src/test/e2e/iframeMessageGate.spec.ts
+++ b/src/test/e2e/iframeMessageGate.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test, type Page } from "@playwright/test";
+
+type HarnessWindow = Window & typeof globalThis & {
+    __IFRAME_MESSAGE_GATE_HARNESS__: {
+        sendValidContext: () => void;
+        sendInvalidEnvelopeContext: () => void;
+        sendSiblingContext: () => void;
+        sendWrongOriginContext: () => void;
+        sendSiblingStorageResult: () => void;
+        sendStorageResult: () => void;
+    };
+};
+
+async function callHarness(
+    page: Page,
+    action: keyof HarnessWindow["__IFRAME_MESSAGE_GATE_HARNESS__"],
+): Promise<void> {
+    await page.evaluate((name) => {
+        (window as HarnessWindow).__IFRAME_MESSAGE_GATE_HARNESS__[name]();
+    }, action);
+}
+
+test.describe("iframe message trust gate", () => {
+    test("actual parent sourceだけがvalid envelopeをcomposer context serviceへ届ける", async ({ page }) => {
+        await page.goto("iframe-message-gate-playwright.html");
+        await expect(page.getByLabel("Harness ready")).toHaveText("true");
+
+        const target = page.frameLocator('iframe[title="iframe-message-gate-target"]');
+        await expect(target.getByLabel("Child ready")).toHaveText("true");
+
+        await callHarness(page, "sendInvalidEnvelopeContext");
+        await callHarness(page, "sendValidContext");
+        await expect(target.getByLabel("Composer count")).toHaveText("1");
+
+        await callHarness(page, "sendSiblingContext");
+        await expect(page.getByLabel("Sibling send status")).toHaveText("sent");
+        await callHarness(page, "sendValidContext");
+        await expect(target.getByLabel("Composer count")).toHaveText("2");
+    });
+
+    test("trusted origin不一致のchildはactual parentからのmessageをroutingしない", async ({ page }) => {
+        await page.goto("iframe-message-gate-playwright.html");
+        await expect(page.getByLabel("Harness ready")).toHaveText("true");
+
+        const target = page.frameLocator('iframe[title="iframe-message-gate-wrong-origin-target"]');
+        await expect(target.getByLabel("Child ready")).toHaveText("true");
+        await callHarness(page, "sendWrongOriginContext");
+        await expect(target.getByLabel("Composer count")).toHaveText("0");
+    });
+
+    test("wrong source storage responseはpendingを消費せずparent responseでresolveする", async ({ page }) => {
+        await page.goto("iframe-message-gate-playwright.html");
+        await expect(page.getByLabel("Harness ready")).toHaveText("true");
+
+        const target = page.frameLocator('iframe[title="iframe-message-gate-target"]');
+        await target.getByRole("button", { name: "Request storage" }).click();
+        await expect(page.getByLabel("Storage request ID")).not.toBeEmpty();
+
+        await callHarness(page, "sendSiblingStorageResult");
+        await expect(page.getByLabel("Sibling send status")).toHaveText("sent");
+        await callHarness(page, "sendStorageResult");
+        await expect(target.getByLabel("Storage result")).toHaveText("en");
+    });
+});

--- a/src/test/e2e/iframeMessageGateChildHarnessEntry.ts
+++ b/src/test/e2e/iframeMessageGateChildHarnessEntry.ts
@@ -1,0 +1,40 @@
+import { STORAGE_KEYS } from "../../lib/constants";
+import { EmbedComposerContextService } from "../../lib/embedComposerContextService";
+import { EmbedSettingsService } from "../../lib/embedSettingsService";
+import { EmbedStorageService } from "../../lib/embedStorageService";
+
+const composerCount = document.getElementById("composer-count")!;
+const settingsCount = document.getElementById("settings-count")!;
+const storageButton = document.getElementById("storage-request")!;
+const storageResult = document.getElementById("storage-result")!;
+
+const composerContextService = new EmbedComposerContextService(window, console);
+const settingsService = new EmbedSettingsService(window, console);
+const storageService = new EmbedStorageService(window, console, 5_000);
+
+let composerMessages = 0;
+let settingsMessages = 0;
+
+composerContextService.onRemoteSetContext(() => {
+    composerMessages += 1;
+    composerCount.textContent = String(composerMessages);
+});
+settingsService.onRemoteSetSettings(() => {
+    settingsMessages += 1;
+    settingsCount.textContent = String(settingsMessages);
+});
+
+composerContextService.initialize();
+settingsService.initialize();
+storageService.initialize();
+
+storageButton.addEventListener("click", () => {
+    storageResult.textContent = "";
+    void storageService.get([STORAGE_KEYS.LOCALE]).then((result) => {
+        storageResult.textContent = result.values?.[STORAGE_KEYS.LOCALE] ?? "missing";
+    }).catch((error) => {
+        storageResult.textContent = error.code ?? "error";
+    });
+});
+
+document.getElementById("child-ready")!.textContent = "true";

--- a/src/test/e2e/iframeMessageGateHarnessEntry.ts
+++ b/src/test/e2e/iframeMessageGateHarnessEntry.ts
@@ -1,0 +1,130 @@
+import {
+    EMBED_MESSAGE_NAMESPACE,
+    EMBED_MESSAGE_VERSION,
+} from "../../lib/embedProtocol";
+
+type HarnessWindow = Window & typeof globalThis & {
+    __IFRAME_MESSAGE_GATE_HARNESS__?: {
+        sendValidContext: () => void;
+        sendInvalidEnvelopeContext: () => void;
+        sendSiblingContext: () => void;
+        sendWrongOriginContext: () => void;
+        sendSiblingStorageResult: () => void;
+        sendStorageResult: () => void;
+    };
+};
+
+type StorageRequest = {
+    requestId: string;
+};
+
+const frames = document.getElementById("frames")!;
+const ready = document.getElementById("harness-ready")!;
+const storageRequestId = document.getElementById("storage-request-id")!;
+const siblingSendStatus = document.getElementById("sibling-send-status")!;
+const origin = window.location.origin;
+
+function createFrame(name: string, src: string): HTMLIFrameElement {
+    const iframe = document.createElement("iframe");
+    iframe.name = name;
+    iframe.title = name;
+    iframe.src = src;
+    frames.append(iframe);
+    return iframe;
+}
+
+const target = createFrame(
+    "iframe-message-gate-target",
+    `iframe-message-gate-child-playwright.html?parentOrigin=${encodeURIComponent(origin)}`,
+);
+const wrongOriginTarget = createFrame(
+    "iframe-message-gate-wrong-origin-target",
+    "iframe-message-gate-child-playwright.html?parentOrigin=https%3A%2F%2Funtrusted.example.com",
+);
+const sender = createFrame(
+    "iframe-message-gate-sender",
+    "iframe-message-gate-sender-playwright.html",
+);
+
+let latestStorageRequest: StorageRequest | null = null;
+
+function contextEnvelope() {
+    return {
+        namespace: EMBED_MESSAGE_NAMESPACE,
+        version: EMBED_MESSAGE_VERSION,
+        type: "composer.setContext",
+        requestId: "context-request",
+        payload: { content: "iframe gate harness" },
+    };
+}
+
+function storageResultEnvelope(value: string) {
+    if (!latestStorageRequest) return null;
+    return {
+        namespace: EMBED_MESSAGE_NAMESPACE,
+        version: EMBED_MESSAGE_VERSION,
+        type: "storage.result",
+        requestId: latestStorageRequest.requestId,
+        payload: {
+            timestamp: Date.now(),
+            values: { locale: value },
+        },
+    };
+}
+
+function postFromParent(targetFrame: HTMLIFrameElement, message: unknown): void {
+    targetFrame.contentWindow?.postMessage(message, origin);
+}
+
+function postFromSibling(message: unknown): void {
+    siblingSendStatus.textContent = "";
+    sender.contentWindow?.postMessage(
+        {
+            type: "iframe-message-gate.send",
+            targetName: target.name,
+            targetOrigin: origin,
+            message,
+        },
+        origin,
+    );
+}
+
+window.addEventListener("message", (event) => {
+    if (event.source === sender.contentWindow && event.data?.type === "iframe-message-gate.sender.sent") {
+        siblingSendStatus.textContent = "sent";
+        return;
+    }
+
+    if (
+        event.source === target.contentWindow
+        && event.data?.type === "storage.get"
+        && typeof event.data.requestId === "string"
+    ) {
+        latestStorageRequest = { requestId: event.data.requestId };
+        storageRequestId.textContent = event.data.requestId;
+    }
+});
+
+(window as HarnessWindow).__IFRAME_MESSAGE_GATE_HARNESS__ = {
+    sendValidContext: () => postFromParent(target, contextEnvelope()),
+    sendInvalidEnvelopeContext: () => postFromParent(target, {
+        ...contextEnvelope(),
+        namespace: "invalid.embed",
+    }),
+    sendSiblingContext: () => postFromSibling(contextEnvelope()),
+    sendWrongOriginContext: () => postFromParent(wrongOriginTarget, contextEnvelope()),
+    sendSiblingStorageResult: () => {
+        const message = storageResultEnvelope("fake");
+        if (message) postFromSibling(message);
+    },
+    sendStorageResult: () => {
+        const message = storageResultEnvelope("en");
+        if (message) postFromParent(target, message);
+    },
+};
+
+Promise.all([target, wrongOriginTarget, sender].map((iframe) => new Promise<void>((resolve) => {
+    iframe.addEventListener("load", () => resolve(), { once: true });
+}))).then(() => {
+    ready.textContent = "true";
+});

--- a/src/test/e2e/iframeMessageGateSenderHarnessEntry.ts
+++ b/src/test/e2e/iframeMessageGateSenderHarnessEntry.ts
@@ -1,0 +1,27 @@
+type SenderCommand = {
+    type: "iframe-message-gate.send";
+    targetName: string;
+    targetOrigin: string;
+    message: unknown;
+};
+
+window.addEventListener("message", (event) => {
+    const command = event.data as Partial<SenderCommand> | null;
+    if (
+        event.source !== window.parent
+        || command?.type !== "iframe-message-gate.send"
+        || typeof command.targetName !== "string"
+        || typeof command.targetOrigin !== "string"
+    ) {
+        return;
+    }
+
+    const target = Array.from(window.parent.document.querySelectorAll("iframe"))
+        .find((iframe) => iframe.name === command.targetName)
+        ?.contentWindow;
+    target?.postMessage(command.message, command.targetOrigin);
+    window.parent.postMessage(
+        { type: "iframe-message-gate.sender.sent" },
+        event.origin,
+    );
+});

--- a/src/test/unit/embedComposerContextService.test.ts
+++ b/src/test/unit/embedComposerContextService.test.ts
@@ -98,6 +98,26 @@ describe('EmbedComposerContextService', () => {
         expect(onRemoteSetContext).not.toHaveBeenCalled();
     });
 
+    it.each([
+        ['source がparentではない', { namespace: EMBED_MESSAGE_NAMESPACE, version: 1, type: 'composer.setContext', requestId: 'composer-request-3' }, {}],
+        ['envelopeが不正', { namespace: 'other.embed', version: 1, type: 'composer.setContext', requestId: 'composer-request-3' }, null],
+        ['serviceと無関係なtype', { namespace: EMBED_MESSAGE_NAMESPACE, version: 1, type: 'settings.set', requestId: 'composer-request-3' }, null],
+    ])('%s messageはroutingしない', (_description, data, source) => {
+        const { windowObj, parent, listeners } = createMockWindow();
+        const service = new EmbedComposerContextService(windowObj, mockConsole);
+        const onRemoteSetContext = vi.fn();
+        service.onRemoteSetContext(onRemoteSetContext);
+        service.initialize();
+
+        listeners.get('message')?.({
+            data,
+            origin: 'https://parent.example.com',
+            source: source ?? parent,
+        } as unknown as MessageEvent);
+
+        expect(onRemoteSetContext).not.toHaveBeenCalled();
+    });
+
     it('有効requestIdの不正payloadもControllerがerror ackできるようlistenerへ渡す', () => {
         const { windowObj, parent, listeners } = createMockWindow();
         const service = new EmbedComposerContextService(windowObj, mockConsole);

--- a/src/test/unit/embedIndexedDbService.test.ts
+++ b/src/test/unit/embedIndexedDbService.test.ts
@@ -177,4 +177,48 @@ describe("EmbedIndexedDbService", () => {
             code: "idb_request_timeout",
         });
     });
+
+    it("sourceまたはenvelopeが不正なresponseではpendingを消費しない", async () => {
+        const { windowObj, parent, listeners } = createMockWindow();
+        const service = new EmbedIndexedDbService(windowObj, mockConsole);
+        service.initialize();
+
+        const pending = service.getUploadDestinationsSnapshot(UPLOAD_DESTINATION_GLOBAL_SCOPE);
+        const sentMessage = parent.postMessage.mock.calls[0][0];
+        const response = {
+            namespace: EMBED_MESSAGE_NAMESPACE,
+            version: EMBED_MESSAGE_VERSION,
+            type: "idb.result",
+            requestId: sentMessage.requestId,
+            payload: {
+                timestamp: Date.now(),
+                store: "uploadDestinations",
+                scopeKey: UPLOAD_DESTINATION_GLOBAL_SCOPE,
+                records: [createDestinationRecord()],
+            },
+        };
+
+        listeners.get("message")?.({
+            data: response,
+            origin: "https://parent.example.com",
+            source: {},
+        } as unknown as MessageEvent);
+        listeners.get("message")?.({
+            data: { ...response, namespace: "other.embed" },
+            origin: "https://parent.example.com",
+            source: parent,
+        } as unknown as MessageEvent);
+        listeners.get("message")?.({
+            data: { ...response, type: "settings.set" },
+            origin: "https://parent.example.com",
+            source: parent,
+        } as unknown as MessageEvent);
+        listeners.get("message")?.({
+            data: response,
+            origin: "https://parent.example.com",
+            source: parent,
+        } as unknown as MessageEvent);
+
+        await expect(pending).resolves.toEqual(response.payload.records);
+    });
 });

--- a/src/test/unit/embedMessageTrustGate.test.ts
+++ b/src/test/unit/embedMessageTrustGate.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+    EMBED_MESSAGE_NAMESPACE,
+    EMBED_MESSAGE_VERSION,
+} from "../../lib/embedProtocol";
+import { getTrustedParentEmbedMessage } from "../../lib/embedMessageTrustGate";
+import { createMockWindow } from "../embedWindowTestUtils";
+
+function createEvent(
+    data: unknown,
+    origin: string,
+    source: MessageEventSource | null,
+): MessageEvent {
+    return { data, origin, source } as MessageEvent;
+}
+
+function createEnvelope() {
+    return {
+        namespace: EMBED_MESSAGE_NAMESPACE,
+        version: EMBED_MESSAGE_VERSION,
+        type: "settings.set",
+        requestId: "request-1",
+    };
+}
+
+describe("getTrustedParentEmbedMessage", () => {
+    it("valid envelope、exact parent source、exact trusted originを受理する", () => {
+        const { windowObj, parent } = createMockWindow();
+        const event = createEvent(
+            createEnvelope(),
+            "https://parent.example.com",
+            parent as unknown as MessageEventSource,
+        );
+
+        expect(getTrustedParentEmbedMessage(
+            event,
+            windowObj,
+            "https://parent.example.com",
+        )).toEqual(createEnvelope());
+    });
+
+    it.each([
+        ["namespace不一致", { ...createEnvelope(), namespace: "other.embed" }],
+        ["version不一致", { ...createEnvelope(), version: 2 }],
+        ["envelopeではないdata", { type: "settings.set" }],
+    ])("%sを拒否する", (_description, data) => {
+        const { windowObj, parent } = createMockWindow();
+
+        expect(getTrustedParentEmbedMessage(
+            createEvent(
+                data,
+                "https://parent.example.com",
+                parent as unknown as MessageEventSource,
+            ),
+            windowObj,
+            "https://parent.example.com",
+        )).toBeNull();
+    });
+
+    it("source不一致を拒否する", () => {
+        const { windowObj } = createMockWindow();
+
+        expect(getTrustedParentEmbedMessage(
+            createEvent(
+                createEnvelope(),
+                "https://parent.example.com",
+                {} as MessageEventSource,
+            ),
+            windowObj,
+            "https://parent.example.com",
+        )).toBeNull();
+    });
+
+    it("同一originのsibling sourceを拒否する", () => {
+        const { windowObj } = createMockWindow();
+        const sibling = {} as MessageEventSource;
+
+        expect(getTrustedParentEmbedMessage(
+            createEvent(createEnvelope(), "https://parent.example.com", sibling),
+            windowObj,
+            "https://parent.example.com",
+        )).toBeNull();
+    });
+
+    it("origin不一致を拒否する", () => {
+        const { windowObj, parent } = createMockWindow();
+
+        expect(getTrustedParentEmbedMessage(
+            createEvent(
+                createEnvelope(),
+                "https://other.example.com",
+                parent as unknown as MessageEventSource,
+            ),
+            windowObj,
+            "https://parent.example.com",
+        )).toBeNull();
+    });
+
+    it("trusted originがnullの場合は既存どおりoriginを追加で判定しない", () => {
+        const { windowObj, parent } = createMockWindow();
+        const event = createEvent(
+            createEnvelope(),
+            "https://other.example.com",
+            parent as unknown as MessageEventSource,
+        );
+
+        expect(getTrustedParentEmbedMessage(event, windowObj, null)).toEqual(
+            createEnvelope(),
+        );
+    });
+
+    it("runtimeでunknown typeでも既存envelope判定どおり返す", () => {
+        const { windowObj, parent } = createMockWindow();
+        const message = { ...createEnvelope(), type: "future.message" };
+
+        expect(getTrustedParentEmbedMessage(
+            createEvent(
+                message,
+                "https://parent.example.com",
+                parent as unknown as MessageEventSource,
+            ),
+            windowObj,
+            "https://parent.example.com",
+        )).toEqual(message);
+    });
+});

--- a/src/test/unit/embedSettingsService.test.ts
+++ b/src/test/unit/embedSettingsService.test.ts
@@ -66,6 +66,26 @@ describe('EmbedSettingsService', () => {
         expect(onRemoteSetSettings).not.toHaveBeenCalled();
     });
 
+    it.each([
+        ['source がparentではない', { namespace: EMBED_MESSAGE_NAMESPACE, version: 1, type: 'settings.set', requestId: 'settings-request-4' }, {}],
+        ['envelopeが不正', { namespace: 'other.embed', version: 1, type: 'settings.set', requestId: 'settings-request-4' }, null],
+        ['serviceと無関係なtype', { namespace: EMBED_MESSAGE_NAMESPACE, version: 1, type: 'composer.setContext', requestId: 'settings-request-4' }, null],
+    ])('%s messageはroutingしない', (_description, data, source) => {
+        const { windowObj, parent, listeners } = createMockWindow();
+        const service = new EmbedSettingsService(windowObj, mockConsole);
+        const onRemoteSetSettings = vi.fn();
+        service.onRemoteSetSettings(onRemoteSetSettings);
+        service.initialize();
+
+        listeners.get('message')?.({
+            data,
+            origin: 'https://parent.example.com',
+            source: source ?? parent,
+        } as unknown as MessageEvent);
+
+        expect(onRemoteSetSettings).not.toHaveBeenCalled();
+    });
+
     it('requestId がない settings.set は拒否する', () => {
         const { windowObj, parent, listeners } = createMockWindow();
         const service = new EmbedSettingsService(windowObj, mockConsole);

--- a/src/test/unit/embedStorageService.test.ts
+++ b/src/test/unit/embedStorageService.test.ts
@@ -92,6 +92,50 @@ describe('EmbedStorageService', () => {
         });
     });
 
+    it('sourceまたはenvelopeが不正なresponseではpendingを消費しない', async () => {
+        const { windowObj, parent, listeners } = createMockWindow();
+        const service = new EmbedStorageService(windowObj, mockConsole);
+        service.initialize();
+
+        const pending = service.get([STORAGE_KEYS.THEME_MODE]);
+        const sentMessage = parent.postMessage.mock.calls[0][0];
+        const response = {
+            namespace: EMBED_MESSAGE_NAMESPACE,
+            version: EMBED_MESSAGE_VERSION,
+            type: 'storage.result',
+            requestId: sentMessage.requestId,
+            payload: {
+                timestamp: Date.now(),
+                values: { [STORAGE_KEYS.THEME_MODE]: 'dark' },
+            },
+        };
+
+        listeners.get('message')?.({
+            data: response,
+            origin: 'https://parent.example.com',
+            source: {},
+        } as unknown as MessageEvent);
+        listeners.get('message')?.({
+            data: { ...response, namespace: 'other.embed' },
+            origin: 'https://parent.example.com',
+            source: parent,
+        } as unknown as MessageEvent);
+        listeners.get('message')?.({
+            data: { ...response, type: 'settings.set' },
+            origin: 'https://parent.example.com',
+            source: parent,
+        } as unknown as MessageEvent);
+        listeners.get('message')?.({
+            data: response,
+            origin: 'https://parent.example.com',
+            source: parent,
+        } as unknown as MessageEvent);
+
+        await expect(pending).resolves.toMatchObject({
+            values: { [STORAGE_KEYS.THEME_MODE]: 'dark' },
+        });
+    });
+
     it('localStorage の値と削除状態を親へ保存要求する', () => {
         const { windowObj, parent } = createMockWindow();
         const storage = new MockStorage();


### PR DESCRIPTION
## Summary
- Share the receive-only iframe trust gate across composer context, settings, storage, and IndexedDB services.
- Preserve the existing embed envelope, exact direct-parent source, and exact trusted-origin contract without changing wire formats.
- Add focused unit coverage plus a real iframe Playwright harness for parent, sibling, and request/response paths.

## Scope and preserved responsibilities
- The helper only returns an accepted `EmbedMessageEnvelope` or `null`; service-specific routing, requestId and payload validation, pending maps, timeouts, resolve/reject behavior, lifecycle, and outbound messages stay in their current services.
- `ParentClientAuthService` is unchanged and remains outside this helper; its existing regression suite was run.
- Outbound `IframeMessageService` is unchanged.
- `parentOrigin` query establishment and all protocol namespace/version/type/payload wire formats are unchanged.

## Validation
- `npm run test -- src/test/unit/embedMessageTrustGate.test.ts src/test/unit/embedComposerContextService.test.ts src/test/unit/embedSettingsService.test.ts src/test/unit/embedStorageService.test.ts src/test/unit/embedIndexedDbService.test.ts src/test/unit/parentClientAuthService.test.ts src/test/integration/app-parent-client.integration.test.ts` (69 passed)
- Real iframe Playwright: valid parent delivery, invalid-envelope rejection, same-origin sibling-source rejection, trusted-origin mismatch rejection, and storage pending preservation followed by valid parent resolution; desktop Chromium and mobile Chromium passed.
- `npx playwright test --reporter=line` (73 passed, 10 existing skips)
- `npm run check`
- `npm test` (312 files, 3,532 tests passed)
- `npm run build`
- `git diff --check`

No package.json or package-lock.json changes.