### PR TITLE
Sanitize inline quote relay hints

### DIFF
--- a/.agents/skills/ehagaki-nostr/references/implementation-map.md
+++ b/.agents/skills/ehagaki-nostr/references/implementation-map.md
@@ -72,7 +72,7 @@
 - event kind: URIが指すeventに従う。
 - 主なtag: inline quoteでは解決結果から`q`、必要に応じて`p`を作る。
 - 主な実装ファイル: `src/lib/replyQuoteService.ts`、`src/lib/urlQueryHandler.ts`、`src/lib/embedComposerContextValidation.ts`、`src/lib/embedComposerContextNotification.ts`、`src/lib/composerTargetUtils.ts`、`src/lib/postHistoryQuoteUtils.ts`
-- 主な関数または責務: `generateNostrUri`、`extractInlineQuoteTags`、`decodeEventPointerValue`、`parseComposerTargetInput`が生成・decode・入力検証を分担する。
+- 主な関数または責務: `generateNostrUri`、`extractInlineQuoteTags`、`decodeEventPointerValue`、`parseComposerTargetInput`が生成・decode・入力検証を分担する。`extractInlineQuoteTags`のnote/nevent pointer projectionは`decodeEventPointerValue`へ委譲し、本文URI検出とq/p tag policyのみを保持する。
 - 関連テスト: `src/test/unit/replyQuoteService.test.ts`、`src/test/unit/urlQueryHandler.test.ts`、`src/test/unit/eventPointerUtils.test.ts`、`src/test/unit/composerTargetUtils.test.ts`、`src/test/unit/postHistoryQuoteUtils.test.ts`
 - 注意点: inline quoteの抽出対象はnote/neventである。post history表示でもnaddr URIはquote targetとして解決しないことがテストされている。
 

--- a/src/lib/replyQuoteService.ts
+++ b/src/lib/replyQuoteService.ts
@@ -5,6 +5,7 @@ import type { NostrEvent, ReplyQuoteState, RelayConfig } from "./types";
 import { RelayConfigUtils } from "./relayConfigUtils";
 import { FALLBACK_RELAYS } from "./relayLists";
 import { parsePostHistoryThreadReferences } from "./postHistoryNip10Utils";
