### PR TITLE
Filter decommissioned relays before connection

### DIFF
--- a/src/lib/channelContextService.ts
+++ b/src/lib/channelContextService.ts
@@ -1,6 +1,6 @@
 import { createRxBackwardReq } from "rx-nostr";
 import type { RxNostr } from "rx-nostr";
-import { FALLBACK_RELAYS } from "./constants";
+import { FALLBACK_RELAYS } from "./relayLists";
 import { compareChannelMetadataEventVersions } from "./channelMetadataEventOrder";
 import { normalizeChannelPictureUrl } from "./channelPictureUrlUtils";
 import {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,18 +1,3 @@
-export const BOOTSTRAP_RELAYS = [
-    "wss://purplepag.es/",
-    "wss://directory.yabu.me/",
-    "wss://indexer.coracle.social/",
-    "wss://user.kindpag.es/",
-];
-
-export const FALLBACK_RELAYS = [
-    "wss://nos.lol/",
-    "wss://relay.damus.io/",
-    "wss://relay.nostr.wirednet.jp/",
-    "wss://yabu.me/",
-    "wss://x.kojira.io/",
-];
-
 // --- fileUploadManager用定数 ---
 export const DEFAULT_API_URL = "https://nostr.build/api/v2/upload/files";
 export const MAX_FILE_SIZE = 1024 * 1024 * 1024; // 1GB

--- a/src/lib/nip46Service.ts
+++ b/src/lib/nip46Service.ts
@@ -425,6 +425,11 @@ class Nip46WebSocket extends WebSocket {
 async function createConnectedPool(
     relays: string[],
 ): Promise<{ pool: SimplePool; connectedRelays: string[] }> {
+    const uniqueRelays = [...new Set(sanitizeNip46NostrConnectRelays(relays))];
+    if (uniqueRelays.length === 0) {
+        throw new Error('Relay connection failed: no reachable relays');
+    }
+
     // NIP-46用WebSocket(デバッグログ + limit:0パッチ)を設定
     const origWs = globalThis.WebSocket;
     useWebSocketImplementation(Nip46WebSocket);
@@ -433,7 +438,6 @@ async function createConnectedPool(
     const connectedRelays: string[] = [];
     const connectionErrors: string[] = [];
 
-    const uniqueRelays = [...new Set(relays)];
     for (const [index, relay] of uniqueRelays.entries()) {
         try {
             console.debug('[NIP-46] relay connection attempt', {
@@ -488,12 +492,16 @@ async function createConnectedPoolReadyOnFirstReachable(
         FIRST_REACHABLE_RELAY_CONNECTION_LOG_MESSAGES,
     collectReadyWindowMs: number = 0,
 ): Promise<{ pool: SimplePool; connectedRelays: string[] }> {
+    const uniqueRelays = [...new Set(sanitizeNip46NostrConnectRelays(relays))];
+    if (uniqueRelays.length === 0) {
+        throw new Error('Relay connection failed: no reachable relays');
+    }
+
     const origWs = globalThis.WebSocket;
     useWebSocketImplementation(Nip46WebSocket);
     const pool = new SimplePool();
     useWebSocketImplementation(origWs);
 
-    const uniqueRelays = [...new Set(relays)];
     const connectedRelays: string[] = [];
     const connectionErrors: string[] = [];
 
@@ -624,12 +632,16 @@ async function createConnectedPoolForReachableRelays(
     relays: string[],
     logMessages: RelayConnectionLogMessages,
 ): Promise<{ pool: SimplePool; connectedRelays: string[] }> {
+    const uniqueRelays = [...new Set(sanitizeNip46NostrConnectRelays(relays))];
+    if (uniqueRelays.length === 0) {
+        throw new Error('Relay connection failed: no reachable relays');
+    }
+
     const origWs = globalThis.WebSocket;
     useWebSocketImplementation(Nip46WebSocket);
     const pool = new SimplePool();
     useWebSocketImplementation(origWs);
 
-    const uniqueRelays = [...new Set(relays)];
     const connectedRelaySet = new Set<string>();
     const connectionErrors: string[] = [];
 
@@ -2590,7 +2602,9 @@ export class Nip46Service {
             return {
                 clientSecretKeyHex: session.clientSecretKeyHex,
                 remoteSignerPubkey: session.remoteSignerPubkey,
-                relays: session.relays.filter((relay): relay is string => typeof relay === 'string'),
+                relays: sanitizeNip46NostrConnectRelays(
+                    session.relays.filter((relay): relay is string => typeof relay === 'string'),
+                ),
                 userPubkey: session.userPubkey,
                 pingVerified: session.pingVerified === true,
                 ...(normalizeRelayResolution(session.relayResolution)

--- a/src/lib/postEventBuilder.ts
+++ b/src/lib/postEventBuilder.ts
@@ -152,6 +152,15 @@ export class PostEventSender {
         event: any,
         signerOrOptions?: any | SendEventOptions,
     ): Promise<PostResult> {
+        const options = normalizeSendEventOptions(signerOrOptions);
+        if (
+            hasExplicitTargetRelays(signerOrOptions)
+            && !options.includeDefaultWriteRelays
+            && (options.targetRelays?.length ?? 0) === 0
+        ) {
+            return Promise.resolve({ success: false, error: "no_write_relays" });
+        }
+
         return new Promise((resolve) => {
             let resolved = false;
             let subscription: any = null;
@@ -163,7 +172,6 @@ export class PostEventSender {
             const authRequiredRelays = new Set<string>();
             const pendingAuthRelays = new Set<string>();
 
-            const options = normalizeSendEventOptions(signerOrOptions);
             const targetRelays = resolveTargetRelays(this.rxNostr, options);
 
             const safeUnsubscribe = () => {
@@ -298,6 +306,12 @@ export class PostEventSender {
             subscription = this.rxNostr.send(event, sendOptions).subscribe(observer);
         });
     }
+}
+
+function hasExplicitTargetRelays(signerOrOptions?: any | SendEventOptions): boolean {
+    return !!signerOrOptions
+        && typeof signerOrOptions === "object"
+        && "targetRelays" in signerOrOptions;
 }
 
 export interface SendEventOptions {

--- a/src/lib/postHistoryContextFetchService.ts
+++ b/src/lib/postHistoryContextFetchService.ts
@@ -2,7 +2,7 @@ import {
     createRxBackwardReq,
     type RxNostr,
 } from "rx-nostr";
-import { FALLBACK_RELAYS } from "./constants";
+import { FALLBACK_RELAYS } from "./relayLists";
 import { RelayConfigUtils } from "./relayConfigUtils";
 import type { NostrEvent, RelayConfig } from "./types";
 import { usePostHistoryRelayEvents } from "./postHistoryRawEventVerification";

--- a/src/lib/postHistoryDeletionFetchService.ts
+++ b/src/lib/postHistoryDeletionFetchService.ts
@@ -2,7 +2,7 @@ import {
     createRxBackwardReq,
     type RxNostr,
 } from "rx-nostr";
-import { FALLBACK_RELAYS } from "./constants";
+import { FALLBACK_RELAYS } from "./relayLists";
 import { isSameSignedNostrEvent } from "./postHistoryEventUtils";
 import { RelayConfigUtils } from "./relayConfigUtils";
 import type { NostrEvent, RelayConfig } from "./types";

--- a/src/lib/postHistoryRelayFetchService.ts
+++ b/src/lib/postHistoryRelayFetchService.ts
@@ -5,7 +5,7 @@ import {
     type MessagePacket,
     type RxNostr,
 } from "rx-nostr";
-import { FALLBACK_RELAYS } from "./constants";
+import { FALLBACK_RELAYS } from "./relayLists";
 import { isSameSignedNostrEvent } from "./postHistoryEventUtils";
 import { RelayConfigUtils } from "./relayConfigUtils";
 import type { NostrEvent, RelayConfig } from "./types";

--- a/src/lib/postHistoryRelayResolver.ts
+++ b/src/lib/postHistoryRelayResolver.ts
@@ -1,4 +1,4 @@
-import { FALLBACK_RELAYS } from "./constants";
+import { FALLBACK_RELAYS } from "./relayLists";
 import { RelayConfigUtils } from "./relayConfigUtils";
 import type { RelayConfig } from "./types";
 

--- a/src/lib/postHistoryReplyFetchService.ts
+++ b/src/lib/postHistoryReplyFetchService.ts
@@ -2,7 +2,7 @@ import {
     createRxBackwardReq,
     type RxNostr,
 } from "rx-nostr";
-import { FALLBACK_RELAYS } from "./constants";
+import { FALLBACK_RELAYS } from "./relayLists";
 import {
     validatePostHistoryDirectReplyRelation,
     type PostHistoryDirectReplyParentContext,

--- a/src/lib/postHistorySelfParentFetchService.ts
+++ b/src/lib/postHistorySelfParentFetchService.ts
@@ -1,5 +1,5 @@
 import { createRxBackwardReq, type RxNostr } from "rx-nostr";
-import { FALLBACK_RELAYS } from "./constants";
+import { FALLBACK_RELAYS } from "./relayLists";
 import { RelayConfigUtils } from "./relayConfigUtils";
 import type { NostrEvent, RelayConfig } from "./types";
 import { usePostHistoryRelayEvents } from "./postHistoryRawEventVerification";

--- a/src/lib/postHistoryVisibleRangeChildInteractionRepairService.ts
+++ b/src/lib/postHistoryVisibleRangeChildInteractionRepairService.ts
@@ -2,7 +2,7 @@ import {
     createRxBackwardReq,
     type RxNostr,
 } from "rx-nostr";
-import { FALLBACK_RELAYS } from "./constants";
+import { FALLBACK_RELAYS } from "./relayLists";
 import {
     postHistoryDirectReplyRepairSaveService,
     type PostHistoryDirectReplyRepairItem,

--- a/src/lib/profileRelayTiers.ts
+++ b/src/lib/profileRelayTiers.ts
@@ -1,4 +1,4 @@
-import { BOOTSTRAP_RELAYS, FALLBACK_RELAYS } from "./constants";
+import { BOOTSTRAP_RELAYS, FALLBACK_RELAYS } from "./relayLists";
 import { RelayConfigUtils } from "./relayConfigUtils";
 
 export interface ProfileRelayTiers {

--- a/src/lib/relayConfigUtils.ts
+++ b/src/lib/relayConfigUtils.ts
@@ -1,7 +1,9 @@
 import { utils as nostrToolsUtils } from 'nostr-tools';
+import { DECOMMISSIONED_RELAYS } from './relayLists';
 import type { RelayConfig } from "./types";
 
 const ALLOWED_EXTERNAL_RELAY_PROTOCOLS = new Set(['ws:', 'wss:']);
+const DECOMMISSIONED_RELAY_URLS = new Set<string>(DECOMMISSIONED_RELAYS);
 
 // --- 純粋関数（依存性なし） ---
 export class RelayConfigParser {
@@ -79,6 +81,34 @@ export class RelayConfigUtils {
     }
 
     static normalizeExternalRelayUrl(url: string): string | null {
+        const normalized = this.normalizeExternalRelayUrlCandidate(url);
+        return normalized && !this.isDecommissionedRelayUrl(url)
+            ? normalized
+            : null;
+    }
+
+    static filterDecommissionedRelayConfig(config: RelayConfig): RelayConfig {
+        if (Array.isArray(config)) {
+            return config.filter((url) => !this.isDecommissionedRelayUrl(url));
+        }
+
+        return Object.fromEntries(
+            Object.entries(config).filter(([url]) => !this.isDecommissionedRelayUrl(url)),
+        );
+    }
+
+    static hasRelayEntries(config: RelayConfig): boolean {
+        return Array.isArray(config) ? config.length > 0 : Object.keys(config).length > 0;
+    }
+
+    private static isDecommissionedRelayUrl(url: string): boolean {
+        const normalized = this.normalizeExternalRelayUrlCandidate(url);
+        return normalized !== null
+            && !hasExplicitRelayPort(url)
+            && DECOMMISSIONED_RELAY_URLS.has(normalized);
+    }
+
+    private static normalizeExternalRelayUrlCandidate(url: string): string | null {
         if (typeof url !== 'string') {
             return null;
         }
@@ -155,10 +185,11 @@ export class RelayConfigUtils {
         const relaySet = new Set<string>();
 
         configs.forEach(config => {
-            if (Array.isArray(config)) {
-                config.forEach(url => relaySet.add(this.normalizeRelayUrl(url)));
-            } else if (typeof config === 'object') {
-                Object.keys(config).forEach(url => {
+            const filteredConfig = this.filterDecommissionedRelayConfig(config);
+            if (Array.isArray(filteredConfig)) {
+                filteredConfig.forEach(url => relaySet.add(this.normalizeRelayUrl(url)));
+            } else if (typeof filteredConfig === 'object') {
+                Object.keys(filteredConfig).forEach(url => {
                     relaySet.add(this.normalizeRelayUrl(url));
                 });
             }
@@ -171,11 +202,12 @@ export class RelayConfigUtils {
      * リレー設定からreadリレーのみを抽出
      */
     static extractReadRelays(config: RelayConfig): string[] {
-        if (Array.isArray(config)) {
-            return config.map(url => this.normalizeRelayUrl(url));
-        } else if (typeof config === 'object') {
-            return Object.keys(config)
-                .filter(url => config[url]?.read !== false)
+        const filteredConfig = this.filterDecommissionedRelayConfig(config);
+        if (Array.isArray(filteredConfig)) {
+            return filteredConfig.map(url => this.normalizeRelayUrl(url));
+        } else if (typeof filteredConfig === 'object') {
+            return Object.keys(filteredConfig)
+                .filter(url => filteredConfig[url]?.read !== false)
                 .map(url => this.normalizeRelayUrl(url));
         }
         return [];
@@ -185,11 +217,12 @@ export class RelayConfigUtils {
      * リレー設定からwriteリレーのみを抽出
      */
     static extractWriteRelays(config: RelayConfig): string[] {
-        if (Array.isArray(config)) {
-            return config.map(url => this.normalizeRelayUrl(url));
-        } else if (typeof config === 'object') {
-            return Object.keys(config)
-                .filter(url => config[url]?.write !== false)
+        const filteredConfig = this.filterDecommissionedRelayConfig(config);
+        if (Array.isArray(filteredConfig)) {
+            return filteredConfig.map(url => this.normalizeRelayUrl(url));
+        } else if (typeof filteredConfig === 'object') {
+            return Object.keys(filteredConfig)
+                .filter(url => filteredConfig[url]?.write !== false)
                 .map(url => this.normalizeRelayUrl(url));
         }
         return [];
@@ -199,11 +232,23 @@ export class RelayConfigUtils {
      * リレー設定から全リレーを抽出
      */
     static extractAllRelays(config: RelayConfig): string[] {
-        if (Array.isArray(config)) {
-            return config.map(url => this.normalizeRelayUrl(url));
-        } else if (typeof config === 'object') {
-            return Object.keys(config).map(url => this.normalizeRelayUrl(url));
+        const filteredConfig = this.filterDecommissionedRelayConfig(config);
+        if (Array.isArray(filteredConfig)) {
+            return filteredConfig.map(url => this.normalizeRelayUrl(url));
+        } else if (typeof filteredConfig === 'object') {
+            return Object.keys(filteredConfig).map(url => this.normalizeRelayUrl(url));
         }
         return [];
     }
+}
+
+function hasExplicitRelayPort(url: string): boolean {
+    const authority = url.trim().match(/^[a-z][a-z\d+.-]*:\/\/([^/?#]+)/i)?.[1];
+    if (!authority) return false;
+
+    if (authority.startsWith('[')) {
+        return /\]:\d+$/.test(authority);
+    }
+
+    return /:\d+$/.test(authority);
 }

--- a/src/lib/relayConfigUtils.ts
+++ b/src/lib/relayConfigUtils.ts
@@ -103,9 +103,7 @@ export class RelayConfigUtils {
 
     private static isDecommissionedRelayUrl(url: string): boolean {
         const normalized = this.normalizeExternalRelayUrlCandidate(url);
-        return normalized !== null
-            && !hasExplicitRelayPort(url)
-            && DECOMMISSIONED_RELAY_URLS.has(normalized);
+        return normalized !== null && DECOMMISSIONED_RELAY_URLS.has(normalized);
     }
 
     private static normalizeExternalRelayUrlCandidate(url: string): string | null {
@@ -240,15 +238,4 @@ export class RelayConfigUtils {
         }
         return [];
     }
-}
-
-function hasExplicitRelayPort(url: string): boolean {
-    const authority = url.trim().match(/^[a-z][a-z\d+.-]*:\/\/([^/?#]+)/i)?.[1];
-    if (!authority) return false;
-
-    if (authority.startsWith('[')) {
-        return /\]:\d+$/.test(authority);
-    }
-
-    return /:\d+$/.test(authority);
 }

--- a/src/lib/relayLists.ts
+++ b/src/lib/relayLists.ts
@@ -1,0 +1,21 @@
+export const BOOTSTRAP_RELAYS = [
+    "wss://purplepag.es/",
+    "wss://directory.yabu.me/",
+    "wss://indexer.coracle.social/",
+    "wss://user.kindpag.es/",
+];
+
+export const FALLBACK_RELAYS = [
+    "wss://nos.lol/",
+    "wss://relay.damus.io/",
+    "wss://relay.nostr.wirednet.jp/",
+    "wss://yabu.me/",
+    "wss://x.kojira.io/",
+];
+
+// サービス終了を確認した relay。追加時は正規化済みのルート URL をここで管理する。
+export const DECOMMISSIONED_RELAYS = [
+    "wss://relay.nostr.band/",
+    "wss://nrelay.c-stellar.net/",
+    "wss://nrelay-jp.c-stellar.net/",
+] as const;

--- a/src/lib/relayManager.ts
+++ b/src/lib/relayManager.ts
@@ -1,6 +1,6 @@
 import { createRxBackwardReq } from "rx-nostr";
 import type { RxNostr } from "rx-nostr";
-import { BOOTSTRAP_RELAYS, FALLBACK_RELAYS } from "./constants";
+import { BOOTSTRAP_RELAYS, FALLBACK_RELAYS } from "./relayLists";
 import type { RelayConfig, RelayManagerDeps, RelayFetchOptions, RelayFetchResult, UserRelaysFetchResult } from "./types";
 import { RelayConfigParser, RelayConfigUtils } from "./relayConfigUtils";
 import {
@@ -52,7 +52,8 @@ export class RelayStorage {
                 return;
             }
 
-            await this.repository.put(pubkeyHex, relays, {
+            const filteredRelays = RelayConfigUtils.filterDecommissionedRelayConfig(relays);
+            await this.repository.put(pubkeyHex, filteredRelays, {
                 source: options.source,
                 updatedAtFromEvent: options.updatedAtFromEvent,
             });
@@ -60,7 +61,7 @@ export class RelayStorage {
             // UI側のストア更新は呼び出し元から注入された callback に委譲する
             if (this.onRelayConfigSaved) {
                 try {
-                    await this.onRelayConfigSaved(pubkeyHex, relays);
+                    await this.onRelayConfigSaved(pubkeyHex, filteredRelays);
                 } catch (e) {
                     // ストア更新失敗は無視（IndexedDB保存は成功）
                     this.console.warn('ストアの更新に失敗:', e);
@@ -156,8 +157,10 @@ export class RelayNetworkFetcher {
 
                         if (packet.event?.kind === 10002 && packet.event.pubkey === pubkeyHex) {
                             try {
-                                const relayConfigs = RelayConfigParser.parseKind10002Tags(packet.event.tags);
-                                if (Object.keys(relayConfigs).length > 0) {
+                                const relayConfigs = RelayConfigUtils.filterDecommissionedRelayConfig(
+                                    RelayConfigParser.parseKind10002Tags(packet.event.tags),
+                                );
+                                if (RelayConfigUtils.hasRelayEntries(relayConfigs)) {
                                     found = true;
                                     this.console.log("Kind 10002からリレーを取得:", relayConfigs);
                                     safeResolve({
@@ -238,8 +241,11 @@ export class RelayNetworkFetcher {
                         if (resolved) return;
 
                         if (packet.event?.kind === 3 && packet.event.pubkey === pubkeyHex) {
-                            const relayObj = RelayConfigParser.parseKind3Content(packet.event.content);
-                            if (relayObj) {
+                            const parsedRelayConfig = RelayConfigParser.parseKind3Content(packet.event.content);
+                            const relayObj = parsedRelayConfig
+                                ? RelayConfigUtils.filterDecommissionedRelayConfig(parsedRelayConfig)
+                                : null;
+                            if (relayObj && RelayConfigUtils.hasRelayEntries(relayObj)) {
                                 found = true;
                                 this.console.log("Kind 3からリレーを取得:", relayObj);
                                 safeResolve({

--- a/src/lib/replyQuoteService.ts
+++ b/src/lib/replyQuoteService.ts
@@ -3,7 +3,7 @@ import type { RxNostr } from "rx-nostr";
 import { nip19 } from "nostr-tools";
 import type { NostrEvent, ReplyQuoteState, RelayConfig } from "./types";
 import { RelayConfigUtils } from "./relayConfigUtils";
-import { FALLBACK_RELAYS } from "./constants";
+import { FALLBACK_RELAYS } from "./relayLists";
 
 export interface ReplyQuoteServiceDeps {
     console?: Console;

--- a/src/lib/storage/relayConfigsRepository.ts
+++ b/src/lib/storage/relayConfigsRepository.ts
@@ -26,11 +26,13 @@ export interface RelayConfigsRepository {
 
 function toCache(record: RelayConfigRecord): RelayConfigCache | null {
     if (!RelayConfigParser.isValidRelayConfig(record.config)) return null;
+    const config = RelayConfigUtils.filterDecommissionedRelayConfig(record.config);
+    if (!RelayConfigUtils.hasRelayEntries(config)) return null;
 
     return {
-        config: record.config,
-        writeRelays: record.writeRelays,
-        readRelays: record.readRelays,
+        config,
+        writeRelays: RelayConfigUtils.extractWriteRelays(config),
+        readRelays: RelayConfigUtils.extractReadRelays(config),
         source: record.source,
         fetchedAt: record.fetchedAt,
         updatedAtFromEvent: record.updatedAtFromEvent,
@@ -48,12 +50,13 @@ function toRecord(
     } = {},
 ): RelayConfigRecord {
     const updatedAt = now();
+    const filteredConfig = RelayConfigUtils.filterDecommissionedRelayConfig(config);
 
     return {
         pubkeyHex,
-        config,
-        writeRelays: RelayConfigUtils.extractWriteRelays(config),
-        readRelays: RelayConfigUtils.extractReadRelays(config),
+        config: filteredConfig,
+        writeRelays: RelayConfigUtils.extractWriteRelays(filteredConfig),
+        readRelays: RelayConfigUtils.extractReadRelays(filteredConfig),
         source: options.source,
         fetchedAt: options.fetchedAt || updatedAt,
         updatedAtFromEvent: options.updatedAtFromEvent,
@@ -99,6 +102,10 @@ export class DexieRelayConfigsRepository implements RelayConfigsRepository {
 
         const legacyConfig = readLegacyRelayConfig(pubkeyHex, this.getStorage());
         if (!legacyConfig) return null;
+        const legacyCache = toCache(toRecord(pubkeyHex, legacyConfig, this.now, {
+            source: "localStorage",
+        }));
+        if (!legacyCache) return null;
 
         try {
             await this.put(pubkeyHex, legacyConfig, { source: "localStorage" });
@@ -106,9 +113,7 @@ export class DexieRelayConfigsRepository implements RelayConfigsRepository {
             // Legacy data remains available as a compatibility fallback.
         }
 
-        return toCache(toRecord(pubkeyHex, legacyConfig, this.now, {
-            source: "localStorage",
-        }));
+        return legacyCache;
     }
 
     async put(

--- a/src/lib/upload/bud03ServerList.ts
+++ b/src/lib/upload/bud03ServerList.ts
@@ -2,6 +2,7 @@ import { createRxBackwardReq, type RxNostr } from "rx-nostr";
 import type { Signer } from "nostr-tools/signer";
 import type { PostResult } from "../types";
 import { PostEventSender } from "../postEventBuilder";
+import { RelayConfigUtils } from "../relayConfigUtils";
 import { normalizeServerUrl } from "./uploadDestinationPresets";
 
 export const BUD03_KIND = 10063;
@@ -87,6 +88,12 @@ export function fetchBud03ServerList(params: {
     timeoutMs?: number;
 }): Promise<Bud03FetchResult> {
     const { rxNostr, pubkeyHex, relays, timeoutMs = 4000 } = params;
+    const hasExplicitRelays = relays !== undefined;
+    const sanitizedRelays = RelayConfigUtils.sanitizeExternalRelayUrls(relays);
+
+    if (hasExplicitRelays && sanitizedRelays.length === 0) {
+        return Promise.resolve({ success: false, servers: [], error: "not_found" });
+    }
 
     return new Promise((resolve) => {
         const rxReq = createRxBackwardReq();
@@ -125,7 +132,10 @@ export function fetchBud03ServerList(params: {
         try {
             timeoutId = setTimeout(() =>
                 safeResolve({ success: false, servers: [], error: "timeout" }), timeoutMs);
-            subscription = rxNostr.use(rxReq, relays?.length ? { on: { relays } } : undefined).subscribe({
+            subscription = rxNostr.use(
+                rxReq,
+                hasExplicitRelays ? { on: { relays: sanitizedRelays } } : undefined,
+            ).subscribe({
                 next: (packet: any) => {
                     if (packet?.event?.kind === BUD03_KIND && packet.event.pubkey === pubkeyHex) {
                         events.push(packet.event as Bud03ServerListEvent);

--- a/src/test/unit/bud03ServerList.test.ts
+++ b/src/test/unit/bud03ServerList.test.ts
@@ -6,6 +6,7 @@ import {
     parseBud03ServerTags,
     publishBud03ServerList,
 } from "../../lib/upload/bud03ServerList";
+import { DECOMMISSIONED_RELAYS } from "../../lib/relayLists";
 
 describe("bud03ServerList", () => {
     it("parses server tags with normalization, de-duplication, and ordering", () => {
@@ -75,6 +76,39 @@ describe("bud03ServerList", () => {
 
         expect(result.success).toBe(true);
         expect(result.servers).toEqual(["https://new.example.com"]);
+    });
+
+    it("explicit relay が終了済みのみならデフォルト relay を使わず即時に失敗する", async () => {
+        const rxNostr = { use: vi.fn() };
+
+        await expect(fetchBud03ServerList({
+            rxNostr: rxNostr as never,
+            pubkeyHex: "pubkey",
+            relays: [DECOMMISSIONED_RELAYS[0]],
+        })).resolves.toEqual({ success: false, servers: [], error: "not_found" });
+
+        expect(rxNostr.use).not.toHaveBeenCalled();
+    });
+
+    it("explicit relay の混在時は有効 relay だけを rx-nostr に渡す", async () => {
+        const rxNostr = {
+            use: vi.fn().mockReturnValue({
+                subscribe: vi.fn((observer) => {
+                    observer.complete();
+                    return { unsubscribe: vi.fn() };
+                }),
+            }),
+        };
+
+        await fetchBud03ServerList({
+            rxNostr: rxNostr as never,
+            pubkeyHex: "pubkey",
+            relays: [DECOMMISSIONED_RELAYS[0], "wss://relay.example.com"],
+        });
+
+        expect(rxNostr.use).toHaveBeenCalledWith(expect.anything(), {
+            on: { relays: ["wss://relay.example.com/"] },
+        });
     });
 
     it("signs and sends a BUD-03 event", async () => {

--- a/src/test/unit/channelContextService.test.ts
+++ b/src/test/unit/channelContextService.test.ts
@@ -5,7 +5,7 @@ import {
     channelContextServiceInternals,
 } from "../../lib/channelContextService";
 import { CHANNEL_TEMPORARY_READ_RELAY_LIMIT } from "../../lib/channelContextConstants";
-import { FALLBACK_RELAYS } from "../../lib/constants";
+import { FALLBACK_RELAYS } from "../../lib/relayLists";
 import type { NostrEvent } from "../../lib/types";
 import { createMockConsole } from "../helpers";
 import type { MockConsole } from "../helpers";

--- a/src/test/unit/nip46Service.test.ts
+++ b/src/test/unit/nip46Service.test.ts
@@ -9,7 +9,9 @@ import {
     NIP46_REQUESTED_PERMISSIONS,
     NIP46_REQUESTED_PERMS,
     normalizeSupportedNip46FinalRelay,
+    sanitizeNip46NostrConnectRelays,
 } from '../../lib/nip46Service';
+import { DECOMMISSIONED_RELAYS } from '../../lib/relayLists';
 import { createDeferred } from '../deferredTestUtils';
 import { MockStorage } from '../helpers';
 import { expectConsoleCallsNotToContain } from '../logAssertions';
@@ -22,6 +24,15 @@ describe('NIP46_REQUESTED_PERMISSIONS', () => {
     it('NIP-42 AUTHイベントの署名許可を要求する', () => {
         expect(NIP46_REQUESTED_PERMISSIONS).toContain('sign_event:22242');
         expect(NIP46_REQUESTED_PERMS).toContain('sign_event:22242');
+    });
+});
+
+describe('sanitizeNip46NostrConnectRelays', () => {
+    it('サービス終了 relay を Nostr Connect 候補から除外する', () => {
+        expect(sanitizeNip46NostrConnectRelays([
+            DECOMMISSIONED_RELAYS[0],
+            'wss://relay.example.com',
+        ])).toEqual(['wss://relay.example.com']);
     });
 });
 
@@ -216,6 +227,10 @@ describe('normalizeSupportedNip46FinalRelay', () => {
         'not a relay',
     ])('rejects %s as an unsupported final relay candidate', (relay) => {
         expect(normalizeSupportedNip46FinalRelay(relay)).toBeNull();
+    });
+
+    it('終了済み relay を final relay candidate として拒否する', () => {
+        expect(normalizeSupportedNip46FinalRelay(DECOMMISSIONED_RELAYS[0])).toBeNull();
     });
 });
 
@@ -778,6 +793,21 @@ describe('Nip46Service', () => {
             });
 
             await expect(service.connect(`bunker://${'a'.repeat(64)}`)).rejects.toThrow('No relays specified');
+        });
+
+        it('終了済み relay だけの bunker input は接続試行せず直ちに失敗する', async () => {
+            const { parseBunkerInput, BunkerSigner } = await import('nostr-tools/nip46');
+            (parseBunkerInput as any).mockResolvedValue({
+                pubkey: 'a'.repeat(64),
+                relays: [DECOMMISSIONED_RELAYS[0]],
+                secret: null,
+            });
+
+            await expect(service.connect(`bunker://${'a'.repeat(64)}`)).rejects.toThrow(
+                'Relay connection failed: no reachable relays',
+            );
+            expect(mockPool.ensureRelay).not.toHaveBeenCalled();
+            expect(BunkerSigner.fromBunker).not.toHaveBeenCalled();
         });
     });
 
@@ -2459,6 +2489,22 @@ describe('Nip46Service', () => {
 
             const loaded = Nip46Service.loadSession(mockStorage);
             expect(loaded).toEqual(sessionData);
+        });
+
+        it('loadSession: 保存済み relay の終了済み URL を除外する', () => {
+            const sessionData = {
+                clientSecretKeyHex: 'ab'.repeat(32),
+                remoteSignerPubkey: 'c'.repeat(64),
+                relays: [DECOMMISSIONED_RELAYS[2], 'wss://relay.test.com'],
+                userPubkey: 'user-pub',
+                pingVerified: true,
+            };
+            mockStorage.setItem('nostr-nip46-session', JSON.stringify(sessionData));
+
+            expect(Nip46Service.loadSession(mockStorage)).toEqual({
+                ...sessionData,
+                relays: ['wss://relay.test.com'],
+            });
         });
 
         it('loadSession: pubkeyHex指定時にprefixキーから読み取る', () => {

--- a/src/test/unit/nip46WebSocketLog.test.ts
+++ b/src/test/unit/nip46WebSocketLog.test.ts
@@ -20,6 +20,9 @@ vi.mock('nostr-tools', () => ({
         getConversationKey: vi.fn(() => new Uint8Array([1])),
         decrypt: vi.fn(),
     },
+    utils: {
+        normalizeURL: vi.fn((url: string) => url),
+    },
 }));
 
 vi.mock('nostr-tools/nip46', () => ({

--- a/src/test/unit/postHistoryRelayFetchService.test.ts
+++ b/src/test/unit/postHistoryRelayFetchService.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { FALLBACK_RELAYS } from "../../lib/constants";
+import { FALLBACK_RELAYS } from "../../lib/relayLists";
 import type { NostrEvent } from "../../lib/types";
 import { createEvent as createPostHistoryEvent } from "../postHistoryEventTestUtils";
 

--- a/src/test/unit/postHistoryRelayResolver.test.ts
+++ b/src/test/unit/postHistoryRelayResolver.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { FALLBACK_RELAYS } from "../../lib/constants";
+import { FALLBACK_RELAYS } from "../../lib/relayLists";
 import { resolvePostHistoryRelayUrls } from "../../lib/postHistoryRelayResolver";
 
 describe("resolvePostHistoryRelayUrls", () => {

--- a/src/test/unit/postManager.test.ts
+++ b/src/test/unit/postManager.test.ts
@@ -16,6 +16,7 @@ import { hashtagDataStore } from '../../stores/tagsStore.svelte';
 import type { RxNostr } from 'rx-nostr';
 import { createMockConsole, createMockRxNostr, MockKeyManager } from '../helpers';
 import { nip19 } from 'nostr-tools';
+import { DECOMMISSIONED_RELAYS } from '../../lib/relayLists';
 
 vi.mock('../../lib/postHistoryRawEventVerification', () => ({
     RAW_EVENT_VERIFICATION_RULE_VERSION: 1,
@@ -914,6 +915,19 @@ describe('PostEventSender', () => {
 
         expect(result.success).toBe(true);
         expect(mockRxNostr.send).toHaveBeenCalledWith(event, expect.objectContaining({ completeOn: 'all-ok' }));
+    });
+
+    it('明示 relay が終了済みのみで default write relay を含めない場合は送信しない', async () => {
+        const result = await sender.sendEvent(
+            { kind: 1, content: 'test' },
+            {
+                targetRelays: [DECOMMISSIONED_RELAYS[0]],
+                includeDefaultWriteRelays: false,
+            },
+        );
+
+        expect(result).toEqual({ success: false, error: 'no_write_relays' });
+        expect(mockRxNostr.send).not.toHaveBeenCalled();
     });
 
     it('AUTH後に成功したリレーを拒否一覧へ残さない', async () => {

--- a/src/test/unit/profileMetadataCache.test.ts
+++ b/src/test/unit/profileMetadataCache.test.ts
@@ -3,7 +3,7 @@ import {
     profileMetadataCache,
     profileMetadataCacheInternals,
 } from "../../lib/profileMetadataCache.svelte";
-import { BOOTSTRAP_RELAYS, FALLBACK_RELAYS } from "../../lib/constants";
+import { BOOTSTRAP_RELAYS, FALLBACK_RELAYS } from "../../lib/relayLists";
 import { profilesRepository } from "../../lib/storage/profilesRepository";
 import type {
     ProfileEventCandidate,

--- a/src/test/unit/profileRelayTiers.test.ts
+++ b/src/test/unit/profileRelayTiers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { BOOTSTRAP_RELAYS, FALLBACK_RELAYS } from "../../lib/constants";
+import { BOOTSTRAP_RELAYS, FALLBACK_RELAYS } from "../../lib/relayLists";
 import {
     buildProfileRelayTiers,
     groupPubkeysByRelaySet,

--- a/src/test/unit/relayConfigUtils.test.ts
+++ b/src/test/unit/relayConfigUtils.test.ts
@@ -20,10 +20,14 @@ describe('RelayConfigUtils', () => {
             ).toBeNull();
         });
 
-        it('サービス終了 relay を正規化差を含めて除外する', () => {
-            expect(RelayConfigUtils.normalizeExternalRelayUrl('wss://relay.nostr.band')).toBeNull();
-            expect(RelayConfigUtils.normalizeExternalRelayUrl('wss://NRELAY.C-STELLAR.NET/')).toBeNull();
-            expect(RelayConfigUtils.normalizeExternalRelayUrl('wss://nrelay-jp.c-stellar.net')).toBeNull();
+        it.each(DECOMMISSIONED_RELAYS)('サービス終了 relay の canonical URL を除外する: %s', (relay) => {
+            expect(RelayConfigUtils.normalizeExternalRelayUrl(relay)).toBeNull();
+            expect(RelayConfigUtils.normalizeExternalRelayUrl(relay.slice(0, -1))).toBeNull();
+        });
+
+        it('ホスト名の大文字小文字差と default port 443 も除外する', () => {
+            expect(RelayConfigUtils.normalizeExternalRelayUrl('wss://RELAY.NOSTR.BAND')).toBeNull();
+            expect(RelayConfigUtils.normalizeExternalRelayUrl('wss://relay.nostr.band:443')).toBeNull();
         });
     });
 
@@ -48,15 +52,15 @@ describe('RelayConfigUtils', () => {
             ]);
         });
 
-        it('類似ホストや異なる port/path は除外しない', () => {
+        it('類似ホスト、path、非default port は除外しない', () => {
             expect(RelayConfigUtils.sanitizeExternalRelayUrls([
                 'wss://relay.nostr.band.example.com',
-                'wss://relay.nostr.band:443',
                 'wss://relay.nostr.band/path',
+                'wss://relay.nostr.band:444',
             ])).toEqual([
                 'wss://relay.nostr.band.example.com/',
-                'wss://relay.nostr.band/',
                 'wss://relay.nostr.band/path',
+                'wss://relay.nostr.band:444/',
             ]);
         });
     });

--- a/src/test/unit/relayConfigUtils.test.ts
+++ b/src/test/unit/relayConfigUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { RelayConfigUtils } from '../../lib/relayConfigUtils';
+import { DECOMMISSIONED_RELAYS } from '../../lib/relayLists';
 
 describe('RelayConfigUtils', () => {
     describe('normalizeExternalRelayUrl', () => {
@@ -17,6 +18,12 @@ describe('RelayConfigUtils', () => {
             expect(
                 RelayConfigUtils.normalizeExternalRelayUrl('wss://user:pass@relay.example.com'),
             ).toBeNull();
+        });
+
+        it('サービス終了 relay を正規化差を含めて除外する', () => {
+            expect(RelayConfigUtils.normalizeExternalRelayUrl('wss://relay.nostr.band')).toBeNull();
+            expect(RelayConfigUtils.normalizeExternalRelayUrl('wss://NRELAY.C-STELLAR.NET/')).toBeNull();
+            expect(RelayConfigUtils.normalizeExternalRelayUrl('wss://nrelay-jp.c-stellar.net')).toBeNull();
         });
     });
 
@@ -39,6 +46,37 @@ describe('RelayConfigUtils', () => {
                 'wss://relay-2.example.com/',
                 'wss://relay-3.example.com/',
             ]);
+        });
+
+        it('類似ホストや異なる port/path は除外しない', () => {
+            expect(RelayConfigUtils.sanitizeExternalRelayUrls([
+                'wss://relay.nostr.band.example.com',
+                'wss://relay.nostr.band:443',
+                'wss://relay.nostr.band/path',
+            ])).toEqual([
+                'wss://relay.nostr.band.example.com/',
+                'wss://relay.nostr.band/',
+                'wss://relay.nostr.band/path',
+            ]);
+        });
+    });
+
+    describe('filterDecommissionedRelayConfig', () => {
+        it('配列形式では対象 relay のみを順序を保って除外する', () => {
+            expect(RelayConfigUtils.filterDecommissionedRelayConfig([
+                DECOMMISSIONED_RELAYS[0],
+                'wss://relay.example.com',
+                'wss://nrelay.c-stellar.net',
+            ])).toEqual(['wss://relay.example.com']);
+        });
+
+        it('object 形式では read/write 属性を維持する', () => {
+            expect(RelayConfigUtils.filterDecommissionedRelayConfig({
+                [DECOMMISSIONED_RELAYS[1]]: { read: true, write: false },
+                'wss://relay.example.com': { read: false, write: true },
+            })).toEqual({
+                'wss://relay.example.com': { read: false, write: true },
+            });
         });
     });
 });

--- a/src/test/unit/relayManager.test.ts
+++ b/src/test/unit/relayManager.test.ts
@@ -11,7 +11,8 @@ import { MockStorage, createMockRxNostr, createMockConsole } from '../helpers';
 import type { MockConsole } from '../helpers';
 import { EHagakiDB } from '../../lib/storage/ehagakiDb';
 import { DexieRelayConfigsRepository } from '../../lib/storage/relayConfigsRepository';
-import { FALLBACK_RELAYS } from '../../lib/constants';
+import { FALLBACK_RELAYS } from '../../lib/relayLists';
+import { DECOMMISSIONED_RELAYS } from '../../lib/relayLists';
 
 describe('RelayConfigParser', () => {
     describe('parseKind10002Tags', () => {
@@ -182,6 +183,34 @@ describe('RelayStorage', () => {
             expect(onRelayConfigSaved).toHaveBeenCalledWith('pubkey123', config);
         });
 
+        it('サービス終了 relay を保存前と UI callback 前に除外する', async () => {
+            const onRelayConfigSaved = vi.fn();
+            const callbackStorage = new RelayStorage(
+                mockConsole,
+                mockRelayListUpdatedStore,
+                undefined,
+                repository,
+                onRelayConfigSaved,
+            );
+            const config: RelayConfig = {
+                [DECOMMISSIONED_RELAYS[0]]: { read: true, write: true },
+                'wss://relay.example.com': { read: false, write: true },
+            };
+
+            await callbackStorage.save('pubkey123', config);
+
+            const expected = { 'wss://relay.example.com': { read: false, write: true } };
+            await expect(callbackStorage.get('pubkey123')).resolves.toEqual(expected);
+            expect(onRelayConfigSaved).toHaveBeenCalledWith('pubkey123', expected);
+        });
+
+        it('終了済み relay だけの IndexedDB 設定は再読込時にキャッシュミスになる', async () => {
+            await storage.save('pubkey123', [DECOMMISSIONED_RELAYS[2]]);
+
+            await expect(storage.getCache('pubkey123')).resolves.toBeNull();
+            await expect(storage.get('pubkey123')).resolves.toBeNull();
+        });
+
         it('nullを渡すとデータを削除する', async () => {
             await storage.save('pubkey123', ['wss://relay.example.com']);
 
@@ -263,6 +292,15 @@ describe('RelayStorage', () => {
             const result = await storage.get('pubkey123');
 
             expect(result).toBeNull();
+        });
+
+        it('終了済み relay だけの旧 localStorage 設定をキャッシュミスとして扱う', async () => {
+            mockLocalStorage.setItem(
+                'nostr-relays-pubkey123',
+                JSON.stringify(['wss://nrelay.c-stellar.net']),
+            );
+
+            await expect(storage.get('pubkey123')).resolves.toBeNull();
         });
     });
 
@@ -359,6 +397,25 @@ describe('RelayNetworkFetcher', () => {
             expect(mockSubscription.unsubscribe).toHaveBeenCalled();
         });
 
+        it('終了済み relay だけの Kind 10002 を未取得として扱う', async () => {
+            subscribeFn.mockImplementation((observer: any) => {
+                queueMicrotask(() => {
+                    observer.next({
+                        event: {
+                            kind: 10002,
+                            pubkey: 'testpubkey',
+                            tags: [['r', DECOMMISSIONED_RELAYS[0]]],
+                        },
+                    });
+                    observer.complete();
+                });
+                return mockSubscription;
+            });
+
+            await expect(fetcher.fetchKind10002('testpubkey', ['wss://bootstrap.example.com']))
+                .resolves.toMatchObject({ success: false, error: 'not_found' });
+        });
+
         it('エラー発生時にfalseを返す', async () => {
             subscribeFn.mockImplementation((observer: any) => {
                 Promise.resolve().then(() => {
@@ -425,6 +482,27 @@ describe('RelayNetworkFetcher', () => {
 
             expect(result.success).toBe(false);
             expect(result.error).toBe('not_found');
+        });
+
+        it('終了済み relay だけの Kind 3 を未取得として扱う', async () => {
+            subscribeFn.mockImplementation((observer: any) => {
+                queueMicrotask(() => {
+                    observer.next({
+                        event: {
+                            kind: 3,
+                            pubkey: 'testpubkey',
+                            content: JSON.stringify({
+                                [DECOMMISSIONED_RELAYS[1]]: { read: true, write: true },
+                            }),
+                        },
+                    });
+                    observer.complete();
+                });
+                return mockSubscription;
+            });
+
+            await expect(fetcher.fetchKind3('testpubkey', ['wss://bootstrap.example.com']))
+                .resolves.toMatchObject({ success: false, error: 'not_found' });
         });
     });
 });
@@ -626,6 +704,23 @@ describe('RelayManager統合テスト', () => {
             expect((mockDeps.console?.log as any).mock.calls.some(
                 (call: any[]) => call[0] && typeof call[0] === 'string' && call[0].includes('リモート取得失敗、フォールバックリレーを使用')
             )).toBe(true);
+        });
+
+        it('終了済み relay だけの保存済み設定をキャッシュとして復元せず既存フォールバックへ進む', async () => {
+            const pubkey = 'decommissioned-cache-pubkey';
+            mockStorage.setItem(
+                `nostr-relays-${pubkey}`,
+                JSON.stringify([DECOMMISSIONED_RELAYS[0]]),
+            );
+            subscribeFn.mockImplementation((observer: any) => {
+                queueMicrotask(() => observer.complete());
+                return { unsubscribe: vi.fn() };
+            });
+
+            const result = await manager.fetchUserRelays(pubkey, { timeoutMs: 1 });
+
+            expect(result).toMatchObject({ source: 'fallback', relayConfig: FALLBACK_RELAYS });
+            expect(mockRxNostr.setDefaultRelays).toHaveBeenCalledWith(FALLBACK_RELAYS);
         });
     });
 

--- a/src/test/unit/replyQuoteService.test.ts
+++ b/src/test/unit/replyQuoteService.test.ts
@@ -5,7 +5,7 @@ import { createMockConsole, createMockRxNostr, createMockObservable } from "../h
 import type { MockConsole } from "../helpers";
 import type { RxNostr } from "rx-nostr";
 import { nip19 } from "nostr-tools";
-import { FALLBACK_RELAYS } from "../../lib/constants";
+import { FALLBACK_RELAYS } from "../../lib/relayLists";
 
 describe("ReplyQuoteService", () => {
     let service: ReplyQuoteService;


### PR DESCRIPTION
Centralize bootstrap/fallback relay lists and define the three decommissioned relay roots. Filter decommissioned relays at URL normalization, RelayConfig persistence/parsing, publish/BUD-03 selection, and NIP-46 SimplePool connection boundaries. Preserve valid ordering, read/write flags, and existing fallback behavior. Validation: npm test (319 files, 3,626 tests passed); npm run check (0 errors, 0 warnings); git diff --check. Browser DevTools verification was not run because deterministic unit tests cover the connection boundaries.