### PR TITLE
Fix post history E2E menu expectations

### DIFF
--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -768,6 +768,7 @@ test.describe('PostHistoryDialog Playwright', () => {
         await actionTrigger.click();
         const actionMenu = visiblePostHistoryActionMenu(page);
         await expect(actionMenu.getByRole('menuitem')).toHaveText([
+            'nostterで開く',
             '返信 1件を表示',
             'イベントIDをコピー',
             'イベントJSONを表示',
@@ -804,6 +805,7 @@ test.describe('PostHistoryDialog Playwright', () => {
             .click();
         const actionMenu = visiblePostHistoryActionMenu(page);
         await expect(actionMenu.getByRole('menuitem')).toHaveText([
+            'nostterで開く',
             'イベントIDをコピー',
             'イベントJSONを表示',
             'ブロードキャスト',
@@ -830,6 +832,7 @@ test.describe('PostHistoryDialog Playwright', () => {
             .click();
         const actionMenu = visiblePostHistoryActionMenu(page);
         await expect(actionMenu.getByRole('menuitem')).toHaveText([
+            'nostterで開く',
             '返信を確認',
             'イベントJSONを表示',
             'イベントIDをコピー',


### PR DESCRIPTION
## Summary

- Update post history action-menu E2E expectations to include the existing `nostterで開く` item.
- Keep the expected menu order aligned with the production action-item component.

## Root cause

The action menu already renders the external-client item first, but three E2E assertions still expected the previous menu contents.

## Validation

- `npm run test:e2e -- --project=desktop-chromium --project=mobile-chromium src/test/e2e/postHistoryDialog.spec.ts -g "normal post action menu|resolved quote preview action menu|thread graph node action menu"`
- Result: 6 passed.
- `git diff --check`
