### PR TITLE
Adjust upload destination button actions

### DIFF
--- a/src/components/settings/SettingsUploadDestinationSection.svelte
+++ b/src/components/settings/SettingsUploadDestinationSection.svelte
@@ -531,7 +531,7 @@
                     </div>
                     <div class="destination-actions">
                         <Button
-                            variant="primary"
+                            variant="default"
                             shape="rounded"
                             onClick={() =>
                                 uploadDestinationStore.setDefault(

--- a/src/components/settings/SettingsUploadDestinationSection.svelte
+++ b/src/components/settings/SettingsUploadDestinationSection.svelte
@@ -448,7 +448,7 @@
                             <div class="destination-title">
                                 <span>{destination.name}</span>
                                 {#if destination.isDefault}
-                                    <span class="badge"
+                                    <span class="badge default-badge"
                                         >{$_(
                                             "settingsDialog.uploadDestinationDefault",
                                         ) || "既定"}</span
@@ -790,6 +790,13 @@
         padding: 2px 7px;
         font-size: 0.75rem;
         font-weight: 400;
+    }
+
+    .badge.default-badge {
+        background-color: var(--theme);
+        border-color: var(--theme);
+        color: white;
+        font-weight: 500;
     }
 
     .badge.muted {

--- a/src/components/settings/SettingsUploadDestinationSection.svelte
+++ b/src/components/settings/SettingsUploadDestinationSection.svelte
@@ -531,20 +531,7 @@
                     </div>
                     <div class="destination-actions">
                         <Button
-                            variant="default"
-                            shape="rounded"
-                            onClick={() => testDestination(destination)}
-                            disabled={testingId === destination.id}
-                        >
-                            {testingId === destination.id
-                                ? $_(
-                                      "settingsDialog.uploadDestinationTesting",
-                                  ) || "確認中"
-                                : $_("settingsDialog.uploadDestinationTest") ||
-                                  "接続テスト"}
-                        </Button>
-                        <Button
-                            variant="default"
+                            variant="primary"
                             shape="rounded"
                             onClick={() =>
                                 uploadDestinationStore.setDefault(
@@ -566,6 +553,19 @@
                                   "閉じる"
                                 : $_("settingsDialog.uploadDestinationEdit") ||
                                   "編集"}
+                        </Button>
+                        <Button
+                            variant="default"
+                            shape="rounded"
+                            onClick={() => testDestination(destination)}
+                            disabled={testingId === destination.id}
+                        >
+                            {testingId === destination.id
+                                ? $_(
+                                      "settingsDialog.uploadDestinationTesting",
+                                  ) || "確認中"
+                                : $_("settingsDialog.uploadDestinationTest") ||
+                                  "接続テスト"}
                         </Button>
                         <Button
                             variant="default"
@@ -622,7 +622,7 @@
                               ) || "BUD-03 から取得"}
                     </Button>
                     <Button
-                        variant="primary"
+                        variant="default"
                         shape="rounded"
                         onClick={publishBud03}
                         disabled={!canUseBud03 ||


### PR DESCRIPTION
## Summary
- Reorder upload destination actions to 既定、編集、接続テスト、削除
- Apply the primary variant to 既定
- Change the BUD-03 リレーへ送信 action to the default variant

## Validation
- npm run check
- npm test
- npm run test -- src/test/unit/settingsUploadDestinationSection.test.ts