### PR TITLE
test: update post history boundary assertions

### DIFF
--- a/src/test/unit/postHistoryDialogTimeline.test.ts
+++ b/src/test/unit/postHistoryDialogTimeline.test.ts
@@ -210,7 +210,7 @@ describe('PostHistoryDialog timeline navigation', () => {
         });
 
         await waitFor(() => {
-            expect(screen.getByText('この先には未取得の期間がある可能性があります。保存済みの古い投稿を表示できます。')).toBeTruthy();
+            expect(screen.getByRole('button', { name: '保存済みの古い投稿を表示' })).toBeTruthy();
             expect(screen.getByRole('button', { name: 'リレーから続きを取得' })).toBeTruthy();
             expect(screen.getByRole('button', { name: '保存済みの古い投稿を表示' })).toBeTruthy();
             expect(document.querySelector('.post-history-summary-count')?.textContent).toBe('2件');
@@ -1361,7 +1361,7 @@ describe('PostHistoryDialog timeline navigation', () => {
             expect(screen.getByText('saved reopen 最新')).toBeTruthy();
             expect(screen.queryByText('saved reopen sparse')).toBeNull();
             expect(screen.queryByText('保存済みの古い投稿を表示中です。')).toBeNull();
-            expect(screen.getByText('この先には未取得の期間がある可能性があります。保存済みの古い投稿を表示できます。')).toBeTruthy();
+            expect(screen.getByRole('button', { name: '保存済みの古い投稿を表示' })).toBeTruthy();
         });
 
         expect(repositoryMock.getLatestVisibleChunk).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## 変更概要
PostHistoryDialogの現行UIに合わせ、削除済み説明文を期待していた2件のテストassertionを更新しました。

## 修正内容
- 旧assertionは「この先には未取得の期間がある可能性があります。保存済みの古い投稿を表示できます。」という削除済み説明文を期待していました。
- 現在のbutton主体UI contractである、role=button / name「保存済みの古い投稿を表示」を検証するよう変更しました。
- production codeは変更していません。

## 検証
- `npm run test -- src/test/unit/postHistoryDialogTimeline.test.ts` — 39 passed
- `npm run test -- src/test/unit/postHistoryDialogTimelineSearch.test.ts src/test/unit/postHistoryDialogTimelineRelay.test.ts src/test/unit/postHistoryDialogPresentation.test.ts` — 77 passed
- `npm test` — 319 files / 3633 tests passed
- `git diff --check` — passed
- build/checkはテストコードのみの変更のため未実行です。