### PR TITLE
Implement architecture audit fixes

### DIFF
--- a/.agents/skills/ehagaki-nostr/references/implementation-map.md
+++ b/.agents/skills/ehagaki-nostr/references/implementation-map.md
@@ -28,7 +28,7 @@
 - event kind: 投稿先により`1`または`42`
 - 主なtag: marked `e` (`root`、`reply`)、`p`。kind 42ではchannel rootの`e`も必要になる。
 - 主な実装ファイル: `src/lib/replyQuoteService.ts`、`src/lib/postManager.ts`、`src/lib/postHistoryNip10Utils.ts`、`src/stores/replyQuoteStore.svelte.ts`
-- 主な関数または責務: `ReplyQuoteService.extractThreadInfo`、`buildReplyTags`、`fetchReferencedEventTask`、`parseKind1ThreadReferences`、`parseKind42ThreadReferences`が取得とthread semanticsを分担する。
+- 主な関数または責務: `parsePostHistoryThreadReferences`（`parseKind1ThreadReferences`/`parseKind42ThreadReferences`）がNIP-10 thread semanticsのcanonical ownerであり、`ReplyQuoteService.extractThreadInfo`は既存composer shapeへのprojection、`buildReplyTags`はwire tag構築、`fetchReferencedEventTask`は取得を担う。
 - 関連テスト: `src/test/unit/replyQuoteService.test.ts`、`src/test/unit/postManager.test.ts`、`src/test/unit/postHistoryNip10Utils.test.ts`、`src/test/unit/replyQuoteStore.test.ts`
 - 注意点: root、直接parent、marker、author、relay hintを別々に検証する。kind 42のchannel rootとreply parentを混同しない。
 
@@ -147,7 +147,7 @@
 - event kind: profile metadata `0`、relay list metadata `10002`
 - 主なtag: kind 0自体の主要情報はJSON `content`。REQは`authors`、`kinds`、`until`、`limit`を使う。
 - 主な実装ファイル: `src/lib/profileManager.ts`、`src/lib/profileMetadataCache.svelte.ts`、`src/lib/relayProfileService.ts`、`src/lib/profileEventComparison.ts`、`src/lib/storage/profilesRepository.ts`
-- 主な関数または責務: `ProfileNetworkFetcher.fetchFromNetwork`、`ProfileManager`、`profileMetadataCache`、`RelayProfileService.fetchProfileRealtime`/`subscribeProfile`がnetwork、selection、cache、購読を分担する。
+- 主な関数または責務: `ProfileNetworkFetcher.fetchFromNetwork`、`ProfileManager`、`profileMetadataCache`、`RelayProfileService.fetchProfileRealtime`/`subscribeProfile`/`subscribeProfiles`がnetwork、selection、cache、購読を分担し、`useProfileProjectionSync`がcurrent/account UI projectionのlifecycleだけを所有する。
 - 関連テスト: `src/test/unit/profileManager.test.ts`、`src/test/unit/profileMetadataCache.test.ts`、`src/test/unit/relayProfileService.test.ts`、`src/test/unit/profileEventComparison.test.ts`、`src/test/unit/profilesRepository.test.ts`、`src/test/unit/ProfileComponent.test.ts`
 - 注意点: 複数relayのkind 0はevent freshnessと署名検証を考慮し、negative cache、同時要求共有、timeout、unsubscribeを保つ。
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,6 +6,7 @@
   import type { RelayProfileService } from "./lib/relayProfileService";
   import { createReplyQuoteProfileSyncController } from "./lib/replyQuoteProfileSync";
   import { useReplyQuoteProfileSync } from "./lib/hooks/useReplyQuoteProfileSync.svelte";
+  import { useProfileProjectionSync } from "./lib/hooks/useProfileProjectionSync.svelte";
   import ConfirmDialog from "./components/ConfirmDialog.svelte";
   import { authService, type PendingNip46AuthSession } from "./lib/authService";
   import { iframeMessageService } from "./lib/iframeMessageService";
@@ -1714,6 +1715,22 @@
         updateReplyNotificationRecipientProfile,
         logger: console,
       }),
