### PR TITLE
fix: minimize iframe outbound logging

### DIFF
--- a/src/lib/iframeMessageService.ts
+++ b/src/lib/iframeMessageService.ts
@@ -108,7 +108,7 @@ export class IframeMessageService {
 
         try {
             this.windowObj.parent.postMessage(payload, parentOrigin);
-            this.console.log(`親ウィンドウ (${parentOrigin}) にメッセージを送信しました:`, payload);
+            this.console.log(`iframe postMessage sent: ${payload.type}`);
             return true;
         } catch (error) {
             this.console.error('postMessageの送信に失敗しました:', error);

--- a/src/test/unit/iframeMessageService.test.ts
+++ b/src/test/unit/iframeMessageService.test.ts
@@ -260,7 +260,7 @@ describe("IframeMessageService", () => {
       );
     });
 
-    it("正常にメッセージを送信する", () => {
+    it("wire payloadを維持し、成功ログにはmessage typeだけを含める", () => {
       const postMessageMock = vi.fn();
       mockWindow = {
         self: {},
@@ -280,7 +280,13 @@ describe("IframeMessageService", () => {
         namespace: EMBED_MESSAGE_NAMESPACE,
         version: EMBED_MESSAGE_VERSION,
         type: "post.success",
-        payload: { timestamp: 12345 },
+        requestId: "sensitive-request-id",
+        payload: {
+          timestamp: 12345,
+          eventId: "sensitive-event-id",
+          replyToEventId: "sensitive-reply-id",
+          quotedEventIds: ["sensitive-quote-id"],
+        },
       };
 
       expect(service.sendMessageToParent(payload)).toBe(true);
@@ -288,10 +294,13 @@ describe("IframeMessageService", () => {
         payload,
         "https://example.com"
       );
-      expect(mockConsole.log).toHaveBeenCalledWith(
-        expect.stringContaining("メッセージを送信しました"),
-        payload
-      );
+      expect(mockConsole.log).toHaveBeenCalledWith("iframe postMessage sent: post.success");
+      const loggedArguments = mockConsole.log.mock.calls.flat().join(" ");
+      expect(loggedArguments).not.toContain("sensitive-event-id");
+      expect(loggedArguments).not.toContain("sensitive-reply-id");
+      expect(loggedArguments).not.toContain("sensitive-quote-id");
+      expect(loggedArguments).not.toContain("sensitive-request-id");
+      expect(mockConsole.log.mock.calls.flat()).not.toContain(payload);
     });
 
     it("postMessage送信エラー時はfalseを返す", () => {


### PR DESCRIPTION
## Summary

- Problem: iframe outbound `postMessage` success logging duplicated the entire payload into the browser console.
- Minimized the success log to `iframe postMessage sent: <type>`; payload, request IDs, origins, and envelope data are excluded.
- The wire `postMessage` payload, target origin, warning/error behavior, and notification payloads are unchanged.

## Tests

- Added regression coverage proving the complete wire payload is still sent while sensitive-looking event/reply/quote/request IDs are absent from logger arguments.
- Targeted iframe, parent-client, embed, composer-context, and postManager tests: passed (143 tests).
- `npm run check`: passed.
- `npm test`: passed (324 files, 3756 tests).
- `npm audit --omit=dev`: passed, 0 vulnerabilities.
- `npm run build`: passed.
- `git diff --check`: passed.

Playwright/manual browser verification was not run because this change only minimizes console logging and unit tests directly verify the unchanged `postMessage` behavior. This branch is independent of the parallel BUD-03 worktree; no BUD-03 changes are included.