### PR TITLE
fix: reuse Blossom connection test auth

### DIFF
--- a/src/lib/nostrAuthService.ts
+++ b/src/lib/nostrAuthService.ts
@@ -177,6 +177,26 @@ export class NostrAuthService implements AuthService {
         assertCurrentSession(sessionPubkey);
         return encodeBlossomAuthorizationHeader(JSON.stringify(event));
     }
+
+    async createBlossomConnectionTestAuthorization(params: {
+        serverUrl: string;
+        method: string;
+        sha256?: string;
+        contentType?: string;
+        contentLength?: number;
+    }): Promise<{
+        authorization: string;
+        assertSession: () => void;
+    }> {
+        const sessionPubkey = captureActiveSessionPubkey(authState);
+        const authorization = await this.buildBlossomAuthorizationHeader(params);
+        assertCurrentSession(sessionPubkey);
+
+        return {
+            authorization,
+            assertSession: () => assertCurrentSession(sessionPubkey),
+        };
+    }
 }
 
 function assertCurrentSession(sessionPubkey: string): void {

--- a/src/lib/types/upload.ts
+++ b/src/lib/types/upload.ts
@@ -199,6 +199,16 @@ export interface AuthService {
         contentType?: string;
         contentLength?: number;
     }): Promise<string>;
