### PR TITLE
refactor: prepare Web Component runtime boundaries

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -9,6 +9,7 @@
   import { useProfileProjectionSync } from "./lib/hooks/useProfileProjectionSync.svelte";
   import ConfirmDialog from "./components/ConfirmDialog.svelte";
   import { authService, type PendingNip46AuthSession } from "./lib/authService";
+  import { getAppRuntimeEnvironment } from "./lib/appRuntimeEnvironment";
   import { iframeMessageService } from "./lib/iframeMessageService";
   import { waitNostr } from "nip07-awaiter";
   import { AccountManager } from "./lib/accountManager";
@@ -193,6 +194,8 @@
   import { focusEditor } from "./lib/utils/appDomUtils";
   import { generateMediaItemId } from "./lib/utils/appUtils";
   import { CUSTOM_EMOJI_PICKER_CHROME_HEIGHT } from "./lib/customEmoji";
+
+  const appRuntimeEnvironment = getAppRuntimeEnvironment();
   import type { CustomEmojiSelection } from "./lib/customEmojiUsage";
   import { usePostHistoryInboundInteractionsRealtime } from "./lib/hooks/usePostHistoryInboundInteractionsRealtime.svelte";
   import { usePostHistoryInboundReplyReconciliation } from "./lib/hooks/usePostHistoryInboundReplyReconciliation.svelte";
@@ -591,7 +594,7 @@
     onAuthenticated: handlePostAuth,
     saveLastUsedRelayCandidates: (relayCandidates) => {
       saveLastUsedNip46ConnectionRelayCandidates(
-        typeof localStorage === "undefined" ? undefined : localStorage,
+        appRuntimeEnvironment.storage,
         relayCandidates,
       );
     },
@@ -646,7 +649,9 @@
       replyQuoteState.value.quotes.length > 0,
   );
   // AccountManager初期化
-  const accountManager = new AccountManager({ localStorage });
+  const accountManager = new AccountManager({
+    localStorage: appRuntimeEnvironment.storage,
+  });
   authService.setAccountManager(accountManager);
 
   const loginDialog = createDialogVisibilityHandlers(showLoginDialogStore);
@@ -771,7 +776,7 @@
   });
   function getInitialNip46ConnectRelayCandidates(): string[] {
     return resolveInitialNip46ConnectionRelayCandidates(
-      typeof localStorage === "undefined" ? undefined : localStorage,
+      appRuntimeEnvironment.storage,
     );
   }
 
@@ -826,7 +831,7 @@
     closeDraftLimitConfirm: () => showDraftLimitConfirmStore.set(false),
     logger: console,
     isGalleryMode: () => !mediaFreePlacementStore.value,
-    document,
+    document: appRuntimeEnvironment.document ?? document,
     clearGallery: () => mediaGalleryStore.clearAll(),
     addGalleryItem: (item) => mediaGalleryStore.addItem(item),
     loadDraftContent: (content) => {
@@ -1187,7 +1192,7 @@
         return applied;
       },
     },
-    parentFrame: {
+    notificationPort: {
       notifyComposerContextApplied: (requestId: string) =>
         iframeMessageService.notifyComposerContextApplied(requestId),
       notifyComposerContextError: (error, requestId: string) =>
@@ -1494,7 +1499,7 @@
     });
 
     const cleanupVisibilityHandler = registerNip46VisibilityHandler({
-      document,
+      document: appRuntimeEnvironment.document ?? document,
       authState,
       nip46Service,
       console,
@@ -1505,6 +1510,17 @@
       cleanupRuntimeBindings();
       composerTargetApplyController.dispose();
       channelContextApplyController.dispose();
+      if (
+        rxNostr &&
+        typeof (rxNostr as unknown as { dispose?: unknown }).dispose ===
+          "function"
+      ) {
+        rxNostr = disposeNostrSession(rxNostr);
+      } else {
+        rxNostr = undefined;
+      }
+      void cancelPendingNip46Auth(undefined, { preserveError: true });
+      void nip46Service.disconnect();
     };
   });
 
@@ -1842,6 +1858,7 @@
                     minEditorHeight={postEditorMinHeight}
                     onPostSuccess={handlePostSuccess}
                     onCustomEmojiSelect={recordCustomEmojiUse}
+                    notificationPort={iframeMessageService}
                   />
                 {/if}
                 {#if customEmojiPickerOpen && CustomEmojiPickerComponent}

--- a/src/components/CustomEmojiPicker.svelte
+++ b/src/components/CustomEmojiPicker.svelte
@@ -29,9 +29,11 @@
         preserveKeyboardForScrollableTouch,
         preventKeyboardFocusChange,
     } from "../lib/utils/keyboardFocusUtils";
+    import { getAppStorage } from "../lib/appStorage";
 
     const VIRTUAL_OVERSCAN_ROWS = 3;
     const CUSTOM_EMOJI_GRID_TOP_PADDING = 8;
