### PR TITLE
Extract post history action items

### DIFF
--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -11,6 +11,7 @@
     import ImageFullscreen from "./ImageFullscreen.svelte";
     import LoadingPlaceholder from "./LoadingPlaceholder.svelte";
     import PostHistoryActionMenu from "./PostHistoryActionMenu.svelte";
+    import PostHistoryRecordActionItems from "./PostHistoryRecordActionItems.svelte";
     import PostContentPreview from "./PostContentPreview.svelte";
     import PostHistoryPreviewFooter from "./PostHistoryPreviewFooter.svelte";
     import PostHistoryQuotePreview from "./PostHistoryQuotePreview.svelte";
@@ -875,10 +876,6 @@
 
     function isBroadcastSending(post: PostHistoryRecord): boolean {
         return broadcastRequestState[post.eventId] === "sending";
-    }
-
-    function getBroadcastLabel(): string {
-        return $_("postHistory.broadcast");
     }
 
     function canBroadcastPost(post: PostHistoryRecord): boolean {
@@ -1952,117 +1949,47 @@
                                                                         class="post-history-menu-separator"
                                                                     />
                                                                 {/if}
-                                                                <DropdownMenu.Item
-                                                                    class="menu-action-button"
-                                                                    onpointerdown={(
-                                                                        event,
-                                                                    ) =>
+                                                                <PostHistoryRecordActionItems
+                                                                    order="standard"
+                                                                    copyFailed={copyNeventUi.copyState[
+                                                                        post.eventId
+                                                                    ] === "failed"}
+                                                                    showBroadcast={canBroadcastPost(
+                                                                        post,
+                                                                    )}
+                                                                    broadcastSending={isBroadcastSending(
+                                                                        post,
+                                                                    )}
+                                                                    showDelete={canDeletePost(post)}
+                                                                    showDeleteSeparator={false}
+                                                                    deletionSending={isDeletionSending(
+                                                                        post,
+                                                                    )}
+                                                                    onCopyPointerDown={(event) =>
                                                                         copyNeventUi.captureCopyPointerPosition(
                                                                             post,
                                                                             event,
                                                                         )}
-                                                                    onSelect={(
-                                                                        event,
-                                                                    ) =>
+                                                                    onCopyNevent={(event) =>
                                                                         void copyNeventUi.handleCopyNevent(
                                                                             post,
                                                                             event,
                                                                         )}
-                                                                >
-                                                                    <div
-                                                                        class="copy-icon svg-icon"
-                                                                        aria-hidden="true"
-                                                                    ></div>
-                                                                    <span>
-                                                                        {copyNeventUi
-                                                                            .copyState[
-                                                                            post
-                                                                                .eventId
-                                                                        ] ===
-                                                                        "failed"
-                                                                            ? $_(
-                                                                                  "postHistory.copyFailed",
-                                                                              )
-                                                                            : $_(
-                                                                                  "postHistory.copyNevent",
-                                                                              )}
-                                                                    </span>
-                                                                </DropdownMenu.Item>
-                                                                <DropdownMenu.Item
-                                                                    class="menu-action-button"
-                                                                    onSelect={() =>
-                                                                        openRawJson(
-                                                                            post.rawEvent,
-                                                                        )}
-                                                                >
-                                                                    <div
-                                                                        class="raw-json-icon svg-icon"
-                                                                        aria-hidden="true"
-                                                                    ></div>
-                                                                    <span>
-                                                                        {$_(
-                                                                            "postHistory.rawJson",
-                                                                        )}
-                                                                    </span>
-                                                                </DropdownMenu.Item>
-                                                                {#if canBroadcastPost(post)}
-                                                                    <DropdownMenu.Item
-                                                                        class="menu-action-button"
-                                                                        disabled={isBroadcastSending(
+                                                                    onShowRawJson={() =>
+                                                                        openRawJson(post.rawEvent)}
+                                                                    onBroadcastPointerDown={(event) =>
+                                                                        captureBroadcastPointerPosition(
                                                                             post,
+                                                                            event,
                                                                         )}
-                                                                        onpointerdown={(
-                                                                            event,
-                                                                        ) =>
-                                                                            captureBroadcastPointerPosition(
-                                                                                post,
-                                                                                event,
-                                                                            )}
-                                                                        onSelect={(
-                                                                            event,
-                                                                        ) =>
-                                                                            void handleBroadcastPost(
-                                                                                post,
-                                                                                event,
-                                                                            )}
-                                                                    >
-                                                                        <div
-                                                                            class="broadcast-icon svg-icon"
-                                                                            aria-hidden="true"
-                                                                        ></div>
-                                                                        <span>
-                                                                            {getBroadcastLabel()}
-                                                                        </span>
-                                                                    </DropdownMenu.Item>
-                                                                {/if}
-                                                                {#if canDeletePost(post)}
-                                                                    <DropdownMenu.Item
-                                                                        class="menu-action-button menu-action-button-danger"
-                                                                        disabled={isDeletionSending(
+                                                                    onBroadcastPost={(event) =>
+                                                                        void handleBroadcastPost(
                                                                             post,
+                                                                            event,
                                                                         )}
-                                                                        onSelect={() =>
-                                                                            openDeleteConfirm(
-                                                                                post,
-                                                                            )}
-                                                                    >
-                                                                        <div
-                                                                            class="trash-icon svg-icon"
-                                                                            aria-hidden="true"
-                                                                        ></div>
-                                                                        <span>
-                                                                            {isDeletionSending(
-                                                                                post,
-                                                                            )
-                                                                                ? $_(
-                                                                                      "postHistory.deleteSending",
-                                                                                  )
-                                                                                : $_(
-                                                                                      "postHistory.delete",
-                                                                                  )}
-                                                                        </span>
-                                                                    </DropdownMenu.Item>
-                                                                {/if}
+                                                                    onOpenDeleteConfirm={() =>
+                                                                        openDeleteConfirm(post)}
+                                                                />
                                                             </div>
                                                         </DropdownMenu.Content>
                                                     </DropdownMenu.Portal>
@@ -2222,124 +2149,54 @@
                                                                     )}
                                                                 >
                                                                     {#snippet items()}
-                                                                        <DropdownMenu.Item
-                                                                            class="menu-action-button"
-                                                                            onpointerdown={(
-                                                                                event,
-                                                                            ) =>
+                                                                        <PostHistoryRecordActionItems
+                                                                            order="standard"
+                                                                            copyFailed={copyNeventUi.copyState[
+                                                                                quotePreviewPost
+                                                                                    .eventId
+                                                                            ] === "failed"}
+                                                                            showBroadcast={canBroadcastPost(
+                                                                                quotePreviewPost,
+                                                                            )}
+                                                                            broadcastSending={isBroadcastSending(
+                                                                                quotePreviewPost,
+                                                                            )}
+                                                                            showDelete={canDeletePost(
+                                                                                quotePreviewPost,
+                                                                            )}
+                                                                            showDeleteSeparator={true}
+                                                                            deletionSending={isDeletionSending(
+                                                                                quotePreviewPost,
+                                                                            )}
+                                                                            onCopyPointerDown={(event) =>
                                                                                 copyNeventUi.captureCopyPointerPosition(
                                                                                     quotePreviewPost,
                                                                                     event,
                                                                                 )}
-                                                                            onSelect={(
-                                                                                event,
-                                                                            ) =>
+                                                                            onCopyNevent={(event) =>
                                                                                 void copyNeventUi.handleCopyNevent(
                                                                                     quotePreviewPost,
                                                                                     event,
                                                                                 )}
-                                                                        >
-                                                                            <div
-                                                                                class="copy-icon svg-icon"
-                                                                                aria-hidden="true"
-                                                                            ></div>
-                                                                            <span
-                                                                            >
-                                                                                {copyNeventUi
-                                                                                    .copyState[
-                                                                                    quotePreviewPost
-                                                                                        .eventId
-                                                                                ] ===
-                                                                                "failed"
-                                                                                    ? $_(
-                                                                                          "postHistory.copyFailed",
-                                                                                      )
-                                                                                    : $_(
-                                                                                          "postHistory.copyNevent",
-                                                                                      )}
-                                                                            </span>
-                                                                        </DropdownMenu.Item>
-                                                                        <DropdownMenu.Item
-                                                                            class="menu-action-button"
-                                                                            onSelect={() =>
+                                                                            onShowRawJson={() =>
                                                                                 openRawJson(
                                                                                     quotePreviewPost.rawEvent,
                                                                                 )}
-                                                                        >
-                                                                            <div
-                                                                                class="raw-json-icon svg-icon"
-                                                                                aria-hidden="true"
-                                                                            ></div>
-                                                                            <span
-                                                                            >
-                                                                                {$_(
-                                                                                    "postHistory.rawJson",
+                                                                            onBroadcastPointerDown={(event) =>
+                                                                                captureBroadcastPointerPosition(
+                                                                                    quotePreviewPost,
+                                                                                    event,
                                                                                 )}
-                                                                            </span>
-                                                                        </DropdownMenu.Item>
-                                                                        {#if canBroadcastPost(quotePreviewPost)}
-                                                                            <DropdownMenu.Item
-                                                                                class="menu-action-button"
-                                                                                disabled={isBroadcastSending(
+                                                                            onBroadcastPost={(event) =>
+                                                                                void handleBroadcastPost(
+                                                                                    quotePreviewPost,
+                                                                                    event,
+                                                                                )}
+                                                                            onOpenDeleteConfirm={() =>
+                                                                                openDeleteConfirm(
                                                                                     quotePreviewPost,
                                                                                 )}
-                                                                                onpointerdown={(
-                                                                                    event,
-                                                                                ) =>
-                                                                                    captureBroadcastPointerPosition(
-                                                                                        quotePreviewPost,
-                                                                                        event,
-                                                                                    )}
-                                                                                onSelect={(
-                                                                                    event,
-                                                                                ) =>
-                                                                                    void handleBroadcastPost(
-                                                                                        quotePreviewPost,
-                                                                                        event,
-                                                                                    )}
-                                                                            >
-                                                                                <div
-                                                                                    class="broadcast-icon svg-icon"
-                                                                                    aria-hidden="true"
-                                                                                ></div>
-                                                                                <span
-                                                                                >
-                                                                                    {getBroadcastLabel()}
-                                                                                </span>
-                                                                            </DropdownMenu.Item>
-                                                                        {/if}
-                                                                        {#if canDeletePost(quotePreviewPost)}
-                                                                            <DropdownMenu.Separator
-                                                                                class="post-history-menu-separator"
-                                                                            />
-                                                                            <DropdownMenu.Item
-                                                                                class="menu-action-button menu-action-button-danger"
-                                                                                disabled={isDeletionSending(
-                                                                                    quotePreviewPost,
-                                                                                )}
-                                                                                onSelect={() =>
-                                                                                    openDeleteConfirm(
-                                                                                        quotePreviewPost,
-                                                                                    )}
-                                                                            >
-                                                                                <div
-                                                                                    class="trash-icon svg-icon"
-                                                                                    aria-hidden="true"
-                                                                                ></div>
-                                                                                <span
-                                                                                >
-                                                                                    {isDeletionSending(
-                                                                                        quotePreviewPost,
-                                                                                    )
-                                                                                        ? $_(
-                                                                                              "postHistory.deleteSending",
-                                                                                          )
-                                                                                        : $_(
-                                                                                              "postHistory.delete",
-                                                                                          )}
-                                                                                </span>
-                                                                            </DropdownMenu.Item>
-                                                                        {/if}
+                                                                        />
                                                                     {/snippet}
                                                                 </PostHistoryActionMenu>
                                                             {/if}
@@ -2536,116 +2393,47 @@
                                                                 </span>
                                                             </DropdownMenu.Item>
                                                         {/if}
-                                                        <DropdownMenu.Item
-                                                            class="menu-action-button"
-                                                            onpointerdown={(
-                                                                event,
-                                                            ) =>
+                                                        <PostHistoryRecordActionItems
+                                                            order="standard"
+                                                            copyFailed={copyNeventUi.copyState[
+                                                                post.eventId
+                                                            ] === "failed"}
+                                                            showBroadcast={canBroadcastPost(
+                                                                post,
+                                                            )}
+                                                            broadcastSending={isBroadcastSending(
+                                                                post,
+                                                            )}
+                                                            showDelete={canDeletePost(post)}
+                                                            showDeleteSeparator={true}
+                                                            deletionSending={isDeletionSending(
+                                                                post,
+                                                            )}
+                                                            onCopyPointerDown={(event) =>
                                                                 copyNeventUi.captureCopyPointerPosition(
                                                                     post,
                                                                     event,
                                                                 )}
-                                                            onSelect={(event) =>
+                                                            onCopyNevent={(event) =>
                                                                 void copyNeventUi.handleCopyNevent(
                                                                     post,
                                                                     event,
                                                                 )}
-                                                        >
-                                                            <div
-                                                                class="copy-icon svg-icon"
-                                                                aria-hidden="true"
-                                                            ></div>
-                                                            <span>
-                                                                {copyNeventUi
-                                                                    .copyState[
-                                                                    post.eventId
-                                                                ] === "failed"
-                                                                    ? $_(
-                                                                          "postHistory.copyFailed",
-                                                                      )
-                                                                    : $_(
-                                                                          "postHistory.copyNevent",
-                                                                      )}
-                                                            </span>
-                                                        </DropdownMenu.Item>
-                                                        <DropdownMenu.Item
-                                                            class="menu-action-button"
-                                                            onSelect={() =>
-                                                                openRawJson(
-                                                                    post.rawEvent,
-                                                                )}
-                                                        >
-                                                            <div
-                                                                class="raw-json-icon svg-icon"
-                                                                aria-hidden="true"
-                                                            ></div>
-                                                            <span>
-                                                                {$_(
-                                                                    "postHistory.rawJson",
-                                                                )}
-                                                            </span>
-                                                        </DropdownMenu.Item>
-                                                        {#if canBroadcastPost(post)}
-                                                            <DropdownMenu.Item
-                                                                class="menu-action-button"
-                                                                disabled={isBroadcastSending(
+                                                            onShowRawJson={() =>
+                                                                openRawJson(post.rawEvent)}
+                                                            onBroadcastPointerDown={(event) =>
+                                                                captureBroadcastPointerPosition(
                                                                     post,
+                                                                    event,
                                                                 )}
-                                                                onpointerdown={(
-                                                                    event,
-                                                                ) =>
-                                                                    captureBroadcastPointerPosition(
-                                                                        post,
-                                                                        event,
-                                                                    )}
-                                                                onSelect={(
-                                                                    event,
-                                                                ) =>
-                                                                    void handleBroadcastPost(
-                                                                        post,
-                                                                        event,
-                                                                    )}
-                                                            >
-                                                                <div
-                                                                    class="broadcast-icon svg-icon"
-                                                                    aria-hidden="true"
-                                                                ></div>
-                                                                <span>
-                                                                    {getBroadcastLabel()}
-                                                                </span>
-                                                            </DropdownMenu.Item>
-                                                        {/if}
-                                                        {#if canDeletePost(post)}
-                                                            <DropdownMenu.Separator
-                                                                class="post-history-menu-separator"
-                                                            />
-                                                            <DropdownMenu.Item
-                                                                class="menu-action-button menu-action-button-danger"
-                                                                disabled={isDeletionSending(
+                                                            onBroadcastPost={(event) =>
+                                                                void handleBroadcastPost(
                                                                     post,
+                                                                    event,
                                                                 )}
-                                                                onSelect={() =>
-                                                                    openDeleteConfirm(
-                                                                        post,
-                                                                    )}
-                                                            >
-                                                                <div
-                                                                    class="trash-icon svg-icon"
-                                                                    aria-hidden="true"
-                                                                ></div>
-                                                                <span>
-                                                                    {isDeletionSending(
-                                                                        post,
-                                                                    )
-                                                                        ? $_(
-                                                                              "postHistory.deleteSending",
-                                                                          )
-                                                                        : $_(
-                                                                              "postHistory.delete",
-                                                                          )}
-                                                                </span>
-                                                            </DropdownMenu.Item>
-                                                        {/if}
+                                                            onOpenDeleteConfirm={() =>
+                                                                openDeleteConfirm(post)}
+                                                        />
                                                     {/snippet}
                                                 </PostHistoryActionMenu>
                                             {/snippet}

--- a/src/components/PostHistoryRecordActionItems.svelte
+++ b/src/components/PostHistoryRecordActionItems.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+    import { DropdownMenu } from "bits-ui";
+    import { _ } from "svelte-i18n";
+
+    type ActionOrder = "standard" | "raw-json-first";
+
+    interface Props {
+        order: ActionOrder;
+        copyFailed: boolean;
+        showBroadcast: boolean;
+        broadcastSending: boolean;
+        showDelete: boolean;
+        showDeleteSeparator: boolean;
+        deletionSending: boolean;
+        onCopyPointerDown: (event: PointerEvent) => void;
+        onCopyNevent: (event: Event) => void;
+        onShowRawJson: () => void;
+        onBroadcastPointerDown: (event: PointerEvent) => void;
+        onBroadcastPost: (event: Event) => void;
+        onOpenDeleteConfirm: () => void;
+    }
+
+    let {
+        order,
+        copyFailed,
+        showBroadcast,
+        broadcastSending,
+        showDelete,
+        showDeleteSeparator,
+        deletionSending,
+        onCopyPointerDown,
+        onCopyNevent,
+        onShowRawJson,
+        onBroadcastPointerDown,
+        onBroadcastPost,
+        onOpenDeleteConfirm,
+    }: Props = $props();
+</script>
+
+{#snippet copyItem()}
+    <DropdownMenu.Item
+        class="menu-action-button"
+        onpointerdown={onCopyPointerDown}
+        onSelect={onCopyNevent}
+    >
+        <div class="copy-icon svg-icon" aria-hidden="true"></div>
+        <span>
+            {copyFailed
+                ? $_("postHistory.copyFailed")
+                : $_("postHistory.copyNevent")}
+        </span>
+    </DropdownMenu.Item>
+{/snippet}
+
+{#snippet rawJsonItem()}
+    <DropdownMenu.Item
+        class="menu-action-button"
+        onSelect={() => onShowRawJson()}
+    >
+        <div class="raw-json-icon svg-icon" aria-hidden="true"></div>
+        <span>{$_("postHistory.rawJson")}</span>
+    </DropdownMenu.Item>
+{/snippet}
+
+{#if order === "raw-json-first"}
+    {@render rawJsonItem()}
+    {@render copyItem()}
+{:else}
+    {@render copyItem()}
+    {@render rawJsonItem()}
+{/if}
+
+{#if showBroadcast}
+    <DropdownMenu.Item
+        class="menu-action-button"
+        disabled={broadcastSending}
+        onpointerdown={onBroadcastPointerDown}
+        onSelect={onBroadcastPost}
+    >
+        <div class="broadcast-icon svg-icon" aria-hidden="true"></div>
+        <span>{$_("postHistory.broadcast")}</span>
+    </DropdownMenu.Item>
+{/if}
+
+{#if showDelete}
+    {#if showDeleteSeparator}
+        <DropdownMenu.Separator class="post-history-menu-separator" />
+    {/if}
+    <DropdownMenu.Item
+        class="menu-action-button menu-action-button-danger"
+        disabled={deletionSending}
+        onSelect={() => onOpenDeleteConfirm()}
+    >
+        <div class="trash-icon svg-icon" aria-hidden="true"></div>
+        <span>
+            {deletionSending
+                ? $_("postHistory.deleteSending")
+                : $_("postHistory.delete")}
+        </span>
+    </DropdownMenu.Item>
+{/if}

--- a/src/components/PostHistoryThreadGraphNodeView.svelte
+++ b/src/components/PostHistoryThreadGraphNodeView.svelte
@@ -3,6 +3,7 @@
     import { _ } from "svelte-i18n";
     import Button from "./Button.svelte";
     import PostHistoryActionMenu from "./PostHistoryActionMenu.svelte";
+    import PostHistoryRecordActionItems from "./PostHistoryRecordActionItems.svelte";
     import PostHistoryDeletionLifecycleStatusBadge from "./PostHistoryDeletionLifecycleStatusBadge.svelte";
     import PostHistoryRepliesBadgeButton from "./PostHistoryRepliesBadgeButton.svelte";
     import PostHistoryThreadToggleButton from "./PostHistoryThreadToggleButton.svelte";
@@ -309,63 +310,21 @@
                             ></div>
                             <span>{getRepliesActionLabel()}</span>
                         </DropdownMenu.Item>
-                        <DropdownMenu.Item
-                            class="menu-action-button"
-                            onSelect={handleShowRawJson}
-                        >
-                            <div
-                                class="raw-json-icon svg-icon"
-                                aria-hidden="true"
-                            ></div>
-                            <span>{$_("postHistory.rawJson")}</span>
-                        </DropdownMenu.Item>
-                        <DropdownMenu.Item
-                            class="menu-action-button"
-                            onpointerdown={handleCopyPointerDown}
-                            onSelect={handleCopyNevent}
-                        >
-                            <div
-                                class="copy-icon svg-icon"
-                                aria-hidden="true"
-                            ></div>
-                            <span>
-                                {copyFailed
-                                    ? $_("postHistory.copyFailed")
-                                    : $_("postHistory.copyNevent")}
-                            </span>
-                        </DropdownMenu.Item>
-                        <DropdownMenu.Item
-                            class="menu-action-button"
-                            disabled={broadcastSending}
-                            onpointerdown={handleBroadcastPointerDown}
-                            onSelect={handleBroadcastPost}
-                        >
-                            <div
-                                class="broadcast-icon svg-icon"
-                                aria-hidden="true"
-                            ></div>
-                            <span>{$_("postHistory.broadcast")}</span>
-                        </DropdownMenu.Item>
-                        {#if canDelete}
-                            <DropdownMenu.Separator
-                                class="post-history-menu-separator"
-                            />
-                            <DropdownMenu.Item
-                                class="menu-action-button menu-action-button-danger"
-                                disabled={deletionSending}
-                                onSelect={openDeleteConfirm}
-                            >
-                                <div
-                                    class="trash-icon svg-icon"
-                                    aria-hidden="true"
-                                ></div>
-                                <span>
-                                    {deletionSending
-                                        ? $_("postHistory.deleteSending")
-                                        : $_("postHistory.delete")}
-                                </span>
-                            </DropdownMenu.Item>
-                        {/if}
+                        <PostHistoryRecordActionItems
+                            order="raw-json-first"
+                            {copyFailed}
+                            showBroadcast={true}
+                            {broadcastSending}
+                            showDelete={canDelete}
+                            showDeleteSeparator={true}
+                            {deletionSending}
+                            onCopyPointerDown={handleCopyPointerDown}
+                            onCopyNevent={handleCopyNevent}
+                            onShowRawJson={handleShowRawJson}
+                            onBroadcastPointerDown={handleBroadcastPointerDown}
+                            onBroadcastPost={handleBroadcastPost}
+                            onOpenDeleteConfirm={openDeleteConfirm}
+                        />
                     {/snippet}
                 </PostHistoryActionMenu>
             {/snippet}

--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -178,6 +178,10 @@ async function expectNoHorizontalOverflow(
     expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
 }
 
+function visiblePostHistoryActionMenu(page: Page) {
+    return page.locator('.post-history-menu-content:visible').last();
+}
+
 async function expectTooltip(
     page: Page,
     trigger: ReturnType<Page['locator']>,
@@ -622,6 +626,89 @@ test.describe('PostHistoryDialog Playwright', () => {
         );
     });
 
+    test('normal post action menu keeps extracted actions and opens raw JSON on both browser sizes', async ({
+        page,
+    }) => {
+        const harness = await gotoHarness(page);
+        const postItem = page.locator(
+            `.post-history-item[data-post-history-event-id="${harness.plainPostEventId}"]`,
+        );
+        const actionTrigger = postItem
+            .locator('.post-preview-footer-right')
+            .getByRole('button', { name: 'アクションを表示' });
+
+        await actionTrigger.click();
+        const actionMenu = visiblePostHistoryActionMenu(page);
+        await expect(actionMenu.getByRole('menuitem')).toHaveText([
+            '返信 1件を表示',
+            'イベントIDをコピー',
+            'イベントJSONを表示',
+            '削除',
+        ]);
+
+        await actionMenu
+            .getByRole('menuitem', { name: 'イベントJSONを表示' })
+            .click();
+        const rawJsonDialog = page.getByRole('dialog', { name: 'イベントJSON' });
+        await expect(rawJsonDialog).toBeVisible();
+        await expect(rawJsonDialog.locator('.raw-json-content')).toHaveText('null');
+        await expect(page.locator('.post-history-dialog')).toBeVisible();
+
+        await page.locator('.dialog-overlay').last().click({ position: { x: 8, y: 8 } });
+        await expect(rawJsonDialog).toHaveCount(0);
+        await expect(page.locator('.post-history-dialog')).toBeVisible();
+    });
+
+    test('resolved quote preview action menu keeps the extracted actions usable', async ({
+        page,
+    }) => {
+        const harness = await gotoHarness(page);
+        const quoteItem = page.locator(
+            `.post-history-item[data-post-history-event-id="${harness.quotePostEventId}"]`,
+        );
+        const quoteCard = quoteItem
+            .locator('.post-history-related-card')
+            .filter({ hasText: harness.quoteContent });
+
+        await expect(quoteCard).toBeVisible();
+        await quoteCard
+            .getByRole('button', { name: 'アクションを表示' })
+            .click();
+        const actionMenu = visiblePostHistoryActionMenu(page);
+        await expect(actionMenu.getByRole('menuitem')).toHaveText([
+            'イベントIDをコピー',
+            'イベントJSONを表示',
+            'ブロードキャスト',
+        ]);
+    });
+
+    test('thread graph node action menu keeps raw JSON before copy', async ({
+        page,
+    }) => {
+        const harness = await gotoHarness(page);
+        const threadParentItem = page.locator(
+            `.post-history-item[data-post-history-event-id="${harness.threadParentPostEventId}"]`,
+        );
+
+        await threadParentItem
+            .getByRole('button', { name: '返信先を見る' })
+            .click();
+        const parentCard = threadParentItem
+            .locator('.post-history-related-card')
+            .filter({ hasText: harness.quoteContent });
+        await expect(parentCard).toBeVisible();
+        await parentCard
+            .getByRole('button', { name: 'アクションを表示' })
+            .click();
+        const actionMenu = visiblePostHistoryActionMenu(page);
+        await expect(actionMenu.getByRole('menuitem')).toHaveText([
+            '返信を確認',
+            'イベントJSONを表示',
+            'イベントIDをコピー',
+            'ブロードキャスト',
+        ]);
+    });
+
     test('mobile reference link stays tappable without changing parent state or overflowing', async ({
         page,
         isMobile,
@@ -715,20 +802,4 @@ test.describe('PostHistoryDialog Playwright', () => {
         await expect(page.getByRole('menuitem', { name: '削除' })).toHaveCount(0);
     });
 
-    test('raw JSON opens above post history and closes from its overlay only', async ({ page, isMobile }) => {
-        test.skip(isMobile, 'desktop only');
-
-        await gotoHarness(page);
-        await page.getByRole('button', { name: 'アクションを表示' }).first().click();
-        await page.getByRole('menuitem', { name: 'イベントJSONを表示' }).click();
-
-        const rawJsonDialog = page.getByRole('dialog', { name: 'イベントJSON' });
-        await expect(rawJsonDialog).toBeVisible();
-        await expect(rawJsonDialog.locator('.raw-json-content')).toHaveText('null');
-        await expect(page.locator('.post-history-dialog')).toBeVisible();
-
-        await page.locator('.dialog-overlay').last().click({ position: { x: 8, y: 8 } });
-        await expect(rawJsonDialog).toHaveCount(0);
-        await expect(page.locator('.post-history-dialog')).toBeVisible();
-    });
 });

--- a/src/test/unit/fixtures/PostHistoryRecordActionItemsHarness.svelte
+++ b/src/test/unit/fixtures/PostHistoryRecordActionItemsHarness.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+    import PostHistoryActionMenu from "../../../components/PostHistoryActionMenu.svelte";
+    import PostHistoryRecordActionItems from "../../../components/PostHistoryRecordActionItems.svelte";
+
+    type ActionOrder = "standard" | "raw-json-first";
+
+    interface Props {
+        order?: ActionOrder;
+        copyFailed?: boolean;
+        showBroadcast?: boolean;
+        broadcastSending?: boolean;
+        showDelete?: boolean;
+        showDeleteSeparator?: boolean;
+        deletionSending?: boolean;
+        onCopyPointerDown?: (event: PointerEvent) => void;
+        onCopyNevent?: (event: Event) => void;
+        onShowRawJson?: () => void;
+        onBroadcastPointerDown?: (event: PointerEvent) => void;
+        onBroadcastPost?: (event: Event) => void;
+        onOpenDeleteConfirm?: () => void;
+    }
+
+    let {
+        order = "standard",
+        copyFailed = false,
+        showBroadcast = true,
+        broadcastSending = false,
+        showDelete = true,
+        showDeleteSeparator = true,
+        deletionSending = false,
+        onCopyPointerDown = () => undefined,
+        onCopyNevent = () => undefined,
+        onShowRawJson = () => undefined,
+        onBroadcastPointerDown = () => undefined,
+        onBroadcastPost = () => undefined,
+        onOpenDeleteConfirm = () => undefined,
+    }: Props = $props();
+
+    let open = $state(true);
+</script>
+
+<PostHistoryActionMenu
+    {open}
+    onOpenChange={(nextOpen) => (open = nextOpen)}
+    triggerAriaLabel="アクションを表示"
+>
+    {#snippet items()}
+        <PostHistoryRecordActionItems
+            {order}
+            {copyFailed}
+            {showBroadcast}
+            {broadcastSending}
+            {showDelete}
+            {showDeleteSeparator}
+            {deletionSending}
+            {onCopyPointerDown}
+            {onCopyNevent}
+            {onShowRawJson}
+            {onBroadcastPointerDown}
+            {onBroadcastPost}
+            {onOpenDeleteConfirm}
+        />
+    {/snippet}
+</PostHistoryActionMenu>

--- a/src/test/unit/postHistoryDialog.test.ts
+++ b/src/test/unit/postHistoryDialog.test.ts
@@ -439,7 +439,7 @@ vi.mock('../../lib/postDeletionService', () => ({
     canRequestPostDeletion: (post: { pubkeyHex: string; deletedAt?: number; kind: number }, currentPubkey?: string | null) =>
         !!currentPubkey
         && post.pubkeyHex === currentPubkey
-        && post.deletedAt === undefined
+        && typeof post.deletedAt !== 'number'
         && [1, 42].includes(post.kind),
     postDeletionService: postDeletionServiceMock,
 }));
@@ -6469,6 +6469,160 @@ describe('PostHistoryDialog', () => {
         });
 
         countDeferred.resolve(1);
+    });
+
+    function expectDeleteSeparatorInOpenMenu(expected: boolean): void {
+        const body = document.querySelector<HTMLElement>(
+            '.post-history-menu-content .post-history-menu-body',
+        );
+        expect(body).toBeTruthy();
+
+        const children = Array.from(body!.children);
+        const broadcastIndex = children.findIndex((element) =>
+            element.textContent?.includes('ブロードキャスト'),
+        );
+        const deleteIndex = children.findIndex((element) =>
+            element.textContent?.includes('削除'),
+        );
+        expect(broadcastIndex).toBeGreaterThanOrEqual(0);
+        expect(deleteIndex).toBeGreaterThan(broadcastIndex);
+        expect(
+            children
+                .slice(broadcastIndex + 1, deleteIndex)
+                .some((element) =>
+                    element.classList.contains('post-history-menu-separator'),
+                ),
+        ).toBe(expected);
+    }
+
+    async function waitForOpenRecordActionMenu(): Promise<void> {
+        await waitFor(() => {
+            expect(
+                document.querySelector(
+                    '.post-history-menu-content .post-history-menu-body',
+                ),
+            ).toBeTruthy();
+        });
+    }
+
+    function createBroadcastableRecord(overrides: Record<string, any> = {}) {
+        const eventId = overrides.eventId ?? 'c'.repeat(64);
+        const content = overrides.content ?? 'action separator target';
+        return createRecord({
+            ...overrides,
+            eventId,
+            content,
+            rawEvent: {
+                id: eventId,
+                pubkey: overrides.pubkeyHex ?? 'a'.repeat(64),
+                kind: overrides.kind ?? 1,
+                content,
+                tags: overrides.tags ?? [],
+                created_at: 1_700_000_000,
+                sig: 'd'.repeat(128),
+            },
+        });
+    }
+
+    it('[record-action-items-header-separator] header keeps broadcast and delete adjacent', async () => {
+        const post = createBroadcastableRecord();
+        repositoryMock.getPage.mockResolvedValue([post]);
+        repositoryMock.countForPubkey.mockResolvedValue(1);
+
+        render(PostHistoryDialog, {
+            props: { show: true, onClose: vi.fn(), pubkeyHex: 'a'.repeat(64) },
+        });
+
+        const historyItem = await findHistoryItem(post.eventId);
+        const headerActions = historyItem.querySelector<HTMLElement>(
+            '.post-preview-header-right',
+        );
+        expect(headerActions).toBeTruthy();
+        await fireEvent.click(within(headerActions!).getByRole('button', {
+            name: 'アクションを表示',
+        }));
+        await waitForOpenRecordActionMenu();
+        expectDeleteSeparatorInOpenMenu(false);
+    });
+
+    it('[record-action-items-footer-separator] footer keeps the delete separator', async () => {
+        const post = createBroadcastableRecord();
+        repositoryMock.getPage.mockResolvedValue([post]);
+        repositoryMock.countForPubkey.mockResolvedValue(1);
+
+        render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                onQuotePost: vi.fn(),
+                pubkeyHex: 'a'.repeat(64),
+            },
+        });
+
+        const historyItem = await findHistoryItem(post.eventId);
+        const footerActions = historyItem.querySelector<HTMLElement>(
+            '.post-preview-footer-right',
+        );
+        expect(footerActions).toBeTruthy();
+        await fireEvent.click(within(footerActions!).getByRole('button', {
+            name: 'アクションを表示',
+        }));
+        await waitForOpenRecordActionMenu();
+        expectDeleteSeparatorInOpenMenu(true);
+    });
+
+    it('[record-action-items-quote-separator] quote preview keeps the delete separator', async () => {
+        const { quotedRecord, post, quoteId } = createQuoteContextRecords({
+            quoteAuthorPubkey: 'a'.repeat(64),
+        });
+        repositoryMock.getPage.mockResolvedValue([post]);
+        repositoryMock.countForPubkey.mockResolvedValue(1);
+        repositoryMock.getByEventId.mockImplementation(async (eventId: string) =>
+            eventId === quoteId ? quotedRecord : null,
+        );
+
+        render(PostHistoryDialog, {
+            props: { show: true, onClose: vi.fn(), pubkeyHex: 'a'.repeat(64) },
+        });
+
+        const historyItem = await findHistoryItem(post.eventId);
+        const quoteCard = (await within(historyItem).findByText('引用元の投稿'))
+            .closest('.post-history-related-card') as HTMLElement;
+        await fireEvent.click(within(quoteCard).getByRole('button', {
+            name: 'アクションを表示',
+        }));
+        await waitForOpenRecordActionMenu();
+        expectDeleteSeparatorInOpenMenu(true);
+    });
+
+    it('[record-action-items-node-separator] thread node keeps the delete separator', async () => {
+        const { parentRecord, post, replyId } = createReplyContextRecords();
+        const ownParentRecord = {
+            ...parentRecord,
+            pubkeyHex: 'a'.repeat(64),
+            rawEvent: {
+                ...parentRecord.rawEvent,
+                pubkey: 'a'.repeat(64),
+            },
+        };
+        repositoryMock.getPage.mockResolvedValue([post]);
+        repositoryMock.countForPubkey.mockResolvedValue(1);
+        repositoryMock.getByEventId.mockImplementation(async (eventId: string) =>
+            eventId === replyId ? ownParentRecord : null,
+        );
+
+        render(PostHistoryDialog, {
+            props: { show: true, onClose: vi.fn(), pubkeyHex: 'a'.repeat(64) },
+        });
+
+        await fireEvent.click(await screen.findByRole('button', { name: '返信先を見る' }));
+        const relatedNode = (await screen.findByText('返信先の投稿'))
+            .closest('.post-history-thread-node-anchor') as HTMLElement;
+        await fireEvent.click(within(relatedNode).getByRole('button', {
+            name: 'アクションを表示',
+        }));
+        await waitForOpenRecordActionMenu();
+        expectDeleteSeparatorInOpenMenu(true);
     });
 
 });

--- a/src/test/unit/postHistoryRecordActionItems.test.ts
+++ b/src/test/unit/postHistoryRecordActionItems.test.ts
@@ -1,0 +1,133 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { describe, expect, it, vi } from "vitest";
+import { readable } from "svelte/store";
+import PostHistoryRecordActionItemsHarness from "./fixtures/PostHistoryRecordActionItemsHarness.svelte";
+
+vi.mock("svelte-i18n", () => ({
+    _: readable((key: string) => {
+        const messages: Record<string, string> = {
+            "postHistory.copyNevent": "neventをコピー",
+            "postHistory.copyFailed": "コピーに失敗しました",
+            "postHistory.rawJson": "イベントJSONを表示",
+            "postHistory.broadcast": "ブロードキャスト",
+            "postHistory.delete": "削除",
+            "postHistory.deleteSending": "送信中",
+        };
+        return messages[key] ?? key;
+    }),
+    locale: readable("ja-JP"),
+}));
+
+function menuItemNames(): string[] {
+    return screen
+        .getAllByRole("menuitem", { hidden: true })
+        .map((item) => item.textContent?.trim() ?? "");
+}
+
+describe("PostHistoryRecordActionItems", () => {
+    it("standard order keeps a delete separator only when requested", () => {
+        const { container } = render(PostHistoryRecordActionItemsHarness, {
+            showDeleteSeparator: false,
+        });
+
+        expect(menuItemNames()).toEqual([
+            "neventをコピー",
+            "イベントJSONを表示",
+            "ブロードキャスト",
+            "削除",
+        ]);
+        expect(container.ownerDocument.querySelectorAll(".post-history-menu-separator")).toHaveLength(0);
+    });
+
+    it("keeps the thread-node raw JSON first order and delete separator", () => {
+        const { container } = render(PostHistoryRecordActionItemsHarness, {
+            order: "raw-json-first",
+            showDeleteSeparator: true,
+        });
+
+        expect(menuItemNames()).toEqual([
+            "イベントJSONを表示",
+            "neventをコピー",
+            "ブロードキャスト",
+            "削除",
+        ]);
+        expect(container.ownerDocument.querySelectorAll(".post-history-menu-separator")).toHaveLength(1);
+    });
+
+    it("does not leave a separator when delete is hidden", () => {
+        const { container } = render(PostHistoryRecordActionItemsHarness, {
+            showDelete: false,
+            showDeleteSeparator: true,
+        });
+
+        expect(menuItemNames()).toEqual([
+            "neventをコピー",
+            "イベントJSONを表示",
+            "ブロードキャスト",
+        ]);
+        expect(container.ownerDocument.querySelectorAll(".post-history-menu-separator")).toHaveLength(0);
+    });
+
+    it("forwards action callbacks in the existing pointer and selection order", async () => {
+        const onCopyPointerDown = vi.fn();
+        const onCopyNevent = vi.fn();
+        const onShowRawJson = vi.fn();
+        const onBroadcastPointerDown = vi.fn();
+        const onBroadcastPost = vi.fn();
+        const onOpenDeleteConfirm = vi.fn();
+
+        render(PostHistoryRecordActionItemsHarness, {
+            onCopyPointerDown,
+            onCopyNevent,
+        });
+
+        const copy = screen.getByRole("menuitem", { name: "neventをコピー" });
+        await fireEvent.pointerDown(copy);
+        await fireEvent.click(copy);
+
+        expect(onCopyPointerDown).toHaveBeenCalledTimes(1);
+        expect(onCopyNevent).toHaveBeenCalledTimes(1);
+
+        cleanup();
+        render(PostHistoryRecordActionItemsHarness, { onShowRawJson });
+        await fireEvent.click(
+            screen.getByRole("menuitem", { name: "イベントJSONを表示" }),
+        );
+        expect(onShowRawJson).toHaveBeenCalledTimes(1);
+
+        cleanup();
+        render(PostHistoryRecordActionItemsHarness, {
+            onBroadcastPointerDown,
+            onBroadcastPost,
+        });
+        const broadcast = screen.getByRole("menuitem", { name: "ブロードキャスト" });
+        await fireEvent.pointerDown(broadcast);
+        await fireEvent.click(broadcast);
+        expect(onBroadcastPointerDown).toHaveBeenCalledTimes(1);
+        expect(onBroadcastPost).toHaveBeenCalledTimes(1);
+
+        cleanup();
+        render(PostHistoryRecordActionItemsHarness, { onOpenDeleteConfirm });
+        await fireEvent.click(screen.getByRole("menuitem", { name: "削除" }));
+        expect(onOpenDeleteConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps a sending broadcast item disabled", async () => {
+        const onBroadcastPointerDown = vi.fn();
+        const onBroadcastPost = vi.fn();
+
+        render(PostHistoryRecordActionItemsHarness, {
+            broadcastSending: true,
+            onBroadcastPointerDown,
+            onBroadcastPost,
+        });
+
+        const broadcast = screen.getByRole("menuitem", { name: "ブロードキャスト" });
+        await fireEvent.pointerDown(broadcast);
+        await fireEvent.click(broadcast);
+
+        expect(broadcast.hasAttribute("data-disabled")).toBe(true);
+        expect(onBroadcastPointerDown).toHaveBeenCalledTimes(1);
+        expect(onBroadcastPost).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

- Extract post history copy, raw JSON, broadcast, and delete actions into a shared presentational component.
- Preserve surface-specific action order and delete separator behavior, including no separator in the normal post header.
- Add component and surface regression coverage for action order, callbacks, disabled state, and separators.

## Validation

- `npm test` — 314 files / 3,551 tests passed
- `npm run check` — 0 errors, 0 warnings
- `npx playwright test src/test/e2e/postHistoryDialog.spec.ts --project=desktop-chromium --project=mobile-chromium` — 20 passed / 10 skipped