+  });
+  useProfileProjectionSync({
+    getRelayProfileService: () => relayProfileService,
+    getCurrentPubkey: () => authState.value?.pubkey || null,
+    getAccountPubkeys: () => accountListStore.value.map((account) => account.pubkeyHex),
+    applyCurrentProfile: (profile) => {
+      profileDataStore.set(profile);
+      profileLoadedStore.set(true);
+    },
+    applyAccountProfile: (pubkeyHex, profile) => {
+      accountProfileCacheStore.setProfile(pubkeyHex, {
+        name: profile.name,
+        displayName: profile.displayName,
+        picture: profile.picture,
+      });
+    },
   });
 
   // --- 設定ダイアログからのリレー・プロフィール再取得ハンドラ ---

--- a/src/lib/hooks/useProfileProjectionSync.svelte.ts
+++ b/src/lib/hooks/useProfileProjectionSync.svelte.ts
@@ -1,0 +1,78 @@
+import type { RelayProfileService } from "../relayProfileService";
+import type { ProfileData } from "../types";
+
+export interface ProfileProjectionSyncDependencies {
+    getRelayProfileService: () => RelayProfileService | undefined;
+    getCurrentPubkey: () => string | null | undefined;
+    getAccountPubkeys: () => string[];
+    applyCurrentProfile: (profile: ProfileData) => void;
+    applyAccountProfile: (pubkeyHex: string, profile: ProfileData) => void;
+}
+
+function uniqueNonEmptyPubkeys(pubkeys: string[]): string[] {
+    return Array.from(new Set(pubkeys.filter((pubkey) => !!pubkey)));
+}
+
+/**
+ * Keeps the current-account and account-list projections connected to the
+ * shared profile metadata cache subscription. Fetching and persistence remain
+ * owned by RelayProfileService/profileMetadataCache.
+ */
+export function useProfileProjectionSync(
+    deps: ProfileProjectionSyncDependencies,
+): void {
+    $effect(() => {
+        const service = deps.getRelayProfileService();
+        const currentPubkey = deps.getCurrentPubkey() || null;
+        const accountPubkeys = uniqueNonEmptyPubkeys(deps.getAccountPubkeys());
+        const subscribedPubkeys = uniqueNonEmptyPubkeys([
+            ...(currentPubkey ? [currentPubkey] : []),
+            ...accountPubkeys,
+        ]);
+
+        if (
+            !service
+            || typeof service.subscribeProfiles !== "function"
+            || subscribedPubkeys.length === 0
+        ) {
+            return;
+        }
+
+        let active = true;
+        const subscriptionService = service;
+        const subscriptionPubkeys = new Set(subscribedPubkeys);
+        const unsubscribe = service.subscribeProfiles(
+            subscribedPubkeys,
+            (pubkeyHex, profile) => {
+                if (
+                    !active
+                    || subscriptionService !== deps.getRelayProfileService()
+                    || !subscriptionPubkeys.has(pubkeyHex)
+                    || !profile
+                ) {
+                    return;
+                }
+
+                const currentPubkeyNow = deps.getCurrentPubkey() || null;
+                const currentAccountPubkeys = new Set(
+                    uniqueNonEmptyPubkeys(deps.getAccountPubkeys()),
+                );
+                const isCurrentProfile = currentPubkeyNow === pubkeyHex;
+
+                if (!isCurrentProfile && !currentAccountPubkeys.has(pubkeyHex)) {
+                    return;
+                }
+
+                deps.applyAccountProfile(pubkeyHex, profile);
+                if (isCurrentProfile) {
+                    deps.applyCurrentProfile(profile);
+                }
+            },
+        );
+
+        return () => {
+            active = false;
+            unsubscribe();
+        };
+    });
+}

--- a/src/lib/postHistoryDirectReplyLifecycleTrigger.ts
+++ b/src/lib/postHistoryDirectReplyLifecycleTrigger.ts
@@ -287,5 +287,9 @@ export async function triggerPostHistoryDirectReplyLifecycle(
         };
     } finally {
         removeInFlightPostHistoryDirectReplyLifecycleRequests(admittedRequestKeys);
+        await reconcilePendingDeletionRequestsForRequestKeys([
+            ...admittedRequestKeys,
+            ...uniqueRequestKeysFromCandidates(skippedCandidates),
+        ]).catch(() => undefined);
     }
 }

