### PR TITLE
Change post history menu icons

### DIFF
--- a/public/icons/download_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg
+++ b/public/icons/download_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#000000"><path d="M480-320 280-520l56-58 104 104v-326h80v326l104-104 56 58-200 200ZM160-160v-200h80v120h480v-120h80v200H160Z"/></svg>

--- a/public/icons/upload_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg
+++ b/public/icons/upload_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#000000"><path d="M440-320v-326L336-542l-56-58 200-200 200 200-56 58-104-104v326h-80ZM160-160v-200h80v120h480v-120h80v200H160Z"/></svg>

--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -3546,7 +3546,12 @@
     }
 
     :global(.post-history-menu-content .menu-action-button .export-icon) {
-        mask-image: url("/icons/cloud_download_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg");
+        mask-image: url("/icons/upload_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg");
+        background-color: currentColor;
+    }
+
+    :global(.post-history-menu-content .menu-action-button .import-icon) {
+        mask-image: url("/icons/download_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg");
         background-color: currentColor;
     }
 


### PR DESCRIPTION
投稿履歴ダイアログ右上メニューのJSONL操作アイコンを更新しました。

- JSONLをインポート: downloadアイコン
- JSONLをエクスポート: uploadアイコン

指定されたSVGをpublic/iconsへ追加し、メニュー表示に割り当てています。

Validation: npm run check (passed)