### PR TITLE
設定ダイアログのリレー一覧チェックマークをSVG化

### DIFF
--- a/public/icons/check_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg
+++ b/public/icons/check_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#000000"><path d="M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z"/></svg>

--- a/src/components/settings/SettingsRelaySection.svelte
+++ b/src/components/settings/SettingsRelaySection.svelte
@@ -127,7 +127,14 @@
                                               "settingsDialog.relay_read_disabled",
                                           ) || "Read disabled"}
                                 >
-                                    {relay.read ? "✓" : "–"}
+                                    {#if relay.read}
+                                        <span
+                                            class="relay-check-icon svg-icon"
+                                            aria-hidden="true"
+                                        ></span>
+                                    {:else}
+                                        –
+                                    {/if}
                                 </span>
                                 <span
                                     class:enabled={relay.write}
@@ -140,7 +147,14 @@
                                               "settingsDialog.relay_write_disabled",
                                           ) || "Write disabled"}
                                 >
-                                    {relay.write ? "✓" : "–"}
+                                    {#if relay.write}
+                                        <span
+                                            class="relay-check-icon svg-icon"
+                                            aria-hidden="true"
+                                        ></span>
+                                    {:else}
+                                        –
+                                    {/if}
                                 </span>
                                 <div class="relay-copy-cell">
                                     <Button
@@ -254,6 +268,14 @@
 
         .relay-capability.enabled {
             color: var(--theme);
+        }
+
+        .relay-check-icon {
+            display: inline-block;
+            width: 20px;
+            height: 20px;
+            vertical-align: middle;
+            mask-image: url("/icons/check_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg");
         }
     }
     .relay-toggle-icon {


### PR DESCRIPTION
## 概要
設定ダイアログ内のリレー一覧で、Read/Write有効状態のチェックマークを指定SVGアイコンへ置き換えました。

## 変更内容
- check_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg を追加
- Read/Write有効時にSVGアイコンを表示
- 無効時の表示、アクセシブルラベル、既存のリレー一覧操作は維持

## 確認
- npm run test -- src/test/unit/settingsRelaySection.test.ts
- npm run check
- git diff --check