### PR TITLE
fix: support sparse post-history oldest jump

### DIFF
--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -737,12 +737,15 @@ export function usePostHistoryListing({
         !isSearchMode
         && !isRefetchingAroundCurrentView
         && state.hasOlderLocal
-        && !(
-            typeof visibleOldestCreatedAt === "number"
-            && (
-                state.visibleUntil === null
-                    ? state.hasJumpCacheAnchors
-                    : visibleOldestCreatedAt < state.visibleUntil
+        && (
+            state.listingMode === "sparse"
+            || !(
+                typeof visibleOldestCreatedAt === "number"
+                && (
+                    state.visibleUntil === null
+                        ? state.hasJumpCacheAnchors
+                        : visibleOldestCreatedAt < state.visibleUntil
+                )
             )
         ),
     );
@@ -1975,6 +1978,15 @@ export function usePostHistoryListing({
                         limit: 1,
                     })
                     : Promise.resolve([])
+                : state.sparseSource === "jump"
+                    ? oldestCursor
+                        ? postHistoryRepository.getOlderVisibleChunk({
+                            pubkeyHex,
+                            visibleUntil: null,
+                            cursor: oldestCursor,
+                            limit: 1,
+                        })
+                        : Promise.resolve([])
                 : oldestCursor
                     ? postHistoryRepository.getOlderVisibleChunk({
                         pubkeyHex,
@@ -3430,6 +3442,39 @@ export function usePostHistoryListing({
     async function jumpToOldest(): Promise<boolean> {
         if (isSearchMode || !canJumpToOldest) {
             return false;
+        }
+
+        if (state.listingMode === "sparse") {
+            clearContiguousProgress();
+            const pubkeyHex = getPubkeyHex();
+            if (!pubkeyHex) {
+                return false;
+            }
+
+            const requestId = ++loadRequestId;
+            const posts = await postHistoryRepository.getVisibleChunkFromCreatedAt({
+                pubkeyHex,
+                visibleUntil: state.visibleUntil,
+                createdAt: 0,
+                limit: pageSize,
+                query: {
+                    contiguous: false,
+                },
+            });
+
+            if (!getShow() || requestId !== loadRequestId) {
+                return false;
+            }
+
+            if (posts.length === 0) {
+                return false;
+            }
+
+            refreshTotalCountFromRepository();
+            state.loadedPosts = posts;
+            resetOlderBackfillSearchState();
+            await refreshTimelineAvailability(pubkeyHex, posts, requestId);
+            return true;
         }
 
         return jumpToCreatedAt(0);

--- a/src/test/e2e/PostHistoryDialogHarness.svelte
+++ b/src/test/e2e/PostHistoryDialogHarness.svelte
@@ -18,9 +18,11 @@
 
     const HARNESS_SECRET_KEY = generateSecretKey();
     const HARNESS_PUBKEY = getPublicKey(HARNESS_SECRET_KEY);
-    const TOTAL_POSTS = 70;
+    const isSparseOldestScenario = new URLSearchParams(window.location.search).has("sparse-oldest");
+    const TOTAL_POSTS = isSparseOldestScenario ? 120 : 70;
     const SEARCH_MATCHING_POSTS = 55;
-    const isSparseScenario = new URLSearchParams(window.location.search).has("sparse");
+    const isSparseScenario = new URLSearchParams(window.location.search).has("sparse")
+        || isSparseOldestScenario;
     const isExportScenario = new URLSearchParams(window.location.search).has("export");
     const HARNESS_YEAR = new Date().getFullYear();
     const STARTED_AT_MS = Date.UTC(HARNESS_YEAR, 0, 20, 12, 0, 0);
@@ -58,6 +60,7 @@
         importEventJsonl: string;
         sparseVisiblePostContent: string;
         sparseStoredPostContent: string;
+        absoluteOldestPostContent: string;
     };
 
     type HarnessWindow = Window &
@@ -301,6 +304,7 @@
     const scrollTargetPost = posts[60];
     const sparseVisiblePost = posts[29];
     const sparseStoredPost = posts[31];
+    const absoluteOldestPost = posts[posts.length - 1];
     const initialMonthLabel = formatPostHistoryMonthLabel(
         posts[0].postedAt,
         "ja",
@@ -334,6 +338,7 @@
         importEventJsonl: IMPORT_EVENT_JSONL,
         sparseVisiblePostContent: sparseVisiblePost.content,
         sparseStoredPostContent: sparseStoredPost.content,
+        absoluteOldestPostContent: absoluteOldestPost.content,
     };
 
     onMount(async () => {
@@ -401,6 +406,7 @@
             importEventJsonl: IMPORT_EVENT_JSONL,
             sparseVisiblePostContent: sparseVisiblePost.content,
             sparseStoredPostContent: sparseStoredPost.content,
+            absoluteOldestPostContent: absoluteOldestPost.content,
         };
     });
 </script>

--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -23,6 +23,7 @@ type HarnessState = {
     importEventJsonl: string;
     sparseVisiblePostContent: string;
     sparseStoredPostContent: string;
+    absoluteOldestPostContent: string;
 };
 
 type HarnessWindow = Window & typeof globalThis & {
@@ -37,6 +38,12 @@ async function gotoHarness(page: Page) {
 
 async function gotoSparseHarness(page: Page) {
     await page.goto('post-history-dialog-playwright.html?sparse=1');
+    await page.waitForFunction(() => Boolean((window as HarnessWindow).__POST_HISTORY_HARNESS__?.ready));
+    return page.evaluate<HarnessState>(() => (window as HarnessWindow).__POST_HISTORY_HARNESS__ as HarnessState);
+}
+
+async function gotoSparseOldestHarness(page: Page) {
+    await page.goto('post-history-dialog-playwright.html?sparse-oldest=1');
     await page.waitForFunction(() => Boolean((window as HarnessWindow).__POST_HISTORY_HARNESS__?.ready));
     return page.evaluate<HarnessState>(() => (window as HarnessWindow).__POST_HISTORY_HARNESS__ as HarnessState);
 }
@@ -387,6 +394,36 @@ test.describe('PostHistoryDialog Playwright', () => {
         await expect(page.getByText(harness.sparseStoredPostContent, { exact: true })).toBeVisible();
         await page.getByRole('button', { name: '最新へ戻る' }).click();
         await expect(page.getByText(harness.sparseVisiblePostContent, { exact: true })).toBeVisible();
+    });
+
+    test('saved sparse pages can jump to the absolute local oldest and scroll to the bottom', async ({
+        page,
+        isMobile,
+    }) => {
+        test.skip(isMobile, 'desktop only');
+
+        const harness = await gotoSparseOldestHarness(page);
+        await expect(page.getByRole('button', { name: '保存済みの古い投稿を表示' })).toBeVisible();
+
+        await page.getByRole('button', { name: '保存済みの古い投稿を表示' }).click();
+        await expect(page.getByText('保存済みの古い投稿を表示中です。', { exact: true })).toBeVisible();
+        await expect(page.getByText(harness.sparseStoredPostContent, { exact: true })).toBeVisible();
+
+        const container = page.locator('.post-history-container');
+        await container.evaluate((element) => {
+            const historyContainer = element as HTMLDivElement;
+            historyContainer.scrollTop = 0;
+            historyContainer.dispatchEvent(new Event('scroll', { bubbles: true }));
+        });
+
+        await page.getByRole('button', { name: '投稿履歴メニューを開く' }).click();
+        await page.getByRole('menuitem', { name: '最古へ移動' }).click();
+
+        await expect(page.getByText(harness.absoluteOldestPostContent, { exact: true })).toBeVisible();
+        await expect.poll(() => container.evaluate((element) => {
+            const historyContainer = element as HTMLDivElement;
+            return historyContainer.scrollHeight - historyContainer.clientHeight - historyContainer.scrollTop;
+        })).toBeLessThanOrEqual(1);
     });
 
     test('desktop timeline browsing flow works in a real browser', async ({ page, isMobile }) => {

--- a/src/test/unit/postHistoryDialogTimeline.test.ts
+++ b/src/test/unit/postHistoryDialogTimeline.test.ts
@@ -488,6 +488,242 @@ describe('PostHistoryDialog timeline navigation', () => {
         view.unmount();
     });
 
+    it('jump sparse では jump cache anchor があってもローカル最古へ移動し、リレー修復しない', async () => {
+        const newest = createRecord({
+            eventId: 'jump-oldest-newest',
+            content: 'jump oldest 最新',
+            createdAt: 1_700_000_000,
+            postedAt: 1_700_000_000_000,
+        });
+        const jumpTarget = createRecord({
+            eventId: 'jump-oldest-target',
+            content: 'jump oldest 対象',
+            createdAt: 1_600_000_000,
+            postedAt: 1_600_000_000_000,
+        });
+        const older = createRecord({
+            eventId: 'jump-oldest-older',
+            content: 'jump oldest 古い投稿',
+            createdAt: 1_599_900_000,
+            postedAt: 1_599_900_000_000,
+        });
+        const oldest = createRecord({
+            eventId: 'jump-oldest-oldest',
+            content: 'jump oldest 最古投稿',
+            createdAt: 1_500_000_000,
+            postedAt: 1_500_000_000_000,
+        });
+
+        visibleRangeRepositoryMock.get.mockResolvedValue({
+            pubkeyHex: PUBKEY_HEX,
+            kindsKey: '1,42',
+            visibleUntil: 1_650_000_000,
+            updatedAt: 1,
+        });
+        repositoryMock.countForPubkey.mockResolvedValue(4);
+        repositoryMock.getLatestVisibleChunk.mockResolvedValue([newest]);
+        repositoryMock.getVisibleChunkFromCreatedAt.mockImplementation(async ({
+            createdAt,
+            query,
+        }: Record<string, any>) => {
+            if (createdAt === 0 && query?.contiguous === false) {
+                return [oldest];
+            }
+            return query?.contiguous === false ? [jumpTarget] : [newest];
+        });
+        repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
+        repositoryMock.getOlderVisibleChunk.mockImplementation(async ({
+            cursor,
+            visibleUntil,
+        }: Record<string, any>) => (
+            cursor?.eventId === jumpTarget.eventId && visibleUntil === null
+                ? [older]
+                : []
+        ));
+        jumpCacheAnchorRepositoryMock.getForPubkey.mockResolvedValue([{
+            centerCreatedAt: 1_600_000_000,
+            radiusSec: 86_400,
+            fetchedAt: Date.now(),
+        }]);
+        jumpCacheAnchorRepositoryMock.hasNearbyAnchorForPubkey.mockResolvedValue(true);
+
+        const view = render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: PUBKEY_HEX,
+                rxNostr: {} as any,
+            },
+        });
+
+        await waitFor(() => expect(screen.getByText('jump oldest 最新')).toBeTruthy());
+        await waitFor(() => expect(relayFetchServiceMock.fetchLatest).toHaveBeenCalled());
+        relayFetchServiceMock.fetchLatest.mockClear();
+        await clickMenuAction('日付へ移動');
+        await setJumpDateValue('2020-09-13');
+        await fireEvent.click(getJumpDateSubmitButton());
+        await waitFor(() => expect(screen.getByText('jump oldest 対象')).toBeTruthy());
+
+        const historyContainer = getHistoryContainer();
+        Object.defineProperty(historyContainer, 'clientHeight', {
+            configurable: true,
+            value: 320,
+        });
+        Object.defineProperty(historyContainer, 'scrollHeight', {
+            configurable: true,
+            value: 720,
+        });
+        historyContainer.scrollTop = 0;
+        await fireEvent.scroll(historyContainer);
+
+        await openPostHistoryMenu();
+        await fireEvent.click(await screen.findByRole('menuitem', { name: '最古へ移動' }));
+
+        await waitFor(() => {
+            expect(screen.getByText('jump oldest 最古投稿')).toBeTruthy();
+            expect(historyContainer.scrollTop).toBe(720);
+        });
+        expect(repositoryMock.getOlderVisibleChunk).toHaveBeenCalledWith(
+            expect.objectContaining({
+                pubkeyHex: PUBKEY_HEX,
+                visibleUntil: null,
+                cursor: expect.objectContaining({ eventId: jumpTarget.eventId }),
+                limit: 1,
+            }),
+        );
+        expect(repositoryMock.getVisibleChunkFromCreatedAt).toHaveBeenCalledWith(
+            expect.objectContaining({
+                pubkeyHex: PUBKEY_HEX,
+                createdAt: 0,
+                query: { contiguous: false },
+            }),
+        );
+        expect(repositoryMock.getOlderVisibleChunk).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                pubkeyHex: PUBKEY_HEX,
+                visibleUntil: null,
+                cursor: expect.objectContaining({ eventId: oldest.eventId }),
+                limit: 1,
+            }),
+        );
+        await openPostHistoryMenu();
+        expect((await screen.findByRole('menuitem', { name: '最古へ移動' }))
+            .getAttribute('aria-disabled')).toBe('true');
+        expect(relayFetchServiceMock.fetchLatest).not.toHaveBeenCalled();
+
+        view.unmount();
+    });
+
+    it('saved sparse でも最古へ移動すると absolute local oldest へ移動し source を維持する', async () => {
+        const newest = createRecord({
+            eventId: 'saved-oldest-newest',
+            content: 'saved oldest 最新',
+            createdAt: 1_700,
+            postedAt: 1_700_000,
+        });
+        const savedFirst = createRecord({
+            eventId: 'saved-oldest-first',
+            content: 'saved oldest first',
+            createdAt: 900,
+            postedAt: 900_000,
+        });
+        const savedOlder = createRecord({
+            eventId: 'saved-oldest-older',
+            content: 'saved oldest older',
+            createdAt: 800,
+            postedAt: 800_000,
+        });
+        const oldest = createRecord({
+            eventId: 'saved-oldest-oldest',
+            content: 'saved oldest 最古投稿',
+            createdAt: 700,
+            postedAt: 700_000,
+        });
+
+        visibleRangeRepositoryMock.get.mockResolvedValue({
+            pubkeyHex: PUBKEY_HEX,
+            kindsKey: '1,42',
+            visibleUntil: 1_000,
+            updatedAt: 1,
+        });
+        repositoryMock.countForPubkey.mockResolvedValue(4);
+        repositoryMock.getLatestVisibleChunk.mockResolvedValue([newest]);
+        repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
+        repositoryMock.getOlderVisibleChunk.mockResolvedValue([]);
+        repositoryMock.hasPostsBeforeCreatedAt.mockResolvedValue(true);
+        repositoryMock.getSparseChunk.mockImplementation(async ({
+            direction,
+            cursor,
+        }: Record<string, any>) => {
+            if (direction === 'latest') return [savedFirst];
+            if (direction === 'older' && cursor?.eventId === savedFirst.eventId) {
+                return [savedOlder];
+            }
+            return [];
+        });
+        repositoryMock.getVisibleChunkFromCreatedAt.mockResolvedValue([oldest]);
+
+        const view = render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: PUBKEY_HEX,
+                rxNostr: {} as any,
+            },
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('saved oldest 最新')).toBeTruthy();
+            expect(screen.getByRole('button', { name: '保存済みの古い投稿を表示' })).toBeTruthy();
+        });
+        await waitFor(() => expect(relayFetchServiceMock.fetchLatest).toHaveBeenCalled());
+        relayFetchServiceMock.fetchLatest.mockClear();
+        await fireEvent.click(screen.getByRole('button', { name: '保存済みの古い投稿を表示' }));
+        await waitFor(() => expect(screen.getByText('saved oldest first')).toBeTruthy());
+
+        const historyContainer = getHistoryContainer();
+        Object.defineProperty(historyContainer, 'clientHeight', {
+            configurable: true,
+            value: 320,
+        });
+        Object.defineProperty(historyContainer, 'scrollHeight', {
+            configurable: true,
+            value: 720,
+        });
+        historyContainer.scrollTop = 0;
+        await fireEvent.scroll(historyContainer);
+
+        await openPostHistoryMenu();
+        await fireEvent.click(await screen.findByRole('menuitem', { name: '最古へ移動' }));
+
+        await waitFor(() => {
+            expect(screen.getByText('saved oldest 最古投稿')).toBeTruthy();
+            expect(historyContainer.scrollTop).toBe(720);
+        });
+        expect(repositoryMock.getVisibleChunkFromCreatedAt).toHaveBeenCalledWith(
+            expect.objectContaining({
+                pubkeyHex: PUBKEY_HEX,
+                createdAt: 0,
+                visibleUntil: 1_000,
+                query: { contiguous: false },
+            }),
+        );
+        expect(repositoryMock.getSparseChunk).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                pubkeyHex: PUBKEY_HEX,
+                cursor: expect.objectContaining({ eventId: oldest.eventId }),
+                direction: 'older',
+                limit: 1,
+            }),
+        );
+        await openPostHistoryMenu();
+        expect((await screen.findByRole('menuitem', { name: '最古へ移動' }))
+            .getAttribute('aria-disabled')).toBe('true');
+        expect(relayFetchServiceMock.fetchLatest).not.toHaveBeenCalled();
+
+        view.unmount();
+    });
+
     it('visibleUntil が null の日付ジャンプ後も jump 用 sparse 経路で古い投稿を読む', async () => {
         const newest = createRecord({
             eventId: 'jump-null-newest',


### PR DESCRIPTION
## 変更概要
投稿履歴のsparse listingで、メニューの「最古へ移動」が現在ページの下端へのscrollだけになるno-opを修正しました。

## 原因
jump sparseのolder availabilityがnumeric visibleUntil付きのcontiguous queryを使い、boundary外のローカル投稿を見落としていました。さらにcanJumpToOldestがsparseにもcontiguous用のboundary/jump-cache guardを適用していました。

## 主な修正内容
- jump sparseのolder availabilityをgetOlderVisibleChunk(visibleUntil: null, cursor, limit: 1)へ分離
- sparse listingではsource-aware availabilityだけで最古data jumpを許可
- sparseの最古移動はgetVisibleChunkFromCreatedAt(createdAt: 0, query: { contiguous: false })でlocal absolute oldest pageを取得
- sparseSource、visibleUntil、jump cache anchor、永続化仕様を維持
- contiguous listingのboundary/jump-cache guard、通常の日付ジャンプのrelay repairは維持

## 回帰テスト
- numeric visibleUntil + jump cache anchorの日付ジャンプ後のjump sparse最古移動
- saved sparseからのabsolute local oldest移動
- absolute oldest到達後のolder availability false
- contiguous + visibleUntil null + jump cache anchorの既存guard
- 120件seedのPlaywright saved sparse複数ページ実ブラウザ操作

## 実行したテストと結果
- npm run test -- src/test/unit/postHistoryDialogTimeline.test.ts: 成功（39 tests）
- npm run test -- src/test/unit/postHistoryDialogTimelineRelay.test.ts: 成功（49 tests）
- npm run test -- src/test/unit/postHistoryRepository.test.ts: 成功（45 tests）
- npm run check: 成功
- npm test: 成功（319 files / 3612 tests）
- npm run build: 成功
- npx playwright test src/test/e2e/postHistoryDialog.spec.ts --project=desktop-chromium: 成功（17 passed / 2 skipped）
- 新規saved sparse E2E: 成功

## 未実行・未成功の検証
全projectのPlaywright実行では既存のmobile timeline testが、今回の変更と無関係なquote loading assertion（loading中を期待する箇所で「引用投稿が見つかりませんでした」）で失敗しました。該当テスト単体でも同じ結果でした。mobile projectでは新規desktop-onlyテストはskipされます。