--- a/src/lib/replyQuoteService.ts
+++ b/src/lib/replyQuoteService.ts
@@ -4,6 +4,7 @@ import { nip19 } from "nostr-tools";
 import type { NostrEvent, ReplyQuoteState, RelayConfig } from "./types";
 import { RelayConfigUtils } from "./relayConfigUtils";
 import { FALLBACK_RELAYS } from "./relayLists";
+import { parsePostHistoryThreadReferences } from "./postHistoryNip10Utils";
 
 export interface ReplyQuoteServiceDeps {
     console?: Console;
@@ -171,33 +172,11 @@ export class ReplyQuoteService {
         rootRelayHint: string | null;
         rootPubkey: string | null;
     } {
-        const eTags = event.tags.filter(tag => tag[0] === 'e');
-
-        // marked e-tags: "root" マーカーを探す
-        const rootTag = eTags.find(tag => tag[3] === 'root');
-        if (rootTag) {
-            return {
-                rootEventId: rootTag[1],
-                rootRelayHint: rootTag[2] || null,
-                rootPubkey: rootTag[4] || null,
-            };
-        }
-
-        // マーカーなしのe-tagsの場合はpositional: 最初のeタグがroot
-        if (eTags.length > 0) {
-            const firstETag = eTags[0];
-            return {
-                rootEventId: firstETag[1],
-                rootRelayHint: firstETag[2] || null,
-                rootPubkey: null,
-            };
-        }
-
-        // eタグなし: このイベント自体がroot（スレッドではない）
+        const references = parsePostHistoryThreadReferences(event);
         return {
-            rootEventId: null,
-            rootRelayHint: null,
-            rootPubkey: null,
+            rootEventId: references.rootId,
+            rootRelayHint: references.rootRelayHint,
+            rootPubkey: references.rootAuthorHint,
         };
     }
 

--- a/src/test/helpers/profileProjectionSyncHookHarness.svelte.ts
+++ b/src/test/helpers/profileProjectionSyncHookHarness.svelte.ts
@@ -1,0 +1,34 @@
+import type { RelayProfileService } from "../../lib/relayProfileService";
+import {
+    useProfileProjectionSync,
+    type ProfileProjectionSyncDependencies,
+} from "../../lib/hooks/useProfileProjectionSync.svelte";
+
+export function createProfileProjectionSyncHookHarness(
+    deps: Omit<ProfileProjectionSyncDependencies, "getRelayProfileService" | "getCurrentPubkey" | "getAccountPubkeys">,
+) {
+    let service = $state<RelayProfileService | undefined>();
+    let currentPubkey = $state<string | null>(null);
+    let accountPubkeys = $state<string[]>([]);
+    const dispose = $effect.root(() => {
+        useProfileProjectionSync({
+            ...deps,
+            getRelayProfileService: () => service,
+            getCurrentPubkey: () => currentPubkey,
+            getAccountPubkeys: () => accountPubkeys,
+        });
+    });
+
+    return {
+        setService(nextService: RelayProfileService | undefined) {
+            service = nextService;
+        },
+        setCurrentPubkey(nextPubkey: string | null) {
+            currentPubkey = nextPubkey;
+        },
+        setAccountPubkeys(nextPubkeys: string[]) {
+            accountPubkeys = nextPubkeys;
+        },
+        dispose,
+    };
+}

--- a/src/test/unit/postHistoryDirectReplyLifecycleTrigger.test.ts
+++ b/src/test/unit/postHistoryDirectReplyLifecycleTrigger.test.ts
@@ -252,4 +252,30 @@ describe("triggerPostHistoryDirectReplyLifecycle", () => {
         expect(saveManyReplyStateMock).not.toHaveBeenCalled();
         expect(result.status).toBe("completed");
     });
+
+    it("最終状態をdirect replyのUI projectionへreconcileする", async () => {
+        await triggerPostHistoryDirectReplyLifecycle({
+            source: "listing-current-view",
+            parentEventIds: [PARENT_ID],
+            rxNostr: { use: vi.fn() } as any,
+        });
+
+        expect(reconcilePendingDeletionRequestsForRequestKeysMock).toHaveBeenLastCalledWith([
+            `${PARENT_ID}:${REPLY_ID}:1`,
+        ]);
+    });
+
+    it("reconcile失敗はlifecycle結果を壊さない", async () => {
+        reconcilePendingDeletionRequestsForRequestKeysMock.mockRejectedValueOnce(
+            new Error("reconcile failed"),
+        );
+
+        const result = await triggerPostHistoryDirectReplyLifecycle({
+            source: "listing-current-view",
+            parentEventIds: [PARENT_ID],
+            rxNostr: { use: vi.fn() } as any,
+        });
+
+        expect(result.status).toBe("completed");
+    });
 });