+    createBlossomConnectionTestAuthorization?(params: {
+        serverUrl: string;
+        method: string;
+        sha256?: string;
+        contentType?: string;
+        contentLength?: number;
+    }): Promise<{
+        authorization: string;
+        assertSession: () => void;
+    }>;
 }
 
 export interface MimeTypeSupportInterface {

--- a/src/lib/upload/BlossomUploadAdapter.ts
+++ b/src/lib/upload/BlossomUploadAdapter.ts
@@ -148,6 +148,11 @@ function isUploadRequirementAccepted(status: number): boolean {
     return status >= 200 && status < 300;
 }
 
+type BlossomConnectionTestAuthorization = {
+    authorization: string;
+    assertSession: () => void;
+};
+
 async function probeBlossomUploadRequirement(params: {
     destination: UploadDestination;
     fetch: typeof fetch;
@@ -155,6 +160,7 @@ async function probeBlossomUploadRequirement(params: {
     sha256: string;
     contentType: string;
     contentLength: number;
+    authorizationContext?: BlossomConnectionTestAuthorization;
 }): Promise<Response | null> {
     const headers: Record<string, string> = {
         "X-SHA-256": params.sha256,
@@ -162,15 +168,17 @@ async function probeBlossomUploadRequirement(params: {
         "X-Content-Length": String(params.contentLength),
     };
 
-    const authorization = await params.authService?.buildBlossomAuthorizationHeader?.({
-        serverUrl: normalizeBlossomServerUrl(params.destination),
-        method: "upload",
-        sha256: params.sha256,
-        contentType: params.contentType,
-        contentLength: params.contentLength,
-    });
+    const authorization = params.authorizationContext?.authorization
+        ?? await params.authService?.buildBlossomAuthorizationHeader?.({
+            serverUrl: normalizeBlossomServerUrl(params.destination),
+            method: "upload",
+            sha256: params.sha256,
+            contentType: params.contentType,
+            contentLength: params.contentLength,
+        });
     if (authorization) headers.Authorization = authorization;
 
+    params.authorizationContext?.assertSession();
     try {
         return await params.fetch(getUploadUrl(params.destination), {
             method: "HEAD",
@@ -187,6 +195,7 @@ async function probeSupportedMimeTypes(params: {
     authService?: UploadAdapterUploadParams["authService"];
     sha256: string;
     contentLength: number;
+    authorizationContext?: BlossomConnectionTestAuthorization;
 }): Promise<string[]> {
     const supportedMimeTypes: string[] = [];
 
@@ -320,6 +329,14 @@ export class BlossomUploadAdapter implements UploadProtocolAdapter {
                 type: "image/png",
             });
         const sha256 = await calculateSHA256Hex(sampleFile);
+        const authorizationContext = await params.authService
+            ?.createBlossomConnectionTestAuthorization?.({
+                serverUrl: normalizeBlossomServerUrl(params.destination),
+                method: "upload",
+                sha256,
+                contentType: sampleFile.type || "image/png",
+                contentLength: sampleFile.size,
+            });
         const response = await probeBlossomUploadRequirement({
             destination: params.destination,
             fetch: params.fetch,
@@ -327,6 +344,7 @@ export class BlossomUploadAdapter implements UploadProtocolAdapter {
             sha256,
             contentType: sampleFile.type || "image/png",
             contentLength: sampleFile.size,
+            authorizationContext,
         });
 
         if (!response) {
@@ -346,6 +364,7 @@ export class BlossomUploadAdapter implements UploadProtocolAdapter {
                     authService: params.authService,
                     sha256,
                     contentLength: sampleFile.size,
+                    authorizationContext,
                 }),
             }
             : undefined;

--- a/src/lib/upload/BlossomUploadAdapter.ts
+++ b/src/lib/upload/BlossomUploadAdapter.ts
@@ -156,7 +156,6 @@ type BlossomConnectionTestAuthorization = {
 async function probeBlossomUploadRequirement(params: {
     destination: UploadDestination;
     fetch: typeof fetch;
-    authService?: UploadAdapterUploadParams["authService"];
     sha256: string;
     contentType: string;
     contentLength: number;
@@ -168,14 +167,7 @@ async function probeBlossomUploadRequirement(params: {
         "X-Content-Length": String(params.contentLength),
     };
 
-    const authorization = params.authorizationContext?.authorization
-        ?? await params.authService?.buildBlossomAuthorizationHeader?.({
-            serverUrl: normalizeBlossomServerUrl(params.destination),
-            method: "upload",
-            sha256: params.sha256,
-            contentType: params.contentType,
-            contentLength: params.contentLength,
-        });
+    const authorization = params.authorizationContext?.authorization;
     if (authorization) headers.Authorization = authorization;
 
     params.authorizationContext?.assertSession();
@@ -192,7 +184,6 @@ async function probeBlossomUploadRequirement(params: {
 async function probeSupportedMimeTypes(params: {
     destination: UploadDestination;
     fetch: typeof fetch;
-    authService?: UploadAdapterUploadParams["authService"];
     sha256: string;
     contentLength: number;
     authorizationContext?: BlossomConnectionTestAuthorization;
@@ -329,6 +320,14 @@ export class BlossomUploadAdapter implements UploadProtocolAdapter {
                 type: "image/png",
             });
         const sha256 = await calculateSHA256Hex(sampleFile);
+        const createAuthorizationContext = params.authService
+            ?.createBlossomConnectionTestAuthorization;
+        if (
+            params.authService?.buildBlossomAuthorizationHeader
+            && !createAuthorizationContext
+        ) {
+            throw new Error("Authentication required");
+        }
         const authorizationContext = await params.authService
             ?.createBlossomConnectionTestAuthorization?.({
                 serverUrl: normalizeBlossomServerUrl(params.destination),
@@ -340,7 +339,6 @@ export class BlossomUploadAdapter implements UploadProtocolAdapter {
         const response = await probeBlossomUploadRequirement({
             destination: params.destination,
             fetch: params.fetch,
-            authService: params.authService,
             sha256,
             contentType: sampleFile.type || "image/png",
             contentLength: sampleFile.size,
@@ -361,7 +359,6 @@ export class BlossomUploadAdapter implements UploadProtocolAdapter {
                 supportedMimeTypes: await probeSupportedMimeTypes({
                     destination: params.destination,
                     fetch: params.fetch,
-                    authService: params.authService,
                     sha256,
                     contentLength: sampleFile.size,
                     authorizationContext,

--- a/src/test/unit/blossomUploadAdapter.test.ts
+++ b/src/test/unit/blossomUploadAdapter.test.ts
@@ -73,6 +73,17 @@ function decodeBase64UrlHeader(header: string): string {
     return new TextDecoder().decode(Uint8Array.from(atob(padded), (character) => character.charCodeAt(0)));
 }
 
+function createConnectionTestAuthService(authorization: string) {
+    return {
+        buildAuthHeader: vi.fn(),
+        buildBlossomAuthorizationHeader: vi.fn(async () => authorization),
+        createBlossomConnectionTestAuthorization: vi.fn(async () => ({
+            authorization,
+            assertSession: vi.fn(),
+        })),
+    };
+}
+
 type BlossomHttpCall = {
     httpCall: (
         method: string,
@@ -416,10 +427,9 @@ describe("BlossomUploadAdapter", () => {
     it("uses an image/png probe for HEAD /upload connection tests", async () => {
         const adapter = new BlossomUploadAdapter();
         const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
-        const authService = {
-            buildAuthHeader: vi.fn(),
-            buildBlossomAuthorizationHeader: vi.fn(async () => "Nostr eyJpZCI6ImEiLCJwdWJrZXkiOiJiIiwic2lnIjoiYyIsImtpbmQiOjI0MjQyLCJjcmVhdGVkX2F0IjoxLCJjb250ZW50IjoiYmxvc3NvbSBzdHVmZiIsInRhZ3MiOltdfQ"),
-        };
+        const authService = createConnectionTestAuthService(
+            "Nostr eyJpZCI6ImEiLCJwdWJrZXkiOiJiIiwic2lnIjoiYyIsImtpbmQiOjI0MjQyLCJjcmVhdGVkX2F0IjoxLCJjb250ZW50IjoiYmxvc3NvbSBzdHVmZiIsInRhZ3MiOltdfQ",
+        );
 
         const result = await adapter.testConnection({
             destination: createDestination(),
@@ -461,10 +471,7 @@ describe("BlossomUploadAdapter", () => {
             }
             return new Response(null, { status: 200 });
         });
-        const authService = {
-            buildAuthHeader: vi.fn(),
-            buildBlossomAuthorizationHeader: vi.fn(async () => "Nostr mock-token"),
-        };
+        const authService = createConnectionTestAuthService("Nostr mock-token");
 
         const result = await adapter.testConnection({
             destination: createDestination(),
@@ -578,6 +585,22 @@ describe("BlossomUploadAdapter", () => {
         expect(fetchMock).not.toHaveBeenCalled();
     });
 
+    it("fails closed when an Authorization builder has no session-bound context API", async () => {
+        const fetchMock = vi.fn();
+        const buildAuthorization = vi.fn(async () => "Nostr unsafe-token");
+
+        await expect(new BlossomUploadAdapter().testConnection({
+            destination: createDestination(),
+            fetch: fetchMock as unknown as typeof fetch,
+            authService: {
+                buildAuthHeader: vi.fn(),
+                buildBlossomAuthorizationHeader: buildAuthorization,
+            },
+        })).rejects.toThrow("Authentication required");
+        expect(buildAuthorization).not.toHaveBeenCalled();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
     it("preserves unauthenticated probes when authService is absent", async () => {
         const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
             new Response(null, { status: 401 }));
@@ -600,10 +623,7 @@ describe("BlossomUploadAdapter", () => {
                 "X-Max-Upload-Size": String(10 * 1024 * 1024),
             },
         }));
-        const authService = {
-            buildAuthHeader: vi.fn(),
-            buildBlossomAuthorizationHeader: vi.fn(async () => "Nostr mock-token"),
-        };
+        const authService = createConnectionTestAuthService("Nostr mock-token");
 
         const result = await adapter.testConnection({
             destination: createDestination(),

--- a/src/test/unit/blossomUploadAdapter.test.ts
+++ b/src/test/unit/blossomUploadAdapter.test.ts
@@ -41,6 +41,19 @@ function createDestination(): UploadDestination {
 }
 
 const SHA256 = "a".repeat(64);
+const MIME_PROBE_TYPES = [
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "image/gif",
+    "image/svg+xml",
+    "video/mp4",
+    "video/webm",
+    "video/quicktime",
+    "audio/mpeg",
+    "audio/mp3",
+    "audio/wav",
+];
 
 function createValidDescriptor(overrides: Record<string, unknown> = {}) {
     return {
@@ -467,6 +480,116 @@ describe("BlossomUploadAdapter", () => {
         expect(result.capabilities?.supportedMimeTypes).not.toContain("video/mp4");
         expect(result.capabilities?.maxUploadSize).toBeNull();
         expect(fetchMock).toHaveBeenCalledTimes(1 + 11);
+    });
+
+    it("reuses one session-bound Authorization for the initial and MIME HEAD probes", async () => {
+        const sampleFile = new File(["probe-body"], "probe.png", { type: "image/png" });
+        const assertSession = vi.fn();
+        const createAuthorization = vi.fn(async () => ({
+            authorization: "Nostr connection-test-token",
+            assertSession,
+        }));
+        const buildAuthorization = vi.fn();
+        const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+            new Response(null, { status: 200 }));
+
+        const result = await new BlossomUploadAdapter().testConnection({
+            destination: createDestination(),
+            fetch: fetchMock as unknown as typeof fetch,
+            authService: {
+                buildAuthHeader: vi.fn(),
+                buildBlossomAuthorizationHeader: buildAuthorization,
+                createBlossomConnectionTestAuthorization: createAuthorization,
+            },
+            sampleFile,
+        });
+
+        expect(result.success).toBe(true);
+        expect(createAuthorization).toHaveBeenCalledOnce();
+        expect(createAuthorization).toHaveBeenCalledWith(expect.objectContaining({
+            sha256: SHA256,
+            contentType: "image/png",
+            contentLength: sampleFile.size,
+        }));
+        expect(buildAuthorization).not.toHaveBeenCalled();
+        expect(assertSession).toHaveBeenCalledTimes(1 + MIME_PROBE_TYPES.length);
+        expect(fetchMock).toHaveBeenCalledTimes(1 + MIME_PROBE_TYPES.length);
+
+        const requestHeaders = fetchMock.mock.calls.map((call) =>
+            (call[1] as RequestInit).headers as Record<string, string>);
+        expect(requestHeaders.every((headers) =>
+            headers.Authorization === "Nostr connection-test-token")).toBe(true);
+        expect(requestHeaders.map((headers) => headers["X-SHA-256"])).toEqual(
+            Array(1 + MIME_PROBE_TYPES.length).fill(SHA256),
+        );
+        expect(requestHeaders.map((headers) => headers["X-Content-Length"])).toEqual(
+            Array(1 + MIME_PROBE_TYPES.length).fill(String(sampleFile.size)),
+        );
+        expect(requestHeaders.slice(1).map((headers) => headers["X-Content-Type"])).toEqual(
+            MIME_PROBE_TYPES,
+        );
+    });
+
+    it("creates an independent Authorization context for each connection test invocation", async () => {
+        let invocation = 0;
+        const createAuthorization = vi.fn(async () => ({
+            authorization: `Nostr connection-test-token-${++invocation}`,
+            assertSession: vi.fn(),
+        }));
+        const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+            new Response(null, { status: 200 }));
+        const adapter = new BlossomUploadAdapter();
+        const params = {
+            destination: createDestination(),
+            fetch: fetchMock as unknown as typeof fetch,
+            authService: {
+                buildAuthHeader: vi.fn(),
+                createBlossomConnectionTestAuthorization: createAuthorization,
+            },
+        };
+
+        await adapter.testConnection(params);
+        await adapter.testConnection(params);
+
+        expect(createAuthorization).toHaveBeenCalledTimes(2);
+        const authorizations = fetchMock.mock.calls.map((call) =>
+            ((call[1] as RequestInit).headers as Record<string, string>).Authorization);
+        expect(authorizations.slice(0, 1 + MIME_PROBE_TYPES.length)).toEqual(
+            Array(1 + MIME_PROBE_TYPES.length).fill("Nostr connection-test-token-1"),
+        );
+        expect(authorizations.slice(1 + MIME_PROBE_TYPES.length)).toEqual(
+            Array(1 + MIME_PROBE_TYPES.length).fill("Nostr connection-test-token-2"),
+        );
+    });
+
+    it("does not start an anonymous HEAD when Authorization context creation fails", async () => {
+        const fetchMock = vi.fn();
+
+        await expect(new BlossomUploadAdapter().testConnection({
+            destination: createDestination(),
+            fetch: fetchMock as unknown as typeof fetch,
+            authService: {
+                buildAuthHeader: vi.fn(),
+                createBlossomConnectionTestAuthorization: vi.fn(async () => {
+                    throw new Error("Authentication required");
+                }),
+            },
+        })).rejects.toThrow("Authentication required");
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("preserves unauthenticated probes when authService is absent", async () => {
+        const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+            new Response(null, { status: 401 }));
+
+        const result = await new BlossomUploadAdapter().testConnection({
+            destination: createDestination(),
+            fetch: fetchMock as unknown as typeof fetch,
+        });
+
+        expect(result).toMatchObject({ success: false, status: 401 });
+        const headers = (fetchMock.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
+        expect(headers.Authorization).toBeUndefined();
     });
 
     it("uses explicit upload size headers when a Blossom server exposes them", async () => {

--- a/src/test/unit/nostrAuthService.test.ts
+++ b/src/test/unit/nostrAuthService.test.ts
@@ -441,6 +441,37 @@ describe('NostrAuthService', () => {
 
             vi.mocked(keyManager.getFromStore).mockReturnValue(null);
         });
+
+        it('connection test contextは既存builderを1回使い、captured sessionを検証する', async () => {
+            const { keyManager } = await import('../../lib/keyManager.svelte');
+            vi.mocked(keyManager.getFromStore).mockReturnValue('nsec1testkey');
+            const buildAuthorization = vi.spyOn(service, 'buildBlossomAuthorizationHeader');
+
+            const context = await service.createBlossomConnectionTestAuthorization({
+                serverUrl: 'https://blossom.example',
+                method: 'upload',
+                sha256: 'a'.repeat(64),
+                contentType: 'image/png',
+                contentLength: 123,
+            });
+
+            expect(buildAuthorization).toHaveBeenCalledOnce();
+            expect(context.authorization).toMatch(/^Nostr [A-Za-z0-9_-]+$/);
+            expect(() => context.assertSession()).not.toThrow();
+
+            mockAuthStoreModule.authState.value = {
+                ...mockAuthStoreModule.authState.value,
+                pubkey: 'switched-account',
+            };
+            expect(() => context.assertSession()).toThrow('Authentication required');
+
+            mockAuthStoreModule.authState.value = {
+                isAuthenticated: true,
+                type: 'nsec',
+                pubkey: 'testpubkey123',
+            };
+            vi.mocked(keyManager.getFromStore).mockReturnValue(null);
+        });
     });
 });
 

--- a/src/test/unit/signedEventSessionBoundaries.integration.test.ts
+++ b/src/test/unit/signedEventSessionBoundaries.integration.test.ts
@@ -159,6 +159,14 @@ function installDeferredNip07Signer() {
     };
 }
 
+function createBlossomProbeFile(): File {
+    const file = new File(["data"], "test.png", { type: "image/png" });
+    Object.defineProperty(file, "arrayBuffer", {
+        value: async () => new TextEncoder().encode("data").buffer,
+    });
+    return file;
+}
+
 afterEach(() => {
     (window as any).nostr = originalNostr;
     (authState as any).value = {
@@ -415,6 +423,152 @@ describe("active session liveness at authorization and protocol boundaries", () 
         signer.resolveValid();
 
         await expect(probePromise).rejects.toThrow("Authentication required");
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("signs once and reuses the same BUD-11 Authorization across one connection test", async () => {
+        (authState as any).value = createAuthState();
+        const signEvent = vi.fn(async (template) => finalizeEvent(template, secretKeyA));
+        (window as any).nostr = {
+            getPublicKey: vi.fn(async () => pubkeyA),
+            signEvent,
+        };
+        const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+            new Response(null, { status: 200 }));
+
+        const result = await new BlossomUploadAdapter().testConnection({
+            destination: createBlossomDestination(),
+            authService: new NostrAuthService(),
+            fetch: fetchMock as unknown as typeof fetch,
+            sampleFile: createBlossomProbeFile(),
+        });
+
+        expect(result.success).toBe(true);
+        expect(signEvent).toHaveBeenCalledOnce();
+        expect(signEvent).toHaveBeenCalledWith(expect.objectContaining({ kind: 24242 }));
+        expect(fetchMock).toHaveBeenCalledTimes(12);
+        const authorizations = fetchMock.mock.calls.map((call) =>
+            ((call[1] as RequestInit).headers as Record<string, string>).Authorization);
+        expect(new Set(authorizations).size).toBe(1);
+        expect(authorizations[0]).toMatch(/^Nostr [A-Za-z0-9_-]+$/);
+    });
+
+    it("signs once per connection test when invocations are separate", async () => {
+        (authState as any).value = createAuthState();
+        const signEvent = vi.fn(async (template) => finalizeEvent(template, secretKeyA));
+        (window as any).nostr = {
+            getPublicKey: vi.fn(async () => pubkeyA),
+            signEvent,
+        };
+        const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+        const adapter = new BlossomUploadAdapter();
+
+        await adapter.testConnection({
+            destination: createBlossomDestination(),
+            authService: new NostrAuthService(),
+            fetch: fetchMock as unknown as typeof fetch,
+            sampleFile: createBlossomProbeFile(),
+        });
+        await adapter.testConnection({
+            destination: createBlossomDestination(),
+            authService: new NostrAuthService(),
+            fetch: fetchMock as unknown as typeof fetch,
+            sampleFile: createBlossomProbeFile(),
+        });
+
+        expect(signEvent).toHaveBeenCalledTimes(2);
+        expect(fetchMock).toHaveBeenCalledTimes(24);
+    });
+
+    it("does not fall back to an anonymous HEAD when the external signer rejects", async () => {
+        (authState as any).value = createAuthState();
+        const signEvent = vi.fn(async () => {
+            throw new Error("Signer rejected");
+        });
+        (window as any).nostr = {
+            getPublicKey: vi.fn(async () => pubkeyA),
+            signEvent,
+        };
+        const fetchMock = vi.fn();
+
+        const probePromise = new BlossomUploadAdapter().testConnection({
+            destination: createBlossomDestination(),
+            authService: new NostrAuthService(),
+            fetch: fetchMock as unknown as typeof fetch,
+            sampleFile: createBlossomProbeFile(),
+        });
+
+        await expect(probePromise).rejects.toThrow("Signer rejected");
+        expect(signEvent).toHaveBeenCalledOnce();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        {
+            name: "account switch",
+            changeSession: () => {
+                (authState as any).value = { ...authState.value, pubkey: pubkeyB };
+            },
+        },
+        {
+            name: "logout",
+            changeSession: () => {
+                (authState as any).value = {
+                    ...authState.value,
+                    isAuthenticated: false,
+                    type: "none",
+                    pubkey: "",
+                };
+            },
+        },
+    ])("stops MIME probes after $name without re-signing or anonymous fallback", async ({ changeSession }) => {
+        (authState as any).value = createAuthState();
+        const signEvent = vi.fn(async (template) => finalizeEvent(template, secretKeyA));
+        (window as any).nostr = {
+            getPublicKey: vi.fn(async () => pubkeyA),
+            signEvent,
+        };
+        const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => {
+            changeSession();
+            return new Response(null, { status: 200 });
+        });
+
+        const probePromise = new BlossomUploadAdapter().testConnection({
+            destination: createBlossomDestination(),
+            authService: new NostrAuthService(),
+            fetch: fetchMock as unknown as typeof fetch,
+            sampleFile: createBlossomProbeFile(),
+        });
+
+        await expect(probePromise).rejects.toThrow("Authentication required");
+        expect(signEvent).toHaveBeenCalledOnce();
+        expect(fetchMock).toHaveBeenCalledOnce();
+        const headers = (fetchMock.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
+        expect(headers.Authorization).toMatch(/^Nostr /);
+    });
+
+    it("does not start the initial HEAD when the session changes after signing", async () => {
+        (authState as any).value = createAuthState();
+        const signEvent = vi.fn(async (template) => {
+            const signedEvent = finalizeEvent(template, secretKeyA);
+            (authState as any).value = { ...authState.value, pubkey: pubkeyB };
+            return signedEvent;
+        });
+        (window as any).nostr = {
+            getPublicKey: vi.fn(async () => pubkeyA),
+            signEvent,
+        };
+        const fetchMock = vi.fn();
+
+        const probePromise = new BlossomUploadAdapter().testConnection({
+            destination: createBlossomDestination(),
+            authService: new NostrAuthService(),
+            fetch: fetchMock as unknown as typeof fetch,
+            sampleFile: createBlossomProbeFile(),
+        });
+
+        await expect(probePromise).rejects.toThrow("Authentication required");
+        expect(signEvent).toHaveBeenCalledOnce();
         expect(fetchMock).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary

- reuse one session-bound BUD-11 Authorization across the initial Blossom connection-test HEAD and all supported-MIME HEAD probes
- keep the reuse scope local to one `BlossomUploadAdapter.testConnection()` invocation
- assert the captured owner session immediately before every external HEAD request
- preserve the legacy unauthenticated path when no auth service is supplied

## Root cause

`probeBlossomUploadRequirement()` built a new BUD-11 Authorization on every call. An accepted initial probe is followed by 11 MIME probes, so one authenticated connection test could request 12 kind `24242` signatures even though the signed event is bound to the same upload method and sample SHA-256 throughout the invocation.

## Design and behavior

`NostrAuthService.createBlossomConnectionTestAuthorization()` captures the active session, uses the existing `buildBlossomAuthorizationHeader()` path once, and returns the canonical Authorization plus a session-liveness assertion. The adapter passes that invocation-local context to the initial and MIME probes.

The assertion runs synchronously immediately before each HEAD fetch. If account A switches to B or logs out after signing, the operation stops before another request, does not ask B to sign, does not send A's cached Authorization, and does not fall back to an anonymous HEAD. A session change after signing but before the initial fetch is also rejected.

Separate connection-test invocations create separate contexts and each signs once. There is no module-global, destination-wide, account-wide, persisted, or expiration-spanning cache. An injected auth service that exposes the legacy Authorization builder without the new session-bound context API now fails closed before signing or fetching, instead of falling back to repeated signing or unsafe reuse. The no-auth-service path remains unauthenticated as before.

BUD-11 semantics are unchanged: kind `24242`, `t=upload`, sample SHA-256 `x`, expiration, existing content, Base64url without padding, `Nostr` scheme, fixed expected pubkey, signed-event validation, and session-bound signer remain on the existing builder path. No `server`, Content-Type, or Content-Length signed tags were added. MIME probe headers and ordering are unchanged.

This branch was created from the fetched `origin/main` in a separate worktree and contains no parallel BUD-03, iframe logging, implementation-map, dependency, package manifest, DB, UI, or upload behavior changes.

## Changed files

- `src/lib/upload/BlossomUploadAdapter.ts`
- `src/lib/nostrAuthService.ts`
- `src/lib/types/upload.ts`
- `src/test/unit/blossomUploadAdapter.test.ts`
- `src/test/unit/nostrAuthService.test.ts`
- `src/test/unit/signedEventSessionBoundaries.integration.test.ts`

## Validation

- targeted upload/auth/session/store/file-upload tests: 7 files, 155 tests passed
- `npm run check`: passed, 0 errors and 0 warnings
- `npm test`: passed, 324 files and 3771 tests
- `npm audit --omit=dev`: passed, 0 vulnerabilities
- `npm run build`: passed; existing chunk-size warning only
- `git diff --check`: passed

Playwright and manual browser/device verification were not run because there are no UI or browser-interaction changes; deterministic unit and integration tests cover the protocol and race boundaries. `npm ci` was not run because dependencies and lockfiles are unchanged.
