### PR TITLE
Fix saved post history boundary layout

### DIFF
--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -3901,6 +3901,13 @@
         background: color-mix(in srgb, var(--bg-input) 72%, transparent);
     }
 
+    .post-history-saved-boundary {
+        padding: 0;
+        border: 0;
+        border-radius: 0;
+        background: transparent;
+    }
+
     .post-history-saved-boundary p,
     .post-history-sparse-state p {
         margin: 0;

--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -3925,6 +3925,23 @@
         gap: 8px;
     }
 
+    :global(.post-history-saved-boundary-actions .post-history-nav-button) {
+        height: 52px;
+    }
+
+    @media (max-width: 600px) {
+        .post-history-saved-boundary-actions {
+            width: min(100%, 320px);
+            flex-direction: column;
+            align-items: center;
+        }
+
+        :global(.post-history-saved-boundary-actions .post-history-nav-button) {
+            width: 100%;
+            flex: 0 0 52px;
+        }
+    }
+
     .import-icon {
         mask-image: url("/icons/cloud_download_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg");
     }

--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -2773,7 +2773,6 @@
 
             {#if history.showSavedPostsBoundary}
                 <div class="post-history-saved-boundary" role="status">
-                    <p>{$_("postHistory.savedOlderPostsBoundary")}</p>
                     <div class="post-history-saved-boundary-actions">
                         {#if history.canFetchOlderFromRelays || history.isFetchingFromRelays}
                             <Button
@@ -3909,7 +3908,13 @@
 
     .post-history-saved-boundary-actions {
         display: flex;
+        width: fit-content;
+        max-width: 100%;
+        box-sizing: border-box;
+        justify-self: center;
         flex-wrap: wrap;
+        justify-content: center;
+        align-items: flex-start;
         gap: 8px;
     }
 

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -155,7 +155,6 @@
     "fetchUnfetchedFromRelays": "Fetch unfetched posts",
     "fetchOlderFromRelaysLoading": "Fetching from relays...",
     "showSavedOlderPosts": "Show saved older posts",
-    "savedOlderPostsBoundary": "There may be an unfetched period ahead. You can show saved older posts.",
     "savedOlderPostsShowing": "Showing saved older posts.",
     "savedOlderPostsGapNotice": "There may be an unfetched period between these and recent posts.",
     "empty": "No post history",

--- a/src/lib/i18n/ja.json
+++ b/src/lib/i18n/ja.json
@@ -155,7 +155,6 @@
     "fetchUnfetchedFromRelays": "未取得の投稿を取得",
     "fetchOlderFromRelaysLoading": "リレーから取得中...",
     "showSavedOlderPosts": "保存済みの古い投稿を表示",
-    "savedOlderPostsBoundary": "この先には未取得の期間がある可能性があります。保存済みの古い投稿を表示できます。",
     "savedOlderPostsShowing": "保存済みの古い投稿を表示中です。",
     "savedOlderPostsGapNotice": "最近の投稿との間に未取得の期間がある可能性があります。",
     "empty": "投稿履歴はありません",

--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -381,7 +381,7 @@ test.describe('PostHistoryDialog Playwright', () => {
         await expect(dropZone).toContainText('JSONLファイルをここにドラッグ＆ドロップ');
     });
 
-    test('saved posts outside the visible range can be viewed without changing the range', async ({ page }) => {
+    test('saved posts outside the visible range can be viewed without changing the range', async ({ page, isMobile }) => {
         const harness = await gotoSparseHarness(page);
 
         await expectSummary(page, harness.totalPosts);
@@ -402,7 +402,7 @@ test.describe('PostHistoryDialog Playwright', () => {
             };
         });
         expect(boundaryLayout.justifyContent).toBe('center');
-        expect(boundaryLayout.alignItems).toBe('flex-start');
+        expect(boundaryLayout.alignItems).toBe(isMobile ? 'center' : 'flex-start');
         expect(boundaryLayout.buttonRects.length).toBeGreaterThan(0);
         expect(new Set(boundaryLayout.buttonRects.map((rect) => rect.height)).size).toBe(1);
 

--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -387,6 +387,24 @@ test.describe('PostHistoryDialog Playwright', () => {
         await expectSummary(page, harness.totalPosts);
         await expect(page.getByText(harness.sparseVisiblePostContent, { exact: true })).toBeVisible();
         await expect(page.getByText('保存済みの古い投稿を表示', { exact: true })).toBeVisible();
+        await expect(page.getByText('この先には未取得の期間がある可能性があります。保存済みの古い投稿を表示できます。', { exact: true })).toHaveCount(0);
+
+        const boundaryLayout = await page.locator('.post-history-saved-boundary-actions').evaluate((element) => {
+            const actionElement = element as HTMLElement;
+            const buttons = Array.from(actionElement.querySelectorAll<HTMLElement>('button'));
+            return {
+                justifyContent: getComputedStyle(actionElement).justifyContent,
+                alignItems: getComputedStyle(actionElement).alignItems,
+                buttonRects: buttons.map((button) => {
+                    const rect = button.getBoundingClientRect();
+                    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+                }),
+            };
+        });
+        expect(boundaryLayout.justifyContent).toBe('center');
+        expect(boundaryLayout.alignItems).toBe('flex-start');
+        expect(boundaryLayout.buttonRects.length).toBeGreaterThan(0);
+        expect(new Set(boundaryLayout.buttonRects.map((rect) => rect.height)).size).toBe(1);
 
         await page.getByRole('button', { name: '保存済みの古い投稿を表示' }).click();
 

--- a/src/test/unit/postHistoryDialogTestHarness.ts
+++ b/src/test/unit/postHistoryDialogTestHarness.ts
@@ -49,7 +49,6 @@ const hoisted = vi.hoisted(() => {
             'postHistory.fetchUnfetchedFromRelays': '未取得の投稿を取得',
             'postHistory.fetchOlderFromRelaysLoading': 'リレーから取得中...',
             'postHistory.showSavedOlderPosts': '保存済みの古い投稿を表示',
-            'postHistory.savedOlderPostsBoundary': 'この先には未取得の期間がある可能性があります。保存済みの古い投稿を表示できます。',
             'postHistory.savedOlderPostsShowing': '保存済みの古い投稿を表示中です。',
             'postHistory.savedOlderPostsGapNotice': '最近の投稿との間に未取得の期間がある可能性があります。',
             'postHistory.repair': '表示中の投稿付近を再取得',


### PR DESCRIPTION
## 変更概要
投稿履歴ダイアログの「保存済みの古い投稿」境界UIから説明文を削除し、境界アクションをPC・狭いviewportで中央配置できるように修正しました。

## 主な実装内容
- PostHistoryDialog.svelte の境界説明文を削除
- 境界アクションを局所CSSで中央配置
- 折り返し時に align-items: flex-start を指定し、ボタンを通常高さに維持
- 未使用になった savedOlderPostsBoundary 翻訳キーとテストハーネス定義を削除
- 既存Playwrightテストに説明文非表示・CSS配置・ボタン高さの回帰確認を追加

## テストと確認結果
- PostHistoryDialog unit tests 8 files: 134 passed
- npm run check: passed
- Playwright desktop-chromium / Desktop Chrome: passed
- Playwright mobile-chromium / iPhone 13 viewport: passed
- npm test: 3611 passed, 2 failed
  - postHistoryDialogTimeline.test.ts の既存のタイミング依存と思われる2件。今回のレイアウト変更とは無関係です。

## 実ブラウザ確認
- PC幅: 説明文なし、境界アクションの中央配置指定、通常のボタン高さを確認
- スマートフォン相当幅: 説明文なし、折り返し可能、通常のボタン高さ、各行の中央配置指定を確認

## 未実行
- 実機Android/iOSの確認は、利用可能な実端末環境がないため未実行です。