--- a/src/test/unit/postManager.test.ts
+++ b/src/test/unit/postManager.test.ts
@@ -17,6 +17,7 @@ import type { RxNostr } from 'rx-nostr';
 import { createMockConsole, createMockRxNostr, MockKeyManager } from '../helpers';
 import { nip19 } from 'nostr-tools';
 import { DECOMMISSIONED_RELAYS } from '../../lib/relayLists';
+import { ReplyQuoteService } from '../../lib/replyQuoteService';
 
 vi.mock('../../lib/postHistoryRawEventVerification', () => ({
     RAW_EVENT_VERIFICATION_RULE_VERSION: 1,
@@ -1503,6 +1504,192 @@ describe('PostManager統合テスト', () => {
             }),
             expect.any(Object),
         );
+    });
+
+    it('canonical NIP-10のkind 42 reply stateを最終eventへ正しく構築する', async () => {
+        const mockObservable = {
+            subscribe: vi.fn((observer) => {
+                process.nextTick(() => {
+                    observer.next({
+                        from: 'relay1',
+                        ok: true,
+                        done: true,
+                        eventId: 'channel-reply-canonical-id',
+                        type: 'ok',
+                        message: '',
+                    });
+                });
+                return { unsubscribe: vi.fn() };
+            }),
+        };
+        vi.mocked(mockRxNostr.send).mockReturnValue(mockObservable as any);
+
+        const channelEventId = 'a'.repeat(64);
+        const replyEventId = 'b'.repeat(64);
+        const channelAuthor = 'c'.repeat(64);
+        const replyAuthor = 'd'.repeat(64);
+        const replyRelay = 'wss://reply-relay.example.com';
+        const threadEvent = {
+            id: replyEventId,
+            pubkey: replyAuthor,
+            created_at: 1000,
+            kind: 42,
+            tags: [
+                ['e', channelEventId, 'wss://channel-relay.example.com', 'ROOT', channelAuthor],
+            ],
+            content: 'existing channel message',
+            sig: 'sig',
+        } as any;
+        const replyQuoteService = new ReplyQuoteService();
+        const threadInfo = replyQuoteService.extractThreadInfo(threadEvent);
+
+        expect(threadInfo).toEqual({
+            rootEventId: null,
+            rootRelayHint: 'wss://channel-relay.example.com/',
+            rootPubkey: channelAuthor,
+        });
+
+        (mockDeps as any).replyQuoteService = replyQuoteService;
+        (mockDeps as any).channelContextState = {
+            value: {
+                eventId: channelEventId,
+                relayHints: ['wss://channel-lookup.example.com'],
+                channelRelays: ['wss://channel-relay.example.com'],
+                name: 'General',
+                about: null,
+                picture: null,
+            },
+        };
+        mockDeps.replyQuoteState = {
+            value: {
+                reply: {
+                    mode: 'reply',
+                    eventId: replyEventId,
+                    relayHints: [replyRelay],
+                    authorPubkey: replyAuthor,
+                    quoteNotificationEnabled: false,
+                    authorDisplayName: null,
+                    authorPicture: null,
+                    referencedEvent: threadEvent,
+                    rootEventId: threadInfo.rootEventId,
+                    rootRelayHint: threadInfo.rootRelayHint,
+                    rootPubkey: threadInfo.rootPubkey,
+                    loading: false,
+                    error: null,
+                },
+                quotes: [],
+            },
+        } as any;
+
+        manager = new PostManager(mockRxNostr, mockDeps);
+        const result = await manager.submitPost('Reply to channel message');
+
+        expect(result.success).toBe(true);
+        const [sentEvent] = vi.mocked(mockRxNostr.send).mock.calls[0] as [any, any];
+        const eTags = sentEvent.tags.filter((tag: string[]) => tag[0] === 'e');
+
+        expect(sentEvent.kind).toBe(42);
+        expect(eTags).toEqual([
+            ['e', channelEventId, 'wss://channel-relay.example.com', 'root'],
+            ['e', replyEventId, replyRelay, 'reply', replyAuthor],
+        ]);
+        expect(eTags.filter((tag: string[]) => tag[3] === 'root')).toHaveLength(1);
+        expect(eTags.filter((tag: string[]) => tag[3] === 'reply')).toHaveLength(1);
+        expect(eTags.some((tag: string[]) => tag[1] === replyEventId && tag[3] === 'root')).toBe(false);
+    });
+
+    it('canonical thread情報のinvalid rootとhintをkind 42 wire eventへ再出力しない', async () => {
+        const mockObservable = {
+            subscribe: vi.fn((observer) => {
+                process.nextTick(() => {
+                    observer.next({
+                        from: 'relay1',
+                        ok: true,
+                        done: true,
+                        eventId: 'channel-reply-invalid-thread-id',
+                        type: 'ok',
+                        message: '',
+                    });
+                });
+                return { unsubscribe: vi.fn() };
+            }),
+        };
+        vi.mocked(mockRxNostr.send).mockReturnValue(mockObservable as any);
+
+        const channelEventId = 'e'.repeat(64);
+        const replyEventId = 'f'.repeat(64);
+        const replyAuthor = '1'.repeat(64);
+        const invalidThreadEvent = {
+            id: replyEventId,
+            pubkey: replyAuthor,
+            created_at: 1000,
+            kind: 42,
+            tags: [['e', 'invalid-root-id', 'https://unsafe.example.com', 'rOoT', 'invalid-author']],
+            content: 'malformed channel message',
+            sig: 'sig',
+        } as any;
+        const replyQuoteService = new ReplyQuoteService();
+        const threadInfo = replyQuoteService.extractThreadInfo(invalidThreadEvent);
+
+        expect(threadInfo).toEqual({
+            rootEventId: null,
+            rootRelayHint: null,
+            rootPubkey: null,
+        });
+
+        (mockDeps as any).replyQuoteService = replyQuoteService;
+        (mockDeps as any).channelContextState = {
+            value: {
+                eventId: channelEventId,
+                relayHints: [],
+                channelRelays: ['wss://safe-channel.example.com'],
+                name: 'General',
+                about: null,
+                picture: null,
+            },
+        };
+        mockDeps.replyQuoteState = {
+            value: {
+                reply: {
+                    mode: 'reply',
+                    eventId: replyEventId,
+                    relayHints: ['wss://safe-reply.example.com'],
+                    authorPubkey: replyAuthor,
+                    quoteNotificationEnabled: false,
+                    authorDisplayName: null,
+                    authorPicture: null,
+                    referencedEvent: invalidThreadEvent,
+                    rootEventId: threadInfo.rootEventId,
+                    rootRelayHint: threadInfo.rootRelayHint,
+                    rootPubkey: threadInfo.rootPubkey,
+                    loading: false,
+                    error: null,
+                },
+                quotes: [],
+            },
+        } as any;
+
+        manager = new PostManager(mockRxNostr, mockDeps);
+        const result = await manager.submitPost('Reply without malformed thread root');
+
+        expect(result.success).toBe(true);
+        const [sentEvent] = vi.mocked(mockRxNostr.send).mock.calls[0] as [any, any];
+        expect(sentEvent.kind).toBe(42);
+        expect(sentEvent.tags).toEqual(expect.arrayContaining([
+            ['e', channelEventId, 'wss://safe-channel.example.com', 'root'],
+            ['e', replyEventId, 'wss://safe-reply.example.com', 'reply', replyAuthor],
+        ]));
+        expect(sentEvent.tags).not.toContainEqual([
+            'e',
+            'invalid-root-id',
+            'https://unsafe.example.com',
+            'root',
+            'invalid-author',
+        ]);
+        expect(sentEvent.tags.some((tag: string[]) =>
+            tag[0] === 'e'
+            && (tag[1] === 'invalid-root-id' || tag[2] === 'https://unsafe.example.com' || tag[4] === 'invalid-author'),
+        )).toBe(false);
     });
 
     it('NIP-07認証で投稿を送信する', async () => {

--- a/src/test/unit/replyQuoteService.test.ts
+++ b/src/test/unit/replyQuoteService.test.ts
@@ -10,6 +10,9 @@ import { FALLBACK_RELAYS } from "../../lib/relayLists";
 describe("ReplyQuoteService", () => {
     let service: ReplyQuoteService;
     let mockConsole: MockConsole;
+    const rootId = "1".repeat(64);
+    const parentId = "2".repeat(64);
+    const rootPubkey = "3".repeat(64);
 
     beforeEach(() => {
         mockConsole = createMockConsole();
@@ -24,16 +27,16 @@ describe("ReplyQuoteService", () => {
                 created_at: 1000,
                 kind: 1,
                 tags: [
-                    ["e", "root-id", "wss://relay.example.com", "root"],
-                    ["e", "parent-id", "wss://relay2.example.com", "reply"],
+                    ["e", rootId, "wss://relay.example.com", "root"],
+                    ["e", parentId, "wss://relay2.example.com", "reply"],
                 ],
                 content: "test",
                 sig: "sig1",
             };
 
             const result = service.extractThreadInfo(event);
-            expect(result.rootEventId).toBe("root-id");
-            expect(result.rootRelayHint).toBe("wss://relay.example.com");
+            expect(result.rootEventId).toBe(rootId);
+            expect(result.rootRelayHint).toBe("wss://relay.example.com/");
             expect(result.rootPubkey).toBeNull();
         });
 
@@ -44,15 +47,15 @@ describe("ReplyQuoteService", () => {
                 created_at: 1000,
                 kind: 1,
                 tags: [
-                    ["e", "root-id", "wss://relay.example.com", "root", "root-pubkey"],
+                    ["e", rootId, "wss://relay.example.com", "root", rootPubkey],
                 ],
                 content: "test",
                 sig: "sig1",
             };
 
             const result = service.extractThreadInfo(event);
-            expect(result.rootEventId).toBe("root-id");
-            expect(result.rootPubkey).toBe("root-pubkey");
+            expect(result.rootEventId).toBe(rootId);
+            expect(result.rootPubkey).toBe(rootPubkey);
         });
 
         it("マーカーなしのeタグの場合、最初のeタグをrootとする", () => {
@@ -62,16 +65,16 @@ describe("ReplyQuoteService", () => {
                 created_at: 1000,
                 kind: 1,
                 tags: [
-                    ["e", "first-id", "wss://relay.example.com"],
-                    ["e", "second-id", "wss://relay2.example.com"],
+                    ["e", rootId, "wss://relay.example.com"],
+                    ["e", parentId, "wss://relay2.example.com"],
                 ],
                 content: "test",
                 sig: "sig1",
             };
 
             const result = service.extractThreadInfo(event);
-            expect(result.rootEventId).toBe("first-id");
-            expect(result.rootRelayHint).toBe("wss://relay.example.com");
+            expect(result.rootEventId).toBe(rootId);
+            expect(result.rootRelayHint).toBe("wss://relay.example.com/");
         });
 
         it("eタグがない場合はすべてnullを返す", () => {
@@ -89,6 +92,61 @@ describe("ReplyQuoteService", () => {
             expect(result.rootEventId).toBeNull();
             expect(result.rootRelayHint).toBeNull();
             expect(result.rootPubkey).toBeNull();
+        });
+
+        it("不正なroot IDやhintをcomposer stateへ採用しない", () => {
+            const event: NostrEvent = {
+                id: "event1",
+                pubkey: "pubkey1",
+                created_at: 1000,
+                kind: 1,
+                tags: [["e", "not-an-event-id", "https://not-a-relay", "ROOT", "not-a-pubkey"]],
+                content: "test",
+                sig: "sig1",
+            };
+
+            expect(service.extractThreadInfo(event)).toEqual({
+                rootEventId: null,
+                rootRelayHint: null,
+                rootPubkey: null,
+            });
+        });
+
+        it("markerを正規化し、valid rootからunsafeなhintだけを除外する", () => {
+            const event: NostrEvent = {
+                id: "event1",
+                pubkey: "pubkey1",
+                created_at: 1000,
+                kind: 1,
+                tags: [["e", rootId, "https://not-a-relay", "ROOT", "not-a-pubkey"]],
+                content: "test",
+                sig: "sig1",
+            };
+
+            expect(service.extractThreadInfo(event)).toEqual({
+                rootEventId: rootId,
+                rootRelayHint: null,
+                rootPubkey: null,
+            });
+        });
+
+        it("kind 42のchannel rootをkind 1のthread rootとして継承しない", () => {
+            const channelId = "4".repeat(64);
+            const event: NostrEvent = {
+                id: "event1",
+                pubkey: "pubkey1",
+                created_at: 1000,
+                kind: 42,
+                tags: [["e", channelId, "wss://channel.example.com", "ROOT", rootPubkey]],
+                content: "test",
+                sig: "sig1",
+            };
+
+            expect(service.extractThreadInfo(event)).toEqual({
+                rootEventId: null,
+                rootRelayHint: "wss://channel.example.com/",
+                rootPubkey,
+            });
         });
     });
 

--- a/src/test/unit/useProfileProjectionSync.test.ts
+++ b/src/test/unit/useProfileProjectionSync.test.ts
@@ -1,0 +1,146 @@
+import { flushSync } from "svelte";
+import { describe, expect, it, vi } from "vitest";
+
+import { createProfileProjectionSyncHookHarness } from "../helpers/profileProjectionSyncHookHarness.svelte";
+import type { ProfileData } from "../../lib/types";
+
+const PROFILE_A: ProfileData = {
+    name: "alice",
+    displayName: "Alice",
+    picture: "https://example.com/alice.png",
+    npub: "npub-alice",
+    nprofile: "nprofile-alice",
+};
+
+const PROFILE_B: ProfileData = {
+    name: "bob",
+    displayName: "Bob",
+    picture: "https://example.com/bob.png",
+    npub: "npub-bob",
+    nprofile: "nprofile-bob",
+};
+
+describe("useProfileProjectionSync", () => {
+    it("current profile and account projectionをcache通知から更新する", () => {
+        const applyCurrentProfile = vi.fn();
+        const applyAccountProfile = vi.fn();
+        let callback: ((pubkeyHex: string, profile: ProfileData | null) => void) | undefined;
+        const unsubscribe = vi.fn();
+        const service = {
+            subscribeProfiles: vi.fn((_pubkeys, next) => {
+                callback = next;
+                return unsubscribe;
+            }),
+        } as never;
+        const harness = createProfileProjectionSyncHookHarness({
+            applyCurrentProfile,
+            applyAccountProfile,
+        });
+
+        flushSync(() => {
+            harness.setCurrentPubkey("alice");
+            harness.setAccountPubkeys(["alice", "alice", "bob"]);
+            harness.setService(service);
+        });
+
+        expect((service as any).subscribeProfiles).toHaveBeenCalledWith(
+            ["alice", "bob"],
+            expect.any(Function),
+        );
+
+        callback?.("alice", PROFILE_A);
+        expect(applyAccountProfile).toHaveBeenCalledWith("alice", PROFILE_A);
+        expect(applyCurrentProfile).toHaveBeenCalledWith(PROFILE_A);
+
+        callback?.("bob", PROFILE_B);
+        expect(applyAccountProfile).toHaveBeenCalledWith("bob", PROFILE_B);
+        expect(applyCurrentProfile).toHaveBeenCalledTimes(1);
+
+        harness.dispose();
+        expect(unsubscribe).toHaveBeenCalledOnce();
+    });
+
+    it("service/account変更後のstale callbackを無視する", () => {
+        const applyCurrentProfile = vi.fn();
+        const applyAccountProfile = vi.fn();
+        const callbacks: Array<(pubkeyHex: string, profile: ProfileData | null) => void> = [];
+        const unsubscribes = [vi.fn(), vi.fn()];
+        const services = [
+            {
+                subscribeProfiles: vi.fn((_pubkeys, next) => {
+                    callbacks.push(next);
+                    return unsubscribes[0];
+                }),
+            },
+            {
+                subscribeProfiles: vi.fn((_pubkeys, next) => {
+                    callbacks.push(next);
+                    return unsubscribes[1];
+                }),
+            },
+        ] as never[];
+        const harness = createProfileProjectionSyncHookHarness({
+            applyCurrentProfile,
+            applyAccountProfile,
+        });
+
+        flushSync(() => {
+            harness.setCurrentPubkey("alice");
+            harness.setAccountPubkeys(["alice", "bob"]);
+            harness.setService(services[0]);
+        });
+        flushSync(() => harness.setService(services[1]));
+
+        callbacks[0]("alice", PROFILE_A);
+        expect(applyCurrentProfile).not.toHaveBeenCalled();
+        expect(applyAccountProfile).not.toHaveBeenCalled();
+
+        callbacks[1]("alice", PROFILE_A);
+        expect(applyCurrentProfile).toHaveBeenCalledWith(PROFILE_A);
+        expect(unsubscribes[0]).toHaveBeenCalledOnce();
+
+        flushSync(() => {
+            harness.setAccountPubkeys(["alice", "carol"]);
+        });
+        callbacks[1]("bob", PROFILE_B);
+        expect(applyAccountProfile).toHaveBeenCalledTimes(1);
+
+        harness.dispose();
+        expect(unsubscribes[1]).toHaveBeenCalledTimes(2);
+    });
+
+    it("null通知やlogout後の通知で既存projectionを消さない", () => {
+        const applyCurrentProfile = vi.fn();
+        const applyAccountProfile = vi.fn();
+        let callback: ((pubkeyHex: string, profile: ProfileData | null) => void) | undefined;
+        const service = {
+            subscribeProfiles: vi.fn((_pubkeys, next) => {
+                callback = next;
+                return vi.fn();
+            }),
+        } as never;
+        const harness = createProfileProjectionSyncHookHarness({
+            applyCurrentProfile,
+            applyAccountProfile,
+        });
+
+        flushSync(() => {
+            harness.setCurrentPubkey("alice");
+            harness.setAccountPubkeys(["alice"]);
+            harness.setService(service);
+        });
+        callback?.("alice", null);
+        expect(applyCurrentProfile).not.toHaveBeenCalled();
+        expect(applyAccountProfile).not.toHaveBeenCalled();
+
+        flushSync(() => {
+            harness.setCurrentPubkey(null);
+            harness.setAccountPubkeys([]);
+        });
+        callback?.("alice", PROFILE_A);
+        expect(applyCurrentProfile).not.toHaveBeenCalled();
+        expect(applyAccountProfile).not.toHaveBeenCalled();
+
+        harness.dispose();
+    });
+});


### PR DESCRIPTION
## Summary

- Canonicalize composer NIP-10 thread-root interpretation through the existing Post History parser.
- Reconcile direct-reply deletion lifecycle projections on every terminal path.
- Subscribe current-account and account-list profile projections to the shared profile metadata cache.

## Root cause

The audit found three independently evolved paths: composer NIP-10 parsing bypassed the canonical validator, direct-reply lifecycle lacked the sibling reaction trigger's final reconciliation, and background profile-cache updates had no app-level projection subscriber.

## Impact

- Invalid NIP-10 IDs, relay hints, and author hints are no longer propagated into composer reply state.
- Direct-reply deletion badges converge after success, failure, cancellation, and skipped requests.
- Current and inactive account profile displays update after accepted background metadata refreshes while preserving logout and null-result behavior.

## Validation

- 
pm test — 325 files / 3778 tests passed
- 
pm run check — 0 errors, 0 warnings
- Targeted new and related tests passed
- git diff --check passed

No schema, wire format, repository API, or service-worker protocol changes were made.