### PR TITLE
chore: update dompurify security patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "blurhash": "^2.0.5",
         "browser-image-compression": "^2.0.2",
         "dexie": "^4.4.2",
-        "dompurify": "^3.4.12",
+        "dompurify": "^3.4.13",
         "ipaddr.js": "^2.3.0",
         "mediabunny": "^1.24.2",
         "nip07-awaiter": "^1.1.0",
@@ -4774,9 +4774,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "blurhash": "^2.0.5",
     "browser-image-compression": "^2.0.2",
     "dexie": "^4.4.2",
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.13",
     "ipaddr.js": "^2.3.0",
     "mediabunny": "^1.24.2",
     "nip07-awaiter": "^1.1.0",


### PR DESCRIPTION
## 変更概要
DOMPurifyのセキュリティアドバイザリを解消するため、production dependencyを最小の互換patchへ更新しました。

## Advisory
- GHSA: GHSA-55q2-fjhq-7xh7
- Severity: moderate
- 影響範囲: `dompurify <=3.4.12`
- 変更前: `3.4.12`
- 変更後: `3.4.13`
- 変更: `package.json`のrangeと`package-lock.json`のresolved version/integrity

sanitize policy、sanitize options、呼び出しコード、production UIは変更していません。既知のfdir / picomatch問題も今回の変更へ含めていません。

## 検証
- 変更前 `npm audit --omit=dev`: DOMPurify 1 moderate（GHSA-55q2-fjhq-7xh7）
- `npm ls dompurify`: `dompurify@3.4.13`
- 変更後 `npm audit --omit=dev`: 0 vulnerabilities
- sanitize関連unit tests: 3 files / 13 tests passed
- `npm run check`: passed
- `npm test`: 319 files / 3633 tests passed
- `npm run build`: passed
- `git diff --check`: passed
- `npm ci`: 未実行（既存の依存関係環境を変更せず、lockfile整合性と必要な検証を実施）