### PR TITLE
fix: prevent profile projection Svelte effect loop

### DIFF
--- a/src/lib/hooks/useProfileProjectionSync.svelte.ts
+++ b/src/lib/hooks/useProfileProjectionSync.svelte.ts
@@ -1,3 +1,5 @@
+import { untrack } from "svelte";
+
 import type { RelayProfileService } from "../relayProfileService";
 import type { ProfileData } from "../types";
 
@@ -41,7 +43,7 @@ export function useProfileProjectionSync(
         let active = true;
         const subscriptionService = service;
         const subscriptionPubkeys = new Set(subscribedPubkeys);
-        const unsubscribe = service.subscribeProfiles(
+        const unsubscribe = untrack(() => service.subscribeProfiles(
             subscribedPubkeys,
             (pubkeyHex, profile) => {
                 if (
@@ -68,7 +70,7 @@ export function useProfileProjectionSync(
                     deps.applyCurrentProfile(profile);
                 }
             },
-        );
+        ));
 
         return () => {
             active = false;

--- a/src/test/helpers/profileProjectionSyncHookHarness.svelte.ts
+++ b/src/test/helpers/profileProjectionSyncHookHarness.svelte.ts
@@ -1,4 +1,5 @@
 import type { RelayProfileService } from "../../lib/relayProfileService";
+import type { ProfileData } from "../../lib/types";
 import {
     useProfileProjectionSync,
     type ProfileProjectionSyncDependencies,
@@ -30,5 +31,20 @@ export function createProfileProjectionSyncHookHarness(
             accountPubkeys = nextPubkeys;
         },
         dispose,
+    };
+}
+
+export function createReactiveProfileProjectionState() {
+    let profiles = $state<Map<string, ProfileData>>(new Map());
+
+    return {
+        get value() {
+            return profiles;
+        },
+        setProfile(pubkeyHex: string, profile: ProfileData) {
+            const nextProfiles = new Map(profiles);
+            nextProfiles.set(pubkeyHex, profile);
+            profiles = nextProfiles;
+        },
     };
 }

--- a/src/test/unit/useProfileProjectionSync.test.ts
+++ b/src/test/unit/useProfileProjectionSync.test.ts
@@ -1,7 +1,10 @@
 import { flushSync } from "svelte";
 import { describe, expect, it, vi } from "vitest";
 
-import { createProfileProjectionSyncHookHarness } from "../helpers/profileProjectionSyncHookHarness.svelte";
+import {
+    createProfileProjectionSyncHookHarness,
+    createReactiveProfileProjectionState,
+} from "../helpers/profileProjectionSyncHookHarness.svelte";
 import type { ProfileData } from "../../lib/types";
 
 const PROFILE_A: ProfileData = {
@@ -21,6 +24,42 @@ const PROFILE_B: ProfileData = {
 };
 
 describe("useProfileProjectionSync", () => {
+    it("同期的なcache通知でreactive projectionを更新しても購読を再帰実行しない", () => {
+        const applyCurrentProfile = vi.fn();
+        const accountProfiles = createReactiveProfileProjectionState();
+        let subscriptionCount = 0;
+        const unsubscribe = vi.fn();
+        const service = {
+            subscribeProfiles: vi.fn((_pubkeys, next) => {
+                subscriptionCount += 1;
+                next("alice", PROFILE_A);
+                return unsubscribe;
+            }),
+        } as never;
+        const harness = createProfileProjectionSyncHookHarness({
+            applyCurrentProfile,
+            applyAccountProfile: (pubkeyHex, profile) => {
+                // Mirror accountProfileCacheStore.setProfile's reactive read/write.
+                accountProfiles.value;
+                accountProfiles.setProfile(pubkeyHex, profile);
+            },
+        });
+
+        expect(() => {
+            flushSync(() => {
+                harness.setCurrentPubkey("alice");
+                harness.setAccountPubkeys(["alice"]);
+                harness.setService(service);
+            });
+        }).not.toThrow();
+
+        expect(subscriptionCount).toBe(1);
+        expect(accountProfiles.value.get("alice")).toBe(PROFILE_A);
+        expect(applyCurrentProfile).toHaveBeenCalledWith(PROFILE_A);
+
+        harness.dispose();
+    });
+
     it("current profile and account projectionをcache通知から更新する", () => {
         const applyCurrentProfile = vi.fn();
         const applyAccountProfile = vi.fn();


### PR DESCRIPTION
## Summary

- Prevent the profile projection Svelte effect from tracking reactive reads performed during subscription registration.
- Add a regression test for synchronous cached-profile notifications that update a reactive account projection.

## Root cause

`useProfileProjectionSync` called `RelayProfileService.subscribeProfiles` directly inside `$effect`. When the profile cache already contained an entry, subscription registration synchronously invoked the callback. The callback reached `accountProfileCacheStore.setProfile`, which reads the reactive cache and writes a new `Map`. Because that read occurred while the effect was tracking dependencies, the same effect reran and subscribed again until Svelte reported `effect_update_depth_exceeded`.

## Fix

The service/current pubkey/account pubkey reads remain normal `$effect` dependencies. Only the `subscribeProfiles` registration boundary is wrapped with Svelte `untrack`, preserving cleanup, deduplication, stale-callback checks, logout handling, and current/account projection behavior.

## Regression test

The new test invokes the profile callback synchronously from `subscribeProfiles`, mirrors `accountProfileCacheStore.setProfile` with a reactive `Map` read/write, verifies current and account projections update, and asserts the stable subscription is created only once.

## Validation

- `npm run test -- src/test/unit/useProfileProjectionSync.test.ts` — passed (4 tests)
- `npm run test -- src/test/unit/authStore.test.ts src/test/unit/profileMetadataCache.test.ts src/test/unit/relayProfileService.test.ts` — passed (84 tests)
- `npm run check` — passed
- `npm test` — passed (325 files, 3786 tests)
- `npm run build` — passed, including legacy bridge verification
- `git diff --check` — passed

Browser/manual login verification was not run because the repository does not provide a reproducible existing fixture for starting the app with a pre-populated profile cache; no new E2E infrastructure was added for this narrow lifecycle fix.
