### PR TITLE
fix: make post-history jump to oldest local-only

### DIFF
--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -223,6 +223,10 @@ interface FetchOlderFromRelaysOptions {
     anchorEventId?: string | null;
 }
 
+interface JumpToCreatedAtOptions {
+    allowRelayRepair?: boolean;
+}
+
 function resolveFetchedAuthoredEventIds(
     events: Array<{ event?: { id?: string } }>,
 ): string[] {
@@ -2700,7 +2704,10 @@ export function usePostHistoryListing({
         return true;
     }
 
-    async function jumpToCreatedAt(createdAt: number): Promise<boolean> {
+    async function jumpToCreatedAt(
+        createdAt: number,
+        options: JumpToCreatedAtOptions = {},
+    ): Promise<boolean> {
         clearContiguousProgress();
         const pubkeyHex = getPubkeyHex();
         if (!pubkeyHex) {
@@ -2738,7 +2745,7 @@ export function usePostHistoryListing({
             return true;
         }
 
-        if (createdAt <= 0) {
+        if (options.allowRelayRepair === false) {
             refreshTotalCountFromRepository();
             state.listingMode = "contiguous";
             state.sparseSource = null;
@@ -3432,7 +3439,7 @@ export function usePostHistoryListing({
             return false;
         }
 
-        return jumpToCreatedAt(0);
+        return jumpToCreatedAt(0, { allowRelayRepair: false });
     }
 
     async function fetchOlderFromRelays(

--- a/src/test/e2e/PostHistoryDialogHarness.svelte
+++ b/src/test/e2e/PostHistoryDialogHarness.svelte
@@ -58,6 +58,7 @@
         importEventJsonl: string;
         sparseVisiblePostContent: string;
         sparseStoredPostContent: string;
+        oldestPostContent: string;
     };
 
     type HarnessWindow = Window &
@@ -334,6 +335,7 @@
         importEventJsonl: IMPORT_EVENT_JSONL,
         sparseVisiblePostContent: sparseVisiblePost.content,
         sparseStoredPostContent: sparseStoredPost.content,
+        oldestPostContent: posts[posts.length - 1].content,
     };
 
     onMount(async () => {
@@ -401,6 +403,7 @@
             importEventJsonl: IMPORT_EVENT_JSONL,
             sparseVisiblePostContent: sparseVisiblePost.content,
             sparseStoredPostContent: sparseStoredPost.content,
+            oldestPostContent: posts[posts.length - 1].content,
         };
     });
 </script>

--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -23,6 +23,7 @@ type HarnessState = {
     importEventJsonl: string;
     sparseVisiblePostContent: string;
     sparseStoredPostContent: string;
+    oldestPostContent: string;
 };
 
 type HarnessWindow = Window & typeof globalThis & {
@@ -421,6 +422,28 @@ test.describe('PostHistoryDialog Playwright', () => {
         await expectSummary(page, harness.matchingPosts);
         await expectVisiblePostCount(page, harness.matchingPosts);
         await expect(page.getByRole('button', { name: '新しい検索結果を表示' })).toHaveCount(0);
+    });
+
+    test('desktop menu jump to oldest shows the locally oldest post at the bottom with rxNostr present', async ({ page, isMobile }) => {
+        test.skip(isMobile, 'desktop only');
+
+        const harness = await gotoHarness(page);
+        await expectVisiblePostCount(page, 50);
+
+        await page.getByRole('button', { name: '投稿履歴メニューを開く' }).click();
+        await page.getByRole('menuitem', { name: '最古へ移動' }).click();
+
+        await expect(page.getByText(harness.oldestPostContent, { exact: true })).toBeVisible();
+        await expectVisiblePostCount(page, 50);
+
+        const scrollState = await page.locator('.post-history-container').evaluate((element) => {
+            const container = element as HTMLElement;
+            return {
+                scrollTop: container.scrollTop,
+                maxScrollTop: container.scrollHeight - container.clientHeight,
+            };
+        });
+        expect(scrollState.scrollTop).toBeGreaterThanOrEqual(scrollState.maxScrollTop - 1);
     });
 
     test('desktop newer prepend keeps the current post anchored', async ({ page, isMobile }) => {

--- a/src/test/unit/postHistoryDialogTimeline.test.ts
+++ b/src/test/unit/postHistoryDialogTimeline.test.ts
@@ -1910,7 +1910,7 @@ describe('PostHistoryDialog timeline navigation', () => {
         view.unmount();
     });
 
-    it('メニューの最古へ移動はリレー同期せずローカル最古ページへ移動する', async () => {
+    it('rxNostr があってもメニューの最古へ移動は repair relay 同期せずローカル最古ページへ移動する', async () => {
         const newest = createRecord({
             eventId: 'oldest-menu-newest',
             content: '最新投稿',
@@ -1959,6 +1959,8 @@ describe('PostHistoryDialog timeline navigation', () => {
             expect(screen.getByText('最新投稿')).toBeTruthy();
         });
 
+        relayFetchServiceMock.fetchLatest.mockClear();
+
         const historyContainer = getHistoryContainer();
         Object.defineProperty(historyContainer, 'scrollHeight', {
             configurable: true,
@@ -1977,8 +1979,12 @@ describe('PostHistoryDialog timeline navigation', () => {
                     createdAt: 0,
                 }),
             );
-            expect(relayFetchServiceMock.fetchLatest).toHaveBeenCalledTimes(1);
         });
+
+        expect(relayFetchServiceMock.fetchLatest).not.toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ reason: 'repair-visible-range' }),
+        );
 
         view.unmount();
     });


### PR DESCRIPTION
## 変更概要

投稿履歴メニューの「最古へ移動」を、ローカル保存済みの最古ページへ移動する操作として修正しました。

## 原因

repository の `getVisibleChunkFromCreatedAt({ createdAt: 0 })` は、0以前の投稿がない場合にローカル最古ページをフォールバックで返します。しかし listing の日付ジャンプ経路では、最古ページの `createdAt` がターゲットの 0 より新しいため、通常の日付ジャンプと同じ relay repair 判定へ進み得る責務になっていました。既存 unit は初期表示時の別 relay 呼び出しを数えており、`repair-visible-range` の不発を直接検証できていませんでした。

## 主な修正内容

- `jumpToCreatedAt()` に relay repair を許可するかの局所オプションを追加。
- `jumpToOldest()` からは `allowRelayRepair: false` を渡し、ローカル最古ページを採用。
- `visibleUntil`、sparse listing、jump cache anchor、repository API は変更なし。
- `rxNostr` ありの unit 回帰テストで `repair-visible-range` が発生しないこと、既存の日付ジャンプ repair を維持することを確認。
- Playwright harness にメニューからの実ブラウザ回帰テストを追加し、最古投稿の表示と最下部スクロールを確認。

## テストと検証

- `npm run test -- src/test/unit/postHistoryDialogTimeline.test.ts` — 37 passed
- `npm run test -- src/test/unit/postHistoryRepository.test.ts` — 45 passed
- `npm run check` — passed
- `npm test` — 319 files / 3610 tests passed
- `npm run build` — passed
- `npx playwright test src/test/e2e/postHistoryDialog.spec.ts -g "desktop menu jump to oldest" --project=desktop-chromium` — passed
- 投稿履歴 E2E desktop Chromium — passed
- 投稿履歴 E2E 全体のうち mobile Chromium の既存 `mobile timeline controls stay usable and fit the viewport` は、引用カードの「読み込み中」から「見つかりませんでした」へのタイミング差で失敗し、単独再実行でも再現しました。今回の変更とは無関係な既存 failure として未修正です。
