### PR TITLE
Fix post history client labels and icon

### DIFF
--- a/public/icons/open_in_new_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg
+++ b/public/icons/open_in_new_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#000000"><path d="M120-120v-720h360v80H200v560h560v-280h80v360H120Zm268-212-56-56 372-372H560v-80h280v280h-80v-144L388-332Z"/></svg>

--- a/src/components/PostHistoryRecordActionItems.svelte
+++ b/src/components/PostHistoryRecordActionItems.svelte
@@ -117,6 +117,6 @@
 
 <style>
     :global(.open-in-new-icon) {
-        mask-image: url("/icons/arrow_top_right_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg");
+        mask-image: url("/icons/open_in_new_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg");
     }
 </style>

--- a/src/components/SettingsDialog.svelte
+++ b/src/components/SettingsDialog.svelte
@@ -437,6 +437,8 @@
                         <option value={client}>
                             {client === "custom"
                                 ? $_("settingsDialog.external_nostr_client_custom")
+                                : client === "nostter"
+                                  ? "nostter"
                                 : client === "njump"
                                   ? "njump"
                                   : client[0].toUpperCase() + client.slice(1)}

--- a/src/lib/postHistoryExternalClient.ts
+++ b/src/lib/postHistoryExternalClient.ts
@@ -29,7 +29,7 @@ export const EXTERNAL_NOSTR_CLIENT_PRESET_TEMPLATES: Record<
 };
 
 const EXTERNAL_NOSTR_CLIENT_LABELS: Record<ExternalNostrClient, string> = {
-    nostter: "Nostter",
+    nostter: "nostter",
     jumble: "Jumble",
     primal: "Primal",
     njump: "njump",

--- a/src/test/unit/postHistoryRecordActionItems.test.ts
+++ b/src/test/unit/postHistoryRecordActionItems.test.ts
@@ -137,13 +137,13 @@ describe("PostHistoryRecordActionItems", () => {
         const onOpenExternalClient = vi.fn();
 
         render(PostHistoryRecordActionItemsHarness, {
-            externalClientLabel: "Nostterで開く",
+            externalClientLabel: "nostterで開く",
             onOpenExternalClient,
         });
 
-        const item = screen.getByRole("menuitem", { name: "Nostterで開く" });
+        const item = screen.getByRole("menuitem", { name: "nostterで開く" });
         expect(menuItemNames()).toEqual([
-            "Nostterで開く",
+            "nostterで開く",
             "neventをコピー",
             "イベントJSONを表示",
             "ブロードキャスト",

--- a/src/test/unit/settingsDialogAccessibility.test.ts
+++ b/src/test/unit/settingsDialogAccessibility.test.ts
@@ -188,7 +188,7 @@ describe('SettingsDialog accessibility', () => {
             name: '投稿を開くクライアント',
         }) as HTMLSelectElement;
         expect(Array.from(clientSelect.options).map((option) => option.text)).toEqual([
-            'Nostter',
+            'nostter',
             'Jumble',
             'Lumilumi',
             'Primal',

--- a/src/test/unit/settingsStorage.test.ts
+++ b/src/test/unit/settingsStorage.test.ts
@@ -164,7 +164,7 @@ describe('external Nostr client preference', () => {
         storage = new MockStorage();
     });
 
-    it('未保存かつ日本語ではNostterを初期値として保存する', () => {
+    it('未保存かつ日本語ではnostterを初期値として保存する', () => {
         expect(getExternalNostrClientPreference(storage, 'ja')).toEqual({
             client: 'nostter',
             customUrlTemplate: '',


### PR DESCRIPTION
## Summary
- change the post history external-open action to use the specified open-in-new icon
- preserve the official lowercase 
ostter name in settings and post history labels
- update affected unit test expectations

## Validation
- 
pm run test -- src/test/unit/settingsDialogAccessibility.test.ts src/test/unit/postHistoryRecordActionItems.test.ts
- 
pm run check

The broader targeted test command also ran the thread-graph complexity check; it reported the existing baseline deltas and the selected tests passed except for the stale capitalization expectation, which was corrected before the final validation.