+    const appStorage = getAppStorage();
 
     interface Props {
         rxNostr?: RxNostr | null;
@@ -206,7 +208,7 @@
 
     function updatePickerHeight(nextHeight: number): void {
         pickerHeight = writeCustomEmojiPickerHeight(
-            localStorage,
+            appStorage,
             nextHeight,
             getPickerHeightClampViewport(),
             pickerStorageMaxHeight,
@@ -238,7 +240,7 @@
 
     onMount(() => {
         pickerHeight = readCustomEmojiPickerHeight(
-            localStorage,
+            appStorage,
             getPickerHeightClampViewport(),
             pickerStorageMaxHeight,
         );
@@ -357,7 +359,7 @@
     $effect(() => {
         pickerStorageMaxHeight;
         pickerHeight = readCustomEmojiPickerHeight(
-            localStorage,
+            appStorage,
             getPickerHeightClampViewport(),
             pickerStorageMaxHeight,
         );

--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -77,6 +77,7 @@
   } from "../lib/utils/composerLayoutUtils";
   import ImageFullscreen from "./ImageFullscreen.svelte";
   import type { InitializeEditorResult, MenuItem } from "../lib/types";
+  import type { AppPostNotificationPort } from "../lib/appNotificationPort";
 
   interface Props {
     rxNostr?: RxNostr;
@@ -85,6 +86,7 @@
     availableComposerHeight?: number;
     minEditorHeight?: number;
     onCustomEmojiSelect?: (emoji: CustomEmojiSelection) => void;
+    notificationPort?: AppPostNotificationPort;
   }
 
   let {
@@ -94,6 +96,7 @@
     availableComposerHeight = POST_EDITOR_MIN_HEIGHT,
     minEditorHeight = POST_EDITOR_MIN_HEIGHT,
     onCustomEmojiSelect,
+    notificationPort,
   }: Props = $props();
   let editor: any = $state(null);
   let currentEditor: TipTapEditor | null = $state(null);
@@ -201,6 +204,7 @@
               input,
               postHistoryRepositoryImpl: postHistoryRepository,
             }),
+          notificationPort,
         });
       else postManager.setRxNostr(rxNostr as RxNostr);
     }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -3,13 +3,14 @@ import {
   getStoredLocalePreference,
   normalizeLocale,
 } from "./lib/utils/settingsStorage";
+import { getAppStorage } from "./lib/appStorage";
 
 register("ja", () => import("./lib/i18n/ja.json"));
 register("en", () => import("./lib/i18n/en.json"));
 
 // ロケール判定ロジックを関数として抽出
 export function determineInitialLocale(): string {
-  const storedLocale = getStoredLocalePreference(localStorage);
+  const storedLocale = getStoredLocalePreference(getAppStorage());
   if (storedLocale) {
     return storedLocale;
   }

--- a/src/lib/accountDataReset.ts
+++ b/src/lib/accountDataReset.ts
@@ -1,6 +1,7 @@
 import Dexie from "dexie";
 import { STORAGE_KEYS } from "./constants";
 import { EHAGAKI_DB_NAME, ehagakiDb } from "./storage/ehagakiDb";
+import { getAppStorage } from "./appStorage";
 
 const PROFILE_CACHE_NAMES = [
     "ehagaki-profile-images-v2",
@@ -55,7 +56,7 @@ function removeManagedLocalStorageKeys(localStorage: Storage): void {
 export async function resetManagedAccountData(
     deps: AccountDataResetDependencies = {},
 ): Promise<void> {
-    const localStorage = deps.localStorage ?? globalThis.localStorage;
+    const localStorage = deps.localStorage ?? getAppStorage();
     const cacheStorage = deps.caches ?? globalThis.caches;
 
     removeManagedLocalStorageKeys(localStorage);

--- a/src/lib/appEmbedController.ts
+++ b/src/lib/appEmbedController.ts
@@ -85,7 +85,7 @@ export interface AppEmbedComposerContextUpdatedNotification {
     channel: EmbedChannelContextPayload | null;
 }
 
-export interface AppEmbedParentFramePort {
+export interface AppEmbedNotificationPort {
     notifyComposerContextApplied(requestId: string): void;
     notifyComposerContextError(
         error: AppEmbedComposerError,
@@ -129,6 +129,9 @@ export interface AppEmbedControllerLogger {
     error(message: string, meta?: unknown): void;
 }
 
+/** @deprecated Use AppEmbedNotificationPort; the iframe transport remains an adapter. */
+export type AppEmbedParentFramePort = AppEmbedNotificationPort;
+
 export interface AppEmbedControllerDependencies {
     composerInput: {
         get(): AppEmbedComposerInputPort | null;
@@ -139,7 +142,8 @@ export interface AppEmbedControllerDependencies {
     };
     composerContextApply: AppEmbedComposerContextApplyPort;
     settingsApply: AppEmbedSettingsApplyPort;
-    parentFrame: AppEmbedParentFramePort;
+    notificationPort?: AppEmbedNotificationPort;
+    parentFrame?: AppEmbedParentFramePort;
     runtime: AppEmbedRuntimeStateGetters;
     storage: AppEmbedStoragePort;
     logger: AppEmbedControllerLogger;
@@ -183,6 +187,12 @@ function shouldQueueAction(getters: AppEmbedRuntimeStateGetters): boolean {
 export function createAppEmbedController(
     deps: AppEmbedControllerDependencies,
 ): AppEmbedController {
+    const notificationPort: AppEmbedNotificationPort =
+        deps.notificationPort ??
+        deps.parentFrame ??
+        (() => {
+            throw new Error("AppEmbedController requires a notification port");
+        })();
     const state: AppEmbedControllerState = {
         pendingComposerAction: undefined,
         lastNotifiedComposerContextSignature: null,
@@ -271,7 +281,7 @@ export function createAppEmbedController(
         state.applyingComposerContext = true;
         try {
             const backgroundTasks = applyRemoteComposerSetContext(payload);
-            deps.parentFrame.notifyComposerContextApplied(requestId);
+            notificationPort.notifyComposerContextApplied(requestId);
             state.lastNotifiedComposerContextSignature = buildComposerContextSignature(
                 buildCurrentComposerContextPayload(),
             );
@@ -287,7 +297,7 @@ export function createAppEmbedController(
         logPrefix: string,
     ): void {
         deps.logger.error(logPrefix, error);
-        deps.parentFrame.notifyComposerContextError(
+        notificationPort.notifyComposerContextError(
             {
                 code: "composer_context_apply_failed",
                 message: error instanceof Error ? error.message : String(error),
@@ -324,10 +334,10 @@ export function createAppEmbedController(
         ): Promise<void> {
             try {
                 const applied = await deps.settingsApply.applySettings(payload);
-                deps.parentFrame.notifySettingsApplied(applied, requestId);
+                notificationPort.notifySettingsApplied(applied, requestId);
             } catch (error) {
                 deps.logger.error("settings.set の適用に失敗:", error);
-                deps.parentFrame.notifySettingsError(
+                notificationPort.notifySettingsError(
                     {
                         code: "settings_apply_failed",
                         message: error instanceof Error ? error.message : String(error),
@@ -387,7 +397,7 @@ export function createAppEmbedController(
             }
 
             state.lastNotifiedComposerContextSignature = signature;
-            deps.parentFrame.notifyComposerContextUpdated({
+            notificationPort.notifyComposerContextUpdated({
                 reply: payload.reply,
                 quotes: payload.quotes,
                 channel: payload.channel ?? null,

--- a/src/lib/appNotificationPort.ts
+++ b/src/lib/appNotificationPort.ts
@@ -1,0 +1,8 @@
+export interface AppPostNotificationPort {
+    notifyPostSuccess(options?: {
+        eventId?: string;
+        replyToEventId?: string;
+        quotedEventIds?: string[];
+    }): boolean;
+    notifyPostError(error?: string | { code: string; message?: string }): boolean;
+}

--- a/src/lib/appRuntimeEnvironment.ts
+++ b/src/lib/appRuntimeEnvironment.ts
@@ -1,0 +1,72 @@
+import {
+    configureAppStorage,
+    getAppStorage,
+} from "./appStorage";
+
+export interface AppRuntimeEnvironment {
+    storage: Storage;
+    window: Window | undefined;
+    document: Document | undefined;
+    domRoot: Document | ShadowRoot | undefined;
+    styleTarget: HTMLElement;
+    layoutTarget: HTMLElement;
+    overlayTarget: HTMLElement;
+    themeTarget: HTMLElement;
+    assetBase: URL | undefined;
+    serviceWorkerEnabled: boolean;
+    externalInputEnabled: boolean;
+    historyEnabled: boolean;
+}
+
+function createFallbackElement(): HTMLElement {
+    return {
+        style: {
+            setProperty: () => undefined,
+            removeProperty: () => "",
+            getPropertyValue: () => "",
+        } as unknown as CSSStyleDeclaration,
+    } as HTMLElement;
+}
+
+function createDefaultEnvironment(): AppRuntimeEnvironment {
+    const windowObj = typeof window !== "undefined" ? window : undefined;
+    const documentObj = windowObj?.document;
+    const documentElement = documentObj?.documentElement ?? createFallbackElement();
+    const body = documentObj?.body ?? documentElement;
+
+    return {
+        storage: getAppStorage(),
+        window: windowObj,
+        document: documentObj,
+        domRoot: documentObj,
+        styleTarget: documentElement,
+        layoutTarget: body,
+        overlayTarget: body,
+        themeTarget: documentElement,
+        assetBase: windowObj?.location?.href
+            ? new URL(".", windowObj.location.href)
+            : undefined,
+        serviceWorkerEnabled: false,
+        externalInputEnabled: true,
+        historyEnabled: true,
+    };
+}
+
+let runtimeEnvironment = createDefaultEnvironment();
+
+export type AppRuntimeEnvironmentOverrides = Partial<AppRuntimeEnvironment>;
+
+export function configureAppRuntimeEnvironment(
+    overrides: AppRuntimeEnvironmentOverrides,
+): AppRuntimeEnvironment {
+    runtimeEnvironment = {
+        ...runtimeEnvironment,
+        ...overrides,
+    };
+    configureAppStorage(runtimeEnvironment.storage);
+    return runtimeEnvironment;
+}
+
+export function getAppRuntimeEnvironment(): AppRuntimeEnvironment {
+    return runtimeEnvironment;
+}

--- a/src/lib/appStorage.ts
+++ b/src/lib/appStorage.ts
@@ -1,0 +1,114 @@
+/**
+ * Storage used by the eHagaki application runtime.
+ *
+ * The default remains the current window localStorage so PWA and iframe
+ * behavior is unchanged. A future embedding entry can configure another
+ * Storage implementation before importing App.svelte.
+ */
+
+let configuredStorage: Storage | undefined;
+
+/** Reserved prefix for the future same-origin Web Component entry. */
+export const EHAGAKI_WEB_COMPONENT_STORAGE_PREFIX = "ehagaki-web-component:";
+
+const memoryStorage = new Map<string, string>();
+
+const fallbackStorage: Storage = {
+    get length() {
+        return memoryStorage.size;
+    },
+    clear() {
+        memoryStorage.clear();
+    },
+    getItem(key: string) {
+        return memoryStorage.get(key) ?? null;
+    },
+    key(index: number) {
+        return [...memoryStorage.keys()][index] ?? null;
+    },
+    removeItem(key: string) {
+        memoryStorage.delete(key);
+    },
+    setItem(key: string, value: string) {
+        memoryStorage.set(key, String(value));
+    },
+};
+
+function resolveDefaultStorage(): Storage {
+    if (typeof globalThis !== "undefined") {
+        const storage = (globalThis as typeof globalThis & {
+            localStorage?: Storage;
+        }).localStorage;
+        if (storage) {
+            return storage;
+        }
+    }
+
+    return fallbackStorage;
+}
+
+export function getAppStorage(): Storage {
+    return configuredStorage ?? resolveDefaultStorage();
+}
+
+export function configureAppStorage(storage: Storage): void {
+    configuredStorage = storage;
+}
+
+export function resetAppStorage(): void {
+    configuredStorage = undefined;
+}
+
+function getNamespacedKeys(storage: Storage, prefix: string): string[] {
+    const keys: string[] = [];
+    for (let index = 0; index < storage.length; index += 1) {
+        const key = storage.key(index);
+        if (key?.startsWith(prefix)) {
+            keys.push(key.slice(prefix.length));
+        }
+    }
+    return keys;
+}
+
+/**
+ * Creates a Storage facade that exposes only keys under `prefix`.
+ *
+ * This is intentionally a small adapter rather than a repository-wide
+ * storage abstraction. It lets a future Web Component entry isolate its
+ * localStorage keys while PWA and iframe entries continue using raw storage.
+ */
+export function createNamespacedStorage(
+    storage: Storage,
+    prefix: string,
+): Storage {
+    return {
+        get length() {
+            return getNamespacedKeys(storage, prefix).length;
+        },
+        clear() {
+            const keys = getNamespacedKeys(storage, prefix);
+            for (const key of keys) {
+                storage.removeItem(`${prefix}${key}`);
+            }
+        },
+        getItem(key: string) {
+            return storage.getItem(`${prefix}${key}`);
+        },
+        key(index: number) {
+            return getNamespacedKeys(storage, prefix)[index] ?? null;
+        },
+        removeItem(key: string) {
+            storage.removeItem(`${prefix}${key}`);
+        },
+        setItem(key: string, value: string) {
+            storage.setItem(`${prefix}${key}`, String(value));
+        },
+    };
+}
+
+export function createWebComponentStorage(storage: Storage): Storage {
+    return createNamespacedStorage(
+        storage,
+        EHAGAKI_WEB_COMPONENT_STORAGE_PREFIX,
+    );
+}

--- a/src/lib/authService.ts
+++ b/src/lib/authService.ts
@@ -360,7 +360,11 @@ export class AuthService {
 
     private clearProfileImageCache(): void {
         try {
-            if (!('serviceWorker' in this.runtime.navigator) || !this.runtime.navigator.serviceWorker.controller) return;
+            if (
+                !this.runtime.serviceWorkerEnabled
+                || !('serviceWorker' in this.runtime.navigator)
+                || !this.runtime.navigator.serviceWorker.controller
+            ) return;
 
             const messageChannel = new MessageChannel();
             messageChannel.port1.onmessage = (event) => {

--- a/src/lib/authServiceRuntime.ts
+++ b/src/lib/authServiceRuntime.ts
@@ -5,6 +5,7 @@ import { Nip07AuthService } from './nip07AuthService';
 import { nip46Service, type Nip46Service } from './nip46Service';
 import { parentClientAuthService, type ParentClientAuthService } from './parentClientAuthService';
 import { getAppStorage } from './appStorage';
+import { getAppRuntimeEnvironment } from './appRuntimeEnvironment';
 
 type AuthSetter = (pubkey: string, npub: string, nprofile: string) => void;
 
@@ -50,6 +51,7 @@ export interface AuthServiceRuntime {
     indexedDB: IDBFactory;
     caches: CacheStorage;
     navigator: Navigator;
+    serviceWorkerEnabled: boolean;
     console: Console;
     nip46Svc: Nip46Service;
     parentClientSvc: ParentClientAuthService;
@@ -71,6 +73,9 @@ export function createAuthServiceRuntime(dependencies: AuthServiceDependencies =
         });
     const windowObj = dependencies.window ?? (typeof window !== 'undefined' ? window : {} as Window);
     const navigator = dependencies.navigator ?? (typeof window !== 'undefined' ? window.navigator : {} as Navigator);
+    const serviceWorkerEnabled =
+        dependencies.serviceWorkerEnabled ??
+        getAppRuntimeEnvironment().serviceWorkerEnabled;
     const consoleObj = dependencies.console ?? (typeof window !== 'undefined' ? window.console : {} as Console);
     const indexedDB =
         dependencies.indexedDB ??
@@ -88,6 +93,7 @@ export function createAuthServiceRuntime(dependencies: AuthServiceDependencies =
         indexedDB,
         caches,
         navigator,
+        serviceWorkerEnabled,
         console: consoleObj,
         keyManager,
         nip46Svc: nip46Service,

--- a/src/lib/authServiceRuntime.ts
+++ b/src/lib/authServiceRuntime.ts
@@ -4,6 +4,7 @@ import type { AuthServiceDependencies, PublicKeyData } from './types';
 import { Nip07AuthService } from './nip07AuthService';
 import { nip46Service, type Nip46Service } from './nip46Service';
 import { parentClientAuthService, type ParentClientAuthService } from './parentClientAuthService';
+import { getAppStorage } from './appStorage';
 
 type AuthSetter = (pubkey: string, npub: string, nprofile: string) => void;
 
@@ -59,7 +60,7 @@ export interface AuthServiceRuntime {
 }
 
 export function createAuthServiceRuntime(dependencies: AuthServiceDependencies = {}): AuthServiceRuntime {
-    const localStorage = dependencies.localStorage ?? (typeof window !== 'undefined' ? window.localStorage : {} as Storage);
+    const localStorage = dependencies.localStorage ?? getAppStorage();
     const clearAuthStateFn = dependencies.clearAuthState ?? clearAuthState;
     const keyManager = isAuthServiceKeyManager(dependencies.keyManager)
         ? dependencies.keyManager

--- a/src/lib/bootstrap/embedSettingsBootstrap.ts
+++ b/src/lib/bootstrap/embedSettingsBootstrap.ts
@@ -18,6 +18,7 @@ import {
     type SupportedLocale,
     type ThemeMode,
 } from "../utils/settingsStorage";
+import { getAppStorage } from "../appStorage";
 
 export const EMBED_SETTINGS_QUERY_KEYS = [
     "embedLocale",
@@ -332,7 +333,7 @@ function applySetting(
 }
 
 export function applyEmbedSettingsBootstrap({
-    storage = localStorage,
+    storage = getAppStorage(),
     navigatorObj = navigator,
     documentObj = document,
     windowObj = window,

--- a/src/lib/bootstrap/serviceWorkerBootstrap.ts
+++ b/src/lib/bootstrap/serviceWorkerBootstrap.ts
@@ -3,16 +3,15 @@
 import { useRegisterSW } from "virtual:pwa-register/svelte";
 import { subscribeEHagakiDbUpgradeState } from "../storage/ehagakiDb";
 import {
-    createAcceptedServiceWorkerUpdateReloadController,
     watchServiceWorkerUpdateInstallation,
 } from "../swUpdateDetectionUtils";
 import {
     configureSwUpdateServiceWorker,
     enableServiceWorkerStore,
+    handleServiceWorkerControlChange,
     setDbUpgradeBlocked,
     setSwUpdateStatus,
 } from "../../stores/swStore.svelte";
-import { requestStaleReloadPrompt, markStaleAssetReloadRequired } from "../../stores/staleAssetReloadStore.svelte";
 
 let started = false;
 
@@ -32,15 +31,6 @@ export function startServiceWorkerRegistration(): void {
             }
         });
     }
-
-    const updateReloadController = createAcceptedServiceWorkerUpdateReloadController(
-        () => window.location.reload(),
-        () => {
-            if (markStaleAssetReloadRequired()) {
-                requestStaleReloadPrompt();
-            }
-        },
-    );
 
     try {
         if (typeof useRegisterSW !== "function") return;
@@ -63,7 +53,7 @@ export function startServiceWorkerRegistration(): void {
                 setSwUpdateStatus("ready");
             },
             onNeedReload() {
-                updateReloadController.handleControlChange();
+                return handleServiceWorkerControlChange();
             },
             immediate: true,
             onOfflineReady() {

--- a/src/lib/bootstrap/serviceWorkerBootstrap.ts
+++ b/src/lib/bootstrap/serviceWorkerBootstrap.ts
@@ -1,0 +1,85 @@
+/// <reference types="vite/client" />
+// @ts-expect-error: virtual module provided by Vite plugin
+import { useRegisterSW } from "virtual:pwa-register/svelte";
+import { subscribeEHagakiDbUpgradeState } from "../storage/ehagakiDb";
+import {
+    createAcceptedServiceWorkerUpdateReloadController,
+    watchServiceWorkerUpdateInstallation,
+} from "../swUpdateDetectionUtils";
+import {
+    configureSwUpdateServiceWorker,
+    enableServiceWorkerStore,
+    setDbUpgradeBlocked,
+    setSwUpdateStatus,
+} from "../../stores/swStore.svelte";
+import { requestStaleReloadPrompt, markStaleAssetReloadRequired } from "../../stores/staleAssetReloadStore.svelte";
+
+let started = false;
+
+export function startServiceWorkerRegistration(): void {
+    if (started) return;
+    started = true;
+    enableServiceWorkerStore();
+
+    subscribeEHagakiDbUpgradeState(setDbUpgradeBlocked);
+
+    if (typeof navigator !== "undefined" && navigator.serviceWorker) {
+        navigator.serviceWorker.addEventListener("message", (event) => {
+            if (event.data?.type === "EHAGAKI_DB_UPGRADE_BLOCKED") {
+                setDbUpgradeBlocked(true);
+            } else if (event.data?.type === "EHAGAKI_DB_UPGRADE_UNBLOCKED") {
+                setDbUpgradeBlocked(false);
+            }
+        });
+    }
+
+    const updateReloadController = createAcceptedServiceWorkerUpdateReloadController(
+        () => window.location.reload(),
+        () => {
+            if (markStaleAssetReloadRequired()) {
+                requestStaleReloadPrompt();
+            }
+        },
+    );
+
+    try {
+        if (typeof useRegisterSW !== "function") return;
+        const register = useRegisterSW({
+            onRegistered: (registration: ServiceWorkerRegistration | undefined) => {
+                console.log("SW registered successfully", registration);
+                if (registration) {
+                    watchServiceWorkerUpdateInstallation({
+                        registration,
+                        hasController: Boolean(navigator.serviceWorker?.controller),
+                        setStatus: setSwUpdateStatus,
+                    });
+                }
+            },
+            onRegisterError(error: Error) {
+                console.warn("SW registration error", error);
+            },
+            onNeedRefresh() {
+                console.log("SW needs refresh - showing prompt");
+                setSwUpdateStatus("ready");
+            },
+            onNeedReload() {
+                updateReloadController.handleControlChange();
+            },
+            immediate: true,
+            onOfflineReady() {
+                console.log("App ready to work offline");
+            },
+        });
+
+        configureSwUpdateServiceWorker(register.updateServiceWorker);
+        register.needRefresh.subscribe((needRefresh: boolean) => {
+            if (needRefresh) {
+                setSwUpdateStatus("ready");
+            } else {
+                setSwUpdateStatus("idle");
+            }
+        });
+    } catch (error) {
+        console.warn("Failed to initialize Service Worker:", error);
+    }
+}

--- a/src/lib/embedStorageService.ts
+++ b/src/lib/embedStorageService.ts
@@ -16,6 +16,7 @@ import {
     filterAllowedEmbedStorageKeys,
     isAllowedEmbedStorageKey,
 } from "./embedStorageKeys";
+import { getAppStorage } from "./appStorage";
 
 type PendingStorageRequest = {
     resolve: (payload: EmbedStorageResultPayload) => void;
@@ -126,7 +127,7 @@ export class EmbedStorageService {
         return this.sendRequest("storage.get", { keys: allowedKeys });
     }
 
-    persistLocalStorageKeys(keys: string[], storage: Pick<Storage, "getItem"> = localStorage): void {
+    persistLocalStorageKeys(keys: string[], storage: Pick<Storage, "getItem"> = getAppStorage()): void {
         const values: Record<string, string> = {};
         const removeKeys: string[] = [];
 
@@ -174,7 +175,7 @@ export class EmbedStorageService {
 
     applySnapshotToLocalStorage(
         values: Record<string, string | null> | undefined,
-        storage: Pick<Storage, "setItem"> = localStorage,
+        storage: Pick<Storage, "setItem"> = getAppStorage(),
     ): string[] {
         if (!values) return [];
 

--- a/src/lib/fileUploadManager.ts
+++ b/src/lib/fileUploadManager.ts
@@ -31,6 +31,7 @@ import { isDefaultUploadAborted } from './uploadAbortUtils';
 import { getUploadAdapter } from "./upload/uploadAdapterRegistry";
 import { createLegacyUploadDestination } from "./upload/uploadDestinationPresets";
 import { postMediaCacheService } from "./postMediaCacheService";
+import { getAppStorage } from "./appStorage";
 
 // ファイルアップロード専用マネージャークラス
 export class FileUploadManager implements FileUploadManagerInterface {
@@ -41,7 +42,7 @@ export class FileUploadManager implements FileUploadManagerInterface {
 
   constructor(
     private dependencies: FileUploadDependencies = {
-      localStorage: window.localStorage,
+      localStorage: getAppStorage(),
       fetch: window.fetch.bind(window),
       crypto: window.crypto.subtle,
       document: window.document,
@@ -488,4 +489,3 @@ export class FileUploadManager implements FileUploadManagerInterface {
     }
   }
 }
-

--- a/src/lib/keyManager.svelte.ts
+++ b/src/lib/keyManager.svelte.ts
@@ -2,6 +2,7 @@ import type { PublicKeyData, KeyManagerDeps, KeyManagerError } from "./types";
 import { isValidNsec, derivePublicKeyFromNsec, toNpub } from './utils/nostrUtils';
 import { getNsecStorageKey } from './authStorageKeys';
 import { secretKeyStore } from '../stores/authStore.svelte';
+import { getAppStorage } from './appStorage';
 
 // --- 純粋関数（テストしやすい） ---
 export class KeyValidator {
@@ -260,7 +261,7 @@ export class KeyManager {
 
     constructor(deps: KeyManagerDeps = {}) {
         // デフォルト依存性の設定
-        const localStorage = deps.localStorage || (typeof window !== 'undefined' ? window.localStorage : {} as Storage);
+        const localStorage = deps.localStorage || getAppStorage();
         const console = deps.console || (typeof window !== 'undefined' ? window.console : {} as Console);
         const secretKeyStoreObj = deps.secretKeyStore || { value: null, set: () => { } };
         const windowObj = deps.window || (typeof window !== 'undefined' ? window : undefined);

--- a/src/lib/postManager.ts
+++ b/src/lib/postManager.ts
@@ -88,7 +88,11 @@ export class PostManager {
     this.deps.extractImageBlurhashMapFn = deps.extractImageBlurhashMapFn || extractImageBlurhashMap;
     this.deps.resetEditorStateFn = deps.resetEditorStateFn || resetEditorState;
     this.deps.resetPostStatusFn = deps.resetPostStatusFn || resetPostStatus;
-    this.deps.iframeMessageService = deps.iframeMessageService || iframeMessageService;
+    this.deps.notificationPort =
+      deps.iframeMessageService || deps.notificationPort || iframeMessageService;
+    // Keep the legacy dependency field populated for existing callers/tests;
+    // all post notifications use the transport-neutral port above.
+    this.deps.iframeMessageService = this.deps.notificationPort;
     this.deps.hashtagPinStore = deps.hashtagPinStore || hashtagPinStore;
     this.deps.saveHashtagsToHistoryFn = deps.saveHashtagsToHistoryFn || saveHashtagsToHistory;
     this.deps.clearReplyQuoteFn = deps.clearReplyQuoteFn || clearReplyQuote;
@@ -120,7 +124,7 @@ export class PostManager {
   }
 
   private notifyPostFailure(error: string): PostResult {
-    this.deps.iframeMessageService?.notifyPostError(error);
+    this.deps.notificationPort?.notifyPostError(error);
     return { success: false, error };
   }
 
@@ -173,14 +177,14 @@ export class PostManager {
         });
       });
       this.clearReplyQuoteAfterSuccess();
-      this.deps.iframeMessageService?.notifyPostSuccess({
+      this.deps.notificationPort?.notifyPostSuccess({
         ...rqNotifyOptions,
         ...(result.eventId ? { eventId: result.eventId } : {}),
       });
       return result;
     }
 
-    this.deps.iframeMessageService?.notifyPostError(result.error);
+    this.deps.notificationPort?.notifyPostError(result.error);
     return result;
   }
 

--- a/src/lib/profileManager.ts
+++ b/src/lib/profileManager.ts
@@ -12,6 +12,7 @@ import {
   isSameOriginProfilePictureUrl,
   normalizeProfilePictureUrl,
 } from './profilePictureUrlUtils';
+import { getAppStorage } from './appStorage';
 
 // --- URL処理の純粋関数（依存性なし） ---
 export class ProfileUrlUtils {
@@ -261,7 +262,7 @@ export class ProfileManager {
     deps: ProfileManagerDeps = {}
   ) {
     // デフォルト依存性の設定
-    const localStorage = deps.localStorage || (typeof window !== 'undefined' ? window.localStorage : undefined);
+    const localStorage = deps.localStorage || getAppStorage();
     const navigator = deps.navigator || (typeof window !== 'undefined' ? window.navigator : { onLine: true } as Navigator);
     const setTimeoutFn = deps.setTimeoutFn || ((fn, ms) => setTimeout(fn, ms));
     const clearTimeoutFn = deps.clearTimeoutFn || ((id) => clearTimeout(id));

--- a/src/lib/relayManager.ts
+++ b/src/lib/relayManager.ts
@@ -9,6 +9,7 @@ import {
     type RelayConfigCache,
     type RelayConfigsRepository,
 } from "./storage/relayConfigsRepository";
+import { getAppStorage } from './appStorage';
 
 // 後方互換性のためre-export
 export { RelayConfigParser, RelayConfigUtils } from "./relayConfigUtils";
@@ -301,7 +302,7 @@ export class RelayManager {
         deps: RelayManagerDeps = {}
     ) {
         // デフォルト依存性の設定
-        const localStorage = deps.localStorage || (typeof window !== 'undefined' ? window.localStorage : undefined);
+        const localStorage = deps.localStorage || getAppStorage();
         const consoleImpl = deps.console || (typeof window !== 'undefined' ? window.console : {} as Console);
         const setTimeoutFn = deps.setTimeoutFn || ((fn, ms) => setTimeout(fn, ms));
         const clearTimeoutFn = deps.clearTimeoutFn || ((id) => clearTimeout(id));

--- a/src/lib/storage/draftsRepository.ts
+++ b/src/lib/storage/draftsRepository.ts
@@ -2,6 +2,7 @@ import { MAX_DRAFTS, STORAGE_KEYS } from "../constants";
 import { compareDraftsByDisplayOrder } from "../draftSortUtils";
 import type { Draft, DraftChannelData, DraftReplyQuoteData, MediaGalleryItem } from "../types";
 import { ehagakiDb, type DraftRecord, type EHagakiDB } from "./ehagakiDb";
+import { getAppStorage } from "../appStorage";
 
 const DRAFT_SCHEMA_VERSION = 1;
 const LOCAL_DRAFT_BACKEND_VERSION = 1;
@@ -65,7 +66,7 @@ function isRecordVisible(
     return getVisibleScopeKeys(options.pubkeyHex).includes(record.scopeKey);
 }
 
-function readLegacyDraftsFromLocalStorage(storage: Pick<Storage, "getItem"> = localStorage): Draft[] {
+function readLegacyDraftsFromLocalStorage(storage: Pick<Storage, "getItem"> = getAppStorage()): Draft[] {
     const draftsJson = storage.getItem(STORAGE_KEYS.DRAFTS);
     if (!draftsJson) return [];
 
@@ -116,7 +117,7 @@ export class DexieDraftsRepository implements DraftsRepository {
     constructor(
         private db: EHagakiDB = ehagakiDb,
         private now: () => number = Date.now,
-        private getStorage: () => Pick<Storage, "getItem" | "removeItem"> = () => localStorage,
+        private getStorage: () => Pick<Storage, "getItem" | "removeItem"> = () => getAppStorage(),
     ) { }
 
     async getAll(options: DraftsRepositoryOptions = {}): Promise<Draft[]> {
@@ -272,7 +273,7 @@ export class DexieDraftsRepository implements DraftsRepository {
 
 export class LocalStorageDraftsRepository implements DraftsRepository {
     constructor(
-        private getStorage: () => DraftStorage = () => localStorage,
+        private getStorage: () => DraftStorage = () => getAppStorage(),
         private now: () => number = Date.now,
     ) { }
 

--- a/src/lib/storage/hashtagHistoryRepository.ts
+++ b/src/lib/storage/hashtagHistoryRepository.ts
@@ -1,6 +1,7 @@
 import { STORAGE_KEYS } from "../constants";
 import type { HashtagHistoryEntry } from "../types";
 import { ehagakiDb, type EHagakiDB, type HashtagHistoryRecord } from "./ehagakiDb";
+import { getAppStorage } from "../appStorage";
 
 export const MAX_HASHTAG_HISTORY = 100;
 export const MAX_HASHTAG_SUGGESTIONS = 5;
@@ -25,7 +26,7 @@ function isLegacyEntry(value: unknown): value is HashtagHistoryEntry {
 }
 
 function readLegacyHistory(
-    storage: Pick<Storage, "getItem"> = localStorage,
+    storage: Pick<Storage, "getItem"> = getAppStorage(),
 ): HashtagHistoryEntry[] {
     const raw = storage.getItem(STORAGE_KEYS.HASHTAG_HISTORY);
     if (!raw) return [];
@@ -94,7 +95,7 @@ export class DexieHashtagHistoryRepository implements HashtagHistoryRepository {
     constructor(
         private db: EHagakiDB = ehagakiDb,
         private now: () => number = Date.now,
-        private getStorage: () => Pick<Storage, "getItem" | "removeItem"> = () => localStorage,
+        private getStorage: () => Pick<Storage, "getItem" | "removeItem"> = () => getAppStorage(),
     ) { }
 
     async getAll(): Promise<HashtagHistoryEntry[]> {

--- a/src/lib/storage/profilesRepository.ts
+++ b/src/lib/storage/profilesRepository.ts
@@ -8,6 +8,7 @@ import { RelayConfigUtils } from "../relayConfigUtils";
 import type { ProfileData } from "../types";
 import { areStringArraysEqual } from "../utils/arrayEqualityUtils";
 import { ehagakiDb, type EHagakiDB, type ProfileRecord } from "./ehagakiDb";
+import { getAppStorage } from "../appStorage";
 
 const PROFILE_SCHEMA_VERSION = 2;
 
@@ -176,7 +177,7 @@ export class DexieProfilesRepository implements ProfilesRepository {
     constructor(
         private db: EHagakiDB = ehagakiDb,
         private now: () => number = Date.now,
-        private getStorage: () => Pick<Storage, "getItem" | "removeItem"> = () => localStorage,
+        private getStorage: () => Pick<Storage, "getItem" | "removeItem"> = () => getAppStorage(),
     ) { }
 
     async get(pubkeyHex: string): Promise<ProfileData | null> {

--- a/src/lib/storage/relayConfigsRepository.ts
+++ b/src/lib/storage/relayConfigsRepository.ts
@@ -2,6 +2,7 @@ import { STORAGE_KEYS } from "../constants";
 import { RelayConfigParser, RelayConfigUtils } from "../relayConfigUtils";
 import type { RelayConfig } from "../types";
 import { ehagakiDb, type EHagakiDB, type RelayConfigRecord } from "./ehagakiDb";
+import { getAppStorage } from "../appStorage";
 
 const RELAY_CONFIG_SCHEMA_VERSION = 1;
 
@@ -84,7 +85,7 @@ export class DexieRelayConfigsRepository implements RelayConfigsRepository {
     constructor(
         private db: EHagakiDB = ehagakiDb,
         private now: () => number = Date.now,
-        private getStorage: () => Pick<Storage, "getItem" | "removeItem"> = () => localStorage,
+        private getStorage: () => Pick<Storage, "getItem" | "removeItem"> = () => getAppStorage(),
     ) { }
 
     async get(pubkeyHex: string): Promise<RelayConfigCache | null> {

--- a/src/lib/storage/uploadDestinationsRepository.ts
+++ b/src/lib/storage/uploadDestinationsRepository.ts
@@ -15,6 +15,7 @@ import {
     normalizeServerUrl,
 } from "../upload/uploadDestinationPresets";
 import { getEffectiveLocale } from "../utils/settingsStorage";
+import { getAppStorage } from "../appStorage";
 
 const LEGACY_UPLOAD_DESTINATION_MIGRATION_KEY = "migrated.localStorage.uploadEndpoint.v1";
 
@@ -207,7 +208,7 @@ export class DexieUploadDestinationsRepository implements UploadDestinationsRepo
     constructor(
         private db: EHagakiDB = ehagakiDb,
         private now: () => number = Date.now,
-        private getStorage: () => Pick<Storage, "getItem" | "setItem" | "removeItem"> = () => localStorage,
+        private getStorage: () => Pick<Storage, "getItem" | "setItem" | "removeItem"> = () => getAppStorage(),
         private parentSync: UploadDestinationsParentSync | null = uploadDestinationsParentSync,
         private getNavigator: () => NavigatorAdapter = () =>
             (typeof navigator !== "undefined" ? navigator : { language: "en" }),

--- a/src/lib/types/nostr.ts
+++ b/src/lib/types/nostr.ts
@@ -2,6 +2,7 @@
 
 import type { createRxNostr } from "rx-nostr";
 import type { Editor as TipTapEditor } from "@tiptap/core";
+import type { AppPostNotificationPort } from "../appNotificationPort";
 import type { PostHistoryRawEventAttestation } from "../postHistoryRawEventVerification";
 
 // App Store types
@@ -211,6 +212,7 @@ export interface PostManagerDeps {
         }) => boolean;
         notifyPostError: (error?: string | { code: string; message?: string }) => boolean;
     };
+    notificationPort?: AppPostNotificationPort;
     hashtagPinStore?: { value: boolean };
     saveHashtagsToHistoryFn?: (hashtags: string[]) => void | Promise<void>;
     channelContextState?: { value: ChannelContextState | null };

--- a/src/lib/types/nostr.ts
+++ b/src/lib/types/nostr.ts
@@ -73,6 +73,7 @@ export interface AuthServiceDependencies {
     caches?: CacheStorage;
     window?: Window;
     navigator?: Navigator;
+    serviceWorkerEnabled?: boolean;
     console?: Console;
     setNsecAuth?: (pubkey: string, npub: string, nprofile: string) => void;
     setNip07Auth?: (pubkey: string, npub: string, nprofile: string) => void;

--- a/src/lib/uploadHelper.ts
+++ b/src/lib/uploadHelper.ts
@@ -52,6 +52,7 @@ import {
 import { uploadDestinationsRepository } from "./storage/uploadDestinationsRepository";
 import { authState } from "../stores/authStore.svelte";
 import { resolveUploadDestinationForUse } from "./upload/uploadDestinationResolver";
+import { getAppStorage } from "./appStorage";
 
 function createFileUploadManager(
     dependencies: UploadHelperDependencies,
@@ -269,7 +270,7 @@ async function replaceUploadedPlaceholders(params: {
 
 // デフォルトの依存関係
 const createDefaultDependencies = (): UploadHelperDependencies => ({
-    localStorage: window.localStorage,
+    localStorage: getAppStorage(),
     crypto: window.crypto.subtle,
     tick,
     FileUploadManager: FileUploadManager as unknown as new (

--- a/src/lib/utils/appDomUtils.ts
+++ b/src/lib/utils/appDomUtils.ts
@@ -1,17 +1,19 @@
 /**
  * DOM操作ユーティリティ（テスト時にモック可能）
  */
+import { getAppRuntimeEnvironment } from "../appRuntimeEnvironment";
+
 export const domUtils = {
     setBodyStyle(property: string, value: string): void {
-        document.body.style.setProperty(property, value);
+        getAppRuntimeEnvironment().layoutTarget.style.setProperty(property, value);
     },
 
     querySelector(selector: string): HTMLElement | null {
-        return document.querySelector(selector) as HTMLElement;
+        return getAppRuntimeEnvironment().domRoot?.querySelector(selector) as HTMLElement;
     },
 
     querySelectorAll(selector: string): NodeListOf<HTMLElement> {
-        return document.querySelectorAll(selector) as NodeListOf<HTMLElement>;
+        return getAppRuntimeEnvironment().domRoot?.querySelectorAll(selector) as NodeListOf<HTMLElement>;
     },
 
     focusElement(element: HTMLElement): void {
@@ -31,7 +33,10 @@ export function clearBodyStyles(): void {
 
 // === 追加: DOM操作の抽象化 ===
 export function getActiveElement(): HTMLElement | null {
-    return document.activeElement as HTMLElement | null;
+    const root = getAppRuntimeEnvironment().domRoot;
+    return (root && "activeElement" in root
+        ? root.activeElement
+        : getAppRuntimeEnvironment().document?.activeElement) as HTMLElement | null;
 }
 
 export function isEditorElement(element: HTMLElement): boolean {
@@ -46,7 +51,7 @@ export function blurActiveElement(): void {
     const active = getActiveElement();
     if (active && (isEditorElement(active) || isFormControl(active))) {
         active.blur?.();
-        (document.body as HTMLElement)?.focus?.();
+        getAppRuntimeEnvironment().layoutTarget.focus?.();
     }
 }
 
@@ -65,7 +70,7 @@ export function blurEditorAndBody() {
         // タッチデバイスでのキーボード非表示を強化
         if (isTouchDevice()) {
             // エディター要素を明示的にblur
-            const editorElement = document.querySelector('.tiptap-editor') as HTMLElement;
+            const editorElement = getAppRuntimeEnvironment().domRoot?.querySelector('.tiptap-editor') as HTMLElement;
             if (editorElement) {
                 editorElement.blur?.();
             }

--- a/src/lib/utils/appUtils.ts
+++ b/src/lib/utils/appUtils.ts
@@ -7,6 +7,7 @@ import {
   getClientTagEnabledPreference,
   getImageCompressionLevelPreference,
 } from './settingsStorage';
+import { getAppStorage } from '../appStorage';
 
 // =============================================================================
 // External Dependencies (Injectable for Testing)
@@ -14,8 +15,8 @@ import {
 
 // Default implementations
 export const defaultStorageAdapter: StorageAdapter = {
-  getItem: (key: string) => localStorage.getItem(key),
-  setItem: (key: string, value: string) => localStorage.setItem(key, value)
+  getItem: (key: string) => getAppStorage().getItem(key),
+  setItem: (key: string, value: string) => getAppStorage().setItem(key, value)
 };
 
 export const defaultNavigatorAdapter: NavigatorAdapter = {
@@ -153,4 +154,3 @@ export function chunkArray<T>(array: T[], size: number): T[][] {
   }
   return chunks;
 }
-

--- a/src/lib/videoCompression/ffmpegCompression.ts
+++ b/src/lib/videoCompression/ffmpegCompression.ts
@@ -4,6 +4,7 @@ import type { VideoCompressionResult } from '../types';
 import { isDefaultUploadAborted, type UploadAbortChecker } from '../uploadAbortUtils';
 import { BaseCompression } from './baseCompression';
 import { createCompressedFile, devLog, devWarn } from './compressionUtils';
+import { getAppRuntimeEnvironment } from '../appRuntimeEnvironment';
 
 /**
  * FFmpegを使用した動画圧縮クラス
@@ -58,8 +59,12 @@ export class FFmpegCompression extends BaseCompression {
 
             try {
                 // Viteの静的アセットimportを使用
+                const configuredAssetBase = getAppRuntimeEnvironment().assetBase;
                 const base = import.meta.env.BASE_URL || '/';
-                const baseURL = new URL(base, window.location.origin).href;
+                const baseURL = (
+                    configuredAssetBase ??
+                    new URL(base, window.location.origin)
+                ).href;
                 const coreURL = new URL('ffmpeg-core/ffmpeg-core.js', baseURL).href;
                 const wasmURL = new URL('ffmpeg-core/ffmpeg-core.wasm', baseURL).href;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,24 @@ import 'photoswipe/style.css'
 import { applyEmbedSettingsBootstrap } from './lib/bootstrap/embedSettingsBootstrap'
 import { applyUploadDestinationBootstrap } from './lib/bootstrap/uploadDestinationBootstrap'
 import { handleStaleAssetPreloadError } from './lib/staleAssetPreloadError'
+import { configureAppRuntimeEnvironment } from './lib/appRuntimeEnvironment'
+import { startServiceWorkerRegistration } from './lib/bootstrap/serviceWorkerBootstrap'
+
+configureAppRuntimeEnvironment({
+  storage: window.localStorage,
+  window,
+  document,
+  domRoot: document,
+  styleTarget: document.documentElement,
+  layoutTarget: document.body,
+  overlayTarget: document.body,
+  themeTarget: document.documentElement,
+  assetBase: new URL(import.meta.env.BASE_URL, window.location.href),
+  serviceWorkerEnabled: true,
+  externalInputEnabled: true,
+  historyEnabled: true,
+})
+startServiceWorkerRegistration()
 
 window.addEventListener('vite:preloadError', (event) => {
   handleStaleAssetPreloadError(event)

--- a/src/stores/settingsStore.svelte.ts
+++ b/src/stores/settingsStore.svelte.ts
@@ -39,6 +39,10 @@ import {
     persistAllEmbedSettingKeys,
     persistChangedEmbedSettingKeys,
 } from "../lib/embedSettingsPersistence";
+import { getAppStorage } from "../lib/appStorage";
+import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
+
+const appStorage = getAppStorage();
 
 interface SettingsState {
     locale: SupportedLocale;
@@ -66,22 +70,22 @@ interface DirectSettingDescriptor<K extends DirectSettingKey> {
 }
 
 function readSettingsState(): SettingsState {
-    const effectiveLocale = getEffectiveLocale(localStorage, navigator);
+    const effectiveLocale = getEffectiveLocale(appStorage, navigator);
     const externalNostrClient = getExternalNostrClientPreference(
-        localStorage,
+        appStorage,
         effectiveLocale,
     );
 
     return {
         locale: effectiveLocale,
-        clientTagEnabled: getClientTagEnabledPreference(localStorage),
-        quoteNotificationEnabled: getQuoteNotificationEnabledPreference(localStorage),
-        replyNotificationEnabled: getReplyNotificationEnabledPreference(localStorage),
-        imageQualityLevel: getImageCompressionLevelPreference(localStorage),
-        videoQualityLevel: getVideoCompressionLevelPreference(localStorage),
-        mediaFreePlacement: getMediaFreePlacementPreference(localStorage),
-        showMascot: getShowMascotPreference(localStorage),
-        showFlavorText: getShowFlavorTextPreference(localStorage),
+        clientTagEnabled: getClientTagEnabledPreference(appStorage),
+        quoteNotificationEnabled: getQuoteNotificationEnabledPreference(appStorage),
+        replyNotificationEnabled: getReplyNotificationEnabledPreference(appStorage),
+        imageQualityLevel: getImageCompressionLevelPreference(appStorage),
+        videoQualityLevel: getVideoCompressionLevelPreference(appStorage),
+        mediaFreePlacement: getMediaFreePlacementPreference(appStorage),
+        showMascot: getShowMascotPreference(appStorage),
+        showFlavorText: getShowFlavorTextPreference(appStorage),
         externalNostrClient: externalNostrClient.client,
         externalNostrClientCustomUrl: externalNostrClient.customUrlTemplate,
     };
@@ -101,17 +105,17 @@ const directSettingDescriptors: {
     clientTagEnabled: {
         storageKeys: [STORAGE_KEYS.CLIENT_TAG_ENABLED],
         apply: (value: boolean, source: PreferenceSource) =>
-            setClientTagEnabledPreference(localStorage, value, source),
+            setClientTagEnabledPreference(appStorage, value, source),
     },
     quoteNotificationEnabled: {
         storageKeys: [STORAGE_KEYS.QUOTE_NOTIFICATION_ENABLED],
         apply: (value: boolean, source: PreferenceSource) =>
-            setQuoteNotificationEnabledPreference(localStorage, value, source),
+            setQuoteNotificationEnabledPreference(appStorage, value, source),
     },
     replyNotificationEnabled: {
         storageKeys: [STORAGE_KEYS.REPLY_NOTIFICATION_ENABLED],
         apply: (value: boolean, source: PreferenceSource) =>
-            setReplyNotificationEnabledPreference(localStorage, value, source),
+            setReplyNotificationEnabledPreference(appStorage, value, source),
     },
     imageQualityLevel: {
         storageKeys: [
@@ -119,7 +123,7 @@ const directSettingDescriptors: {
             STORAGE_KEYS.LEGACY_IMAGE_COMPRESSION_LEVEL,
         ],
         apply: (value: string, source: PreferenceSource) =>
-            setImageCompressionLevelPreference(localStorage, value, source),
+            setImageCompressionLevelPreference(appStorage, value, source),
     },
     videoQualityLevel: {
         storageKeys: [
@@ -127,23 +131,23 @@ const directSettingDescriptors: {
             STORAGE_KEYS.LEGACY_VIDEO_COMPRESSION_LEVEL,
         ],
         apply: (value: string, source: PreferenceSource) =>
-            setVideoCompressionLevelPreference(localStorage, value, source),
+            setVideoCompressionLevelPreference(appStorage, value, source),
     },
     mediaFreePlacement: {
         storageKeys: [STORAGE_KEYS.MEDIA_FREE_PLACEMENT],
         apply: (value: boolean, source: PreferenceSource) =>
-            setMediaFreePlacementPreference(localStorage, value, source),
+            setMediaFreePlacementPreference(appStorage, value, source),
         afterApply: updateMediaPlacement,
     },
     showMascot: {
         storageKeys: [STORAGE_KEYS.SHOW_MASCOT],
         apply: (value: boolean, source: PreferenceSource) =>
-            setShowMascotPreference(localStorage, value, source),
+            setShowMascotPreference(appStorage, value, source),
     },
     showFlavorText: {
         storageKeys: [STORAGE_KEYS.SHOW_FLAVOR_TEXT],
         apply: (value: boolean, source: PreferenceSource) =>
-            setShowFlavorTextPreference(localStorage, value, source),
+            setShowFlavorTextPreference(appStorage, value, source),
     },
 };
 
@@ -178,11 +182,11 @@ function applyLocaleSetting(
         syncDocumentLang?: boolean;
     } = {},
 ): SupportedLocale {
-    const nextLocale = setLocalePreference(localStorage, value, source);
+    const nextLocale = setLocalePreference(appStorage, value, source);
     settingsState.locale = nextLocale;
 
     if (syncDocumentLang) {
-        document.documentElement.lang = nextLocale;
+        getAppRuntimeEnvironment().themeTarget.lang = nextLocale;
     }
 
     i18nLocale.set(nextLocale);
@@ -313,7 +317,7 @@ export const settingsStore = {
     },
 
     set externalNostrClient(value: string) {
-        const nextValue = setExternalNostrClientPreference(localStorage, value);
+        const nextValue = setExternalNostrClientPreference(appStorage, value);
         if (nextValue) {
             settingsState.externalNostrClient = nextValue;
         }
@@ -325,7 +329,7 @@ export const settingsStore = {
 
     set externalNostrClientCustomUrl(value: string) {
         const nextValue = setExternalNostrClientCustomUrlPreference(
-            localStorage,
+            appStorage,
             value,
         );
         if (nextValue) {
@@ -396,21 +400,21 @@ export const settingsStore = {
 };
 
 export function consumeFirstVisitFlag(): boolean {
-    const result = consumeFirstVisit(localStorage);
+    const result = consumeFirstVisit(appStorage);
     embedStorageService.persistLocalStorageKeys([STORAGE_KEYS.FIRST_VISIT]);
     return result;
 }
 
 export function isSharedMediaProcessed(): boolean {
-    return readSharedMediaProcessed(localStorage);
+    return readSharedMediaProcessed(appStorage);
 }
 
 export function markSharedMediaProcessed(): void {
-    writeSharedMediaProcessed(localStorage);
+    writeSharedMediaProcessed(appStorage);
     embedStorageService.persistLocalStorageKeys([STORAGE_KEYS.SHARED_MEDIA_PROCESSED]);
 }
 
 export function clearSharedMediaProcessed(): void {
-    removeSharedMediaProcessed(localStorage);
+    removeSharedMediaProcessed(appStorage);
     embedStorageService.persistLocalStorageKeys([STORAGE_KEYS.SHARED_MEDIA_PROCESSED]);
 }

--- a/src/stores/swStore.svelte.ts
+++ b/src/stores/swStore.svelte.ts
@@ -24,6 +24,10 @@ const updateReloadController = createAcceptedServiceWorkerUpdateReloadController
     },
 );
 
+export function handleServiceWorkerControlChange() {
+    return updateReloadController.handleControlChange();
+}
+
 export function setSwUpdateStatus(value: SwUpdateStatus) {
     if (swUpdateStatusValue === "ready" && value === "installing") {
         return;

--- a/src/stores/swStore.svelte.ts
+++ b/src/stores/swStore.svelte.ts
@@ -1,12 +1,7 @@
-/// <reference types="vite/client" />
-// @ts-expect-error: virtual module provided by Vite plugin
-import { useRegisterSW } from "virtual:pwa-register/svelte";
 import {
     createAcceptedServiceWorkerUpdateReloadController,
-    watchServiceWorkerUpdateInstallation,
     type SwUpdateStatus,
 } from "../lib/swUpdateDetectionUtils";
-import { subscribeEHagakiDbUpgradeState } from "../lib/storage/ehagakiDb";
 import {
     markStaleAssetReloadRequired,
     requestStaleReloadPrompt,
@@ -29,7 +24,7 @@ const updateReloadController = createAcceptedServiceWorkerUpdateReloadController
     },
 );
 
-function setSwUpdateStatus(value: SwUpdateStatus) {
+export function setSwUpdateStatus(value: SwUpdateStatus) {
     if (swUpdateStatusValue === "ready" && value === "installing") {
         return;
     }
@@ -43,7 +38,7 @@ function setSwUpdateStatus(value: SwUpdateStatus) {
     notifySwNeedRefreshSubscribers();
 }
 
-function setDbUpgradeBlocked(value: boolean) {
+export function setDbUpgradeBlocked(value: boolean) {
     if (dbUpgradeBlockedValue === value) {
         return;
     }
@@ -91,77 +86,23 @@ export const dbUpgradeBlocked = {
     set: setDbUpgradeBlocked,
 };
 
-function watchRegistrationUpdate(registration: ServiceWorkerRegistration | undefined) {
-    if (!registration) {
-        return;
-    }
+let serviceWorkerEnabled = false;
+let swUpdateServiceWorkerImpl: (reloadPage?: boolean) => void | Promise<void> =
+    () => undefined;
 
-    watchServiceWorkerUpdateInstallation({
-        registration,
-        hasController: Boolean(navigator.serviceWorker?.controller),
-        setStatus: setSwUpdateStatus,
-    });
+export function enableServiceWorkerStore(): void {
+    serviceWorkerEnabled = true;
 }
 
-subscribeEHagakiDbUpgradeState(setDbUpgradeBlocked);
-
-if (typeof navigator !== "undefined" && navigator.serviceWorker) {
-    navigator.serviceWorker.addEventListener("message", (event) => {
-        if (event.data?.type === "EHAGAKI_DB_UPGRADE_BLOCKED") {
-            setDbUpgradeBlocked(true);
-        } else if (event.data?.type === "EHAGAKI_DB_UPGRADE_UNBLOCKED") {
-            setDbUpgradeBlocked(false);
-        }
-    });
+export function configureSwUpdateServiceWorker(
+    updateServiceWorker: (reloadPage?: boolean) => void | Promise<void>,
+): void {
+    swUpdateServiceWorkerImpl = updateServiceWorker;
 }
 
-// --- Service Worker管理 ---
-const swRegister = (() => {
-    try {
-        if (typeof useRegisterSW === 'function') {
-            const register = useRegisterSW({
-                onRegistered: (r: ServiceWorkerRegistration | undefined) => {
-                    console.log("SW registered successfully", r);
-                    watchRegistrationUpdate(r);
-                },
-                onRegisterError(error: Error) {
-                    console.warn("SW registration error", error);
-                },
-                onNeedRefresh() {
-                    console.log("SW needs refresh - showing prompt");
-                    setSwUpdateStatus("ready");
-                },
-                onNeedReload() {
-                    updateReloadController.handleControlChange();
-                },
-                immediate: true,
-                onOfflineReady() {
-                    console.log("App ready to work offline");
-                }
-            });
-
-            register.needRefresh.subscribe((needRefresh: boolean) => {
-                if (needRefresh) {
-                    setSwUpdateStatus("ready");
-                } else if (swUpdateStatusValue === "ready") {
-                    setSwUpdateStatus("idle");
-                }
-            });
-
-            return register;
-        }
-    } catch (error) {
-        console.warn("Failed to initialize Service Worker:", error);
-    }
-
-    // フォールバック（テスト環境やエラー時）
-    return {
-        needRefresh: { subscribe: () => { } },
-        updateServiceWorker: () => { }
-    };
-})();
-
-export const swUpdateServiceWorker = swRegister.updateServiceWorker;
+export function swUpdateServiceWorker(reloadPage?: boolean): void | Promise<void> {
+    return swUpdateServiceWorkerImpl(reloadPage);
+}
 
 let swVersion = $state<string | null>(null);
 
@@ -180,6 +121,7 @@ export function handleSwUpdate() {
 }
 
 export function fetchSwVersion(): Promise<string | null> {
+    if (!serviceWorkerEnabled) return Promise.resolve(null);
     if (!navigator.serviceWorker?.controller) return Promise.resolve(null);
     return new Promise((resolve) => {
         const messageChannel = new MessageChannel();

--- a/src/stores/themeStore.svelte.ts
+++ b/src/stores/themeStore.svelte.ts
@@ -14,6 +14,8 @@ import {
 } from '../lib/utils/settingsStorage';
 import { STORAGE_KEYS } from '../lib/constants';
 import { persistChangedEmbedSettingKeys } from '../lib/embedSettingsPersistence';
+import { getAppStorage } from '../lib/appStorage';
+import { getAppRuntimeEnvironment } from '../lib/appRuntimeEnvironment';
 
 function getSystemDarkMode(): boolean {
     return window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -35,7 +37,7 @@ function getEffectiveDarkMode(mode: ThemeMode): boolean {
  * <html> 要素にテーマクラスを適用し、color-scheme プロパティも更新
  */
 function applyTheme(isDark: boolean): void {
-    const root = document.documentElement;
+    const root = getAppRuntimeEnvironment().themeTarget;
     if (isDark) {
         root.classList.add('dark');
         root.classList.remove('light');
@@ -48,7 +50,8 @@ function applyTheme(isDark: boolean): void {
 }
 
 // --- ストア状態 ---
-const initialThemeMode = getStoredThemeModePreference(localStorage);
+const appStorage = getAppStorage();
+const initialThemeMode = getStoredThemeModePreference(appStorage);
 const initialDarkMode = getEffectiveDarkMode(initialThemeMode);
 let themeMode = $state<ThemeMode>(initialThemeMode);
 let darkMode = $state(initialDarkMode);
@@ -78,7 +81,7 @@ export const themeModeStore = {
         return darkMode;
     },
     set: (mode: ThemeMode, source: PreferenceSource = 'user') => {
-        const nextMode = setThemeModePreference(localStorage, mode, source);
+        const nextMode = setThemeModePreference(appStorage, mode, source);
         const nextDarkMode = getEffectiveDarkMode(nextMode);
         themeMode = nextMode;
         darkMode = nextDarkMode;
@@ -89,7 +92,7 @@ export const themeModeStore = {
         ]);
     },
     reload: () => {
-        const nextMode = getStoredThemeModePreference(localStorage);
+        const nextMode = getStoredThemeModePreference(appStorage);
         const nextDarkMode = getEffectiveDarkMode(nextMode);
         themeMode = nextMode;
         darkMode = nextDarkMode;

--- a/src/stores/uiStore.svelte.ts
+++ b/src/stores/uiStore.svelte.ts
@@ -12,6 +12,7 @@ import {
 } from "../lib/utils/viewportLayout";
 import { createKeyboardTouchScrollLock } from "../lib/utils/keyboardTouchScrollLock";
 import { isPostEditorFocusActive } from "../lib/utils/keyboardFocusUtils";
+import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
 
 // --- 定数 ---
 /** フッターの高さ（px） */
@@ -47,7 +48,7 @@ function setRootStyleProperty(name: string, value: string): void {
         return;
     }
 
-    document.documentElement.style.setProperty(name, value);
+    getAppRuntimeEnvironment().styleTarget.style.setProperty(name, value);
 }
 
 function isVirtualKeyboardOverlayActive(): boolean {

--- a/src/test/unit/appStorage.test.ts
+++ b/src/test/unit/appStorage.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+    configureAppStorage,
+    createWebComponentStorage,
+    EHAGAKI_WEB_COMPONENT_STORAGE_PREFIX,
+    getAppStorage,
+    resetAppStorage,
+} from "../../lib/appStorage";
+
+function createMemoryStorage(): Storage {
+    const values = new Map<string, string>();
+    return {
+        get length() {
+            return values.size;
+        },
+        clear() {
+            values.clear();
+        },
+        getItem(key) {
+            return values.get(key) ?? null;
+        },
+        key(index) {
+            return [...values.keys()][index] ?? null;
+        },
+        removeItem(key) {
+            values.delete(key);
+        },
+        setItem(key, value) {
+            values.set(key, String(value));
+        },
+    };
+}
+
+afterEach(() => {
+    resetAppStorage();
+});
+
+describe("app storage boundary", () => {
+    it("allows an entry point to inject a storage implementation", () => {
+        const storage = createMemoryStorage();
+        configureAppStorage(storage);
+
+        expect(getAppStorage()).toBe(storage);
+    });
+
+    it("isolates a future embedding namespace without changing host keys", () => {
+        const hostStorage = createMemoryStorage();
+        hostStorage.setItem("locale", "host-locale");
+        hostStorage.setItem("nostr-accounts", "host-accounts");
+        const scopedStorage = createWebComponentStorage(hostStorage);
+
+        scopedStorage.setItem("locale", "ja");
+        scopedStorage.setItem("nostr-accounts", "component-accounts");
+
+        expect(hostStorage.getItem("locale")).toBe("host-locale");
+        expect(hostStorage.getItem("nostr-accounts")).toBe("host-accounts");
+        expect(
+            hostStorage.getItem(`${EHAGAKI_WEB_COMPONENT_STORAGE_PREFIX}locale`),
+        ).toBe("ja");
+        expect(scopedStorage.getItem("locale")).toBe("ja");
+
+        scopedStorage.clear();
+        expect(hostStorage.getItem("locale")).toBe("host-locale");
+        expect(hostStorage.getItem("nostr-accounts")).toBe("host-accounts");
+    });
+});

--- a/src/test/unit/authService.logout.test.ts
+++ b/src/test/unit/authService.logout.test.ts
@@ -170,6 +170,31 @@ describe('AuthService.logoutAccount', () => {
         expect(result).toBe('next-active');
     });
 
+    it.each([
+        { enabled: false, expectedCalls: 0 },
+        { enabled: true, expectedCalls: 1 },
+    ])(
+        'serviceWorkerEnabled=%s のときだけプロフィールキャッシュ削除messageを送る',
+        async ({ enabled, expectedCalls }) => {
+            mockDependencies.serviceWorkerEnabled = enabled;
+            authService = new AuthService(mockDependencies);
+            mockAccountManager.getAccountType.mockReturnValue('nsec');
+            const postMessage = vi.mocked(
+                (mockDependencies.navigator as any).serviceWorker.controller.postMessage,
+            );
+
+            await authService.logoutAccount('pubkey1');
+
+            expect(postMessage).toHaveBeenCalledTimes(expectedCalls);
+            if (enabled) {
+                expect(postMessage).toHaveBeenCalledWith(
+                    { action: 'clearProfileCache' },
+                    expect.any(Array),
+                );
+            }
+        },
+    );
+
     it('最後のアカウント削除でnull返却', async () => {
         mockAccountManager.removeAccount.mockReturnValue(null);
         const result = await authService.logoutAccount('pubkey1');

--- a/src/test/unit/swStore.test.ts
+++ b/src/test/unit/swStore.test.ts
@@ -61,8 +61,17 @@ describe("swStore DB upgrade blocked state", () => {
         }
     });
 
+    it("state import alone does not register a Service Worker", async () => {
+        await import("../../stores/swStore.svelte");
+
+        expect(testState.registerOptions).toBeUndefined();
+        expect(testState.dbUpgradeStateListener).toBeUndefined();
+    });
+
     it("DB blocked の解除で ready のSW更新状態を維持する", async () => {
         const store = await import("../../stores/swStore.svelte");
+        const bootstrap = await import("../../lib/bootstrap/serviceWorkerBootstrap");
+        bootstrap.startServiceWorkerRegistration();
         const statuses: string[] = [];
         const blockedStates: boolean[] = [];
         const refreshStates: boolean[] = [];
@@ -88,6 +97,8 @@ describe("swStore DB upgrade blocked state", () => {
 
     it("未承認controllerchangeは一度だけstale化し、更新操作をreload promptへ振り分ける", async () => {
         const store = await import("../../stores/swStore.svelte");
+        const bootstrap = await import("../../lib/bootstrap/serviceWorkerBootstrap");
+        bootstrap.startServiceWorkerRegistration();
         const staleStore = await import(
             "../../stores/staleAssetReloadStore.svelte"
         );

--- a/src/test/unit/swStore.test.ts
+++ b/src/test/unit/swStore.test.ts
@@ -5,7 +5,7 @@ const testState = vi.hoisted(() => ({
     needRefreshListener: undefined as undefined | ((needRefresh: boolean) => void),
     registerOptions: undefined as undefined | {
         onNeedRefresh?: () => void;
-        onNeedReload?: () => void;
+        onNeedReload?: () => unknown;
     },
     updateServiceWorker: vi.fn(),
 }));
@@ -54,6 +54,7 @@ describe("swStore DB upgrade blocked state", () => {
     });
 
     afterEach(() => {
+        vi.unstubAllGlobals();
         if (originalServiceWorker) {
             Object.defineProperty(navigator, "serviceWorker", originalServiceWorker);
         } else {
@@ -115,5 +116,27 @@ describe("swStore DB upgrade blocked state", () => {
 
         expect(staleStore.staleAssetReloadState.promptRevision).toBe(2);
         expect(testState.updateServiceWorker).not.toHaveBeenCalled();
+    });
+
+    it("承認済み更新のcontrollerchangeはstale化せずreloadする", async () => {
+        const reload = vi.fn();
+        vi.stubGlobal("window", { location: { reload } });
+        const store = await import("../../stores/swStore.svelte");
+        const bootstrap = await import("../../lib/bootstrap/serviceWorkerBootstrap");
+        bootstrap.startServiceWorkerRegistration();
+        const staleStore = await import(
+            "../../stores/staleAssetReloadStore.svelte"
+        );
+        testState.registerOptions?.onNeedRefresh?.();
+        await store.handleSwUpdate();
+
+        expect(testState.updateServiceWorker).toHaveBeenCalledWith(true);
+
+        const result = testState.registerOptions?.onNeedReload?.();
+
+        expect(result).toBe("reloaded");
+        expect(reload).toHaveBeenCalledTimes(1);
+        expect(staleStore.staleAssetReloadState.required).toBe(false);
+        expect(staleStore.staleAssetReloadState.promptRevision).toBe(0);
     });
 });


### PR DESCRIPTION
## Summary

Implements PR1 for Issue #89: prepare runtime boundaries without adding a Web Component entry or changing normal PWA/iframe behavior.

- Adds an injectable app Storage boundary and an eHagaki-specific Web Component namespace facade for future entry-point use. Existing PWA/iframe paths continue to receive raw `window.localStorage`, while settings, auth/account, nsec/NIP-46, parent-client, migration/cleanup, draft, hashtag, profile/relay, upload, and compression defaults now resolve through the app boundary.
- Moves Service Worker registration and DB/message listeners out of `swStore` module evaluation into explicit `main.ts` bootstrap. State import alone no longer registers a Service Worker.
- Adds minimum runtime targets for storage, DOM root/style/layout/overlay/theme targets, and asset base; PWA defaults remain document/body/documentElement and current base URL behavior.
- Adds transport-neutral notification ports while preserving the existing iframe message protocol adapter and compatibility field.
- Adds unmount cleanup for the active rx-nostr session and NIP-46 pending/runtime resources, without deleting persisted account data.

## Validation

- `npm test` — 327 files, 3815 tests passed
- `npm run check` — passed
- `npm run build` — passed, including legacy bridge verification
- `npx playwright test src/test/e2e/iframeMessageGate.spec.ts` — 6 passed (desktop/mobile Chromium)
- `git diff --check` — passed

## Scope

This PR intentionally does not add `<ehagaki-composer>`, Custom Element registration, Shadow DOM, a library build, cross-origin Web Component fixtures, relay-interceptor claims, storage migration, IndexedDB renaming, or unrelated UI changes. Those remain for the follow-up PR after the concrete host-side relay interception mechanism is identified.