### PR TITLE
perf: optimize post history oldest jump

### DIFF
--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -3452,10 +3452,9 @@ export function usePostHistoryListing({
             }
 
             const requestId = ++loadRequestId;
-            const posts = await postHistoryRepository.getVisibleChunkFromCreatedAt({
+            const posts = await postHistoryRepository.getOldestVisibleChunk({
                 pubkeyHex,
                 visibleUntil: state.visibleUntil,
-                createdAt: 0,
                 limit: pageSize,
                 query: {
                     contiguous: false,
@@ -3473,11 +3472,55 @@ export function usePostHistoryListing({
             refreshTotalCountFromRepository();
             state.loadedPosts = posts;
             resetOlderBackfillSearchState();
-            await refreshTimelineAvailability(pubkeyHex, posts, requestId);
+            state.hasOlderLocal = false;
+            await refreshTimelineAvailability(
+                pubkeyHex,
+                posts,
+                requestId,
+                { skipOlderCheck: true },
+            );
             return true;
         }
 
-        return jumpToCreatedAt(0);
+        clearContiguousProgress();
+        const pubkeyHex = getPubkeyHex();
+        if (!pubkeyHex) {
+            return false;
+        }
+
+        const requestId = ++loadRequestId;
+        const visibleUntil = await refreshVisibleUntil(pubkeyHex, requestId);
+        const posts = await postHistoryRepository.getOldestVisibleChunk({
+            pubkeyHex,
+            visibleUntil,
+            limit: pageSize,
+        });
+
+        if (!getShow() || requestId !== loadRequestId) {
+            return false;
+        }
+
+        if (posts.length === 0) {
+            refreshTotalCountFromRepository();
+            state.loadedPosts = [];
+            state.hasOlderLocal = false;
+            state.hasNewerLocal = false;
+            return false;
+        }
+
+        refreshTotalCountFromRepository();
+        state.listingMode = "contiguous";
+        state.sparseSource = null;
+        state.loadedPosts = posts;
+        resetOlderBackfillSearchState();
+        state.hasOlderLocal = false;
+        await refreshTimelineAvailability(
+            pubkeyHex,
+            posts,
+            requestId,
+            { skipOlderCheck: true },
+        );
+        return true;
     }
 
     async function fetchOlderFromRelays(

--- a/src/lib/storage/postHistoryRepository.ts
+++ b/src/lib/storage/postHistoryRepository.ts
@@ -72,6 +72,11 @@ export type PostHistoryVisibleChunkFromCreatedAtOptions =
         query?: PostHistoryDateChunkQuery;
     };
 
+export type PostHistoryOldestVisibleChunkOptions =
+    PostHistoryVisibleChunkOptions & {
+        query?: PostHistoryDateChunkQuery;
+    };
+
 export type PostHistoryDateChunkQuery = {
     contiguous?: boolean;
 };
@@ -124,6 +129,7 @@ export interface PostHistoryRepository {
     getLatestVisibleChunk(options: PostHistoryVisibleChunkOptions): Promise<PostHistoryRecord[]>;
     getOlderVisibleChunk(options: PostHistoryVisibleChunkCursorOptions): Promise<PostHistoryRecord[]>;
     getNewerVisibleChunk(options: PostHistoryVisibleChunkCursorOptions): Promise<PostHistoryRecord[]>;
+    getOldestVisibleChunk(options: PostHistoryOldestVisibleChunkOptions): Promise<PostHistoryRecord[]>;
     getVisibleChunkFromCreatedAt(options: PostHistoryVisibleChunkFromCreatedAtOptions): Promise<PostHistoryRecord[]>;
     getVisibleChunkAroundEventId(options: PostHistoryVisibleChunkAroundEventIdOptions): Promise<PostHistoryRecord[]>;
     hasPostsBeforeCreatedAt(pubkeyHex: string | null | undefined, createdAt: number): Promise<boolean>;
@@ -524,6 +530,40 @@ export class DexiePostHistoryRepository implements PostHistoryRepository {
             .toArray();
 
         return records.reverse();
+    }
+
+    async getOldestVisibleChunk(
+        options: PostHistoryOldestVisibleChunkOptions,
+    ): Promise<PostHistoryRecord[]> {
+        if (!options.pubkeyHex) return [];
+
+        const limit = normalizeChunkLimit(options.limit);
+        const query = normalizePostHistoryDateChunkQuery(options.query);
+        const visibleUntil = query.contiguous
+            ? normalizeVisibleUntil(options.visibleUntil)
+            : null;
+        const bounds = getTimelineBounds(options.pubkeyHex);
+        if (visibleUntil !== null) {
+            const visibleRecords = await this.db.postHistory
+                .where("[pubkeyHex+createdAt]")
+                .between(
+                    [options.pubkeyHex, visibleUntil],
+                    [options.pubkeyHex, Dexie.maxKey],
+                )
+                .toArray();
+
+            return visibleRecords
+                .sort(comparePostHistoryTimelineOrder)
+                .slice(-limit);
+        }
+
+        const oldestRecords = await this.db.postHistory
+            .where(POST_HISTORY_TIMELINE_INDEX)
+            .between(bounds.lower, bounds.upper)
+            .limit(limit)
+            .toArray();
+
+        return oldestRecords.reverse();
     }
 
     async getVisibleChunkFromCreatedAt(

--- a/src/test/unit/postHistoryDialogTestHarness.ts
+++ b/src/test/unit/postHistoryDialogTestHarness.ts
@@ -148,6 +148,7 @@ const hoisted = vi.hoisted(() => {
             getLatestVisibleChunk: vi.fn(),
             getOlderVisibleChunk: vi.fn(),
             getNewerVisibleChunk: vi.fn(),
+            getOldestVisibleChunk: vi.fn(),
             getVisibleChunkFromCreatedAt: vi.fn(),
             getVisibleChunkAroundEventId: vi.fn(),
             hasPostsBeforeCreatedAt: vi.fn(),

--- a/src/test/unit/postHistoryDialogTimeline.test.ts
+++ b/src/test/unit/postHistoryDialogTimeline.test.ts
@@ -522,13 +522,10 @@ describe('PostHistoryDialog timeline navigation', () => {
         });
         repositoryMock.countForPubkey.mockResolvedValue(4);
         repositoryMock.getLatestVisibleChunk.mockResolvedValue([newest]);
+        repositoryMock.getOldestVisibleChunk.mockResolvedValue([oldest]);
         repositoryMock.getVisibleChunkFromCreatedAt.mockImplementation(async ({
-            createdAt,
             query,
         }: Record<string, any>) => {
-            if (createdAt === 0 && query?.contiguous === false) {
-                return [oldest];
-            }
             return query?.contiguous === false ? [jumpTarget] : [newest];
         });
         repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
@@ -591,14 +588,16 @@ describe('PostHistoryDialog timeline navigation', () => {
                 limit: 1,
             }),
         );
-        expect(repositoryMock.getVisibleChunkFromCreatedAt).toHaveBeenCalledWith(
+        expect(repositoryMock.getOldestVisibleChunk).toHaveBeenCalledWith(
             expect.objectContaining({
                 pubkeyHex: PUBKEY_HEX,
-                createdAt: 0,
                 query: { contiguous: false },
             }),
         );
-        expect(repositoryMock.getOlderVisibleChunk).toHaveBeenLastCalledWith(
+        expect(repositoryMock.getVisibleChunkFromCreatedAt).not.toHaveBeenCalledWith(
+            expect.objectContaining({ createdAt: 0 }),
+        );
+        expect(repositoryMock.getOlderVisibleChunk).not.toHaveBeenCalledWith(
             expect.objectContaining({
                 pubkeyHex: PUBKEY_HEX,
                 visibleUntil: null,
@@ -661,7 +660,7 @@ describe('PostHistoryDialog timeline navigation', () => {
             }
             return [];
         });
-        repositoryMock.getVisibleChunkFromCreatedAt.mockResolvedValue([oldest]);
+        repositoryMock.getOldestVisibleChunk.mockResolvedValue([oldest]);
 
         const view = render(PostHistoryDialog, {
             props: {
@@ -700,15 +699,17 @@ describe('PostHistoryDialog timeline navigation', () => {
             expect(screen.getByText('saved oldest 最古投稿')).toBeTruthy();
             expect(historyContainer.scrollTop).toBe(720);
         });
-        expect(repositoryMock.getVisibleChunkFromCreatedAt).toHaveBeenCalledWith(
+        expect(repositoryMock.getOldestVisibleChunk).toHaveBeenCalledWith(
             expect.objectContaining({
                 pubkeyHex: PUBKEY_HEX,
-                createdAt: 0,
                 visibleUntil: 1_000,
                 query: { contiguous: false },
             }),
         );
-        expect(repositoryMock.getSparseChunk).toHaveBeenLastCalledWith(
+        expect(repositoryMock.getVisibleChunkFromCreatedAt).not.toHaveBeenCalledWith(
+            expect.objectContaining({ createdAt: 0 }),
+        );
+        expect(repositoryMock.getSparseChunk).not.toHaveBeenCalledWith(
             expect.objectContaining({
                 pubkeyHex: PUBKEY_HEX,
                 cursor: expect.objectContaining({ eventId: oldest.eventId }),
@@ -2174,7 +2175,7 @@ describe('PostHistoryDialog timeline navigation', () => {
 
         repositoryMock.countForPubkey.mockResolvedValue(4);
         repositoryMock.getLatestVisibleChunk.mockResolvedValueOnce([newest, middle]);
-        repositoryMock.getVisibleChunkFromCreatedAt.mockResolvedValueOnce([older, oldest]);
+        repositoryMock.getOldestVisibleChunk.mockResolvedValueOnce([older, oldest]);
         repositoryMock.getNewerVisibleChunk
             .mockResolvedValueOnce([])
             .mockResolvedValueOnce([middle]);
@@ -2207,11 +2208,13 @@ describe('PostHistoryDialog timeline navigation', () => {
         await waitFor(() => {
             expect(screen.getByText('最古投稿')).toBeTruthy();
             expect(historyContainer.scrollTop).toBe(720);
-            expect(repositoryMock.getVisibleChunkFromCreatedAt).toHaveBeenCalledWith(
+            expect(repositoryMock.getOldestVisibleChunk).toHaveBeenCalledWith(
                 expect.objectContaining({
                     pubkeyHex: PUBKEY_HEX,
-                    createdAt: 0,
                 }),
+            );
+            expect(repositoryMock.getVisibleChunkFromCreatedAt).not.toHaveBeenCalledWith(
+                expect.objectContaining({ createdAt: 0 }),
             );
             expect(relayFetchServiceMock.fetchLatest).toHaveBeenCalledTimes(1);
         });

--- a/src/test/unit/postHistoryRepository.test.ts
+++ b/src/test/unit/postHistoryRepository.test.ts
@@ -659,6 +659,50 @@ describe("DexiePostHistoryRepository", () => {
         db.close();
     });
 
+    it("oldest visible chunk はtimeline順で最古ページを取得し、query種別ごとのboundaryを守る", async () => {
+        const db = createTestDb();
+        const repository = new DexiePostHistoryRepository(db, () => 1000);
+        const pubkey = "b".repeat(64);
+
+        await repository.putPostedEvent({
+            event: createSignedEvent({ id: "1".repeat(64), pubkey, created_at: 500 }),
+            postedAt: 1000,
+        });
+        await repository.putPostedEvent({
+            event: createSignedEvent({ id: "2".repeat(64), pubkey, created_at: 300 }),
+            postedAt: 2000,
+        });
+        await repository.putPostedEvent({
+            event: createSignedEvent({ id: "3".repeat(64), pubkey, created_at: 400 }),
+            postedAt: 3000,
+        });
+        await repository.putPostedEvent({
+            event: createSignedEvent({ id: "4".repeat(64), pubkey, created_at: 200 }),
+            postedAt: 4000,
+        });
+
+        await expect(repository.getOldestVisibleChunk({
+            pubkeyHex: pubkey,
+            visibleUntil: 350,
+            limit: 2,
+        })).resolves.toMatchObject([
+            { eventId: "3".repeat(64), createdAt: 400, postedAt: 3000 },
+            { eventId: "1".repeat(64), createdAt: 500, postedAt: 1000 },
+        ]);
+
+        await expect(repository.getOldestVisibleChunk({
+            pubkeyHex: pubkey,
+            visibleUntil: 350,
+            limit: 2,
+            query: { contiguous: false },
+        })).resolves.toMatchObject([
+            { eventId: "2".repeat(64), createdAt: 300, postedAt: 2000 },
+            { eventId: "1".repeat(64), createdAt: 500, postedAt: 1000 },
+        ]);
+
+        db.close();
+    });
+
     it("countVisibleForPubkey は visibleUntil 境界を inclusive に扱い他 pubkey を含めない", async () => {
         const db = createTestDb();
         const repository = new DexiePostHistoryRepository(db, () => 1000);


### PR DESCRIPTION
## 変更概要
投稿履歴メニューの「最古へ移動」で、大量履歴時に不要なdate-chunk sentinel scanが発生しないよう最古ページ取得を最適化しました。

## 原因
`createdAt: 0` の最古移動が `getVisibleChunkFromCreatedAt()` を通り、timeline index全体をreverseしてJavaScript filterでanchorを探していました。通常は該当anchorがないため、大量履歴を走査してからoldest fallbackへ進み、さらにnumeric `visibleUntil`時はavailability queryでもboundary外レコードのscanが発生していました。

## 主な修正内容
- `getOldestVisibleChunk()` を追加し、最古移動専用のlocal queryへ分離
- numeric `visibleUntil`時は既存の`[pubkeyHex+createdAt]` indexでvisible候補を取得し、既存timeline comparatorで並べ替えてtimeline orderを維持
- boundaryなし／non-contiguous時は既存timeline indexの最古側から取得
- contiguous / saved sparse / jump sparseのlisting state、visibleUntil、sparseSource、request ID制御を維持
- absolute oldest取得後は older availability queryを再実行せず、`hasOlderLocal=false`として不要な再走査を回避
- 通常の日付ジャンプと`repair-visible-range`経路は変更していません

## 回帰テスト
- repositoryのtimeline order、numeric boundary、non-contiguous、limitを検証
- contiguous / jump sparse / saved sparseの最古移動がoldest queryを使用することを検証
- sentinel date queryを使わず、absolute oldest後のavailabilityを維持することを検証
- 既存の投稿履歴Playwrightフロー（最古投稿表示・最下部scrollを含む）を確認

## 実測
同じ約70,110件の実ブラウザデータで、変更前はDOM切替約6.755〜6.887秒、scroll完了約10.130〜13.852秒でした。変更後は、oldest queryの一時計測約14ms、DOM切替約2.4秒、scroll完了約2.7秒まで短縮しました。

## 検証結果
- `npm run test -- src/test/unit/postHistoryRepository.test.ts src/test/unit/postHistoryDialogTimeline.test.ts` — 85 passed
- `npm run check` — passed
- `npm test` — 319 files / 3,613 tests passed
- `npm run build` — passed
- `npx playwright test src/test/e2e/postHistoryDialog.spec.ts --project=desktop-chromium` — 17 passed, 2 skipped

実端末（Android/iOS）確認は未実行です。最終のブラウザpoll計測は制御上限でセッションがリセットされましたが、同じ最終コード経路の直前計測とtemporary timing instrumentationでquery・availability・DOM区間を確認し、instrumentationは差分から除去しています。