### PR TITLE
Fix iOS JSONL file picker selection

### DIFF
--- a/src/components/PostHistoryImportDialog.svelte
+++ b/src/components/PostHistoryImportDialog.svelte
@@ -297,7 +297,6 @@
         bind:this={fileInput}
         class="visually-hidden import-file-input"
         type="file"
-        accept=".jsonl,application/json,application/x-ndjson"
         aria-label={$_("postHistory.importChooseFile")}
         onchange={handleFileChange}
     />

--- a/src/test/unit/postHistoryImportDialog.test.ts
+++ b/src/test/unit/postHistoryImportDialog.test.ts
@@ -114,6 +114,20 @@ describe("PostHistoryImportDialog", () => {
         return new File(["{}"], "history.jsonl", { type: "application/x-ndjson" });
     }
 
+    it("ファイル選択をファイル名やMIMEタイプで制限しない", () => {
+        render(PostHistoryImportDialog, {
+            props: {
+                open: true,
+                ownerPubkeyHex: "a".repeat(64),
+                getCurrentPubkeyHex: () => "a".repeat(64),
+            },
+        });
+        const input = screen.getByRole("dialog", { name: "JSONLをインポート" })
+            .querySelector('input[type="file"]') as HTMLInputElement;
+
+        expect(input.hasAttribute("accept")).toBe(false);
+    });
+
     it("ファイル選択で既存のインポートサービスへ先頭のファイルを渡す", async () => {
         importFileMock.mockResolvedValue(createResult());
         render(PostHistoryImportDialog, {
@@ -125,7 +139,7 @@ describe("PostHistoryImportDialog", () => {
         });
         const input = screen.getByRole("dialog", { name: "JSONLをインポート" })
             .querySelector('input[type="file"]') as HTMLInputElement;
-        const firstFile = createFile();
+        const firstFile = new File(["{}"], "history.jsonl", { type: "application/octet-stream" });
         await fireEvent.change(input, {
             target: { files: [firstFile, createFile()] },
         });


### PR DESCRIPTION
## 概要
投稿履歴 JSONL インポートのファイル入力から restrictive な `accept` 属性を削除し、iPhone / iOS の Files ピッカーで JSONL ファイルを選択できるようにしました。

## 原因
`PostHistoryImportDialog.svelte` の `accept=".jsonl,application/json,application/x-ndjson"` が iOS Files のファイル種別判定と組み合わさり、JSONL ファイルを選択不可にしていました。

## 実装
- ファイル入力の `accept` 属性を削除
- ファイル名・MIMEタイプによる入力制限がないことを回帰テストで固定
- 選択ファイルは従来どおり `postHistoryJsonlImportService.importFile` へ渡すことを維持
- JSON parse、Nostrイベント構造、対象pubkey、対応kind、event ID・署名などの既存検証は変更なし

## 検証
- 関連テスト: 2 files / 47 tests passed
- `npm run check`: passed
- `npm test`: 326 files / 3,813 tests passed
- `npm run build`: passed
- `git diff --check`: passed

## 未実行
実 iPhone / iOS Files アプリでの確認は Codex 環境から実行できないため未実行です。ユーザー側で、iPhone の投稿履歴 JSONL インポートダイアログからファイル選択を開き、Files 内の `.jsonl` ファイルがグレーアウトせず選択でき、選択後に通常どおりインポート処理が開始されることを確認してください。