### PR TITLE
Fix post history boundary query performance

### DIFF
--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -170,6 +170,7 @@ interface LoadOlderVisiblePostsOptions {
     metrics?: LoadOlderVisiblePostsMetrics;
     reason?: LoadOlderVisiblePostsReason;
     useContiguousProgress?: boolean;
+    preserveContiguousProgressAfterDatabaseChange?: boolean;
 }
 
 interface ContiguousProgressSnapshot {
@@ -1679,6 +1680,7 @@ export function usePostHistoryListing({
     async function reconcileContiguousProgressAfterDatabaseChange(
         pubkeyHex: string,
         visibleUntil: number | null,
+        options: { preserveReachedVisibleCount: boolean },
     ): Promise<boolean> {
         const snapshot = contiguousProgress;
         if (
@@ -1689,6 +1691,13 @@ export function usePostHistoryListing({
             || state.sparseSource !== null
             || getPubkeyHex() !== pubkeyHex
         ) {
+            return false;
+        }
+
+        // Only the older relay backfill path can prove that new visible
+        // records are strictly older than the current cursor. Other DB
+        // changes may add or reorder records above the cursor and must rebase.
+        if (!options.preserveReachedVisibleCount) {
             return false;
         }
 
@@ -1996,9 +2005,13 @@ export function usePostHistoryListing({
         {
             forceTotalCount = false,
             skipTotalCountRefresh = false,
+            skipOlderAvailabilityCheck = false,
+            awaitProgress = false,
         }: {
             forceTotalCount?: boolean;
             skipTotalCountRefresh?: boolean;
+            skipOlderAvailabilityCheck?: boolean;
+            awaitProgress?: boolean;
         } = {},
     ): Promise<void> {
         clearContiguousProgress();
@@ -2052,9 +2065,15 @@ export function usePostHistoryListing({
             visibleUntil,
             revisionBeforeLatestQuery,
         );
-        void progressReady.catch(() => {
-            clearContiguousProgress();
-        });
+        if (awaitProgress) {
+            await progressReady.catch(() => {
+                clearContiguousProgress();
+            });
+        } else {
+            void progressReady.catch(() => {
+                clearContiguousProgress();
+            });
+        }
 
         void refreshSavedPostsOutsideVisibleRange(
             pubkeyHex,
@@ -2064,7 +2083,12 @@ export function usePostHistoryListing({
             // Saved-range detection is auxiliary and must not delay the first post.
         });
 
-        void refreshTimelineAvailability(pubkeyHex, latestPosts, requestId)
+        void refreshTimelineAvailability(
+            pubkeyHex,
+            latestPosts,
+            requestId,
+            { skipOlderCheck: skipOlderAvailabilityCheck },
+        )
             .then(() => {
                 if (
                     !getShow()
@@ -2328,6 +2352,9 @@ export function usePostHistoryListing({
 
         const useContiguousProgress = options.useContiguousProgress !== false
             && contiguousProgress !== null;
+        const progressToExtend = options.preserveContiguousProgressAfterDatabaseChange
+            ? contiguousProgress
+            : null;
 
         const requestId = ++loadRequestId;
         const progress = useContiguousProgress
@@ -2444,22 +2471,24 @@ export function usePostHistoryListing({
                     mergedResult.posts[mergedResult.posts.length - 1],
                 ) ?? progressAfterQuery.oldestCursor,
             };
-        } else if (!useContiguousProgress) {
-            const didReconcile = await reconcileContiguousProgressAfterDatabaseChange(
-                pubkeyHex,
-                visibleUntil,
-            );
-            if (didReconcile && contiguousProgress) {
+        } else if (
+            !useContiguousProgress
+            && progressToExtend
+            && getPostHistorySearchRevision(pubkeyHex) === progressToExtend.revision
+        ) {
+            if (sameTimelineCursor(oldestCursor, progressToExtend.oldestCursor)) {
                 contiguousProgress = {
-                    ...contiguousProgress,
+                    ...progressToExtend,
                     reachedVisibleCount: Math.min(
-                        contiguousProgress.totalVisibleCount,
-                        contiguousProgress.reachedVisibleCount + newlyVisibleCount,
+                        progressToExtend.totalVisibleCount,
+                        progressToExtend.reachedVisibleCount + newlyVisibleCount,
                     ),
                     oldestCursor: toTimelineCursor(
                         mergedResult.posts[mergedResult.posts.length - 1],
-                    ) ?? contiguousProgress.oldestCursor,
+                    ) ?? progressToExtend.oldestCursor,
                 };
+            } else {
+                clearContiguousProgress();
             }
         }
         const hasReachedVisibleEnd = !!contiguousProgress
@@ -3199,32 +3228,27 @@ export function usePostHistoryListing({
                 state.searchQuery,
             );
         } else if (refreshDecision.applyAction === "load-latest-visible-posts") {
+            const requiresBoundedRebase =
+                refreshDecision.didMateriallyChange
+                && !refreshDecision.didVisibleMateriallyChange;
             await loadLatestVisiblePosts({
                 forceTotalCount: refreshDecision.didMateriallyChange,
+                skipOlderAvailabilityCheck: requiresBoundedRebase,
+                awaitProgress: requiresBoundedRebase,
             });
         } else if (
             refreshDecision.applyAction === "refresh-count-and-availability"
         ) {
-            if (refreshDecision.didVisibleMateriallyChange) {
-                // A changed visible frontier can expose a different contiguous
-                // range. Rebuild the latest window so the progress snapshot is
-                // re-established against that frontier before paging resumes.
+            if (refreshDecision.didMateriallyChange) {
+                // Any dialog-open insert/update can add or reorder records above
+                // the current cursor. Rebuild the latest window and establish a
+                // fresh progress snapshot instead of carrying reached forward.
                 await loadLatestVisiblePosts({
                     forceTotalCount: refreshDecision.didMateriallyChange,
+                    skipOlderAvailabilityCheck:
+                        !refreshDecision.didVisibleMateriallyChange,
+                    awaitProgress: !refreshDecision.didVisibleMateriallyChange,
                 });
-            } else if (await reconcileContiguousProgressAfterDatabaseChange(
-                pubkeyHex,
-                nextVisibleUntil,
-            )) {
-                refreshTotalCountFromRepository({
-                    force: refreshDecision.didMateriallyChange,
-                });
-                await refreshTimelineAvailability(
-                    pubkeyHex,
-                    state.loadedPosts,
-                    null,
-                    { skipOlderCheck: true },
-                );
             } else {
                 clearContiguousProgress();
                 refreshTotalCountFromRepository({
@@ -3584,11 +3608,14 @@ export function usePostHistoryListing({
                 return batchChanged;
             }
 
+            let canPreserveContiguousProgress = false;
             if (!isSparseBackfillContext) {
-                await reconcileContiguousProgressAfterDatabaseChange(
-                    pubkeyHex,
-                    effectiveVisibleUntil,
-                );
+                canPreserveContiguousProgress =
+                    await reconcileContiguousProgressAfterDatabaseChange(
+                        pubkeyHex,
+                        effectiveVisibleUntil,
+                        { preserveReachedVisibleCount: true },
+                    );
             }
 
             await refreshSavedPostsOutsideVisibleRange(
@@ -3684,6 +3711,8 @@ export function usePostHistoryListing({
                                 metrics: olderLoadMetrics,
                                 reason: "normal-older-reveal",
                                 useContiguousProgress: false,
+                                preserveContiguousProgressAfterDatabaseChange:
+                                    canPreserveContiguousProgress,
                             });
                 } else {
                     await refreshTimelineAvailability(pubkeyHex);

--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -1625,7 +1625,7 @@ export function usePostHistoryListing({
         latestPosts: PostHistoryRecord[],
         visibleUntil: number | null,
         revisionBeforeQuery: number,
-    ): Promise<void> {
+    ): Promise<boolean> {
         clearContiguousProgress();
         if (
             latestPosts.length === 0
@@ -1635,7 +1635,7 @@ export function usePostHistoryListing({
             || state.listingMode !== "contiguous"
             || state.sparseSource !== null
         ) {
-            return;
+            return false;
         }
 
         const totalVisibleCount = await countVisiblePostsForProgress(
@@ -1656,14 +1656,14 @@ export function usePostHistoryListing({
             || state.loadedPosts[state.loadedPosts.length - 1]?.eventId !==
                 latestPosts[latestPosts.length - 1]?.eventId
         ) {
-            return;
+            return false;
         }
 
         const oldestCursor = toTimelineCursor(
             latestPosts[latestPosts.length - 1],
         );
         if (!oldestCursor) {
-            return;
+            return false;
         }
 
         contiguousProgress = {
@@ -1675,6 +1675,7 @@ export function usePostHistoryListing({
             oldestCursor,
             latestEventId: latestPosts[0]?.eventId ?? null,
         };
+        return true;
     }
 
     async function reconcileContiguousProgressAfterDatabaseChange(
@@ -2065,14 +2066,30 @@ export function usePostHistoryListing({
             visibleUntil,
             revisionBeforeLatestQuery,
         );
+        let progressEstablished = false;
         if (awaitProgress) {
-            await progressReady.catch(() => {
+            progressEstablished = await progressReady.catch(() => {
                 clearContiguousProgress();
+                return false;
             });
         } else {
             void progressReady.catch(() => {
                 clearContiguousProgress();
             });
+        }
+
+        const canSkipOlderAvailability =
+            skipOlderAvailabilityCheck && progressEstablished;
+        if (skipOlderAvailabilityCheck && !canSkipOlderAvailability) {
+            // A failed/stale rebase must not leave the previous window's
+            // availability value visible while the safe query recomputes it.
+            state.hasOlderLocal = false;
+        } else if (canSkipOlderAvailability && contiguousProgress) {
+            // The awaited snapshot describes this exact latest window, so its
+            // remaining visible count is the authoritative older availability.
+            state.hasOlderLocal =
+                contiguousProgress.totalVisibleCount
+                > contiguousProgress.reachedVisibleCount;
         }
 
         void refreshSavedPostsOutsideVisibleRange(
@@ -2087,7 +2104,7 @@ export function usePostHistoryListing({
             pubkeyHex,
             latestPosts,
             requestId,
-            { skipOlderCheck: skipOlderAvailabilityCheck },
+            { skipOlderCheck: canSkipOlderAvailability },
         )
             .then(() => {
                 if (

--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -44,6 +44,7 @@ import {
     postHistoryCurrentViewRefetchService,
     type PostHistoryCurrentViewRefetchTask,
 } from "../postHistoryCurrentViewRefetchService";
+import { getPostHistorySearchRevision } from "../postHistoryLocalSearchRevision";
 import {
     type PostHistoryVisibleRangeRelationRepairRequest,
 } from "../postHistoryVisibleRangeChildInteractionRepairService";
@@ -168,6 +169,17 @@ interface LoadOlderVisiblePostsOptions {
     anchorEventId?: string | null;
     metrics?: LoadOlderVisiblePostsMetrics;
     reason?: LoadOlderVisiblePostsReason;
+    useContiguousProgress?: boolean;
+}
+
+interface ContiguousProgressSnapshot {
+    pubkeyHex: string;
+    visibleUntil: number | null;
+    revision: number;
+    totalVisibleCount: number;
+    reachedVisibleCount: number;
+    oldestCursor: PostHistoryTimelineCursor;
+    latestEventId: string | null;
 }
 
 type LoadOlderVisiblePostsReason = "normal-older-reveal";
@@ -643,6 +655,7 @@ export function usePostHistoryListing({
     let currentFetchTask: PostHistoryRelayFetchTask | PostHistoryLightweightAuthoredSyncTask | null = null;
     let fetchRequestId = 0;
     let currentViewRefetchTask: PostHistoryCurrentViewRefetchTask | null = null;
+    let contiguousProgress: ContiguousProgressSnapshot | null = null;
     let currentViewRefetchMessageClearTimeout: ReturnType<typeof setTimeout> | null = null;
     let syncStatusMessageClearTimeout: ReturnType<typeof setTimeout> | null = null;
     let activeOlderRevealChildInteractionRepairRxNostr = getRxNostr();
@@ -810,6 +823,20 @@ export function usePostHistoryListing({
         currentFetchTask = null;
     }
 
+    function clearContiguousProgress(): void {
+        contiguousProgress = null;
+    }
+
+    function sameTimelineCursor(
+        left: PostHistoryTimelineCursor | null | undefined,
+        right: PostHistoryTimelineCursor | null | undefined,
+    ): boolean {
+        return !!left && !!right
+            && left.postedAt === right.postedAt
+            && left.createdAt === right.createdAt
+            && left.eventId === right.eventId;
+    }
+
     function isCurrentFetchRequest(requestId: number): boolean {
         return requestId === fetchRequestId;
     }
@@ -960,6 +987,7 @@ export function usePostHistoryListing({
     }
 
     function clearCurrentListingState(): void {
+        clearContiguousProgress();
         invalidateTotalCountRequest();
         state.loadedPosts = [];
         setTotalCountState({ known: false, status: "unknown" });
@@ -989,6 +1017,7 @@ export function usePostHistoryListing({
     }
 
     function resetListingStateAfterLocalDelete(): void {
+        clearContiguousProgress();
         invalidateTotalCountRequest();
         relationRepairCoordinator.resetOlderRevealRepairContext();
         state.loadedPosts = [];
@@ -1042,6 +1071,7 @@ export function usePostHistoryListing({
     }
 
     function invalidatePendingLoadRequests(): void {
+        clearContiguousProgress();
         loadRequestId += 1;
         searchLoadRequestId += 1;
         isSearchPageLoading = false;
@@ -1505,6 +1535,199 @@ export function usePostHistoryListing({
             : postHistoryRepository.countForPubkey(pubkeyHex);
     }
 
+    async function countVisiblePostsForProgress(
+        pubkeyHex: string,
+        visibleUntil: number | null,
+    ): Promise<number> {
+        if (typeof visibleUntil === "number") {
+            return postHistoryRepository.countVisibleForPubkey(
+                pubkeyHex,
+                visibleUntil,
+            );
+        }
+
+        const pendingTotalCount = currentTotalCountRequest;
+        if (pendingTotalCount?.pubkeyHex === pubkeyHex) {
+            await pendingTotalCount.promise;
+            if (state.totalCountKnown) {
+                return state.totalCount;
+            }
+        }
+
+        if (state.totalCountKnown) {
+            return state.totalCount;
+        }
+
+        return postHistoryRepository.countForPubkey(pubkeyHex);
+    }
+
+    function isContiguousProgressShapeValid(
+        pubkeyHex: string,
+        snapshot: ContiguousProgressSnapshot,
+    ): boolean {
+        if (
+            isSearchMode
+            || state.listingMode !== "contiguous"
+            || state.sparseSource !== null
+            || getPubkeyHex() !== pubkeyHex
+            || state.visibleUntil !== snapshot.visibleUntil
+        ) {
+            return false;
+        }
+
+        const oldestCursor = toTimelineCursor(
+            state.loadedPosts[state.loadedPosts.length - 1],
+        );
+        return sameTimelineCursor(oldestCursor, snapshot.oldestCursor);
+    }
+
+    async function validateContiguousProgress(
+        pubkeyHex: string,
+        expectedRequestId: number,
+    ): Promise<ContiguousProgressSnapshot | null> {
+        const snapshot = contiguousProgress;
+        if (!snapshot || snapshot.pubkeyHex !== pubkeyHex) {
+            return null;
+        }
+
+        const visibleUntil = await refreshVisibleUntil(
+            pubkeyHex,
+            expectedRequestId,
+        );
+        if (
+            !getShow()
+            || getPubkeyHex() !== pubkeyHex
+            || expectedRequestId !== loadRequestId
+            || !isContiguousProgressShapeValid(pubkeyHex, snapshot)
+        ) {
+            return null;
+        }
+
+        const [revision, totalVisibleCount] = await Promise.all([
+            Promise.resolve(getPostHistorySearchRevision(pubkeyHex)),
+            countVisiblePostsForProgress(pubkeyHex, visibleUntil),
+        ]);
+        if (
+            !isContiguousProgressShapeValid(pubkeyHex, snapshot)
+            || revision !== snapshot.revision
+            || totalVisibleCount !== snapshot.totalVisibleCount
+        ) {
+            return null;
+        }
+
+        return snapshot;
+    }
+
+    async function establishContiguousProgress(
+        pubkeyHex: string,
+        requestId: number,
+        latestPosts: PostHistoryRecord[],
+        visibleUntil: number | null,
+        revisionBeforeQuery: number,
+    ): Promise<void> {
+        clearContiguousProgress();
+        if (
+            latestPosts.length === 0
+            || !getShow()
+            || getPubkeyHex() !== pubkeyHex
+            || requestId !== loadRequestId
+            || state.listingMode !== "contiguous"
+            || state.sparseSource !== null
+        ) {
+            return;
+        }
+
+        const totalVisibleCount = await countVisiblePostsForProgress(
+            pubkeyHex,
+            visibleUntil,
+        );
+        const currentVisibleUntil = await readVisibleUntil(pubkeyHex);
+        const revisionAfterQuery = getPostHistorySearchRevision(pubkeyHex);
+        if (
+            revisionAfterQuery !== revisionBeforeQuery
+            || currentVisibleUntil !== visibleUntil
+            || !getShow()
+            || getPubkeyHex() !== pubkeyHex
+            || requestId !== loadRequestId
+            || state.listingMode !== "contiguous"
+            || state.sparseSource !== null
+            || state.loadedPosts[0]?.eventId !== latestPosts[0]?.eventId
+            || state.loadedPosts[state.loadedPosts.length - 1]?.eventId !==
+                latestPosts[latestPosts.length - 1]?.eventId
+        ) {
+            return;
+        }
+
+        const oldestCursor = toTimelineCursor(
+            latestPosts[latestPosts.length - 1],
+        );
+        if (!oldestCursor) {
+            return;
+        }
+
+        contiguousProgress = {
+            pubkeyHex,
+            visibleUntil,
+            revision: revisionAfterQuery,
+            totalVisibleCount,
+            reachedVisibleCount: latestPosts.length,
+            oldestCursor,
+            latestEventId: latestPosts[0]?.eventId ?? null,
+        };
+    }
+
+    async function reconcileContiguousProgressAfterDatabaseChange(
+        pubkeyHex: string,
+        visibleUntil: number | null,
+    ): Promise<boolean> {
+        const snapshot = contiguousProgress;
+        if (
+            !snapshot
+            || snapshot.pubkeyHex !== pubkeyHex
+            || isSearchMode
+            || state.listingMode !== "contiguous"
+            || state.sparseSource !== null
+            || getPubkeyHex() !== pubkeyHex
+        ) {
+            return false;
+        }
+
+        const oldestCursor = toTimelineCursor(
+            state.loadedPosts[state.loadedPosts.length - 1],
+        );
+        if (!sameTimelineCursor(oldestCursor, snapshot.oldestCursor)) {
+            return false;
+        }
+
+        const totalVisibleCount = await countVisiblePostsForProgress(
+            pubkeyHex,
+            visibleUntil,
+        );
+        if (
+            !getShow()
+            || getPubkeyHex() !== pubkeyHex
+            || !sameTimelineCursor(
+                oldestCursor,
+                toTimelineCursor(state.loadedPosts[state.loadedPosts.length - 1]),
+            )
+        ) {
+            return false;
+        }
+
+        contiguousProgress = {
+            ...snapshot,
+            visibleUntil,
+            revision: getPostHistorySearchRevision(pubkeyHex),
+            totalVisibleCount,
+        };
+        return true;
+    }
+
+    async function rebaseContiguousProgress(): Promise<void> {
+        clearContiguousProgress();
+        await loadLatestVisiblePosts();
+    }
+
     function isSparseListingContext(
         visibleUntil: number | null,
         currentPosts: PostHistoryRecord[] = state.loadedPosts,
@@ -1695,6 +1918,7 @@ export function usePostHistoryListing({
         pubkeyHex: string,
         currentPosts: PostHistoryRecord[] = state.loadedPosts,
         expectedRequestId: number | null = null,
+        options: { skipOlderCheck?: boolean } = {},
     ): Promise<void> {
         if (currentPosts.length === 0) {
             if (
@@ -1711,47 +1935,48 @@ export function usePostHistoryListing({
         const newestCursor = toTimelineCursor(currentPosts[0]);
         const oldestCursor = toTimelineCursor(currentPosts[currentPosts.length - 1]);
         const visibleUntil = state.visibleUntil;
-        const [newerPosts, olderPosts] = await Promise.all(
-            state.sparseSource === "saved" && typeof visibleUntil === "number"
-                ? [
-                    newestCursor
-                        ? postHistoryRepository.getSparseChunk({
-                            pubkeyHex,
-                            visibleUntil,
-                            cursor: newestCursor,
-                            direction: "newer",
-                            limit: 1,
-                        })
-                        : Promise.resolve([]),
-                    oldestCursor
-                        ? postHistoryRepository.getSparseChunk({
-                            pubkeyHex,
-                            visibleUntil,
-                            cursor: oldestCursor,
-                            direction: "older",
-                            limit: 1,
-                        })
-                        : Promise.resolve([]),
-                ]
-                : [
-                    newestCursor
-                        ? postHistoryRepository.getNewerVisibleChunk({
-                            pubkeyHex,
-                            visibleUntil,
-                            cursor: newestCursor,
-                            limit: 1,
-                        })
-                        : Promise.resolve([]),
-                    oldestCursor
-                        ? postHistoryRepository.getOlderVisibleChunk({
-                            pubkeyHex,
-                            visibleUntil,
-                            cursor: oldestCursor,
-                            limit: 1,
-                        })
-                        : Promise.resolve([]),
-                ],
-        );
+        const newerPostsPromise = state.sparseSource === "saved" && typeof visibleUntil === "number"
+            ? newestCursor
+                ? postHistoryRepository.getSparseChunk({
+                    pubkeyHex,
+                    visibleUntil,
+                    cursor: newestCursor,
+                    direction: "newer",
+                    limit: 1,
+                })
+                : Promise.resolve([])
+            : newestCursor
+                ? postHistoryRepository.getNewerVisibleChunk({
+                    pubkeyHex,
+                    visibleUntil,
+                    cursor: newestCursor,
+                    limit: 1,
+                })
+                : Promise.resolve([]);
+        const olderPostsPromise = options.skipOlderCheck
+            ? Promise.resolve([])
+            : state.sparseSource === "saved" && typeof visibleUntil === "number"
+                ? oldestCursor
+                    ? postHistoryRepository.getSparseChunk({
+                        pubkeyHex,
+                        visibleUntil,
+                        cursor: oldestCursor,
+                        direction: "older",
+                        limit: 1,
+                    })
+                    : Promise.resolve([])
+                : oldestCursor
+                    ? postHistoryRepository.getOlderVisibleChunk({
+                        pubkeyHex,
+                        visibleUntil,
+                        cursor: oldestCursor,
+                        limit: 1,
+                    })
+                    : Promise.resolve([]);
+        const [newerPosts, olderPosts] = await Promise.all([
+            newerPostsPromise,
+            olderPostsPromise,
+        ]);
 
         if (
             !getShow() ||
@@ -1762,7 +1987,9 @@ export function usePostHistoryListing({
         }
 
         state.hasNewerLocal = newerPosts.length > 0;
-        state.hasOlderLocal = olderPosts.length > 0;
+        if (!options.skipOlderCheck) {
+            state.hasOlderLocal = olderPosts.length > 0;
+        }
     }
 
     async function loadLatestVisiblePosts(
@@ -1774,6 +2001,7 @@ export function usePostHistoryListing({
             skipTotalCountRefresh?: boolean;
         } = {},
     ): Promise<void> {
+        clearContiguousProgress();
         const pubkeyHex = getPubkeyHex();
         if (!pubkeyHex) {
             stateOwnerPubkeyKey = null;
@@ -1783,6 +2011,7 @@ export function usePostHistoryListing({
 
         const requestId = ++loadRequestId;
         const visibleUntil = await refreshVisibleUntil(pubkeyHex, requestId);
+        const revisionBeforeLatestQuery = getPostHistorySearchRevision(pubkeyHex);
         const latestPosts = await postHistoryRepository.getLatestVisibleChunk({
             pubkeyHex,
             limit: pageSize,
@@ -1815,6 +2044,18 @@ export function usePostHistoryListing({
         void refreshJumpCacheAnchorAvailability(pubkeyHex, requestId).catch(() => {
             // Anchor availability is auxiliary and must not delay the first post.
         });
+
+        const progressReady = establishContiguousProgress(
+            pubkeyHex,
+            requestId,
+            latestPosts,
+            visibleUntil,
+            revisionBeforeLatestQuery,
+        );
+        void progressReady.catch(() => {
+            clearContiguousProgress();
+        });
+
         void refreshSavedPostsOutsideVisibleRange(
             pubkeyHex,
             visibleUntil,
@@ -1844,6 +2085,7 @@ export function usePostHistoryListing({
     async function reloadVisibleWindowFromCurrentNewest(
         { skipTotalCountRefresh = false }: { skipTotalCountRefresh?: boolean } = {},
     ): Promise<void> {
+        clearContiguousProgress();
         const pubkeyHex = getPubkeyHex();
         if (!pubkeyHex || state.loadedPosts.length === 0) {
             await loadLatestVisiblePosts({ skipTotalCountRefresh });
@@ -1912,6 +2154,7 @@ export function usePostHistoryListing({
         scrollState: PostHistoryDialogScrollState | null,
         pendingLatestRequest: PendingPostHistoryLatestRequest | null,
     ): Promise<void> {
+        clearContiguousProgress();
         const pubkeyHex = getPubkeyHex();
         const currentPosts = state.loadedPosts;
         const newestCursor = toTimelineCursor(currentPosts[0]);
@@ -2001,6 +2244,7 @@ export function usePostHistoryListing({
     async function loadVisibleWindowAroundSessionAnchor(
         scrollState: PostHistoryDialogScrollState,
     ): Promise<boolean> {
+        clearContiguousProgress();
         const pubkeyHex = getPubkeyHex();
         if (!pubkeyHex || !getShow()) {
             return false;
@@ -2082,13 +2326,55 @@ export function usePostHistoryListing({
             return state.loadedPosts.length > 0;
         }
 
+        const useContiguousProgress = options.useContiguousProgress !== false
+            && contiguousProgress !== null;
+
         const requestId = ++loadRequestId;
-        const visibleUntil = await refreshVisibleUntil(pubkeyHex);
+        const progress = useContiguousProgress
+            ? await validateContiguousProgress(pubkeyHex, requestId)
+            : null;
+        if (useContiguousProgress && !progress) {
+            await rebaseContiguousProgress();
+            if (metrics) {
+                metrics.loadedPostsAfterLength = state.loadedPosts.length;
+                metrics.visibleOldestAfter = state.loadedPosts.length > 0
+                    ? state.loadedPosts[state.loadedPosts.length - 1]?.createdAt ?? null
+                    : null;
+            }
+            return false;
+        }
+
+        const visibleUntil = progress?.visibleUntil ??
+            await refreshVisibleUntil(pubkeyHex, requestId);
+        const remainingVisibleCount = progress
+            ? Math.max(
+                0,
+                progress.totalVisibleCount - progress.reachedVisibleCount,
+            )
+            : pageSize;
+        if (progress && remainingVisibleCount === 0) {
+            state.hasOlderLocal = false;
+            if (metrics) {
+                metrics.loadedPostsAfterLength = state.loadedPosts.length;
+                metrics.visibleOldestAfter = state.loadedPosts.length > 0
+                    ? state.loadedPosts[state.loadedPosts.length - 1]?.createdAt ?? null
+                    : null;
+            }
+            await refreshTimelineAvailability(
+                pubkeyHex,
+                state.loadedPosts,
+                requestId,
+                { skipOlderCheck: true },
+            );
+            return false;
+        }
+
+        const queryLimit = Math.min(pageSize, remainingVisibleCount);
         const olderPosts = await postHistoryRepository.getOlderVisibleChunk({
             pubkeyHex,
             visibleUntil,
             cursor: oldestCursor,
-            limit: pageSize,
+            limit: queryLimit,
         });
         if (metrics) {
             metrics.olderPostsLength = olderPosts.length;
@@ -2098,8 +2384,23 @@ export function usePostHistoryListing({
             return false;
         }
 
+        const progressAfterQuery = progress
+            ? await validateContiguousProgress(pubkeyHex, requestId)
+            : null;
+        if (progress && !progressAfterQuery) {
+            await rebaseContiguousProgress();
+            return false;
+        }
+
         if (olderPosts.length === 0) {
-            state.hasOlderLocal = false;
+            if (progress) {
+                // A non-zero remaining count is an invariant violation unless
+                // the database changed between the bounded query and this
+                // check. Do not convert it into a false end-of-history result.
+                await rebaseContiguousProgress();
+            } else {
+                state.hasOlderLocal = false;
+            }
             if (metrics) {
                 metrics.loadedPostsAfterLength = state.loadedPosts.length;
                 metrics.visibleOldestAfter =
@@ -2131,6 +2432,39 @@ export function usePostHistoryListing({
         if (mergedResult.didDeferOlderPosts) {
             state.hasOlderLocal = true;
         }
+        const newlyVisibleCount = newlyVisibleOlderPosts.length;
+        if (progressAfterQuery) {
+            contiguousProgress = {
+                ...progressAfterQuery,
+                reachedVisibleCount: Math.min(
+                    progressAfterQuery.totalVisibleCount,
+                    progressAfterQuery.reachedVisibleCount + newlyVisibleCount,
+                ),
+                oldestCursor: toTimelineCursor(
+                    mergedResult.posts[mergedResult.posts.length - 1],
+                ) ?? progressAfterQuery.oldestCursor,
+            };
+        } else if (!useContiguousProgress) {
+            const didReconcile = await reconcileContiguousProgressAfterDatabaseChange(
+                pubkeyHex,
+                visibleUntil,
+            );
+            if (didReconcile && contiguousProgress) {
+                contiguousProgress = {
+                    ...contiguousProgress,
+                    reachedVisibleCount: Math.min(
+                        contiguousProgress.totalVisibleCount,
+                        contiguousProgress.reachedVisibleCount + newlyVisibleCount,
+                    ),
+                    oldestCursor: toTimelineCursor(
+                        mergedResult.posts[mergedResult.posts.length - 1],
+                    ) ?? contiguousProgress.oldestCursor,
+                };
+            }
+        }
+        const hasReachedVisibleEnd = !!contiguousProgress
+            && contiguousProgress.reachedVisibleCount >=
+                contiguousProgress.totalVisibleCount;
         if (metrics) {
             metrics.loadedPostsAfterLength = mergedResult.posts.length;
             metrics.visibleOldestAfter =
@@ -2140,7 +2474,12 @@ export function usePostHistoryListing({
             metrics.didTrimForOlderAppend = mergedResult.didTrimForOlderAppend;
             metrics.didDeferOlderPosts = mergedResult.didDeferOlderPosts;
         }
-        await refreshTimelineAvailability(pubkeyHex, mergedResult.posts, requestId);
+        await refreshTimelineAvailability(
+            pubkeyHex,
+            mergedResult.posts,
+            requestId,
+            { skipOlderCheck: useContiguousProgress && hasReachedVisibleEnd },
+        );
         return true;
     }
 
@@ -2149,6 +2488,7 @@ export function usePostHistoryListing({
         requestId: number,
         options: LoadOlderVisiblePostsOptions = {},
     ): Promise<boolean> {
+        clearContiguousProgress();
         const currentLoadedPosts = state.loadedPosts;
         const oldestCreatedAt =
             currentLoadedPosts.length > 0
@@ -2196,6 +2536,7 @@ export function usePostHistoryListing({
         requestId: number,
         options: LoadOlderVisiblePostsOptions = {},
     ): Promise<boolean> {
+        clearContiguousProgress();
         const currentLoadedPosts = state.loadedPosts;
         if (typeof state.visibleUntil !== "number") {
             return false;
@@ -2247,7 +2588,16 @@ export function usePostHistoryListing({
         }
 
         const requestId = ++loadRequestId;
-        const visibleUntil = await refreshVisibleUntil(pubkeyHex);
+        const progressBefore = contiguousProgress;
+        const progress = progressBefore
+            ? await validateContiguousProgress(pubkeyHex, requestId)
+            : null;
+        if (progressBefore && !progress) {
+            await rebaseContiguousProgress();
+            return false;
+        }
+        const visibleUntil = progress?.visibleUntil ??
+            await refreshVisibleUntil(pubkeyHex, requestId);
         const newerPosts = await postHistoryRepository.getNewerVisibleChunk({
             pubkeyHex,
             visibleUntil,
@@ -2264,20 +2614,48 @@ export function usePostHistoryListing({
             return false;
         }
 
+        if (progress) {
+            const progressAfterQuery = await validateContiguousProgress(
+                pubkeyHex,
+                requestId,
+            );
+            if (!progressAfterQuery) {
+                await rebaseContiguousProgress();
+                return false;
+            }
+        }
+
+        const currentPosts = state.loadedPosts;
         const nextPosts = trimVisiblePosts(
-            [...newerPosts, ...state.loadedPosts],
+            [...newerPosts, ...currentPosts],
             "newer",
         );
+        state.loadedPosts = nextPosts;
+        if (progress) {
+            const removedOlderCount = Math.max(
+                0,
+                currentPosts.length + newerPosts.length - nextPosts.length,
+            );
+            contiguousProgress = {
+                ...progress,
+                reachedVisibleCount: Math.max(
+                    0,
+                    progress.reachedVisibleCount - removedOlderCount,
+                ),
+                oldestCursor: toTimelineCursor(
+                    nextPosts[nextPosts.length - 1],
+                ) ?? progress.oldestCursor,
+            };
+        }
         await refreshTimelineAvailability(pubkeyHex, nextPosts, requestId);
         if (!getShow() || requestId !== loadRequestId) {
             return false;
         }
-
-        state.loadedPosts = nextPosts;
         return true;
     }
 
     async function jumpToCreatedAt(createdAt: number): Promise<boolean> {
+        clearContiguousProgress();
         const pubkeyHex = getPubkeyHex();
         if (!pubkeyHex) {
             return false;
@@ -2646,6 +3024,7 @@ export function usePostHistoryListing({
     }
 
     async function bootstrapFromRelays(): Promise<void> {
+        clearContiguousProgress();
         const pubkeyHex = getPubkeyHex();
         const rxNostr = getRxNostr();
         if (!pubkeyHex || !rxNostr) {
@@ -2826,10 +3205,33 @@ export function usePostHistoryListing({
         } else if (
             refreshDecision.applyAction === "refresh-count-and-availability"
         ) {
-            refreshTotalCountFromRepository({
-                force: refreshDecision.didMateriallyChange,
-            });
-            await refreshTimelineAvailability(pubkeyHex);
+            if (refreshDecision.didVisibleMateriallyChange) {
+                // A changed visible frontier can expose a different contiguous
+                // range. Rebuild the latest window so the progress snapshot is
+                // re-established against that frontier before paging resumes.
+                await loadLatestVisiblePosts({
+                    forceTotalCount: refreshDecision.didMateriallyChange,
+                });
+            } else if (await reconcileContiguousProgressAfterDatabaseChange(
+                pubkeyHex,
+                nextVisibleUntil,
+            )) {
+                refreshTotalCountFromRepository({
+                    force: refreshDecision.didMateriallyChange,
+                });
+                await refreshTimelineAvailability(
+                    pubkeyHex,
+                    state.loadedPosts,
+                    null,
+                    { skipOlderCheck: true },
+                );
+            } else {
+                clearContiguousProgress();
+                refreshTotalCountFromRepository({
+                    force: refreshDecision.didMateriallyChange,
+                });
+                await refreshTimelineAvailability(pubkeyHex);
+            }
         }
     }
 
@@ -3182,6 +3584,13 @@ export function usePostHistoryListing({
                 return batchChanged;
             }
 
+            if (!isSparseBackfillContext) {
+                await reconcileContiguousProgressAfterDatabaseChange(
+                    pubkeyHex,
+                    effectiveVisibleUntil,
+                );
+            }
+
             await refreshSavedPostsOutsideVisibleRange(
                 pubkeyHex,
                 effectiveVisibleUntil,
@@ -3274,6 +3683,7 @@ export function usePostHistoryListing({
                                 anchorEventId: options.anchorEventId,
                                 metrics: olderLoadMetrics,
                                 reason: "normal-older-reveal",
+                                useContiguousProgress: false,
                             });
                 } else {
                     await refreshTimelineAvailability(pubkeyHex);
@@ -3400,6 +3810,7 @@ export function usePostHistoryListing({
     }
 
     async function refetchAroundCurrentView(): Promise<void> {
+        clearContiguousProgress();
         const pubkeyHex = getPubkeyHex();
         const rxNostr = getRxNostr();
         if (!pubkeyHex || !rxNostr || !canRefetchAroundCurrentView) {
@@ -3600,6 +4011,7 @@ export function usePostHistoryListing({
     }
 
     async function loadNewerSparsePosts(): Promise<boolean> {
+        clearContiguousProgress();
         const pubkeyHex = getPubkeyHex();
         const newestCursor = toTimelineCursor(state.loadedPosts[0]);
         if (!pubkeyHex || !newestCursor || typeof state.visibleUntil !== "number") {
@@ -3633,6 +4045,7 @@ export function usePostHistoryListing({
     }
 
     async function refreshAfterLocalImport(): Promise<void> {
+        clearContiguousProgress();
         if (!getPubkeyHex()) {
             return;
         }

--- a/src/lib/storage/postHistoryRepository.ts
+++ b/src/lib/storage/postHistoryRepository.ts
@@ -692,50 +692,37 @@ export class DexiePostHistoryRepository implements PostHistoryRepository {
                 )
             );
 
-        const lowerPostedAt = options.direction === "newer" && cursor
-            ? cursor.postedAt
-            : Dexie.minKey;
-        const upperPostedAt = options.direction === "older" && cursor
-            ? cursor.postedAt
-            : Dexie.maxKey;
-        const postedAtRange = this.db.postHistory
-            .where("[pubkeyHex+postedAt]")
-            .between(
-                [options.pubkeyHex, lowerPostedAt],
-                [options.pubkeyHex, upperPostedAt],
-                true,
-                true,
-            );
-        const candidates = await (
+        const bounds = getTimelineBounds(options.pubkeyHex);
+        const cursorKey = cursor
+            ? toTimelineKey(options.pubkeyHex, cursor)
+            : null;
+        const range = options.direction === "latest"
+            ? this.db.postHistory
+                .where(POST_HISTORY_TIMELINE_INDEX)
+                .between(bounds.lower, bounds.upper)
+            : options.direction === "older"
+                ? this.db.postHistory
+                    .where(POST_HISTORY_TIMELINE_INDEX)
+                    .between(bounds.lower, cursorKey!, true, false)
+                : this.db.postHistory
+                    .where(POST_HISTORY_TIMELINE_INDEX)
+                    .between(cursorKey!, bounds.upper, false, true);
+
+        const records = await (
             options.direction === "newer"
-                ? postedAtRange
-                : postedAtRange.reverse()
+                ? range
+                : range.reverse()
         )
             .filter(matchesSparseRange)
             .limit(limit)
             .toArray();
 
-        if (candidates.length === 0) {
-            return [];
-        }
-
-        const boundaryPostedAt = candidates[candidates.length - 1]!.postedAt;
-        const boundaryRecords = candidates.length < limit
-            ? []
-            : await this.db.postHistory
-                .where("[pubkeyHex+postedAt]")
-                .equals([options.pubkeyHex, boundaryPostedAt])
-                .filter(matchesSparseRange)
-                .toArray();
-        const recordsByEventId = new Map<string, PostHistoryRecord>();
-        for (const record of [...candidates, ...boundaryRecords]) {
-            recordsByEventId.set(record.eventId, record);
-        }
-        const records = sortPostHistoryRecords(Array.from(recordsByEventId.values()));
-
+        // The timeline index already contains the complete tie-breaker. Keep
+        // the display order (newest first) while avoiding a second same-
+        // postedAt group scan and JavaScript-side re-sort.
         return options.direction === "newer"
-            ? records.slice(Math.max(0, records.length - limit))
-            : records.slice(0, limit);
+            ? records.reverse()
+            : records;
     }
 
     async countForPubkey(pubkeyHex: string | null | undefined): Promise<number> {

--- a/src/test/unit/postHistoryDialogTestHarness.ts
+++ b/src/test/unit/postHistoryDialogTestHarness.ts
@@ -656,9 +656,13 @@ export function resetPostHistoryDialogHarness(options: { listingMode?: 'chunk' |
     repositoryMock.hasPostsBeforeCreatedAt.mockResolvedValue(false);
     repositoryMock.getSparseChunk.mockResolvedValue([]);
     repositoryMock.countForPubkey.mockResolvedValue(0);
-    repositoryMock.countVisibleForPubkey.mockImplementation(async (pubkeyHex: string) =>
-        repositoryMock.countForPubkey(pubkeyHex),
-    );
+    repositoryMock.countVisibleForPubkey.mockImplementation(async () => {
+        const lastCount = repositoryMock.countForPubkey.mock.results.at(-1);
+        if (lastCount?.type === 'return') {
+            return await lastCount.value;
+        }
+        return 0;
+    });
     repositoryMock.getExistingEventIdsForPubkey.mockResolvedValue([]);
     repositoryMock.getOldestCreatedAt.mockResolvedValue(null);
     repositoryMock.upsertFetchedEvents.mockResolvedValue({

--- a/src/test/unit/postHistoryDialogTimeline.test.ts
+++ b/src/test/unit/postHistoryDialogTimeline.test.ts
@@ -28,6 +28,7 @@ import {
 import { readPersistedPostHistoryViewState } from '../../lib/postHistoryDialogViewState';
 import { readPersistedPostHistoryListingSnapshotForPubkey } from '../../lib/hooks/usePostHistoryListing.svelte';
 import { markPostHistoryShouldReturnToLatestAfterLocalPost } from '../../lib/postHistoryLatestRequest';
+import { bumpPostHistorySearchRevision } from '../../lib/postHistoryLocalSearchRevision';
 
 function createMockRect(top: number, height: number) {
     return {
@@ -224,6 +225,185 @@ describe('PostHistoryDialog timeline navigation', () => {
         });
         expect(visibleRangeRepositoryMock.save).not.toHaveBeenCalled();
 
+        view.unmount();
+    });
+
+    it('最終通常ページのremainingだけをqueryし、到達済み後のavailability older queryを省略する', async () => {
+        const newest = createRecord({
+            eventId: 'bounded-newest',
+            content: 'bounded newest',
+            createdAt: 2_000,
+            postedAt: 2_000_000,
+        });
+        const older = createRecord({
+            eventId: 'bounded-older',
+            content: 'bounded older',
+            createdAt: 1_000,
+            postedAt: 1_000_000,
+        });
+
+        visibleRangeRepositoryMock.get.mockResolvedValue({
+            pubkeyHex: PUBKEY_HEX,
+            kindsKey: '1,42',
+            visibleUntil: 1_500,
+            updatedAt: 1,
+        });
+        repositoryMock.countForPubkey.mockResolvedValue(2);
+        repositoryMock.getLatestVisibleChunk.mockResolvedValue([newest]);
+        repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
+        repositoryMock.getOlderVisibleChunk
+            .mockResolvedValueOnce([older])
+            .mockResolvedValueOnce([older]);
+
+        const view = render(PostHistoryDialog, {
+            props: { show: true, onClose: vi.fn(), pubkeyHex: PUBKEY_HEX },
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('bounded newest')).toBeTruthy();
+            expect(screen.getByRole('button', { name: 'さらに古い投稿を表示' })).toBeTruthy();
+        });
+        await fireEvent.click(screen.getByRole('button', { name: 'さらに古い投稿を表示' }));
+
+        await waitFor(() => expect(screen.getByText('bounded older')).toBeTruthy());
+        expect(repositoryMock.getOlderVisibleChunk).toHaveBeenCalledTimes(2);
+        expect(repositoryMock.getOlderVisibleChunk.mock.calls[1]?.[0]).toEqual(
+            expect.objectContaining({ limit: 1 }),
+        );
+
+        view.unmount();
+    });
+
+    it('remainingが0と確定した場合はolder availabilityを再走査しない', async () => {
+        const newest = createRecord({
+            eventId: 'zero-remaining-newest',
+            content: 'zero remaining newest',
+            createdAt: 2_000,
+            postedAt: 2_000_000,
+        });
+        const staleAvailabilityPost = createRecord({
+            eventId: 'zero-remaining-stale',
+            content: 'stale availability result',
+            createdAt: 1_000,
+            postedAt: 1_000_000,
+        });
+
+        visibleRangeRepositoryMock.get.mockResolvedValue({
+            pubkeyHex: PUBKEY_HEX,
+            kindsKey: '1,42',
+            visibleUntil: 1_500,
+            updatedAt: 1,
+        });
+        repositoryMock.countForPubkey.mockResolvedValue(1);
+        repositoryMock.getLatestVisibleChunk.mockResolvedValue([newest]);
+        repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
+        repositoryMock.getOlderVisibleChunk.mockResolvedValue([staleAvailabilityPost]);
+
+        const view = render(PostHistoryDialog, {
+            props: { show: true, onClose: vi.fn(), pubkeyHex: PUBKEY_HEX },
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('zero remaining newest')).toBeTruthy();
+            expect(screen.getByRole('button', { name: 'さらに古い投稿を表示' })).toBeTruthy();
+        });
+        await fireEvent.click(screen.getByRole('button', { name: 'さらに古い投稿を表示' }));
+        await waitFor(() => expect(screen.queryByText('stale availability result')).toBeNull());
+
+        // The original availability probe is the only older scan; the
+        // remaining count lets the click skip both the older page and probe.
+        expect(repositoryMock.getOlderVisibleChunk).toHaveBeenCalledTimes(1);
+        view.unmount();
+    });
+
+    it('revisionまたはvisible件数が変わった進捗は再baseし、older投稿を誤って消費しない', async () => {
+        const newest = createRecord({
+            eventId: 'stale-progress-newest',
+            content: 'stale progress newest',
+            createdAt: 2_000,
+            postedAt: 2_000_000,
+        });
+        const older = createRecord({
+            eventId: 'stale-progress-older',
+            content: 'stale progress older',
+            createdAt: 1_000,
+            postedAt: 1_000_000,
+        });
+
+        visibleRangeRepositoryMock.get.mockResolvedValue({
+            pubkeyHex: PUBKEY_HEX,
+            kindsKey: '1,42',
+            visibleUntil: 1_500,
+            updatedAt: 1,
+        });
+        repositoryMock.countForPubkey.mockResolvedValue(2);
+        repositoryMock.countVisibleForPubkey.mockResolvedValue(3);
+        repositoryMock.getLatestVisibleChunk.mockResolvedValue([newest]);
+        repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
+        repositoryMock.getOlderVisibleChunk.mockResolvedValue([older]);
+
+        const view = render(PostHistoryDialog, {
+            props: { show: true, onClose: vi.fn(), pubkeyHex: PUBKEY_HEX },
+        });
+        await waitFor(() => {
+            expect(screen.getByText('stale progress newest')).toBeTruthy();
+            expect(screen.getByRole('button', { name: 'さらに古い投稿を表示' })).toBeTruthy();
+        });
+
+        bumpPostHistorySearchRevision(PUBKEY_HEX);
+        await fireEvent.click(screen.getByRole('button', { name: 'さらに古い投稿を表示' }));
+
+        await waitFor(() => {
+            expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalledTimes(2);
+            expect(screen.getByText('stale progress newest')).toBeTruthy();
+        });
+        expect(repositoryMock.getOlderVisibleChunk).toHaveBeenCalledTimes(2);
+        view.unmount();
+    });
+
+    it('ページング途中にvisibleUntilが古い方向へ更新された場合は再baseして見落とさない', async () => {
+        const newest = createRecord({
+            eventId: 'frontier-rebase-newest',
+            content: 'frontier rebase newest',
+            createdAt: 2_000,
+            postedAt: 2_000_000,
+        });
+        const older = createRecord({
+            eventId: 'frontier-rebase-older',
+            content: 'frontier rebase older',
+            createdAt: 1_000,
+            postedAt: 1_000_000,
+        });
+        let visibleUntil = 1_500;
+
+        visibleRangeRepositoryMock.get.mockImplementation(async () => ({
+            pubkeyHex: PUBKEY_HEX,
+            kindsKey: '1,42',
+            visibleUntil,
+            updatedAt: 1,
+        }));
+        repositoryMock.countForPubkey.mockResolvedValue(2);
+        repositoryMock.countVisibleForPubkey.mockResolvedValue(2);
+        repositoryMock.getLatestVisibleChunk.mockResolvedValue([newest]);
+        repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
+        repositoryMock.getOlderVisibleChunk.mockResolvedValue([older]);
+
+        const view = render(PostHistoryDialog, {
+            props: { show: true, onClose: vi.fn(), pubkeyHex: PUBKEY_HEX },
+        });
+        await waitFor(() => {
+            expect(screen.getByText('frontier rebase newest')).toBeTruthy();
+            expect(screen.getByRole('button', { name: 'さらに古い投稿を表示' })).toBeTruthy();
+        });
+
+        visibleUntil = 1_400;
+        await fireEvent.click(screen.getByRole('button', { name: 'さらに古い投稿を表示' }));
+
+        await waitFor(() => {
+            expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalledTimes(2);
+            expect(screen.queryByText('frontier rebase older')).toBeNull();
+        });
+        expect(repositoryMock.getOlderVisibleChunk).toHaveBeenCalledTimes(2);
         view.unmount();
     });
 

--- a/src/test/unit/postHistoryDialogTimelineRelay.test.ts
+++ b/src/test/unit/postHistoryDialogTimelineRelay.test.ts
@@ -562,7 +562,7 @@ describe('PostHistoryDialog timeline relay flows', () => {
         repositoryMock.getNewerVisibleChunk.mockResolvedValue([newest]);
         repositoryMock.getOlderVisibleChunk.mockImplementation(async ({ limit }: { limit: number }) =>
             repositoryMock.getOlderVisibleChunk.mock.calls.length === 1
-                ? [olderPosts[0]]
+                ? []
                 : olderPosts.slice(0, limit),
         );
         repositoryMock.upsertFetchedEvents.mockImplementation(async () => {
@@ -600,6 +600,7 @@ describe('PostHistoryDialog timeline relay flows', () => {
         });
         await waitFor(() => expect(visibleCounts.at(-1)).toBe(4));
         await waitFor(() => expect(repositoryMock.getNewerVisibleChunk).toHaveBeenCalledTimes(2));
+        expect(screen.getByRole('button', { name: 'さらに古い投稿を表示' })).toBeTruthy();
         await fireEvent.click(screen.getByRole('button', { name: 'さらに古い投稿を表示' }));
         await waitFor(() => {
             expect(screen.getByText('refresh insert older 1')).toBeTruthy();

--- a/src/test/unit/postHistoryDialogTimelineRelay.test.ts
+++ b/src/test/unit/postHistoryDialogTimelineRelay.test.ts
@@ -535,6 +535,14 @@ describe('PostHistoryDialog timeline relay flows', () => {
             created_at: 2_100,
             sig: 'e'.repeat(128),
         };
+        const insertedPost = createRecord({
+            eventId: insertedEvent.id,
+            content: insertedEvent.content,
+            createdAt: insertedEvent.created_at,
+            postedAt: insertedEvent.created_at * 1000,
+        });
+        let inserted = false;
+        const visibleCounts: number[] = [];
 
         visibleRangeRepositoryMock.get.mockResolvedValue({
             pubkeyHex: PUBKEY_HEX,
@@ -542,21 +550,28 @@ describe('PostHistoryDialog timeline relay flows', () => {
             visibleUntil: 1_500,
             updatedAt: 1,
         });
-        repositoryMock.countForPubkey
-            .mockResolvedValueOnce(2)
-            .mockResolvedValue(3);
-        repositoryMock.countVisibleForPubkey
-            .mockResolvedValueOnce(2)
-            .mockResolvedValue(3);
-        repositoryMock.getLatestVisibleChunk.mockResolvedValue([newest]);
+        repositoryMock.countForPubkey.mockImplementation(async () => inserted ? 4 : 3);
+        repositoryMock.countVisibleForPubkey.mockImplementation(async () => {
+            const count = inserted ? 4 : 3;
+            visibleCounts.push(count);
+            return count;
+        });
+        repositoryMock.getLatestVisibleChunk.mockImplementation(async () =>
+            inserted ? [insertedPost, newest] : [newest],
+        );
         repositoryMock.getNewerVisibleChunk.mockResolvedValue([newest]);
-        repositoryMock.getOlderVisibleChunk
-            .mockResolvedValueOnce([olderPosts[0]])
-            .mockResolvedValue(olderPosts);
-        repositoryMock.upsertFetchedEvents.mockResolvedValue({
-            insertedCount: 1,
-            updatedCount: 0,
-            unchangedCount: 0,
+        repositoryMock.getOlderVisibleChunk.mockImplementation(async ({ limit }: { limit: number }) =>
+            repositoryMock.getOlderVisibleChunk.mock.calls.length === 1
+                ? [olderPosts[0]]
+                : olderPosts.slice(0, limit),
+        );
+        repositoryMock.upsertFetchedEvents.mockImplementation(async () => {
+            inserted = true;
+            return {
+                insertedCount: 1,
+                updatedCount: 0,
+                unchangedCount: 0,
+            };
         });
         relayFetchServiceMock.fetchLatest.mockReturnValue({
             promise: Promise.resolve(createRelayFetchResult({
@@ -579,13 +594,21 @@ describe('PostHistoryDialog timeline relay flows', () => {
 
         await waitFor(() => {
             expect(screen.getByText('refresh insert newest')).toBeTruthy();
+            expect(screen.getByText('relay inserted newer post')).toBeTruthy();
             expect(relayFetchServiceMock.fetchLatest).toHaveBeenCalledOnce();
             expect(repositoryMock.getOlderVisibleChunk).toHaveBeenCalledTimes(1);
         });
+        await waitFor(() => expect(visibleCounts.at(-1)).toBe(4));
+        await waitFor(() => expect(repositoryMock.getNewerVisibleChunk).toHaveBeenCalledTimes(2));
         await fireEvent.click(screen.getByRole('button', { name: 'さらに古い投稿を表示' }));
-        await waitFor(() => expect(screen.getByText('refresh insert older 1')).toBeTruthy());
+        await waitFor(() => {
+            expect(screen.getByText('refresh insert older 1')).toBeTruthy();
+            expect(screen.getByText('refresh insert older 2')).toBeTruthy();
+        });
 
-        expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalledOnce();
+        expect(visibleCounts).toContain(3);
+        expect(visibleCounts.at(-1)).toBe(4);
+        expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalledTimes(2);
         expect(repositoryMock.getOlderVisibleChunk).toHaveBeenCalledTimes(2);
         expect(repositoryMock.getOlderVisibleChunk.mock.calls[1]?.[0]).toEqual(
             expect.objectContaining({ limit: 2 }),

--- a/src/test/unit/postHistoryDialogTimelineRelay.test.ts
+++ b/src/test/unit/postHistoryDialogTimelineRelay.test.ts
@@ -451,6 +451,148 @@ describe('PostHistoryDialog timeline relay flows', () => {
         secondView.unmount();
     });
 
+    it('dialog-open-refresh後も最新からのcontiguous進捗を再利用して境界queryをboundedに保つ', async () => {
+        const newest = createRecord({
+            eventId: 'refresh-progress-newest',
+            content: 'refresh progress newest',
+            createdAt: 2_000,
+            postedAt: 2_000_000,
+        });
+        const older = createRecord({
+            eventId: 'refresh-progress-older',
+            content: 'refresh progress older',
+            createdAt: 1_000,
+            postedAt: 1_000_000,
+        });
+        visibleRangeRepositoryMock.get.mockResolvedValue({
+            pubkeyHex: PUBKEY_HEX,
+            kindsKey: '1,42',
+            visibleUntil: 1_500,
+            updatedAt: 1,
+        });
+        repositoryMock.countForPubkey.mockResolvedValue(2);
+        repositoryMock.countVisibleForPubkey.mockResolvedValue(2);
+        repositoryMock.getLatestVisibleChunk.mockResolvedValue([newest]);
+        repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
+        repositoryMock.getOlderVisibleChunk.mockResolvedValue([older]);
+        relayFetchServiceMock.fetchLatest.mockReturnValue({
+            promise: Promise.resolve(createRelayFetchResult({ fetchedAt: 1000 })),
+            cancel: vi.fn(),
+        });
+
+        const view = render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: PUBKEY_HEX,
+                rxNostr: {} as any,
+            },
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('refresh progress newest')).toBeTruthy();
+            expect(screen.getByRole('button', { name: 'さらに古い投稿を表示' })).toBeTruthy();
+            expect(relayFetchServiceMock.fetchLatest).toHaveBeenCalledOnce();
+        });
+        await fireEvent.click(screen.getByRole('button', { name: 'さらに古い投稿を表示' }));
+        await waitFor(() => expect(screen.getByText('refresh progress older')).toBeTruthy());
+
+        expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalledOnce();
+        expect(repositoryMock.getOlderVisibleChunk).toHaveBeenCalledTimes(2);
+        expect(repositoryMock.getOlderVisibleChunk.mock.calls[1]?.[0]).toEqual(
+            expect.objectContaining({ limit: 1 }),
+        );
+        view.unmount();
+    });
+
+    it('dialog-open-refreshで新規投稿が追加されてもolder availabilityを再走査しない', async () => {
+        const newest = createRecord({
+            eventId: 'refresh-insert-newest',
+            content: 'refresh insert newest',
+            createdAt: 2_000,
+            postedAt: 2_000_000,
+        });
+        const olderPosts = [
+            createRecord({
+                eventId: 'refresh-insert-older-1',
+                content: 'refresh insert older 1',
+                createdAt: 1_400,
+                postedAt: 1_400_000,
+            }),
+            createRecord({
+                eventId: 'refresh-insert-older-2',
+                content: 'refresh insert older 2',
+                createdAt: 1_300,
+                postedAt: 1_300_000,
+            }),
+        ];
+        const insertedEvent = {
+            id: 'refresh-insert-event'.repeat(4),
+            pubkey: PUBKEY_HEX,
+            kind: 1,
+            content: 'relay inserted newer post',
+            tags: [],
+            created_at: 2_100,
+            sig: 'e'.repeat(128),
+        };
+
+        visibleRangeRepositoryMock.get.mockResolvedValue({
+            pubkeyHex: PUBKEY_HEX,
+            kindsKey: '1,42',
+            visibleUntil: 1_500,
+            updatedAt: 1,
+        });
+        repositoryMock.countForPubkey
+            .mockResolvedValueOnce(2)
+            .mockResolvedValue(3);
+        repositoryMock.countVisibleForPubkey
+            .mockResolvedValueOnce(2)
+            .mockResolvedValue(3);
+        repositoryMock.getLatestVisibleChunk.mockResolvedValue([newest]);
+        repositoryMock.getNewerVisibleChunk.mockResolvedValue([newest]);
+        repositoryMock.getOlderVisibleChunk
+            .mockResolvedValueOnce([olderPosts[0]])
+            .mockResolvedValue(olderPosts);
+        repositoryMock.upsertFetchedEvents.mockResolvedValue({
+            insertedCount: 1,
+            updatedCount: 0,
+            unchangedCount: 0,
+        });
+        relayFetchServiceMock.fetchLatest.mockReturnValue({
+            promise: Promise.resolve(createRelayFetchResult({
+                fetchedAt: 1000,
+                events: [{ event: insertedEvent, relayUrls: [] }],
+                oldestCreatedAt: insertedEvent.created_at,
+                newestCreatedAt: insertedEvent.created_at,
+            })),
+            cancel: vi.fn(),
+        });
+
+        const view = render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: PUBKEY_HEX,
+                rxNostr: {} as any,
+            },
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('refresh insert newest')).toBeTruthy();
+            expect(relayFetchServiceMock.fetchLatest).toHaveBeenCalledOnce();
+            expect(repositoryMock.getOlderVisibleChunk).toHaveBeenCalledTimes(1);
+        });
+        await fireEvent.click(screen.getByRole('button', { name: 'さらに古い投稿を表示' }));
+        await waitFor(() => expect(screen.getByText('refresh insert older 1')).toBeTruthy());
+
+        expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalledOnce();
+        expect(repositoryMock.getOlderVisibleChunk).toHaveBeenCalledTimes(2);
+        expect(repositoryMock.getOlderVisibleChunk.mock.calls[1]?.[0]).toEqual(
+            expect.objectContaining({ limit: 2 }),
+        );
+        view.unmount();
+    });
+
     it('dialog-open-refresh は保守的継続時だけ notice を出し、close 後も既存 cursor から続ける', async () => {
         const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1000);
         const post = createRecord({

--- a/src/test/unit/postHistoryRepository.test.ts
+++ b/src/test/unit/postHistoryRepository.test.ts
@@ -113,12 +113,14 @@ function createInstrumentedTimelineDb(records: PostHistoryRecord[]) {
         cmp(timelineKey(left), timelineKey(right))
     );
     const materializedCounts: number[] = [];
+    const filterEvaluatedCounts: number[] = [];
     const queriedIndexes: string[] = [];
 
     class InstrumentedCollection {
         private reversed = false;
         private maximum = Number.POSITIVE_INFINITY;
         private predicates: Array<(record: PostHistoryRecord) => boolean> = [];
+        private filterEvaluated = 0;
 
         constructor(
             private readonly lower: unknown,
@@ -157,10 +159,12 @@ function createInstrumentedTimelineDb(records: PostHistoryRecord[]) {
                     continue;
                 }
 
+                this.filterEvaluated += this.predicates.length;
                 result.push(record);
                 if (result.length >= this.maximum) break;
             }
             materializedCounts.push(result.length);
+            filterEvaluatedCounts.push(this.filterEvaluated);
             return result;
         }
 
@@ -207,6 +211,7 @@ function createInstrumentedTimelineDb(records: PostHistoryRecord[]) {
             transaction: async (_mode: string, _table: unknown, callback: () => unknown) => callback(),
         },
         materializedCounts,
+        filterEvaluatedCounts,
         queriedIndexes,
     };
 }
@@ -1239,6 +1244,36 @@ describe("DexiePostHistoryRepository", () => {
         expect(Math.max(...materializedCounts)).toBeLessThanOrEqual(25);
     });
 
+    it("最終通常ページのbounded limitは後続の範囲外保存投稿をfilter評価しない", async () => {
+        const pubkey = "b".repeat(64);
+        const records = [
+            createPostHistoryRecord({ eventId: "newest", pubkeyHex: pubkey, postedAt: 70_000, createdAt: 2_000 }),
+            createPostHistoryRecord({ eventId: "last-visible", pubkeyHex: pubkey, postedAt: 69_999, createdAt: 1_500 }),
+            ...Array.from({ length: 64_999 }, (_, index) => createPostHistoryRecord({
+                eventId: `imported-${index}`,
+                pubkeyHex: pubkey,
+                postedAt: 69_998 - index,
+                createdAt: 999 - index,
+            })),
+        ];
+        const { db, filterEvaluatedCounts } = createInstrumentedTimelineDb(records);
+        const repository = new DexiePostHistoryRepository(db as any, () => 1000);
+
+        const latest = await repository.getLatestVisibleChunk({
+            pubkeyHex: pubkey,
+            visibleUntil: 1_000,
+            limit: 1,
+        });
+        await repository.getOlderVisibleChunk({
+            pubkeyHex: pubkey,
+            visibleUntil: 1_000,
+            cursor: latest[0]!,
+            limit: 1,
+        });
+
+        expect(filterEvaluatedCounts.at(-1)).toBe(1);
+    });
+
     it("visibleUntil より古い保存投稿を index で検出し、sparse chunk を前後へ移動できる", async () => {
         const db = createTestDb();
         const repository = new DexiePostHistoryRepository(db, () => 1000);
@@ -1280,6 +1315,50 @@ describe("DexiePostHistoryRepository", () => {
         });
         expect(newer).toMatchObject([{ eventId: "3".repeat(64), createdAt: 900 }]);
         db.close();
+    });
+
+    it("sparseの同一postedAt境界を全件展開せずtimeline cursorで順序を保つ", async () => {
+        const pubkey = "b".repeat(64);
+        const records = [
+            createPostHistoryRecord({ eventId: "a", pubkeyHex: pubkey, postedAt: 2_000, createdAt: 300 }),
+            createPostHistoryRecord({ eventId: "b", pubkeyHex: pubkey, postedAt: 2_000, createdAt: 200 }),
+            createPostHistoryRecord({ eventId: "c", pubkeyHex: pubkey, postedAt: 2_000, createdAt: 100 }),
+            ...Array.from({ length: 5_000 }, (_, index) => createPostHistoryRecord({
+                eventId: `old-${index}`,
+                pubkeyHex: pubkey,
+                postedAt: 1_000 - index,
+                createdAt: 90 - index,
+            })),
+        ];
+        const { db, filterEvaluatedCounts, queriedIndexes } = createInstrumentedTimelineDb(records);
+        const repository = new DexiePostHistoryRepository(db as any, () => 1000);
+
+        const latest = await repository.getSparseChunk({
+            pubkeyHex: pubkey,
+            visibleUntil: 1_000,
+            direction: "latest",
+            limit: 2,
+        });
+        const older = await repository.getSparseChunk({
+            pubkeyHex: pubkey,
+            visibleUntil: 1_000,
+            direction: "older",
+            cursor: latest.at(-1)!,
+            limit: 2,
+        });
+        const newer = await repository.getSparseChunk({
+            pubkeyHex: pubkey,
+            visibleUntil: 1_000,
+            direction: "newer",
+            cursor: older[0]!,
+            limit: 2,
+        });
+
+        expect(latest.map((record) => record.eventId)).toEqual(["a", "b"]);
+        expect(older.map((record) => record.eventId)).toEqual(["c", "old-0"]);
+        expect(newer.map((record) => record.eventId)).toEqual(["a", "b"]);
+        expect(queriedIndexes.every((index) => index === POST_HISTORY_TIMELINE_INDEX)).toBe(true);
+        expect(Math.max(...filterEvaluatedCounts)).toBeLessThanOrEqual(2);
     });
 
     it("sparse query を対象pubkeyへ限定し、大量投稿と同一時刻をchunk単位で往復する", async () => {

--- a/src/test/unit/postHistoryRepository.test.ts
+++ b/src/test/unit/postHistoryRepository.test.ts
@@ -154,12 +154,22 @@ function createInstrumentedTimelineDb(records: PostHistoryRecord[]) {
                 if (
                     (lowerComparison < 0 || (!this.includeLower && lowerComparison === 0))
                     || (upperComparison > 0 || (!this.includeUpper && upperComparison === 0))
-                    || this.predicates.some((predicate) => !predicate(record))
                 ) {
                     continue;
                 }
 
-                this.filterEvaluated += this.predicates.length;
+                let rejected = false;
+                for (const predicate of this.predicates) {
+                    this.filterEvaluated += 1;
+                    if (!predicate(record)) {
+                        rejected = true;
+                        break;
+                    }
+                }
+                if (rejected) {
+                    continue;
+                }
+
                 result.push(record);
                 if (result.length >= this.maximum) break;
             }
@@ -1244,12 +1254,14 @@ describe("DexiePostHistoryRepository", () => {
         expect(Math.max(...materializedCounts)).toBeLessThanOrEqual(25);
     });
 
-    it("最終通常ページのbounded limitは後続の範囲外保存投稿をfilter評価しない", async () => {
+    it.each([7_000, 35_000, 64_999])(
+        "最終通常ページのbounded limitは後続の範囲外保存投稿をfilter評価しない (%d件)",
+        async (outOfRangeCount) => {
         const pubkey = "b".repeat(64);
         const records = [
             createPostHistoryRecord({ eventId: "newest", pubkeyHex: pubkey, postedAt: 70_000, createdAt: 2_000 }),
             createPostHistoryRecord({ eventId: "last-visible", pubkeyHex: pubkey, postedAt: 69_999, createdAt: 1_500 }),
-            ...Array.from({ length: 64_999 }, (_, index) => createPostHistoryRecord({
+            ...Array.from({ length: outOfRangeCount }, (_, index) => createPostHistoryRecord({
                 eventId: `imported-${index}`,
                 pubkeyHex: pubkey,
                 postedAt: 69_998 - index,
@@ -1272,7 +1284,36 @@ describe("DexiePostHistoryRepository", () => {
         });
 
         expect(filterEvaluatedCounts.at(-1)).toBe(1);
-    });
+        },
+    );
+
+    it.each([7_000, 35_000, 64_999])(
+        "unbounded older queryは範囲外保存投稿のfilter評価を検出する (%d件)",
+        async (outOfRangeCount) => {
+            const pubkey = "b".repeat(64);
+            const records = [
+                createPostHistoryRecord({ eventId: "newest", pubkeyHex: pubkey, postedAt: 70_000, createdAt: 2_000 }),
+                createPostHistoryRecord({ eventId: "last-visible", pubkeyHex: pubkey, postedAt: 69_999, createdAt: 1_500 }),
+                ...Array.from({ length: outOfRangeCount }, (_, index) => createPostHistoryRecord({
+                    eventId: `imported-${index}`,
+                    pubkeyHex: pubkey,
+                    postedAt: 69_998 - index,
+                    createdAt: 999 - index,
+                })),
+            ];
+            const { db, filterEvaluatedCounts } = createInstrumentedTimelineDb(records);
+            const repository = new DexiePostHistoryRepository(db as any, () => 1000);
+
+            await repository.getOlderVisibleChunk({
+                pubkeyHex: pubkey,
+                visibleUntil: 1_000,
+                cursor: records[1]!,
+                limit: 1,
+            });
+
+            expect(filterEvaluatedCounts.at(-1)).toBe(outOfRangeCount);
+        },
+    );
 
     it("visibleUntil より古い保存投稿を index で検出し、sparse chunk を前後へ移動できる", async () => {
         const db = createTestDb();


### PR DESCRIPTION
## Summary
- bound contiguous older-page and availability work with validated visible-count progress
- invalidate and rebase progress on revision, visibleUntil, cursor, and local/relay history changes
- use the existing timeline index for sparse chunks and add structural large-data regression tests

## Root cause
The final contiguous older query and the following availability probe used Dexie filter() over imported records outside visibleUntil, evaluating 64,999 records each in the 70,000-record reproduction. The fix avoids those scans once the same history state is validated and omits the redundant older availability probe when the remaining visible count is known to be zero.

## Validation
- npm run check
- npm test (319 files, 3604 tests)
- npm run build
- npx playwright test src/test/e2e/postHistoryDialog.spec.ts --project=desktop-chromium (16 passed, 2 skipped)

No IndexedDB schema/version or JSONL data changes.