+import { decodeEventPointerValue } from "./eventPointerUtils";
 
 export interface ReplyQuoteServiceDeps {
     console?: Console;
@@ -260,20 +261,12 @@ export class ReplyQuoteService {
 
         while ((match = regex.exec(content)) !== null) {
             try {
-                const decoded = nip19.decode(match[1]);
-                let eventId: string;
-                let relayHint = '';
-                let authorPubkey: string | undefined;
+                const pointer = decodeEventPointerValue(match[1]);
+                if (!pointer) continue;
 
-                if (decoded.type === 'nevent') {
-                    eventId = decoded.data.id;
-                    relayHint = decoded.data.relays?.[0] || '';
-                    authorPubkey = decoded.data.author;
-                } else if (decoded.type === 'note') {
-                    eventId = decoded.data as string;
-                } else {
-                    continue;
-                }
+                const eventId = pointer.eventId;
+                const relayHint = pointer.relayHints[0] || '';
+                const authorPubkey = pointer.authorPubkey ?? undefined;
 
                 // 同一イベントIDの重複qタグを防ぐ
                 if (seenEventIds.has(eventId)) continue;

--- a/src/test/unit/postManager.test.ts
+++ b/src/test/unit/postManager.test.ts
@@ -2257,6 +2257,47 @@ describe('PostManager統合テスト', () => {
             expect(pTags.some((t: string[]) => t[1] === authorPubkey1)).toBe(false);
         });
 
+        it('最終送信eventではunsafe relayを除外し、valid relayをqタグへ正規化して採用する', async () => {
+            const nevent = nip19.neventEncode({
+                id: eventId1,
+                relays: ['https://unsafe.example/', 'wss://valid.example.com'],
+                author: authorPubkey1,
+            });
+            const content = `テスト投稿\nnostr:${nevent}`;
+
+            vi.mocked(mockRxNostr.send).mockReturnValue(createSuccessMock() as any);
+
+            const result = await manager.submitPost(content);
+            expect(result.success).toBe(true);
+
+            const [sentEvent] = vi.mocked(mockRxNostr.send).mock.calls[0] as [any];
+            const qTags = sentEvent.tags.filter((t: string[]) => t[0] === 'q');
+            expect(qTags).toEqual([
+                ['q', eventId1, 'wss://valid.example.com/', authorPubkey1],
+            ]);
+            expect(qTags.flat()).not.toContain('https://unsafe.example/');
+        });
+
+        it('最終送信eventでは全relayがunsafeでもinline quoteを維持する', async () => {
+            const nevent = nip19.neventEncode({
+                id: eventId1,
+                relays: ['https://unsafe.example/', 'http://also-unsafe.example/'],
+                author: authorPubkey1,
+            });
+            const content = `テスト投稿\nnostr:${nevent}`;
+
+            vi.mocked(mockRxNostr.send).mockReturnValue(createSuccessMock() as any);
+
+            const result = await manager.submitPost(content);
+            expect(result.success).toBe(true);
+
+            const [sentEvent] = vi.mocked(mockRxNostr.send).mock.calls[0] as [any];
+            const qTags = sentEvent.tags.filter((t: string[]) => t[0] === 'q');
+            expect(qTags).toEqual([
+                ['q', eventId1, '', authorPubkey1],
+            ]);
+        });
+
         it('設定オン時はコンテンツ内のnostr:nevent1 URIからqタグとpタグを生成する', async () => {
             const nevent = nip19.neventEncode({
                 id: eventId1,

--- a/src/test/unit/replyQuoteService.test.ts
+++ b/src/test/unit/replyQuoteService.test.ts
@@ -655,7 +655,7 @@ describe("ReplyQuoteService", () => {
             expect(tags).toHaveLength(1);
             expect(tags[0][0]).toBe("q");
             expect(tags[0][1]).toBe(eventId1);
-            expect(tags[0][2]).toBe("wss://relay.example.com");
+            expect(tags[0][2]).toBe("wss://relay.example.com/");
             expect(tags[0][3]).toBe(authorPubkey1);
         });
 
@@ -671,9 +671,39 @@ describe("ReplyQuoteService", () => {
             expect(tags).toHaveLength(2);
             expect(tags[0][0]).toBe("q");
             expect(tags[0][1]).toBe(eventId1);
-            expect(tags[0][2]).toBe("wss://relay.example.com");
+            expect(tags[0][2]).toBe("wss://relay.example.com/");
             expect(tags[0][3]).toBe(authorPubkey1);
             expect(tags[1]).toEqual(["p", authorPubkey1]);
+        });
+
+        it("unsafe relayを除外し、後続のvalid relayをqタグへ正規化して採用する", () => {
+            const nevent = nip19.neventEncode({
+                id: eventId1,
+                relays: ["https://unsafe.example/", "wss://valid.example.com"],
+                author: authorPubkey1,
+            });
+
+            const tags = service.extractInlineQuoteTags(`nostr:${nevent}`, true);
+
+            expect(tags).toEqual([
+                ["q", eventId1, "wss://valid.example.com/", authorPubkey1],
+                ["p", authorPubkey1],
+            ]);
+        });
+
+        it("全relayがunsafeでもquoteを維持し、relay fieldを空にする", () => {
+            const nevent = nip19.neventEncode({
+                id: eventId1,
+                relays: ["https://unsafe.example/", "http://also-unsafe.example/"],
+                author: authorPubkey1,
+            });
+
+            const tags = service.extractInlineQuoteTags(`nostr:${nevent}`, true);
+
+            expect(tags).toEqual([
+                ["q", eventId1, "", authorPubkey1],
+                ["p", authorPubkey1],
+            ]);
         });
 
         it("nostr:note1... URIからqタグを抽出する（pタグなし）", () => {


### PR DESCRIPTION
## Summary

Fixes the B-03 inline quote pointer projection drift.

## Root cause

`ReplyQuoteService.extractInlineQuoteTags()` decoded inline `nostr:note/nevent` values directly with `nip19.decode()` and forwarded the first raw `nevent` relay hint into the outgoing `q` tag. This bypassed the existing canonical relay sanitization used by external pointer paths, allowing unsafe relay hints to reach the signed/published event.

## Changes

- Delegate inline note/nevent pointer projection to the canonical `decodeEventPointerValue()` helper.
- Preserve inline-quote-specific policy: URI detection, note/nevent scope, case-insensitive URI matching, order, q/p tag generation, deduplication, and malformed-pointer ignoring.
- Keep permissive behavior: unsafe relays are removed; a quote with no remaining safe relay is retained with an empty relay field.
- Add ReplyQuoteService regression coverage and PostManager final-event boundary coverage.
- Update the Nostr implementation map to document the projection ownership.

Changed files:
- `.agents/skills/ehagaki-nostr/references/implementation-map.md`
- `src/lib/replyQuoteService.ts`
- `src/test/unit/replyQuoteService.test.ts`
- `src/test/unit/postManager.test.ts`

## Verification

- Targeted Vitest: replyQuoteService, postManager, eventPointerUtils — 3 files / 134 tests passed
- `npm run check` — passed (0 errors, 0 warnings)
- `npm test` — passed (325 files / 3785 tests)
- `npm run build` — passed, including legacy bridge verification
- `git diff --check` — passed
- Playwright/manual browser verification was not run because this is a protocol/event-construction change covered at the service and final event boundary tests.