### PR TITLE
refactor: share post history relay resolver

### DIFF
--- a/src/lib/postHistoryAuthoredPostsRealtimeService.ts
+++ b/src/lib/postHistoryAuthoredPostsRealtimeService.ts
@@ -1,5 +1,5 @@
 import { createRxForwardReq, type RxNostr } from "rx-nostr";
-import { FALLBACK_RELAYS } from "./constants";
+import { resolvePostHistoryRelayUrls } from "./postHistoryRelayResolver";
 import { RelayConfigUtils } from "./relayConfigUtils";
 import {
     postHistoryRepository,
@@ -58,7 +58,7 @@ export class PostHistoryAuthoredPostsRealtimeService {
         let active = true;
         let subscription: SubscriptionLike | undefined;
         let workQueue: Promise<void> = Promise.resolve();
-        const relayUrls = this.resolveRelayUrls(
+        const relayUrls = resolvePostHistoryRelayUrls(
             params.relayConfig,
             normalizeRelayLimit(params.relayLimit),
         );
@@ -156,21 +156,6 @@ export class PostHistoryAuthoredPostsRealtimeService {
         }
     }
 
-    private resolveRelayUrls(relayConfig: RelayConfig | null | undefined, relayLimit: number): string[] {
-        const configuredRelays = relayConfig
-            ? [
-                ...RelayConfigUtils.extractReadRelays(relayConfig),
-                ...RelayConfigUtils.extractWriteRelays(relayConfig),
-            ]
-            : [];
-        const relayUrls = RelayConfigUtils.sanitizeExternalRelayUrls(configuredRelays, {
-            limit: relayLimit,
-        });
-
-        return relayUrls.length > 0
-            ? relayUrls
-            : RelayConfigUtils.sanitizeExternalRelayUrls(FALLBACK_RELAYS, { limit: relayLimit });
-    }
 }
 
 export const postHistoryAuthoredPostsRealtimeService =

--- a/src/lib/postHistoryInboundInteractionsRealtimeService.ts
+++ b/src/lib/postHistoryInboundInteractionsRealtimeService.ts
@@ -1,6 +1,6 @@
 import { createRxForwardReq, type RxNostr } from "rx-nostr";
-import { FALLBACK_RELAYS } from "./constants";
 import { classifyPostHistoryInboundInteraction } from "./postHistoryInboundInteractionClassifier";
+import { resolvePostHistoryRelayUrls } from "./postHistoryRelayResolver";
 import type {
     PostHistoryInboundDirectReplyCandidate,
     PostHistoryInboundReplyReconciliationResult,
@@ -78,7 +78,7 @@ export class PostHistoryInboundInteractionsRealtimeService {
         let active = true;
         let subscription: SubscriptionLike | undefined;
         let workQueue: Promise<void> = Promise.resolve();
-        const relayUrls = this.resolveRelayUrls(
+        const relayUrls = resolvePostHistoryRelayUrls(
             params.relayConfig,
             normalizeRelayLimit(params.relayLimit),
         );
@@ -283,21 +283,6 @@ export class PostHistoryInboundInteractionsRealtimeService {
         }
     }
 
-    private resolveRelayUrls(relayConfig: RelayConfig | null | undefined, relayLimit: number): string[] {
-        const configuredRelays = relayConfig
-            ? [
-                ...RelayConfigUtils.extractReadRelays(relayConfig),
-                ...RelayConfigUtils.extractWriteRelays(relayConfig),
-            ]
-            : [];
-        const relayUrls = RelayConfigUtils.sanitizeExternalRelayUrls(configuredRelays, {
-            limit: relayLimit,
-        });
-
-        return relayUrls.length > 0
-            ? relayUrls
-            : RelayConfigUtils.sanitizeExternalRelayUrls(FALLBACK_RELAYS, { limit: relayLimit });
-    }
 }
 
 export const postHistoryInboundInteractionsRealtimeService =

--- a/src/lib/postHistoryInboundInteractionsSyncService.ts
+++ b/src/lib/postHistoryInboundInteractionsSyncService.ts
@@ -1,5 +1,4 @@
 import { createRxBackwardReq, type RxNostr } from "rx-nostr";
-import { FALLBACK_RELAYS } from "./constants";
 import {
     classifyPostHistoryInboundInteraction,
     type PostHistoryInboundInteractionClassification,
@@ -9,6 +8,7 @@ import type {
     PostHistoryInboundReplyReconciliationResult,
 } from "./postHistoryInboundReplyReconciliationService";
 import { isSameSignedNostrEvent } from "./postHistoryEventUtils";
+import { resolvePostHistoryRelayUrls } from "./postHistoryRelayResolver";
 import {
     buildPostHistoryDirectReplyParentContext,
     validatePostHistoryDirectReplyRelation,
@@ -202,7 +202,7 @@ export class PostHistoryInboundInteractionsSyncService {
             const state = await this.syncStateRepository.get(params.ownerPubkeyHex);
             const limit = resolveLimit(params.reason, params.limit);
             const timeoutMs = resolveTimeoutMs(params.reason, params.timeoutMs);
-            const relayUrls = this.resolveRelayUrls(
+            const relayUrls = resolvePostHistoryRelayUrls(
                 params.relayConfig,
                 resolveRelayLimit(params.reason, params.relayLimit),
             );
@@ -588,22 +588,6 @@ export class PostHistoryInboundInteractionsSyncService {
             0,
             Math.floor(this.now() / 1000) - POST_HISTORY_INBOUND_INTERACTIONS_INITIAL_LOOKBACK_SECONDS,
         );
-    }
-
-    private resolveRelayUrls(relayConfig: RelayConfig | null | undefined, relayLimit: number): string[] {
-        const configuredRelays = relayConfig
-            ? [
-                ...RelayConfigUtils.extractReadRelays(relayConfig),
-                ...RelayConfigUtils.extractWriteRelays(relayConfig),
-            ]
-            : [];
-        const relayUrls = RelayConfigUtils.sanitizeExternalRelayUrls(configuredRelays, {
-            limit: relayLimit,
-        });
-
-        return relayUrls.length > 0
-            ? relayUrls
-            : RelayConfigUtils.sanitizeExternalRelayUrls(FALLBACK_RELAYS, { limit: relayLimit });
     }
 
     private handlePacket(

--- a/src/lib/postHistoryRelayResolver.ts
+++ b/src/lib/postHistoryRelayResolver.ts
@@ -1,0 +1,22 @@
+import { FALLBACK_RELAYS } from "./constants";
+import { RelayConfigUtils } from "./relayConfigUtils";
+import type { RelayConfig } from "./types";
+
+export function resolvePostHistoryRelayUrls(
+    relayConfig: RelayConfig | null | undefined,
+    relayLimit: number,
+): string[] {
+    const configuredRelays = relayConfig
+        ? [
+            ...RelayConfigUtils.extractReadRelays(relayConfig),
+            ...RelayConfigUtils.extractWriteRelays(relayConfig),
+        ]
+        : [];
+    const relayUrls = RelayConfigUtils.sanitizeExternalRelayUrls(configuredRelays, {
+        limit: relayLimit,
+    });
+
+    return relayUrls.length > 0
+        ? relayUrls
+        : RelayConfigUtils.sanitizeExternalRelayUrls(FALLBACK_RELAYS, { limit: relayLimit });
+}

--- a/src/test/unit/postHistoryAuthoredPostsRealtimeService.test.ts
+++ b/src/test/unit/postHistoryAuthoredPostsRealtimeService.test.ts
@@ -74,6 +74,9 @@ describe("PostHistoryAuthoredPostsRealtimeService", () => {
         observer.next({ event, from: "wss://relay.example.com" });
         await subscription.waitForIdle();
 
+        expect(rxNostrMock.use).toHaveBeenCalledWith(expect.anything(), {
+            on: { relays: ["wss://read.example.com/"] },
+        });
         expect(rxNostrMock.emittedFilters).toEqual([{
             authors: [OWNER_PUBKEY],
             kinds: [1, 42],

--- a/src/test/unit/postHistoryInboundInteractionsRealtimeService.test.ts
+++ b/src/test/unit/postHistoryInboundInteractionsRealtimeService.test.ts
@@ -118,6 +118,9 @@ describe("PostHistoryInboundInteractionsRealtimeService", () => {
         observer.next({ event: directReply, from: "wss://relay.example.com" });
         await subscription.waitForIdle();
 
+        expect(rxNostrMock.use).toHaveBeenCalledWith(expect.anything(), {
+            on: { relays: ["wss://read.example.com/"] },
+        });
         expect(rxNostrMock.emittedFilters).toEqual([{
             kinds: [1, 7, 42],
             "#p": [OWNER_PUBKEY],

--- a/src/test/unit/postHistoryInboundInteractionsSyncService.test.ts
+++ b/src/test/unit/postHistoryInboundInteractionsSyncService.test.ts
@@ -127,6 +127,9 @@ describe("PostHistoryInboundInteractionsSyncService", () => {
             relayConfig: { "wss://read.example.com/": { read: true, write: false } },
         }).promise;
 
+        expect(rxNostrMock.use).toHaveBeenCalledWith(expect.anything(), {
+            on: { relays: ["wss://read.example.com/"] },
+        });
         expect(rxNostrMock.emittedFilters).toEqual([{
             kinds: [1, 7, 42],
             "#p": [OWNER_PUBKEY],

--- a/src/test/unit/postHistoryRelayResolver.test.ts
+++ b/src/test/unit/postHistoryRelayResolver.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { FALLBACK_RELAYS } from "../../lib/constants";
+import { resolvePostHistoryRelayUrls } from "../../lib/postHistoryRelayResolver";
+
+describe("resolvePostHistoryRelayUrls", () => {
+    it("keeps read relays first, preserves first duplicate position, and appends write-only relays", () => {
+        expect(resolvePostHistoryRelayUrls({
+            "wss://read-a.example": { read: true, write: false },
+            "wss://shared.example": { read: true, write: true },
+            "wss://write-only.example": { read: false, write: true },
+        }, 10)).toEqual([
+            "wss://read-a.example/",
+            "wss://shared.example/",
+            "wss://write-only.example/",
+        ]);
+    });
+
+    it("keeps the existing array RelayConfig behavior", () => {
+        expect(resolvePostHistoryRelayUrls([
+            "wss://read-a.example",
+            "wss://shared.example",
+        ], 10)).toEqual([
+            "wss://read-a.example/",
+            "wss://shared.example/",
+        ]);
+    });
+
+    it("delegates normalization and rejects malformed, non-WS(S), and credential URLs", () => {
+        expect(resolvePostHistoryRelayUrls([
+            "wss://normalized.example////",
+            "not a url",
+            "https://not-a-relay.example",
+            "wss://user:password@credential.example",
+        ], 10)).toEqual(["wss://normalized.example/"]);
+    });
+
+    it("does not fall back when one configured candidate remains valid", () => {
+        expect(resolvePostHistoryRelayUrls([
+            "not a url",
+            "wss://valid.example",
+        ], 10)).toEqual(["wss://valid.example/"]);
+    });
+
+    it.each([
+        [null, "null"],
+        [undefined, "undefined"],
+        [[], "empty"],
+        [["not a url"], "fully sanitized"],
+    ])("uses sanitized fallback for %s configuration", (relayConfig, _label) => {
+        expect(resolvePostHistoryRelayUrls(relayConfig as null | undefined | string[], 2))
+            .toEqual(FALLBACK_RELAYS.slice(0, 2));
+    });
+
+    it("applies the same limit to configured and fallback relays after sanitize order", () => {
+        expect(resolvePostHistoryRelayUrls([
+            "wss://first.example",
+            "wss://first.example/",
+            "wss://second.example",
+            "wss://third.example",
+        ], 2)).toEqual([
+            "wss://first.example/",
+            "wss://second.example/",
+        ]);
+        expect(resolvePostHistoryRelayUrls(null, 3)).toEqual(FALLBACK_RELAYS.slice(0, 3));
+    });
+
+    it("retains representative policy ordering through invalid candidates and limit", () => {
+        expect(resolvePostHistoryRelayUrls({
+            "wss://read-a.example": { read: true, write: false },
+            "wss://shared.example": { read: true, write: true },
+            "wss://write-only.example": { read: false, write: true },
+            "https://malformed.example": { read: true, write: true },
+            "wss://read-b.example": { read: true, write: false },
+        }, 3)).toEqual([
+            "wss://read-a.example/",
+            "wss://shared.example/",
+            "wss://read-b.example/",
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary

- Extract the duplicated relay URL resolution from the authored-post realtime, inbound-interactions realtime, and inbound-interactions sync services into the pure `resolvePostHistoryRelayUrls` helper.
- Keep service-owned relay-limit resolution, subscriptions/requests, filters, since/reason/timeout/cancellation, packet processing, reconciliation, persistence, and callbacks unchanged.
- Keep other post-history relay resolvers out of scope.

## Relay policy

The helper preserves the existing contract:

- extract read relays, then write relays;
- delegate normalization, invalid URL rejection, credential rejection, protocol checks, deduplication, ordering, and limit handling to `RelayConfigUtils`;
- use sanitized configured relays when at least one remains;
- otherwise sanitize `FALLBACK_RELAYS` with the same limit.

No relay selection policy, fallback contents/order, `RelayConfigUtils`, rx-nostr subscription contract, repository/schema, UI, package.json, or lockfile changes are included.

## Tests

- Pure helper unit test: 10 tests covering ordering, read/write deduplication, array config, normalization, malformed/non-WS(S)/credential rejection, configured-vs-fallback selection, configured and fallback limits, and post-sanitize ordering.
- Three service regression suites: 23 tests passed, including explicit `on.relays` assertions.
- `npm run check`: passed (0 errors, 0 warnings).
- `npm test`: passed (313 files, 3542 tests).
- `git diff --check`: passed.
- Build: not run; this is a pure TypeScript helper extraction and service import/call replacement with no Vite, PWA, worker, asset, or bundling changes.
- Playwright: not run; no UI, DOM, browser lifecycle, iframe, or user-interaction behavior changed.