### PR TITLE
feat: add Web Component embedding

### DIFF
--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -61,22 +61,30 @@ schema or database-name migration. The host is trusted to execute the component
 and can inspect same-origin storage; the namespace is collision protection, not
 a secret boundary.
 
-## Service Workers, relays, and CSP
+## Service Workers, relays, FFmpeg, and CSP
 
 The component neither registers nor messages an eHagaki Service Worker. A host
 Service Worker may observe ordinary HTTP fetches, images, and uploads, but its
 `fetch` event does not demonstrate interception of Nostr WebSocket relay
-traffic. Because the component shares the host Window realm, a host that wraps
-`window.WebSocket` before importing this module can observe the normal
-rx-nostr relay constructor path. No special relay-interceptor API is provided.
+traffic. The component shares the host Window realm, and the current
+`initializeNostrSession()` path creates rx-nostr without a `websocketCtor`;
+rx-nostr therefore uses `globalThis.WebSocket` when it opens a relay. A host
+wrapper installed before this module is imported is the applicable boundary.
+This release does not claim a browser-level relay-interceptor guarantee: the
+normal app relay path requires an authenticated session and no deterministic,
+credential-free local-relay route was found in the existing application. No
+special relay-interceptor API is provided, and Issue #89's relay-interceptor
+proof remains incomplete.
 
 Serve the module, chunks, workers, FFmpeg files, and WASM with CORS headers
 that permit the embedding origin, or set `asset-base` to an accessible delivery
-base. If a deployment changes worker delivery to a Blob/inline worker, its CSP
-must allow `worker-src blob:`; this build otherwise keeps workers as ES module
-assets and does not silently bypass a restrictive CSP. Test iOS Safari with the
-actual delivery origin: mobile emulation does not prove its worker or CORS
-behavior.
+base. In a cross-origin embedding, FFmpeg fetches its bundled class-worker
+module from `asset-base`, creates a host-origin Blob URL for that worker, then
+loads `ffmpeg-core.js` and `ffmpeg-core.wasm` from `asset-base`. Permit both
+the delivery origin and `blob:` in `worker-src`; do not rely on a host Service
+Worker to proxy this path. Same-origin PWA delivery continues to use the emitted
+worker asset directly. Test iOS Safari with the actual delivery origin: mobile
+emulation does not prove its worker or CORS behavior.
 
 The component uses an open ShadowRoot. Dialogs, popovers, tooltips, suggestions,
 and PhotoSwipe are targeted at its overlay root, while browser-history and URL/

--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -1,0 +1,83 @@
+# eHagaki Composer Web Component
+
+`npm run build:web-component` produces `dist-web-component/ehagaki-composer.js`.
+It is an ES module distribution and is deliberately separate from the PWA
+build: it does not contain a manifest, share target, eHagaki Service Worker
+registration, or the iframe bridge.
+
+```html
+<script type="module" src="https://cdn.example/ehagaki-composer.js"></script>
+<ehagaki-composer
+  asset-base="https://cdn.example/"
+  style="--ehagaki-background: #f4f4f4; --ehagaki-font-family: system-ui"
+></ehagaki-composer>
+<script type="module">
+  const composer = document.querySelector('ehagaki-composer');
+  await composer.whenReady();
+  await composer.setSettings({ locale: 'ja', themeMode: 'light' });
+  await composer.setContext({ content: 'Hello from the host.' });
+</script>
+```
+
+Only one connected `ehagaki-composer` is supported in a document. A second
+element remains inert, emits `ehagaki-initialization-error` with
+`multiple_instances_unsupported`, and rejects `whenReady()`. Disconnecting the
+first element releases that slot. Disconnecting does not delete persisted data.
+
+## API and events
+
+- `whenReady(): Promise<void>` resolves after the component mounts.
+- `setContext(context)` uses the same reply, quote, channel, and content
+  validation/apply logic as iframe `composer.setContext`.
+- `setSettings(settings)` applies supported settings and resolves with the
+  applied keys.
+- `assetBase` property / `asset-base` attribute selects the component-delivery
+  base for chunks, workers, WASM, and FFmpeg assets. Set it before connection.
+
+All events bubble and are composed: `ehagaki-ready` (detail
+`{ apiVersion: 1 }`), `ehagaki-post-success`, `ehagaki-post-error`,
+`ehagaki-composer-context-updated`, and `ehagaki-initialization-error`.
+Error details use a safe code/message only; they do not contain secret keys,
+authentication payloads, or raw errors.
+
+The public CSS custom properties are `--ehagaki-background`,
+`--ehagaki-text`, `--ehagaki-border`, `--ehagaki-link`,
+`--ehagaki-input-background`, `--ehagaki-footer-background`,
+`--ehagaki-dialog-background`, and `--ehagaki-font-family`. The component
+also exposes `shell`, `header`, `composer`, `footer`, and `overlay-root` parts.
+
+## Storage, origin, and trust boundary
+
+The component runs in the host Window realm and stores directly in the host
+origin, but every eHagaki localStorage key is confined to
+`ehagaki.web-component.v1:`. This includes account, nsec, NIP-46, relay,
+settings, and legacy-cleanup paths; raw host keys are not read, overwritten, or
+removed. This first release has no migration. Data previously delegated through
+the iframe parent-storage protocol is not automatically moved when switching to
+the Web Component.
+
+IndexedDB remains the app-specific `eHagakiDB` at the host origin. There is no
+schema or database-name migration. The host is trusted to execute the component
+and can inspect same-origin storage; the namespace is collision protection, not
+a secret boundary.
+
+## Service Workers, relays, and CSP
+
+The component neither registers nor messages an eHagaki Service Worker. A host
+Service Worker may observe ordinary HTTP fetches, images, and uploads, but its
+`fetch` event does not demonstrate interception of Nostr WebSocket relay
+traffic. Because the component shares the host Window realm, a host that wraps
+`window.WebSocket` before importing this module can observe the normal
+rx-nostr relay constructor path. No special relay-interceptor API is provided.
+
+Serve the module, chunks, workers, FFmpeg files, and WASM with CORS headers
+that permit the embedding origin, or set `asset-base` to an accessible delivery
+base. If a deployment changes worker delivery to a Blob/inline worker, its CSP
+must allow `worker-src blob:`; this build otherwise keeps workers as ES module
+assets and does not silently bypass a restrictive CSP. Test iOS Safari with the
+actual delivery origin: mobile emulation does not prove its worker or CORS
+behavior.
+
+The component uses an open ShadowRoot. Dialogs, popovers, tooltips, suggestions,
+and PhotoSwipe are targeted at its overlay root, while browser-history and URL/
+share-target input handling are disabled.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite --host",
     "prebuild": "npx rimraf dist",
     "build": "vite build && node scripts/verifyLegacyBridgeBuild.mjs",
+    "build:web-component": "vite build --config vite.web-component.config.ts && node scripts/verifyWebComponentBuild.mjs",
     "verify:legacy-bridge-remote": "node scripts/verifyLegacyBridgeRemote.mjs",
     "preview": "vite preview --host",
     "check": "svelte-check --tsconfig ./tsconfig.json",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -46,10 +46,20 @@ export default defineConfig({
         },
         {
             name: 'mobile-webkit',
-            testMatch: '**/composerTargetDialog.spec.ts',
+            testMatch: [
+                '**/composerTargetDialog.spec.ts',
+                '**/webComponentEmbed.spec.ts',
+            ],
             use: {
                 ...devices['iPhone 13'],
                 browserName: 'webkit',
+            },
+        },
+        {
+            name: 'desktop-firefox',
+            testMatch: '**/webComponentEmbed.spec.ts',
+            use: {
+                ...devices['Desktop Firefox'],
             },
         },
     ],

--- a/scripts/verifyWebComponentBuild.mjs
+++ b/scripts/verifyWebComponentBuild.mjs
@@ -1,0 +1,31 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const outputRoot = join(process.cwd(), "dist-web-component");
+
+async function listFiles(directory) {
+    const entries = await readdir(directory, { withFileTypes: true });
+    const nested = await Promise.all(entries.map(async (entry) => {
+        const path = join(directory, entry.name);
+        return entry.isDirectory() ? listFiles(path) : [path];
+    }));
+    return nested.flat();
+}
+
+const files = await listFiles(outputRoot);
+const entry = join(outputRoot, "ehagaki-composer.js");
+if (!files.includes(entry)) {
+    throw new Error("Web Component entry was not emitted");
+}
+if (files.some((file) => /(^|[\\/])sw\.js$|manifest\.webmanifest$/.test(file))) {
+    throw new Error("Web Component build must not emit a service worker or manifest");
+}
+const source = (await Promise.all(
+    files.filter((file) => file.endsWith(".js")).map((file) => readFile(file, "utf8")),
+)).join("\n");
+for (const forbidden of ["virtual:pwa-register", "serviceWorkerBootstrap", "embed-parent-client-example"]) {
+    if (source.includes(forbidden)) {
+        throw new Error(`Web Component build contains forbidden runtime: ${forbidden}`);
+    }
+}
+console.log("[web-component-build] standalone output verified");

--- a/scripts/verifyWebComponentBuild.mjs
+++ b/scripts/verifyWebComponentBuild.mjs
@@ -28,4 +28,15 @@ for (const forbidden of ["virtual:pwa-register", "serviceWorkerBootstrap", "embe
         throw new Error(`Web Component build contains forbidden runtime: ${forbidden}`);
     }
 }
+const unresolvedAppAssetReferences = [
+    /url\(\s*(["'])?\/icons\//,
+    /src=["']\.\/ehagaki_icon\.svg["']/,
+];
+for (const pattern of unresolvedAppAssetReferences) {
+    if (pattern.test(source)) {
+        throw new Error(
+            `Web Component build contains an unresolved app-owned asset reference: ${pattern}`,
+        );
+    }
+}
 console.log("[web-component-build] standalone output verified");

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -11,6 +11,7 @@
   import { authService, type PendingNip46AuthSession } from "./lib/authService";
   import { getAppRuntimeEnvironment } from "./lib/appRuntimeEnvironment";
   import { iframeMessageService } from "./lib/iframeMessageService";
+  import type { AppPostNotificationPort } from "./lib/appNotificationPort";
   import { waitNostr } from "nip07-awaiter";
   import { AccountManager } from "./lib/accountManager";
   import {
@@ -168,6 +169,7 @@
   import {
     createAppEmbedController,
     type AppEmbedAppliedSettingKey,
+    type AppEmbedNotificationPort,
   } from "./lib/appEmbedController";
   import {
     createAppComponentLoaders,
@@ -195,7 +197,6 @@
   import { generateMediaItemId } from "./lib/utils/appUtils";
   import { CUSTOM_EMOJI_PICKER_CHROME_HEIGHT } from "./lib/customEmoji";
 
-  const appRuntimeEnvironment = getAppRuntimeEnvironment();
   import type { CustomEmojiSelection } from "./lib/customEmojiUsage";
   import { usePostHistoryInboundInteractionsRealtime } from "./lib/hooks/usePostHistoryInboundInteractionsRealtime.svelte";
   import { usePostHistoryInboundReplyReconciliation } from "./lib/hooks/usePostHistoryInboundReplyReconciliation.svelte";
@@ -212,6 +213,28 @@
   import { customEmojiStore } from "./stores/customEmojiStore.svelte";
   import { customEmojiUsageStore } from "./stores/customEmojiUsageStore.svelte";
   import { uploadDestinationStore } from "./stores/uploadDestinationStore.svelte";
+
+  const appRuntimeEnvironment = getAppRuntimeEnvironment();
+  interface Props {
+    /** The iframe transport remains the default for the PWA and iframe entry. */
+    notificationPort?: AppPostNotificationPort & AppEmbedNotificationPort;
+  }
+
+  const iframeNotificationPort: AppPostNotificationPort & AppEmbedNotificationPort = {
+    notifyPostSuccess: (options) => iframeMessageService.notifyPostSuccess(options),
+    notifyPostError: (error) => iframeMessageService.notifyPostError(error),
+    notifyComposerContextApplied: (requestId) =>
+      iframeMessageService.notifyComposerContextApplied(requestId),
+    notifyComposerContextError: (error, requestId) =>
+      iframeMessageService.notifyComposerContextError(error, requestId),
+    notifyComposerContextUpdated: (payload) =>
+      iframeMessageService.notifyComposerContextUpdated(payload),
+    notifySettingsApplied: (applied, requestId) =>
+      iframeMessageService.notifySettingsApplied([...applied], requestId),
+    notifySettingsError: (error, requestId) =>
+      iframeMessageService.notifySettingsError(error, requestId),
+  };
+  let { notificationPort = iframeNotificationPort }: Props = $props();
 
   type PostComponent =
     typeof import("./components/PostComponent.svelte").default;
@@ -1167,7 +1190,7 @@
       applyChannelContextQuery: (query, runtime) => {
         channelContextApplyController.applyExternal({
           query,
-          source: "iframe",
+            source: appRuntimeEnvironment.externalInputEnabled ? "iframe" : "manual",
           rxNostr: runtime.rxNostr,
           relayConfig: runtime.relayConfig,
         });
@@ -1194,9 +1217,9 @@
     },
     notificationPort: {
       notifyComposerContextApplied: (requestId: string) =>
-        iframeMessageService.notifyComposerContextApplied(requestId),
+        notificationPort.notifyComposerContextApplied(requestId),
       notifyComposerContextError: (error, requestId: string) =>
-        iframeMessageService.notifyComposerContextError(
+        notificationPort.notifyComposerContextError(
           {
             code: error.code,
             ...(error.message ? { message: error.message } : {}),
@@ -1204,11 +1227,11 @@
           requestId,
         ),
       notifyComposerContextUpdated: (payload) =>
-        iframeMessageService.notifyComposerContextUpdated(payload),
+        notificationPort.notifyComposerContextUpdated(payload),
       notifySettingsApplied: (applied, requestId: string) =>
-        iframeMessageService.notifySettingsApplied([...applied], requestId),
+        notificationPort.notifySettingsApplied([...applied], requestId),
       notifySettingsError: (error, requestId: string) =>
-        iframeMessageService.notifySettingsError(
+        notificationPort.notifySettingsError(
           {
             code: error.code,
             ...(error.message ? { message: error.message } : {}),
@@ -1283,6 +1306,18 @@
   // Parent client login/logout の保留処理と embed action の flush をまとめる coordinator.
   async function flushPendingRemoteParentClientAndEmbedActions(): Promise<void> {
     await appParentClientSyncController.flushPendingRemoteParentClientAndEmbedActions();
+  }
+
+  /** Public in-process embedding seam used by the Web Component root. */
+  export async function setEmbedContext(payload: unknown): Promise<void> {
+    await appEmbedController.applyComposerContext(payload);
+  }
+
+  /** Public in-process embedding seam used by the Web Component root. */
+  export async function setEmbedSettings(
+    payload: EmbedSettingsSetPayload,
+  ): Promise<ReadonlyArray<AppEmbedAppliedSettingKey>> {
+    return appEmbedController.applySettings(payload);
   }
 
   async function handleRemoteParentClientLogin(
@@ -1377,23 +1412,25 @@
   let localeInitialized = $state(false);
 
   onMount(() => {
-    parentClientAvailable = parentClientAuthService.initialize({
-      locationSearch: window.location.search,
-    });
-    embedComposerContextService.initialize({
-      locationSearch: window.location.search,
-    });
-    embedSettingsService.initialize({
-      locationSearch: window.location.search,
-    });
-    if (
-      embedStorageService.initialize({ locationSearch: window.location.search })
-    ) {
-      void appEmbedController.initializeEmbedStorageSync();
+    if (appRuntimeEnvironment.externalInputEnabled) {
+      parentClientAvailable = parentClientAuthService.initialize({
+        locationSearch: window.location.search,
+      });
+      embedComposerContextService.initialize({
+        locationSearch: window.location.search,
+      });
+      embedSettingsService.initialize({
+        locationSearch: window.location.search,
+      });
+      if (
+        embedStorageService.initialize({ locationSearch: window.location.search })
+      ) {
+        void appEmbedController.initializeEmbedStorageSync();
+      }
+      embedIndexedDbService.initialize({
+        locationSearch: window.location.search,
+      });
     }
-    embedIndexedDbService.initialize({
-      locationSearch: window.location.search,
-    });
 
     const cleanupRuntimeBindings = setupAppRuntimeBindings({
       parentClientAvailable,
@@ -1431,10 +1468,10 @@
         );
       },
       notifySettingsError: (error, requestId) =>
-        iframeMessageService.notifySettingsError(
-          error as Parameters<
-            typeof iframeMessageService.notifySettingsError
-          >[0],
+        notificationPort.notifySettingsError(
+          typeof error === "string"
+            ? { code: "settings_apply_failed", message: error }
+            : error as { code: "settings_apply_failed"; message?: string },
           requestId,
         ),
       notifyComposerContextUpdatedIfChanged: () =>
@@ -1490,6 +1527,7 @@
       refreshAccountList,
       markAuthInitialized: () => authService.markAuthInitialized(),
       getExternalInputBootstrapParams,
+      externalInputEnabled: appRuntimeEnvironment.externalInputEnabled,
       console,
     }).finally(() => {
       isBootstrappingApp = false;
@@ -1858,7 +1896,7 @@
                     minEditorHeight={postEditorMinHeight}
                     onPostSuccess={handlePostSuccess}
                     onCustomEmojiSelect={recordCustomEmojiUse}
-                    notificationPort={iframeMessageService}
+                    {notificationPort}
                   />
                 {/if}
                 {#if customEmojiPickerOpen && CustomEmojiPickerComponent}
@@ -1916,7 +1954,8 @@
         {isAuthenticated}
         {isAuthInitialized}
         {isSwitchingAccount}
-        swNeedRefresh={$swNeedRefresh || staleAssetReloadRequired}
+        swNeedRefresh={appRuntimeEnvironment.serviceWorkerEnabled &&
+          ($swNeedRefresh || staleAssetReloadRequired)}
         onShowLoginDialog={loginDialog.open}
         onPreloadPostHistoryDialog={handlePreloadPostHistoryDialog}
         onOpenPostHistoryDialog={postHistoryDialog.open}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1412,6 +1412,9 @@
   let localeInitialized = $state(false);
 
   onMount(() => {
+    const overlayScopeTarget = appRuntimeEnvironment.overlayTarget;
+    overlayScopeTarget.classList.add("ehagaki-app-root");
+
     if (appRuntimeEnvironment.externalInputEnabled) {
       parentClientAvailable = parentClientAuthService.initialize({
         locationSearch: window.location.search,
@@ -1544,6 +1547,7 @@
     });
 
     return () => {
+      overlayScopeTarget.classList.remove("ehagaki-app-root");
       cleanupVisibilityHandler();
       cleanupRuntimeBindings();
       composerTargetApplyController.dispose();

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1827,7 +1827,7 @@
 
 {#if $locale && localeInitialized}
   <Tooltip.Provider>
-    <main>
+    <main class="ehagaki-app-root">
       <div class="main-content">
         <HeaderComponent
           onResetPostContent={handleResetPostContent}
@@ -1843,7 +1843,11 @@
           showMascot={settingsStore.showMascot}
           showFlavorText={showHeaderBalloonMessage}
         />
-        <div class="composer-scroll-region" bind:this={composerScrollRegionEl}>
+        <div
+          class="composer-scroll-region"
+          part="composer"
+          bind:this={composerScrollRegionEl}
+        >
           <div
             class="composer-scroll-content"
             bind:this={composerScrollContentEl}

--- a/src/components/BlurhashPlaceholder.svelte
+++ b/src/components/BlurhashPlaceholder.svelte
@@ -141,7 +141,8 @@
         );
     }
 
-    :global(:root.dark) .blurhash-placeholder::after {
+    :global(:root.dark .ehagaki-app-root) .blurhash-placeholder::after,
+    :global(:host(.dark) .ehagaki-app-root) .blurhash-placeholder::after {
         background: linear-gradient(
             180deg,
             rgba(0, 0, 0, 0.14),

--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -138,11 +138,11 @@
         background-color: var(--btn-bg);
     }
     /* --- Variant Styles --- */
-    :global(html body :where(.default, .primary, .secondary)) {
+    :global(.ehagaki-app-root :where(.default, .primary, .secondary)) {
         padding: 8px 12px;
     }
 
-    :global(html body :where(.default)) {
+    :global(.ehagaki-app-root :where(.default)) {
         :global(:where(.svg-icon)) {
             width: 24px;
             height: 24px;
@@ -154,7 +154,7 @@
         }
     }
 
-    :global(html body :where(.primary)) {
+    :global(.ehagaki-app-root :where(.primary)) {
         --btn-bg: var(--theme);
         --text: white;
         font-weight: 500;
@@ -199,12 +199,14 @@
         }
     }
 
-    :global(:root.light) button.primary:hover:not(:disabled) :global(.svg-icon),
-    :global(:root.dark) button.primary:hover:not(:disabled) :global(.svg-icon) {
+    :global(:root.light .ehagaki-app-root) button.primary:hover:not(:disabled) :global(.svg-icon),
+    :global(:root.dark .ehagaki-app-root) button.primary:hover:not(:disabled) :global(.svg-icon),
+    :global(:host(.light) .ehagaki-app-root) button.primary:hover:not(:disabled) :global(.svg-icon),
+    :global(:host(.dark) .ehagaki-app-root) button.primary:hover:not(:disabled) :global(.svg-icon) {
         background-color: currentColor;
     }
 
-    :global(html body :where(.secondary)) {
+    :global(.ehagaki-app-root :where(.secondary)) {
         border: 1px solid var(--btn-border);
         --btn-bg: white;
         --text: var(--text-black);
@@ -227,14 +229,16 @@
     .header {
         border: 1px solid var(--hagaki);
         @media (hover: hover) and (pointer: fine) {
-            :global(:root.light) & {
+            :global(:root.light) &,
+            :global(:host(.light)) & {
                 &:hover:not(:disabled) {
                     border-color: color-mix(in srgb, var(--hagaki), black 3%);
                 }
             }
         }
 
-        :global(:root.light) & {
+        :global(:root.light) &,
+        :global(:host(.light)) & {
             --btn-bg: white;
         }
     }
@@ -353,7 +357,7 @@
     }
 
     /* --- Content Layout Styles --- */
-    :global(html body :where(.content-iconText)) {
+    :global(.ehagaki-app-root :where(.content-iconText)) {
         gap: 8px;
         padding: 12px 18px 12px 14px;
     }

--- a/src/components/ChannelPicture.svelte
+++ b/src/components/ChannelPicture.svelte
@@ -3,6 +3,7 @@
         buildChannelPictureProxyUrl,
         normalizeChannelPictureUrl,
     } from "../lib/channelPictureUrlUtils";
+    import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
 
     interface Props {
         eventId: string;
@@ -22,7 +23,8 @@
 
     // Snapshot control once. controllerchange must not switch a live image and
     // cause a second request; a later component mount can use the proxy.
-    const serviceWorkerControlledAtMount = typeof navigator !== "undefined"
+    const serviceWorkerControlledAtMount = getAppRuntimeEnvironment().serviceWorkerEnabled
+        && typeof navigator !== "undefined"
         && !!navigator.serviceWorker?.controller;
     let failedProxyUrl = $state<string | null>(null);
     let normalizedUrl = $derived(normalizeChannelPictureUrl(pictureUrl) ?? "");

--- a/src/components/ComposerTargetDialog.svelte
+++ b/src/components/ComposerTargetDialog.svelte
@@ -1169,7 +1169,7 @@
         outline-offset: -1px;
     }
 
-    :global(html body button.composer-target-clear-button) {
+    :global(.ehagaki-app-root button.composer-target-clear-button) {
         position: absolute;
         inset-block: 50%;
         inset-inline-end: 2px;
@@ -1188,10 +1188,10 @@
         z-index: 1;
     }
 
-    :global(html body button.composer-target-clear-button:hover:not(:disabled)),
-    :global(html body button.composer-target-clear-button:active:not(:disabled)),
-    :global(html body button.composer-target-clear-button:focus-visible),
-    :global(html body button.composer-target-clear-button:disabled) {
+    :global(.ehagaki-app-root button.composer-target-clear-button:hover:not(:disabled)),
+    :global(.ehagaki-app-root button.composer-target-clear-button:active:not(:disabled)),
+    :global(.ehagaki-app-root button.composer-target-clear-button:focus-visible),
+    :global(.ehagaki-app-root button.composer-target-clear-button:disabled) {
         --btn-bg: transparent;
         background-color: transparent;
         background-image: none;
@@ -1199,7 +1199,7 @@
         color: var(--text-muted);
     }
 
-    :global(html body button.composer-target-clear-button:focus-visible) {
+    :global(.ehagaki-app-root button.composer-target-clear-button:focus-visible) {
         outline: 2px solid var(--theme);
         outline-offset: 2px;
     }

--- a/src/components/ConfirmDialog.svelte
+++ b/src/components/ConfirmDialog.svelte
@@ -314,7 +314,8 @@
             color: currentColor;
         }
 
-        :global(:root.dark .btn-cancel.secondary.square) {
+        :global(:root.dark .ehagaki-app-root .btn-cancel.secondary.square),
+        :global(:host(.dark) .ehagaki-app-root .btn-cancel.secondary.square) {
             border: none;
         }
     }

--- a/src/components/ConfirmDialog.svelte
+++ b/src/components/ConfirmDialog.svelte
@@ -2,6 +2,7 @@
     import type { Snippet } from "svelte";
     import { _ } from "svelte-i18n";
     import { AlertDialog } from "bits-ui";
+    import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
     import Button from "./Button.svelte";
     import LoadingPlaceholder from "./LoadingPlaceholder.svelte";
     import { useDialogHistory } from "../lib/hooks/useDialogHistory.svelte";
@@ -119,6 +120,8 @@
         }
     }
 
+    const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
+
     // 確認ボタンのハンドラ
     async function handleConfirm() {
         if (isConfirming) return;
@@ -144,7 +147,7 @@
 </script>
 
 <AlertDialog.Root bind:open onOpenChange={handleOpenChange}>
-    <AlertDialog.Portal>
+    <AlertDialog.Portal to={overlayTarget}>
         <AlertDialog.Overlay class="confirm-dialog-overlay" />
         <AlertDialog.Content
             class={`confirm-dialog-shell ${contentClass}`}

--- a/src/components/DialogWrapper.svelte
+++ b/src/components/DialogWrapper.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { Snippet } from "svelte";
     import { Dialog } from "bits-ui";
+    import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
     import Button from "./Button.svelte";
     import LoadingPlaceholder from "./LoadingPlaceholder.svelte";
 
@@ -95,6 +96,7 @@
     }: Props = $props();
 
     let contentRef: HTMLElement | null = $state(null);
+    const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
     let shouldFocusContent = $derived(initialFocus === "content");
 
     function handleOpenChange(newOpen: boolean) {
@@ -121,7 +123,7 @@
 </script>
 
 <Dialog.Root bind:open onOpenChange={handleOpenChange}>
-    <Dialog.Portal>
+    <Dialog.Portal to={overlayTarget}>
         <Dialog.Overlay class="dialog-overlay" />
         <Dialog.Content
             bind:ref={contentRef}

--- a/src/components/FloatingMessage.svelte
+++ b/src/components/FloatingMessage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { tick } from "svelte";
     import { Portal } from "bits-ui";
+    import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
 
     let {
         show = false,
@@ -21,6 +22,7 @@
     let messageY = $state(0);
 
     const SCREEN_PADDING = 10;
+    const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
 
     $effect(() => {
         if (variant !== "pointer") {
@@ -66,7 +68,7 @@
 </script>
 
 {#if show}
-    <Portal>
+    <Portal to={overlayTarget}>
         <div
             bind:this={container}
             class="floating-message {variant === 'top-right'

--- a/src/components/FooterComponent.svelte
+++ b/src/components/FooterComponent.svelte
@@ -81,7 +81,7 @@
     }
 </script>
 
-<div class="footer-bar">
+<div class="footer-bar" part="footer">
     {#if isSwitchingAccount}
         <Button
             variant="default"
@@ -195,7 +195,8 @@
 </div>
 
 <style>
-    :global(:root.light :where(.footer-bar button):not(.login-btn)) {
+    :global(:root.light .ehagaki-app-root :where(.footer-bar button):not(.login-btn)),
+    :global(:host(.light) .ehagaki-app-root :where(.footer-bar button):not(.login-btn)) {
         --btn-bg: white;
     }
     .footer-bar {

--- a/src/components/HeaderComponent.svelte
+++ b/src/components/HeaderComponent.svelte
@@ -7,6 +7,7 @@
     import { type BalloonMessage as BalloonMessageType } from "../lib/types";
     import { resolveCompactMessageText } from "../lib/utils/headerComponentUtils";
     import { preventKeyboardFocusChange } from "../lib/utils/keyboardFocusUtils";
+    import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
 
     interface Props {
         onResetPostContent: () => void;
@@ -29,6 +30,7 @@
         showMascot = true,
         showFlavorText = true,
     }: Props = $props();
+    const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
 
     let postStatus = $derived(editorState.postStatus);
     let isUploading = $derived(editorState.isUploading);
@@ -103,7 +105,7 @@
                             </Button>
                         {/snippet}
                     </Tooltip.Trigger>
-                    <Tooltip.Portal>
+                    <Tooltip.Portal to={overlayTarget}>
                         <Tooltip.Content sideOffset={8} class="tooltip-content">
                             {$_("postComponent.clear_editor")}
                         </Tooltip.Content>
@@ -133,7 +135,7 @@
                             </Button>
                         {/snippet}
                     </Tooltip.Trigger>
-                    <Tooltip.Portal>
+                    <Tooltip.Portal to={overlayTarget}>
                         <Tooltip.Content sideOffset={8} class="tooltip-content">
                             {$_("draft.list_title") || "下書き"}
                         </Tooltip.Content>
@@ -163,7 +165,7 @@
                             </Button>
                         {/snippet}
                     </Tooltip.Trigger>
-                    <Tooltip.Portal>
+                    <Tooltip.Portal to={overlayTarget}>
                         <Tooltip.Content sideOffset={8} class="tooltip-content">
                             {$_("composerTarget.title")}
                         </Tooltip.Content>

--- a/src/components/HeaderComponent.svelte
+++ b/src/components/HeaderComponent.svelte
@@ -44,7 +44,7 @@
     );
 </script>
 
-<div class="header-container">
+<div class="header-container" part="header">
     <div class="header-left">
         {#if showMascot}
             <a

--- a/src/components/HeaderComponent.svelte
+++ b/src/components/HeaderComponent.svelte
@@ -8,6 +8,7 @@
     import { resolveCompactMessageText } from "../lib/utils/headerComponentUtils";
     import { preventKeyboardFocusChange } from "../lib/utils/keyboardFocusUtils";
     import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
+    import { resolveAppAssetUrl } from "../lib/appAssetUrl";
 
     interface Props {
         onResetPostContent: () => void;
@@ -31,6 +32,7 @@
         showFlavorText = true,
     }: Props = $props();
     const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
+    const ehagakiIconUrl = resolveAppAssetUrl("ehagaki_icon.svg");
 
     let postStatus = $derived(editorState.postStatus);
     let isUploading = $derived(editorState.isUploading);
@@ -53,7 +55,7 @@
                 aria-label="ehagaki"
             >
                 <img
-                    src="./ehagaki_icon.svg"
+                    src={ehagakiIconUrl}
                     alt="ehagaki icon"
                     class="site-icon"
                 />

--- a/src/components/ImageFullscreen.svelte
+++ b/src/components/ImageFullscreen.svelte
@@ -8,6 +8,7 @@
         createFullscreenVideoSlideElement,
         pauseFullscreenVideoContent,
     } from "../lib/utils/fullscreenViewerUtils";
+    import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
 
     interface Props {
         src?: string;
@@ -22,6 +23,7 @@
     type CloseMode = "popstate" | "internal" | null;
 
     const VIEWER_PADDING = { top: 24, bottom: 88, left: 24, right: 24 };
+    const appRuntimeEnvironment = getAppRuntimeEnvironment();
 
     let {
         src = "",
@@ -99,7 +101,7 @@
             }
         }
 
-        if (shouldPopHistory) {
+        if (shouldPopHistory && appRuntimeEnvironment.historyEnabled) {
             history.back();
         }
 
@@ -196,7 +198,7 @@
         const instance = new PhotoSwipe({
             dataSource,
             index: targetIndex,
-            appendToEl: document.body,
+            appendToEl: appRuntimeEnvironment.overlayTarget,
             mainClass: "ehagaki-pswp",
             showHideAnimationType: "none",
             loop: false,
@@ -249,6 +251,7 @@
             normalizedIndex >= 0 &&
             resolvedMediaList.length > 0 &&
             !historyPushed
+            && appRuntimeEnvironment.historyEnabled
         ) {
             history.pushState({ imageFullscreen: true }, "");
             historyPushed = true;

--- a/src/components/InfoPopoverButton.svelte
+++ b/src/components/InfoPopoverButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { Popover } from "bits-ui";
+    import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
 
     interface Props {
         /** ポップオーバーの表示位置 */
@@ -18,13 +19,14 @@
         ariaLabel = "情報を表示",
         children,
     }: Props = $props();
+    const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
 </script>
 
 <Popover.Root>
     <Popover.Trigger class="info-trigger" aria-label={ariaLabel}>
         <div class="info-icon svg-icon"></div>
     </Popover.Trigger>
-    <Popover.Portal>
+    <Popover.Portal to={overlayTarget}>
         <Popover.Content
             {side}
             {sideOffset}

--- a/src/components/KeyboardButtonBar.svelte
+++ b/src/components/KeyboardButtonBar.svelte
@@ -16,6 +16,7 @@
         stopVibration,
     } from "../lib/utils/appDomUtils";
     import { preventKeyboardFocusChange } from "../lib/utils/keyboardFocusUtils";
+    import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
 
     interface Props {
         onUploadImage?: () => void;
@@ -23,6 +24,7 @@
         customEmojiPickerOpen?: boolean;
         onCustomEmojiPickerOpenChange?: (open: boolean) => void;
     }
+    const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
 
     let {
         onUploadImage,
@@ -239,7 +241,7 @@
                         </Button>
                     {/snippet}
                 </Tooltip.Trigger>
-                <Tooltip.Portal>
+                <Tooltip.Portal to={overlayTarget}>
                     <Tooltip.Content sideOffset={8} class="tooltip-content">
                         {$_("keyboardButtonBar.upload_image_tooltip")}
                     </Tooltip.Content>
@@ -364,7 +366,7 @@
                         </Button>
                     {/snippet}
                 </Tooltip.Trigger>
-                <Tooltip.Portal>
+                <Tooltip.Portal to={overlayTarget}>
                     <Tooltip.Content sideOffset={8} class="tooltip-content">
                         {$_("keyboardButtonBar.post_tooltip")}
                     </Tooltip.Content>
@@ -396,7 +398,7 @@
                         </Button>
                     {/snippet}
                 </Tooltip.Trigger>
-                <Tooltip.Portal>
+                <Tooltip.Portal to={overlayTarget}>
                     <Tooltip.Content sideOffset={8} class="tooltip-content">
                         {$_("keyboardButtonBar.content_warning_tooltip")}
                     </Tooltip.Content>
@@ -435,7 +437,7 @@
                         </Button>
                     {/snippet}
                 </Tooltip.Trigger>
-                <Tooltip.Portal>
+                <Tooltip.Portal to={overlayTarget}>
                     <Tooltip.Content sideOffset={8} class="tooltip-content">
                         {$_("keyboardButtonBar.hashtag_pin_tooltip")}
                     </Tooltip.Content>

--- a/src/components/LoadingPlaceholder.svelte
+++ b/src/components/LoadingPlaceholder.svelte
@@ -195,18 +195,20 @@
         transform-origin: center;
     }
 
-    :global(:root.dark) .inline-spinner {
+    :global(:root.dark .ehagaki-app-root) .inline-spinner,
+    :global(:host(.dark) .ehagaki-app-root) .inline-spinner {
         --spinner-track-opacity: 0.14;
         --spinner-arc-opacity: 0.72;
     }
 
-    :global(html body :where(.primary, .danger)) .inline-spinner {
+    :global(.ehagaki-app-root :where(.primary, .danger)) .inline-spinner {
         --spinner-track-opacity: 0.18;
         --spinner-arc-opacity: 0.82;
     }
 
-    :global(html body :where(.secondary, .warning)) .inline-spinner,
-    :global(:root.light body :where(.header)) .inline-spinner {
+    :global(.ehagaki-app-root :where(.secondary, .warning)) .inline-spinner,
+    :global(:root.light .ehagaki-app-root :where(.header)) .inline-spinner,
+    :global(:host(.light) .ehagaki-app-root :where(.header)) .inline-spinner {
         --spinner-track-opacity: 0.12;
         --spinner-arc-opacity: 0.64;
     }

--- a/src/components/LoginDialog.svelte
+++ b/src/components/LoginDialog.svelte
@@ -1322,7 +1322,7 @@
         min-width: 0;
     }
 
-    :global(html body button.clear-input-btn) {
+    :global(.ehagaki-app-root button.clear-input-btn) {
         position: absolute;
         inset: 50% auto 50% auto;
         right: 2px;
@@ -1344,10 +1344,10 @@
         z-index: 1;
     }
 
-    :global(html body button.clear-input-btn:hover:not(:disabled)),
-    :global(html body button.clear-input-btn:active:not(:disabled)),
-    :global(html body button.clear-input-btn:focus-visible),
-    :global(html body button.clear-input-btn:disabled) {
+    :global(.ehagaki-app-root button.clear-input-btn:hover:not(:disabled)),
+    :global(.ehagaki-app-root button.clear-input-btn:active:not(:disabled)),
+    :global(.ehagaki-app-root button.clear-input-btn:focus-visible),
+    :global(.ehagaki-app-root button.clear-input-btn:disabled) {
         --btn-bg: transparent;
         background-color: transparent;
         background-image: none;
@@ -1355,7 +1355,7 @@
         color: var(--text-muted);
     }
 
-    :global(html body button.clear-input-btn:focus-visible) {
+    :global(.ehagaki-app-root button.clear-input-btn:focus-visible) {
         outline: 2px solid var(--theme);
         outline-offset: 2px;
     }

--- a/src/components/MediaGallery.svelte
+++ b/src/components/MediaGallery.svelte
@@ -8,6 +8,7 @@
         SCROLL_MAX_SPEED,
     } from "../lib/constants";
     import { consumeMediaGalleryWheelScroll } from "../lib/utils/mediaGalleryWheelUtils";
+    import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
 
     // PC ドラッグ＆ドロップ状態
     let dragFromIndex = $state(-1);
@@ -218,7 +219,7 @@
                 z-index: 9999;
                 border-radius: 6px;
             `;
-            document.body.appendChild(touchPreviewEl);
+            getAppRuntimeEnvironment().overlayTarget.appendChild(touchPreviewEl);
         }
 
         // タッチイベントリスナーを追加

--- a/src/components/PostHistoryActionMenu.svelte
+++ b/src/components/PostHistoryActionMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { DropdownMenu, Tooltip } from "bits-ui";
     import type { Snippet } from "svelte";
+    import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
 
     interface Props {
         open?: boolean;
@@ -25,6 +26,7 @@
         tooltipContent = undefined,
         enableTooltip = false,
     }: Props = $props();
+    const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
 
     function handleOpenChange(nextOpen: boolean): void {
         onOpenChange?.(nextOpen);
@@ -52,7 +54,7 @@
                         </DropdownMenu.Trigger>
                     {/snippet}
                 </Tooltip.Trigger>
-                <Tooltip.Portal>
+                <Tooltip.Portal to={overlayTarget}>
                     <Tooltip.Content
                         sideOffset={8}
                         class="tooltip-content post-preview-tooltip-content"
@@ -70,7 +72,7 @@
             <div class="more-icon svg-icon"></div>
         </DropdownMenu.Trigger>
     {/if}
-    <DropdownMenu.Portal>
+    <DropdownMenu.Portal to={overlayTarget}>
         <DropdownMenu.Content
             side="bottom"
             {align}

--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -4,6 +4,7 @@
     import { onDestroy, tick, untrack } from "svelte";
     import { _, locale } from "svelte-i18n";
     import { DatePicker, Dialog, DropdownMenu } from "bits-ui";
+    import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
     import Button from "./Button.svelte";
     import ConfirmDialog from "./ConfirmDialog.svelte";
     import DialogWrapper from "./DialogWrapper.svelte";
@@ -21,6 +22,7 @@
     import PostPreviewFooterActionButton from "./PostPreviewFooterActionButton.svelte";
     import PostPreviewToggleButton from "./PostPreviewToggleButton.svelte";
     import PostHistoryThreadGraphPanel from "./PostHistoryThreadGraphPanel.svelte";
+    const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
     import ProfileAvatar from "./ProfileAvatar.svelte";
     import { usePostHistoryChannelDisplay } from "../lib/hooks/usePostHistoryChannelDisplay.svelte";
     import { usePostHistoryCopyNevent } from "../lib/hooks/usePostHistoryCopyNevent.svelte";
@@ -1437,7 +1439,7 @@
             anchor.href = objectUrl;
             anchor.download = `ehagaki-post-history-${getLocalExportDate()}.jsonl`;
             anchor.style.display = "none";
-            document.body.appendChild(anchor);
+            overlayTarget.appendChild(anchor);
             anchor.click();
             setTimeout(() => {
                 anchor.remove();
@@ -1657,7 +1659,7 @@
                 >
                     <div class="more-icon svg-icon"></div>
                 </DropdownMenu.Trigger>
-                <DropdownMenu.Portal>
+                <DropdownMenu.Portal to={overlayTarget}>
                     <DropdownMenu.Content
                         side="bottom"
                         align="end"
@@ -1856,7 +1858,7 @@
                             aria-hidden="true"
                         ></div>
                     </DatePicker.Trigger>
-                    <DatePicker.Portal>
+                    <DatePicker.Portal to={overlayTarget}>
                         <DatePicker.Content
                             sideOffset={8}
                             class="post-history-date-picker-content"
@@ -2103,7 +2105,7 @@
                                                             class="more-icon svg-icon"
                                                         ></div>
                                                     </DropdownMenu.Trigger>
-                                                    <DropdownMenu.Portal>
+                                                    <DropdownMenu.Portal to={overlayTarget}>
                                                         <DropdownMenu.Content
                                                             side="bottom"
                                                             align="start"

--- a/src/components/PostHistoryRepliesBadgeButton.svelte
+++ b/src/components/PostHistoryRepliesBadgeButton.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { Tooltip } from "bits-ui";
     import Button from "./Button.svelte";
+    import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
 
     interface Props {
         count: number;
@@ -11,6 +12,7 @@
     }
 
     let { count, selected, ariaLabel, onClick, tooltipContent = ariaLabel }: Props = $props();
+    const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
 </script>
 
 <Tooltip.Provider>
@@ -37,7 +39,7 @@
                 </Button>
             {/snippet}
         </Tooltip.Trigger>
-        <Tooltip.Portal>
+        <Tooltip.Portal to={overlayTarget}>
             <Tooltip.Content sideOffset={8} class="tooltip-content post-preview-tooltip-content">
                 {tooltipContent}
             </Tooltip.Content>

--- a/src/components/PostPreviewFooterActionButton.svelte
+++ b/src/components/PostPreviewFooterActionButton.svelte
@@ -2,6 +2,7 @@
     import { Tooltip } from "bits-ui";
     import type { Snippet } from "svelte";
     import Button from "./Button.svelte";
+    import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
 
     interface Props {
         tooltipContent: string;
@@ -34,6 +35,7 @@
         ariaLabel = "",
         ...buttonProps
     }: Props = $props();
+    const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
 </script>
 
 <Tooltip.Provider>
@@ -57,7 +59,7 @@
                 </Button>
             {/snippet}
         </Tooltip.Trigger>
-        <Tooltip.Portal>
+        <Tooltip.Portal to={overlayTarget}>
             <Tooltip.Content
                 sideOffset={8}
                 class="tooltip-content post-preview-tooltip-content"

--- a/src/components/PostPreviewToggleButton.svelte
+++ b/src/components/PostPreviewToggleButton.svelte
@@ -27,8 +27,8 @@
     .post-preview-toggle-row {
         display: flex;
 
-        :global(:root) & :global(button.post-preview-toggle-button),
-        :global(:root) & :global(button.post-preview-toggle-button:hover) {
+        :global(.ehagaki-app-root) & :global(button.post-preview-toggle-button),
+        :global(.ehagaki-app-root) & :global(button.post-preview-toggle-button:hover) {
             color: var(--text-muted);
             font-size: 0.875rem;
             font-weight: normal;
@@ -38,7 +38,7 @@
         }
 
         @media (hover: hover) and (pointer: fine) {
-            :global(:root) & :global(button.post-preview-toggle-button:hover) {
+            :global(.ehagaki-app-root) & :global(button.post-preview-toggle-button:hover) {
                 text-decoration: underline;
             }
         }

--- a/src/components/ReplyQuotePreview.svelte
+++ b/src/components/ReplyQuotePreview.svelte
@@ -19,6 +19,7 @@
     } from "../lib/types";
     import { sanitizePlainText } from "../lib/utils/domSanitizer";
     import { shortenMiddle } from "../lib/utils/textDisplayUtils";
+    import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
 
     interface Props {
         reference: ReplyQuoteState;
@@ -41,6 +42,7 @@
         onToggleQuoteNotification?: (enabled: boolean) => void;
         onToggleReplyNotification?: (pubkey: string, enabled: boolean) => void;
     }
+    const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
 
     const LOADING_INDICATOR_DELAY_MS = 300;
 
@@ -236,7 +238,7 @@
                             </Button>
                         {/snippet}
                     </Tooltip.Trigger>
-                    <Tooltip.Portal>
+                    <Tooltip.Portal to={overlayTarget}>
                         <Tooltip.Content
                             sideOffset={8}
                             class="tooltip-content reply-quote-tooltip-content"
@@ -316,7 +318,7 @@
                                     </Button>
                                 {/snippet}
                             </Tooltip.Trigger>
-                            <Tooltip.Portal>
+                            <Tooltip.Portal to={overlayTarget}>
                                 <Tooltip.Content
                                     sideOffset={8}
                                     class="tooltip-content reply-quote-tooltip-content"

--- a/src/components/WelcomeDialog.svelte
+++ b/src/components/WelcomeDialog.svelte
@@ -4,6 +4,7 @@
     import Button from "./Button.svelte";
     import DialogWrapper from "./DialogWrapper.svelte";
     import { useDialogHistory } from "../lib/hooks/useDialogHistory.svelte";
+    import { resolveAppAssetUrl } from "../lib/appAssetUrl";
 
     interface Props {
         show?: boolean;
@@ -11,6 +12,7 @@
     }
 
     let { show = $bindable(false), onClose }: Props = $props();
+    const ehagakiIconUrl = resolveAppAssetUrl("ehagaki_icon.svg");
 
     // ダイアログを閉じるハンドラ
     function handleClose() {
@@ -33,7 +35,7 @@
     <div class="welcome-content">
         <div class="title-section">
             <img
-                src="./ehagaki_icon.svg"
+                src={ehagakiIconUrl}
                 alt="ehagaki icon"
                 class="site-icon"
             />

--- a/src/components/settings/SettingsUploadDestinationSection.svelte
+++ b/src/components/settings/SettingsUploadDestinationSection.svelte
@@ -877,7 +877,7 @@
         outline-offset: -1px;
     }
 
-    :global(html body button.upload-destination-url-clear-button) {
+    :global(.ehagaki-app-root button.upload-destination-url-clear-button) {
         position: absolute;
         inset-block: 50%;
         inset-inline-end: 2px;
@@ -896,10 +896,10 @@
         z-index: 1;
     }
 
-    :global(html body button.upload-destination-url-clear-button:hover:not(:disabled)),
-    :global(html body button.upload-destination-url-clear-button:active:not(:disabled)),
-    :global(html body button.upload-destination-url-clear-button:focus-visible),
-    :global(html body button.upload-destination-url-clear-button:disabled) {
+    :global(.ehagaki-app-root button.upload-destination-url-clear-button:hover:not(:disabled)),
+    :global(.ehagaki-app-root button.upload-destination-url-clear-button:active:not(:disabled)),
+    :global(.ehagaki-app-root button.upload-destination-url-clear-button:focus-visible),
+    :global(.ehagaki-app-root button.upload-destination-url-clear-button:disabled) {
         --btn-bg: transparent;
         background-color: transparent;
         background-image: none;
@@ -907,7 +907,7 @@
         color: var(--text-muted);
     }
 
-    :global(html body button.upload-destination-url-clear-button:focus-visible) {
+    :global(.ehagaki-app-root button.upload-destination-url-clear-button:focus-visible) {
         outline: 2px solid var(--theme);
         outline-offset: 2px;
     }

--- a/src/lib/appAssetUrl.ts
+++ b/src/lib/appAssetUrl.ts
@@ -1,0 +1,7 @@
+import { getAppRuntimeEnvironment } from "./appRuntimeEnvironment";
+
+/** Resolves a small app-owned static asset from the active runtime delivery base. */
+export function resolveAppAssetUrl(path: string): string {
+    const assetBase = getAppRuntimeEnvironment().assetBase;
+    return assetBase ? new URL(path, assetBase).href : `./${path}`;
+}

--- a/src/lib/appEmbedController.ts
+++ b/src/lib/appEmbedController.ts
@@ -162,6 +162,12 @@ interface AppEmbedControllerState {
 }
 
 export interface AppEmbedController {
+    /** Apply the shared composer context semantics without an iframe response. */
+    applyComposerContext(payload: unknown): Promise<void>;
+    /** Apply settings directly for another in-process embedding transport. */
+    applySettings(
+        payload: EmbedSettingsSetPayload,
+    ): Promise<ReadonlyArray<AppEmbedAppliedSettingKey>>;
     handleRemoteComposerSetContext(
         payload: unknown,
         requestId: string,
@@ -308,6 +314,20 @@ export function createAppEmbedController(
     }
 
     return {
+        async applyComposerContext(payload: unknown): Promise<void> {
+            const backgroundTasks = applyRemoteComposerSetContext(payload);
+            state.lastNotifiedComposerContextSignature = buildComposerContextSignature(
+                buildCurrentComposerContextPayload(),
+            );
+            runBackgroundComposerTasks(backgroundTasks);
+        },
+
+        async applySettings(
+            payload: EmbedSettingsSetPayload,
+        ): Promise<ReadonlyArray<AppEmbedAppliedSettingKey>> {
+            return deps.settingsApply.applySettings(payload);
+        },
+
         async handleRemoteComposerSetContext(
             payload: unknown,
             requestId: string,

--- a/src/lib/appRuntimeEnvironment.ts
+++ b/src/lib/appRuntimeEnvironment.ts
@@ -46,7 +46,9 @@ function createDefaultEnvironment(): AppRuntimeEnvironment {
         assetBase: windowObj?.location?.href
             ? new URL(".", windowObj.location.href)
             : undefined,
-        serviceWorkerEnabled: false,
+        // The implicit browser runtime retains the historic PWA behavior.
+        // The Web Component entry explicitly opts out before importing App.
+        serviceWorkerEnabled: true,
         externalInputEnabled: true,
         historyEnabled: true,
     };

--- a/src/lib/appStorage.ts
+++ b/src/lib/appStorage.ts
@@ -8,8 +8,14 @@
 
 let configuredStorage: Storage | undefined;
 
-/** Reserved prefix for the future same-origin Web Component entry. */
-export const EHAGAKI_WEB_COMPONENT_STORAGE_PREFIX = "ehagaki-web-component:";
+/**
+ * The Web Component's host-origin namespace.
+ *
+ * This deliberately uses the documented, versioned public prefix. The
+ * component never receives raw host localStorage, so account cleanup and
+ * legacy migration can only remove keys inside this namespace.
+ */
+export const EHAGAKI_WEB_COMPONENT_STORAGE_PREFIX = "ehagaki.web-component.v1:";
 
 const memoryStorage = new Map<string, string>();
 

--- a/src/lib/bootstrap/appInitializationBootstrap.ts
+++ b/src/lib/bootstrap/appInitializationBootstrap.ts
@@ -44,6 +44,8 @@ interface RunAppInitializationBootstrapParams {
     refreshAccountList: () => void;
     markAuthInitialized: () => void;
     getExternalInputBootstrapParams: () => Omit<RunExternalInputBootstrapParams, "sharedError">;
+    /** Web Component runtime does not consume URL or share-target input. */
+    externalInputEnabled?: boolean;
     console: Nip46RecoveryConsole;
 }
 
@@ -73,6 +75,7 @@ export async function runAppInitializationBootstrap({
     refreshAccountList,
     markAuthInitialized,
     getExternalInputBootstrapParams,
+    externalInputEnabled = true,
     console,
 }: RunAppInitializationBootstrapParams): Promise<void> {
     const sharedError = getSharedErrorFromLocationSearch(locationSearch);
@@ -115,10 +118,12 @@ export async function runAppInitializationBootstrap({
         markAuthInitialized();
     }
 
-    await runExternalInputBootstrap({
-        ...getExternalInputBootstrapParams(),
-        sharedError,
-    });
+    if (externalInputEnabled) {
+        await runExternalInputBootstrap({
+            ...getExternalInputBootstrapParams(),
+            sharedError,
+        });
+    }
 }
 
 export function registerNip46VisibilityHandler({

--- a/src/lib/customEmoji.ts
+++ b/src/lib/customEmoji.ts
@@ -5,6 +5,7 @@ import {
     restoreCachedEmojiItems,
 } from "./customEmojiCachePersistenceUtils";
 import { buildCustomEmojiListFromFetchedEvents } from "./customEmojiFetchUtils";
+import { getAppRuntimeEnvironment } from "./appRuntimeEnvironment";
 import {
     clampCustomEmojiPickerPersistenceHeight,
     readPersistedPickerHeight,
@@ -580,7 +581,11 @@ function scheduleBackgroundTask(task: () => void): void {
 }
 
 export function cacheCustomEmojiImages(urls: string[]): void {
-    if (typeof navigator === "undefined" || !navigator.serviceWorker?.controller) {
+    if (
+        !getAppRuntimeEnvironment().serviceWorkerEnabled
+        || typeof navigator === "undefined"
+        || !navigator.serviceWorker?.controller
+    ) {
         return;
     }
 
@@ -614,6 +619,9 @@ export async function requestCustomEmojiImagesCache(
     urls: string[],
     runtime: RequestCustomEmojiImagesCacheRuntime = {},
 ): Promise<CacheCustomEmojiImagesResult | null> {
+    if (!runtime.navigatorObj && !getAppRuntimeEnvironment().serviceWorkerEnabled) {
+        return null;
+    }
     const navigatorObj = runtime.navigatorObj ??
         (typeof navigator !== "undefined" ? navigator : undefined);
     const controller = navigatorObj?.serviceWorker?.controller;

--- a/src/lib/editor/suggestionRenderer.ts
+++ b/src/lib/editor/suggestionRenderer.ts
@@ -1,4 +1,5 @@
 import { mount, unmount } from 'svelte';
+import { getAppRuntimeEnvironment } from '../appRuntimeEnvironment';
 
 type MountInstance = ReturnType<typeof mount>;
 
@@ -51,7 +52,7 @@ export function createSuggestionRenderer<T>({
             }
             el.style.position = 'fixed';
             el.style.zIndex = zIndex;
-            document.body.appendChild(el);
+            getAppRuntimeEnvironment().overlayTarget.appendChild(el);
             return el;
         }
 

--- a/src/lib/fileUploadManager.ts
+++ b/src/lib/fileUploadManager.ts
@@ -32,6 +32,7 @@ import { getUploadAdapter } from "./upload/uploadAdapterRegistry";
 import { createLegacyUploadDestination } from "./upload/uploadDestinationPresets";
 import { postMediaCacheService } from "./postMediaCacheService";
 import { getAppStorage } from "./appStorage";
+import { getAppRuntimeEnvironment } from "./appRuntimeEnvironment";
 
 // ファイルアップロード専用マネージャークラス
 export class FileUploadManager implements FileUploadManagerInterface {
@@ -426,7 +427,10 @@ export class FileUploadManager implements FileUploadManagerInterface {
 
   // --- 共有メディア処理の統一メソッド ---
   async getSharedMediaFromServiceWorker(): Promise<SharedMediaData | null> {
-    if (!this.dependencies.navigator?.serviceWorker?.controller) return null;
+    if (
+      !getAppRuntimeEnvironment().serviceWorkerEnabled
+      || !this.dependencies.navigator?.serviceWorker?.controller
+    ) return null;
 
     try {
       const channel = new MessageChannel();

--- a/src/lib/hooks/useDialogHistory.svelte.ts
+++ b/src/lib/hooks/useDialogHistory.svelte.ts
@@ -20,6 +20,7 @@
 
 import { onMount, onDestroy } from "svelte";
 import { generateSimpleUUID } from "../utils/appUtils";
+import { getAppRuntimeEnvironment } from "../appRuntimeEnvironment";
 
 /**
  * ダイアログのブラウザ履歴統合を管理するフック
@@ -39,7 +40,8 @@ export function useDialogHistory(
 
     // enabledを評価するヘルパー関数
     const isEnabled = () =>
-        typeof enabled === "function" ? enabled() : enabled;
+        getAppRuntimeEnvironment().historyEnabled
+        && (typeof enabled === "function" ? enabled() : enabled);
 
     // 履歴統合が無効の場合は何もしない（初期チェック）
     if (!isEnabled()) return;

--- a/src/lib/utils/mediaNodeUtils.ts
+++ b/src/lib/utils/mediaNodeUtils.ts
@@ -8,6 +8,7 @@
 
 import type { ImageDimensions, DragEvent } from '../types';
 import { domUtils, isTouchDevice, blurEditorAndBody } from "./appDomUtils";
+import { getAppRuntimeEnvironment } from "../appRuntimeEnvironment";
 
 // =============================================================================
 // サイズ計算
@@ -210,7 +211,7 @@ export function createDragPreview(
 
     applyPreviewStyles(previewEl, dimensions, { x, y });
     previewEl.classList.add("drag-preview");
-    document.body.appendChild(previewEl);
+    getAppRuntimeEnvironment().overlayTarget.appendChild(previewEl);
 
     requestAnimationFrame(() => {
         previewEl!.style.transform = "scale(0.8) rotate(0deg)";

--- a/src/lib/utils/swCommunication.ts
+++ b/src/lib/utils/swCommunication.ts
@@ -1,6 +1,7 @@
 import type { SharedMediaData } from "../types";
 import { SHARE_HANDLER_CONFIG } from '../constants';
 import { sharedMediaRepository } from "../storage/sharedMediaRepository";
+import { getAppRuntimeEnvironment } from "../appRuntimeEnvironment";
 
 /**
  * リクエストIDを生成
@@ -20,7 +21,10 @@ async function sendMessageToServiceWorker(
     message: any,
     timeoutMs: number = SHARE_HANDLER_CONFIG.REQUEST_TIMEOUT
 ): Promise<any> {
-    if (!navigator.serviceWorker.controller) {
+    if (
+        !getAppRuntimeEnvironment().serviceWorkerEnabled
+        || !navigator.serviceWorker.controller
+    ) {
         throw new Error('No ServiceWorker controller available');
     }
 
@@ -77,6 +81,9 @@ export async function acknowledgeSharedMedia(shareId: string): Promise<boolean> 
  * ServiceWorkerの準備を待つ
  */
 async function waitForServiceWorkerController(): Promise<void> {
+    if (!getAppRuntimeEnvironment().serviceWorkerEnabled) {
+        return Promise.reject(new Error("eHagaki ServiceWorker runtime disabled"));
+    }
     if (navigator.serviceWorker.controller) return;
 
     return new Promise<void>((resolve, reject) => {
@@ -171,7 +178,7 @@ export async function checkServiceWorkerStatus(): Promise<{
     hasController: boolean;
     error?: string;
 }> {
-    if (!('serviceWorker' in navigator)) {
+    if (!getAppRuntimeEnvironment().serviceWorkerEnabled || !('serviceWorker' in navigator)) {
         return { isReady: false, hasController: false, error: 'Service Worker not supported' };
     }
 

--- a/src/lib/videoCompression/ffmpegCompression.ts
+++ b/src/lib/videoCompression/ffmpegCompression.ts
@@ -1,4 +1,5 @@
 import { FFmpeg } from '@ffmpeg/ffmpeg';
+import ffmpegClassWorkerAsset from '@ffmpeg/ffmpeg/worker?worker&url';
 import { fetchFile } from '@ffmpeg/util';
 import type { VideoCompressionResult } from '../types';
 import { isDefaultUploadAborted, type UploadAbortChecker } from '../uploadAbortUtils';
@@ -72,7 +73,31 @@ export class FFmpegCompression extends BaseCompression {
                 this.log('Core URL:', coreURL);
                 this.log('WASM URL:', wasmURL);
 
-                await this.ffmpeg.load({ coreURL, wasmURL });
+                const bundledClassWorkerURL = new URL(
+                    ffmpegClassWorkerAsset,
+                    import.meta.url,
+                );
+                // Module workers must be same-origin with their creator. The
+                // PWA's emitted worker already has that origin, but a host
+                // loading this library from a separate asset origin does not.
+                // In that case, fetch the already-bundled worker with CORS and
+                // create the class worker from a host-origin Blob URL.
+                const classWorkerBlobURL = await this.createClassWorkerBlobURL(
+                    bundledClassWorkerURL,
+                );
+                try {
+                    await this.ffmpeg.load({
+                        coreURL,
+                        wasmURL,
+                        ...(classWorkerBlobURL
+                            ? { classWorkerURL: classWorkerBlobURL }
+                            : {}),
+                    });
+                } finally {
+                    if (classWorkerBlobURL) {
+                        URL.revokeObjectURL(classWorkerBlobURL);
+                    }
+                }
                 this.isLoaded = true;
                 this.log('FFmpeg loaded successfully');
             } catch (error) {
@@ -82,6 +107,23 @@ export class FFmpegCompression extends BaseCompression {
         })();
 
         return this.loadPromise;
+    }
+
+    private async createClassWorkerBlobURL(
+        bundledClassWorkerURL: URL,
+    ): Promise<string | null> {
+        if (bundledClassWorkerURL.origin === window.location.origin) {
+            return null;
+        }
+
+        const response = await fetch(bundledClassWorkerURL, { mode: 'cors' });
+        if (!response.ok) {
+            throw new Error('Unable to load the FFmpeg class worker asset.');
+        }
+        const source = await response.text();
+        return URL.createObjectURL(new Blob([source], {
+            type: 'text/javascript',
+        }));
     }
 
     /**

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -16,6 +16,7 @@ let componentOrigin = "";
 let hostOrigin = "";
 let ffmpegCompressionModulePath = "";
 const componentRequests = new Set<string>();
+const hostRequests = new Set<string>();
 
 const sentinels = {
     locale: "host-locale",
@@ -85,6 +86,7 @@ test.beforeAll(async () => {
 
     hostServer = createServer((request, response) => {
         const pathname = new URL(request.url ?? "/", hostOrigin).pathname;
+        hostRequests.add(pathname);
         if (pathname === "/host-sw.js") {
             response.writeHead(200, { "Content-Type": "text/javascript" });
             response.end(`let fetchCount = 0; self.addEventListener('install', () => self.skipWaiting()); self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim())); self.addEventListener('fetch', () => { fetchCount += 1; }); self.addEventListener('message', (event) => { if (event.data?.type === 'host-state') event.ports[0]?.postMessage({ controlled: true, fetchCount }); });`);
@@ -106,6 +108,7 @@ test.beforeAll(async () => {
 
 test.beforeEach(() => {
     componentRequests.clear();
+    hostRequests.clear();
 });
 
 test.afterAll(async () => {
@@ -168,6 +171,46 @@ test("mounts across origins without touching host storage or registering an eHag
     expect(result.hostFetchObserved).toBe(true);
     expect(result.registrationCount).toBe(1);
     await expect(page.locator("#host")).toHaveText("host surface");
+});
+
+test("loads app-owned icons from the component asset base instead of the host", async ({ page }) => {
+    await page.goto(hostOrigin);
+    const result = await page.evaluate(async () => {
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+        };
+        composer.setAttribute("asset-base", `${window.__componentOrigin}/`);
+        document.body.append(composer);
+        await composer.whenReady();
+        const shadow = composer.shadowRoot!;
+        const logo = shadow.querySelector<HTMLImageElement>("img.site-icon")!;
+        await new Promise<void>((resolve, reject) => {
+            if (logo.complete && logo.naturalWidth > 0) {
+                resolve();
+                return;
+            }
+            logo.addEventListener("load", () => resolve(), { once: true });
+            logo.addEventListener("error", () => reject(new Error("logo failed to load")), { once: true });
+        });
+        const masks = [
+            shadow.querySelector<HTMLElement>(".trash-icon")!,
+            shadow.querySelector<HTMLElement>(".login-icon")!,
+            shadow.querySelector<HTMLElement>(".settings-icon")!,
+        ].map((icon) => getComputedStyle(icon).maskImage);
+        return { logoSrc: logo.src, naturalWidth: logo.naturalWidth, masks };
+    });
+
+    expect(result.logoSrc.startsWith(componentOrigin)).toBe(true);
+    expect(result.naturalWidth).toBeGreaterThan(0);
+    for (const mask of result.masks) {
+        expect(mask).not.toBe("none");
+        expect(mask).toContain(componentOrigin);
+    }
+    expect([...hostRequests].some((path) =>
+        path === "/ehagaki_icon.svg" || path.startsWith("/icons/"))).toBe(false);
+    expect(componentRequests).toContain("/ehagaki_icon.svg");
+    expect([...componentRequests].some((path) => path.startsWith("/icons/"))).toBe(true);
 });
 
 test("rejects a second connected component and releases the slot after disconnect", async ({ page }) => {
@@ -249,6 +292,98 @@ test("applies Button variants and host theme classes inside the Shadow DOM", asy
     expect(result.darkHostClass).toBe(true);
     expect(result.lightAppTextColor).not.toBe("rgba(0, 0, 0, 0)");
     expect(result.darkAppTextColor).not.toBe(result.lightAppTextColor);
+});
+
+test("applies Button styles inside a Portal dialog in the Shadow DOM", async ({ page }) => {
+    await page.goto(hostOrigin);
+    await page.evaluate(async () => {
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+            setSettings(value: { themeMode: "light" | "dark" }): Promise<string[]>;
+        };
+        document.body.append(composer);
+        await composer.whenReady();
+        await composer.setSettings({ themeMode: "light" });
+        composer.shadowRoot!.querySelector<HTMLButtonElement>("button.login-btn")!.click();
+    });
+    await page.waitForFunction(() => {
+        const shadow = document.querySelector("ehagaki-composer")?.shadowRoot;
+        const overlay = shadow?.querySelector('[part~="overlay-root"]');
+        return !!overlay?.querySelector(".login-dialog");
+    });
+
+    await page.evaluate(() => {
+        const shadow = document.querySelector("ehagaki-composer")!.shadowRoot!;
+        const overlay = shadow.querySelector<HTMLElement>('[part~="overlay-root"]')!;
+        overlay.querySelector<HTMLDetailsElement>(".remote-signer-details")!.open = true;
+    });
+    await page.waitForFunction(() =>
+        !!document.querySelector("ehagaki-composer")?.shadowRoot
+            ?.querySelector('[part~="overlay-root"] [data-testid="nostrconnect-regenerate"]'),
+    );
+    const lightResult = await page.evaluate(() => {
+        const shadow = document.querySelector("ehagaki-composer")!.shadowRoot!;
+        const overlay = shadow.querySelector<HTMLElement>('[part~="overlay-root"]')!;
+        const primary = overlay.querySelector<HTMLButtonElement>(
+            '[data-testid="nostrconnect-regenerate"]',
+        )!;
+        const secondary = overlay.querySelector<HTMLButtonElement>(
+            ".nostrconnect-relay-editor-actions button.secondary",
+        )!;
+        return {
+            dialogInOverlay: overlay.contains(primary) && overlay.contains(secondary),
+            primaryPadding: getComputedStyle(primary).padding,
+            primaryBackground: getComputedStyle(primary).backgroundColor,
+            secondaryPadding: getComputedStyle(secondary).padding,
+            secondaryBorderTopWidth: getComputedStyle(secondary).borderTopWidth,
+            secondaryBackground: getComputedStyle(secondary).backgroundColor,
+            dialogBackground: getComputedStyle(
+                overlay.querySelector<HTMLElement>(".login-dialog")!,
+            ).backgroundColor,
+        };
+    });
+
+    expect(lightResult.dialogInOverlay).toBe(true);
+    expect(lightResult.primaryPadding).toBe("8px 12px");
+    expect(lightResult.primaryBackground).not.toBe("rgba(0, 0, 0, 0)");
+    expect(lightResult.secondaryPadding).toBe("8px 12px");
+    expect(lightResult.secondaryBorderTopWidth).toBe("1px");
+
+    const darkDialogBackground = await page.evaluate(async () => {
+        const composer = document.querySelector("ehagaki-composer") as HTMLElement & {
+            setSettings(value: { themeMode: "dark" }): Promise<string[]>;
+        };
+        await composer.setSettings({ themeMode: "dark" });
+        return getComputedStyle(
+            composer.shadowRoot!.querySelector<HTMLElement>(
+                '[part~="overlay-root"] .login-dialog',
+            )!,
+        ).backgroundColor;
+    });
+    expect(darkDialogBackground).not.toBe(lightResult.dialogBackground);
+});
+
+test("keeps the normal app Portal Button scope", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForFunction(() =>
+        document.body.classList.contains("ehagaki-app-root")
+            && !!document.querySelector(".welcome-dialog button.primary"),
+    );
+
+    const result = await page.evaluate(() => {
+        const primary = document.querySelector<HTMLButtonElement>(
+            ".welcome-dialog button.primary",
+        )!;
+        return {
+            inBody: document.body.contains(primary),
+            buttonBackground: getComputedStyle(primary).getPropertyValue("--btn-bg"),
+            background: getComputedStyle(primary).backgroundColor,
+        };
+    });
+    expect(result.inBody).toBe(true);
+    expect(result.buttonBackground).toBe("hsl(152, 74%, 43%)");
+    expect(result.background).toBe("rgb(29, 191, 115)");
 });
 
 test("queues setContext before ready and applies content and reply atomically", async ({ page }) => {

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from "@playwright/test";
 import { createServer, type Server } from "node:http";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import { extname, join, normalize } from "node:path";
+import { nip19 } from "nostr-tools";
 
 declare global {
     interface Window {
@@ -13,6 +14,8 @@ let componentServer: Server;
 let hostServer: Server;
 let componentOrigin = "";
 let hostOrigin = "";
+let ffmpegCompressionModulePath = "";
+const componentRequests = new Set<string>();
 
 const sentinels = {
     locale: "host-locale",
@@ -39,9 +42,19 @@ function close(server: Server): Promise<void> {
     return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
 }
 
+function contentTypeFor(filePath: string): string {
+    switch (extname(filePath)) {
+        case ".js": return "text/javascript";
+        case ".wasm": return "application/wasm";
+        case ".svg": return "image/svg+xml";
+        default: return "application/octet-stream";
+    }
+}
+
 test.beforeAll(async () => {
     componentServer = createServer(async (request, response) => {
         const pathname = new URL(request.url ?? "/", componentOrigin).pathname;
+        componentRequests.add(pathname);
         const relativePath = pathname === "/" ? "ehagaki-composer.js" : pathname.slice(1);
         const filePath = normalize(join(process.cwd(), "dist-web-component", relativePath));
         if (!filePath.startsWith(normalize(join(process.cwd(), "dist-web-component")))) {
@@ -52,7 +65,7 @@ test.beforeAll(async () => {
             const body = await readFile(filePath);
             response.writeHead(200, {
                 "Access-Control-Allow-Origin": "*",
-                "Content-Type": extname(filePath) === ".js" ? "text/javascript" : "application/octet-stream",
+                "Content-Type": contentTypeFor(filePath),
             });
             response.end(body);
         } catch {
@@ -61,6 +74,14 @@ test.beforeAll(async () => {
     });
     const componentPort = await listen(componentServer);
     componentOrigin = `http://127.0.0.1:${componentPort}`;
+    const componentAssets = await readdir(join(process.cwd(), "dist-web-component", "assets"));
+    const ffmpegCompressionAsset = componentAssets.find((asset) =>
+        asset.startsWith("ffmpegCompression-") && asset.endsWith(".js"),
+    );
+    if (!ffmpegCompressionAsset) {
+        throw new Error("Web Component FFmpeg compression asset was not emitted.");
+    }
+    ffmpegCompressionModulePath = `assets/${ffmpegCompressionAsset}`;
 
     hostServer = createServer((request, response) => {
         const pathname = new URL(request.url ?? "/", hostOrigin).pathname;
@@ -70,7 +91,9 @@ test.beforeAll(async () => {
             return;
         }
         response.writeHead(200, { "Content-Type": "text/html" });
-        response.end(`<!doctype html><body><script>
+        response.end(`<!doctype html><head><style>
+          ehagaki-composer::part(header) { outline: 3px solid rgb(1, 2, 3); }
+        </style></head><body><script>
           window.__componentOrigin = ${JSON.stringify(componentOrigin)};
           navigator.serviceWorker.register('/host-sw.js');
           for (const [key, value] of Object.entries(${JSON.stringify(sentinels)})) localStorage.setItem(key, value);
@@ -79,6 +102,10 @@ test.beforeAll(async () => {
     const hostPort = await listen(hostServer);
     hostOrigin = `http://127.0.0.1:${hostPort}`;
 
+});
+
+test.beforeEach(() => {
+    componentRequests.clear();
 });
 
 test.afterAll(async () => {
@@ -94,7 +121,7 @@ test("mounts across origins without touching host storage or registering an eHag
             else navigator.serviceWorker.addEventListener("controllerchange", () => resolve(), { once: true });
         });
         await import(`${window.__componentOrigin}/ehagaki-composer.js`);
-        document.body.insertAdjacentHTML("beforeend", "<ehagaki-composer asset-base='" + window.__componentOrigin + "/'></ehagaki-composer>");
+        document.body.insertAdjacentHTML("beforeend", "<ehagaki-composer asset-base='" + window.__componentOrigin + "/' style='--ehagaki-footer-background: rgb(4, 5, 6)'></ehagaki-composer>");
     });
 
     const result = await page.evaluate(async ({ sentinels }) => {
@@ -121,7 +148,9 @@ test("mounts across origins without touching host storage or registering an eHag
             componentKeys,
             applied,
             shadow: !!composer.shadowRoot,
-            parts: ["shell", "overlay-root"].every((part) => !!composer.shadowRoot?.querySelector(`[part~="${part}"]`)),
+            parts: ["shell", "header", "composer", "footer", "overlay-root"].every((part) => !!composer.shadowRoot?.querySelector(`[part~="${part}"]`)),
+            headerOutline: getComputedStyle(composer.shadowRoot!.querySelector('[part~="header"]')!).outlineColor,
+            footerBackground: getComputedStyle(composer.shadowRoot!.querySelector('[part~="footer"]')!).backgroundColor,
             serviceWorkerControlled: !!navigator.serviceWorker.controller,
             hostFetchObserved: afterFetch.fetchCount > beforeFetch.fetchCount,
             registrationCount: registrations.length,
@@ -133,6 +162,8 @@ test("mounts across origins without touching host storage or registering an eHag
     expect(result.applied).toContain("locale");
     expect(result.shadow).toBe(true);
     expect(result.parts).toBe(true);
+    expect(result.headerOutline).toBe("rgb(1, 2, 3)");
+    expect(result.footerBackground).toBe("rgb(4, 5, 6)");
     expect(result.serviceWorkerControlled).toBe(true);
     expect(result.hostFetchObserved).toBe(true);
     expect(result.registrationCount).toBe(1);
@@ -160,4 +191,145 @@ test("rejects a second connected component and releases the slot after disconnec
 
     expect(result.errors).toEqual(["multiple_instances_unsupported"]);
     expect(result.replacementReady).toBe(true);
+});
+
+test("applies Button variants and host theme classes inside the Shadow DOM", async ({ page }) => {
+    await page.goto(hostOrigin);
+    await page.evaluate(async () => {
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+            setSettings(value: { themeMode: "light" | "dark" }): Promise<string[]>;
+        };
+        document.body.append(composer);
+        await composer.whenReady();
+    });
+    await page.waitForFunction(() => {
+        const shadow = document.querySelector("ehagaki-composer")?.shadowRoot;
+        return !!shadow?.querySelector("button.primary.content-iconText")
+            && !!shadow.querySelector("button.default")
+            && !!shadow.querySelector(".footer-bar button");
+    });
+
+    const result = await page.evaluate(async () => {
+        const composer = document.querySelector("ehagaki-composer") as HTMLElement & {
+            setSettings(value: { themeMode: "light" | "dark" }): Promise<string[]>;
+        };
+        const shadow = composer.shadowRoot!;
+        const primary = shadow.querySelector<HTMLButtonElement>("button.primary.content-iconText")!;
+        const defaultButton = shadow.querySelector<HTMLButtonElement>("button.default")!;
+        primary.querySelector(".svg-icon")!.classList.remove("login-icon");
+        defaultButton.classList.remove("circle", "square", "content-icon");
+
+        await composer.setSettings({ themeMode: "light" });
+        const appRoot = shadow.querySelector<HTMLElement>(".ehagaki-app-root")!;
+        const lightAppTextColor = getComputedStyle(appRoot).color;
+        const lightHostClass = composer.classList.contains("light");
+
+        await composer.setSettings({ themeMode: "dark" });
+        const darkAppTextColor = getComputedStyle(appRoot).color;
+
+        return {
+            primaryPadding: getComputedStyle(primary).padding,
+            primaryFontWeight: getComputedStyle(primary).fontWeight,
+            primaryIconWidth: getComputedStyle(primary.querySelector(".svg-icon")!).width,
+            defaultPadding: getComputedStyle(defaultButton).padding,
+            lightHostClass,
+            darkHostClass: composer.classList.contains("dark"),
+            lightAppTextColor,
+            darkAppTextColor,
+        };
+    });
+
+    expect(result.primaryPadding).toBe("12px 18px 12px 14px");
+    expect(result.primaryFontWeight).toBe("500");
+    expect(result.primaryIconWidth).toBe("28px");
+    expect(result.defaultPadding).toBe("8px 12px");
+    expect(result.lightHostClass).toBe(true);
+    expect(result.darkHostClass).toBe(true);
+    expect(result.lightAppTextColor).not.toBe("rgba(0, 0, 0, 0)");
+    expect(result.darkAppTextColor).not.toBe(result.lightAppTextColor);
+});
+
+test("queues setContext before ready and applies content and reply atomically", async ({ page }) => {
+    await page.goto(hostOrigin);
+    const reply = nip19.noteEncode("a".repeat(64));
+    await page.evaluate(async () => {
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+            setContext(value: unknown): Promise<void>;
+        };
+        const queued = composer.setContext({ content: "queued context" });
+        document.body.append(composer);
+        await composer.whenReady();
+        await queued;
+
+    });
+
+    await page.waitForFunction(() =>
+        document.querySelector("ehagaki-composer")?.shadowRoot?.querySelector(".tiptap-editor"),
+    );
+    const result = await page.evaluate(async ({ reply }) => {
+        const composer = document.querySelector("ehagaki-composer") as HTMLElement & {
+            setContext(value: unknown): Promise<void>;
+        };
+        const shadow = composer.shadowRoot!;
+        const contentAfterQueue = shadow.querySelector(".tiptap-editor")?.textContent;
+        await composer.setContext({ reply });
+        const replyApplied = !!shadow.querySelector(".reply-quote-preview");
+
+        const invalidResult = await composer.setContext({
+            content: "must not be applied",
+            reply: "invalid reference",
+        }).then(
+            () => "resolved",
+            (error: Error) => error.name,
+        );
+        return {
+            contentAfterQueue,
+            replyApplied,
+            invalidResult,
+            contentAfterInvalid: shadow.querySelector(".tiptap-editor")?.textContent,
+        };
+    }, { reply });
+
+    expect(result.contentAfterQueue).toContain("queued context");
+    expect(result.replyApplied).toBe(true);
+    expect(result.invalidResult).toBe("EmbedComposerContextValidationError");
+    expect(result.contentAfterInvalid).toContain("queued context");
+    expect(result.contentAfterInvalid).not.toContain("must not be applied");
+});
+
+test("loads the FFmpeg class worker, core, and WASM from a cross-origin Web Component build", async ({ page }) => {
+    await page.goto(hostOrigin);
+    const result = await page.evaluate(async (ffmpegModulePath) => {
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+            assetBase: string | null;
+        };
+        composer.assetBase = `${window.__componentOrigin}/`;
+        document.body.append(composer);
+        await composer.whenReady();
+
+        const module = await import(`${window.__componentOrigin}/${ffmpegModulePath}`) as {
+            FFmpegCompression: new () => { loadFFmpeg(): Promise<void>; cleanup(): Promise<void>; isLoaded: boolean };
+        };
+        const compression = new module.FFmpegCompression();
+        const loadResult = await Promise.race([
+            compression.loadFFmpeg().then(() => "loaded"),
+            new Promise<string>((resolve) => setTimeout(() => resolve("timed-out"), 10_000)),
+        ]);
+        const loaded = compression.isLoaded;
+        await compression.cleanup();
+        return { loaded, loadResult };
+    }, ffmpegCompressionModulePath);
+
+    expect(result.loaded).toBe(true);
+    expect(result.loadResult).toBe("loaded");
+    expect([...componentRequests]).toContain(`/${ffmpegCompressionModulePath}`);
+    expect([...componentRequests].some((path) => /^\/assets\/worker-.*\.js$/.test(path))).toBe(true);
+    expect(componentRequests).toContain("/ffmpeg-core/ffmpeg-core.js");
+    expect(componentRequests).toContain("/ffmpeg-core/ffmpeg-core.wasm");
 });

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect } from "@playwright/test";
+import { createServer, type Server } from "node:http";
+import { readFile } from "node:fs/promises";
+import { extname, join, normalize } from "node:path";
+
+declare global {
+    interface Window {
+        __componentOrigin: string;
+    }
+}
+
+let componentServer: Server;
+let hostServer: Server;
+let componentOrigin = "";
+let hostOrigin = "";
+
+const sentinels = {
+    locale: "host-locale",
+    themeMode: "host-theme",
+    darkMode: "host-dark",
+    firstVisit: "host-first-visit",
+    "nostr-accounts": "host-accounts",
+    "nostr-active-account": "host-active",
+    "__nostrlogin_accounts": "host-legacy-accounts",
+    "__nostrlogin_nip46": "host-legacy-session",
+    "nl-dark-mode": "host-legacy-theme",
+};
+
+function listen(server: Server): Promise<number> {
+    return new Promise((resolve) => {
+        server.listen(0, "127.0.0.1", () => {
+            const address = server.address();
+            resolve(typeof address === "object" && address ? address.port : 0);
+        });
+    });
+}
+
+function close(server: Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+}
+
+test.beforeAll(async () => {
+    componentServer = createServer(async (request, response) => {
+        const pathname = new URL(request.url ?? "/", componentOrigin).pathname;
+        const relativePath = pathname === "/" ? "ehagaki-composer.js" : pathname.slice(1);
+        const filePath = normalize(join(process.cwd(), "dist-web-component", relativePath));
+        if (!filePath.startsWith(normalize(join(process.cwd(), "dist-web-component")))) {
+            response.writeHead(400).end();
+            return;
+        }
+        try {
+            const body = await readFile(filePath);
+            response.writeHead(200, {
+                "Access-Control-Allow-Origin": "*",
+                "Content-Type": extname(filePath) === ".js" ? "text/javascript" : "application/octet-stream",
+            });
+            response.end(body);
+        } catch {
+            response.writeHead(404).end();
+        }
+    });
+    const componentPort = await listen(componentServer);
+    componentOrigin = `http://127.0.0.1:${componentPort}`;
+
+    hostServer = createServer((request, response) => {
+        const pathname = new URL(request.url ?? "/", hostOrigin).pathname;
+        if (pathname === "/host-sw.js") {
+            response.writeHead(200, { "Content-Type": "text/javascript" });
+            response.end(`let fetchCount = 0; self.addEventListener('install', () => self.skipWaiting()); self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim())); self.addEventListener('fetch', () => { fetchCount += 1; }); self.addEventListener('message', (event) => { if (event.data?.type === 'host-state') event.ports[0]?.postMessage({ controlled: true, fetchCount }); });`);
+            return;
+        }
+        response.writeHead(200, { "Content-Type": "text/html" });
+        response.end(`<!doctype html><body><script>
+          window.__componentOrigin = ${JSON.stringify(componentOrigin)};
+          navigator.serviceWorker.register('/host-sw.js');
+          for (const [key, value] of Object.entries(${JSON.stringify(sentinels)})) localStorage.setItem(key, value);
+        </script><div id="host">host surface</div></body>`);
+    });
+    const hostPort = await listen(hostServer);
+    hostOrigin = `http://127.0.0.1:${hostPort}`;
+
+});
+
+test.afterAll(async () => {
+    await Promise.all([close(componentServer), close(hostServer)]);
+});
+
+test("mounts across origins without touching host storage or registering an eHagaki Service Worker", async ({ page }) => {
+    await page.goto(hostOrigin);
+    await page.evaluate(async () => {
+        await navigator.serviceWorker.ready;
+        await new Promise<void>((resolve) => {
+            if (navigator.serviceWorker.controller) resolve();
+            else navigator.serviceWorker.addEventListener("controllerchange", () => resolve(), { once: true });
+        });
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        document.body.insertAdjacentHTML("beforeend", "<ehagaki-composer asset-base='" + window.__componentOrigin + "/'></ehagaki-composer>");
+    });
+
+    const result = await page.evaluate(async ({ sentinels }) => {
+        const composer = document.querySelector("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+            setSettings(value: { locale: "ja"; themeMode: "light" }): Promise<string[]>;
+        };
+        await composer.whenReady();
+        const applied = await composer.setSettings({ locale: "ja", themeMode: "light" });
+        const getHostState = () => new Promise<{ controlled: boolean; fetchCount: number }>((resolve) => {
+            const channel = new MessageChannel();
+            channel.port1.onmessage = (event) => resolve(event.data);
+            navigator.serviceWorker.controller?.postMessage({ type: "host-state" }, [channel.port2]);
+        });
+        const beforeFetch = await getHostState();
+        await fetch("/component-http-probe");
+        const afterFetch = await getHostState();
+        const raw = Object.fromEntries(Object.keys(sentinels).map((key) => [key, localStorage.getItem(key)]));
+        const componentKeys = Array.from({ length: localStorage.length }, (_, index) => localStorage.key(index))
+            .filter((key): key is string => !!key && key.startsWith("ehagaki.web-component.v1:"));
+        const registrations = await navigator.serviceWorker.getRegistrations();
+        return {
+            raw,
+            componentKeys,
+            applied,
+            shadow: !!composer.shadowRoot,
+            parts: ["shell", "overlay-root"].every((part) => !!composer.shadowRoot?.querySelector(`[part~="${part}"]`)),
+            serviceWorkerControlled: !!navigator.serviceWorker.controller,
+            hostFetchObserved: afterFetch.fetchCount > beforeFetch.fetchCount,
+            registrationCount: registrations.length,
+        };
+    }, { sentinels });
+
+    expect(result.raw).toEqual(sentinels);
+    expect(result.componentKeys).toContain("ehagaki.web-component.v1:locale");
+    expect(result.applied).toContain("locale");
+    expect(result.shadow).toBe(true);
+    expect(result.parts).toBe(true);
+    expect(result.serviceWorkerControlled).toBe(true);
+    expect(result.hostFetchObserved).toBe(true);
+    expect(result.registrationCount).toBe(1);
+    await expect(page.locator("#host")).toHaveText("host surface");
+});
+
+test("rejects a second connected component and releases the slot after disconnect", async ({ page }) => {
+    await page.goto(hostOrigin);
+    const result = await page.evaluate(async () => {
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        const first = document.createElement("ehagaki-composer") as HTMLElement & { whenReady(): Promise<void> };
+        document.body.append(first);
+        await first.whenReady();
+        const second = document.createElement("ehagaki-composer") as HTMLElement & { whenReady(): Promise<void> };
+        const errors: string[] = [];
+        second.addEventListener("ehagaki-initialization-error", (event) => errors.push((event as CustomEvent).detail.code));
+        document.body.append(second);
+        await second.whenReady().then(() => "resolved", (error) => error.name);
+        first.remove();
+        const replacement = document.createElement("ehagaki-composer") as HTMLElement & { whenReady(): Promise<void> };
+        document.body.append(replacement);
+        await replacement.whenReady();
+        return { errors, replacementReady: !!replacement.shadowRoot };
+    });
+
+    expect(result.errors).toEqual(["multiple_instances_unsupported"]);
+    expect(result.replacementReady).toBe(true);
+});

--- a/src/test/unit/appAssetUrl.test.ts
+++ b/src/test/unit/appAssetUrl.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+    configureAppRuntimeEnvironment,
+    getAppRuntimeEnvironment,
+} from "../../lib/appRuntimeEnvironment";
+import { resolveAppAssetUrl } from "../../lib/appAssetUrl";
+
+const previousEnvironment = getAppRuntimeEnvironment();
+
+afterEach(() => {
+    configureAppRuntimeEnvironment(previousEnvironment);
+});
+
+describe("resolveAppAssetUrl", () => {
+    it("uses the active runtime asset base", () => {
+        configureAppRuntimeEnvironment({
+            assetBase: new URL("https://component.example/assets/"),
+        });
+
+        expect(resolveAppAssetUrl("ehagaki_icon.svg")).toBe(
+            "https://component.example/assets/ehagaki_icon.svg",
+        );
+    });
+});

--- a/src/test/unit/appEmbedController.test.ts
+++ b/src/test/unit/appEmbedController.test.ts
@@ -108,6 +108,18 @@ describe('createAppEmbedController', () => {
         vi.clearAllMocks();
     });
 
+    it('exposes the same in-process context and settings paths without iframe acknowledgements', async () => {
+        const { controller, composerInput, settingsApply, parentFrame } = createController();
+
+        await controller.applyComposerContext({ content: 'web component content' });
+        await controller.applySettings({ locale: 'en' });
+
+        expect(composerInput.insertText).toHaveBeenCalledWith('web component content');
+        expect(settingsApply.applySettings).toHaveBeenCalledWith({ locale: 'en' });
+        expect(parentFrame.notifyComposerContextApplied).not.toHaveBeenCalled();
+        expect(parentFrame.notifySettingsApplied).not.toHaveBeenCalled();
+    });
+
     it('bootstrapping 中の composer.setContext を保留し、flush で適用する', async () => {
         const { controller, composerInput, parentFrame, setBootstrappingApp } = createController();
         setBootstrappingApp(true);

--- a/src/test/unit/appStorage.test.ts
+++ b/src/test/unit/appStorage.test.ts
@@ -63,4 +63,33 @@ describe("app storage boundary", () => {
         expect(hostStorage.getItem("locale")).toBe("host-locale");
         expect(hostStorage.getItem("nostr-accounts")).toBe("host-accounts");
     });
+
+    it("confines cleanup and legacy-looking keys to the documented v1 namespace", () => {
+        const hostStorage = createMemoryStorage();
+        const sentinels = {
+            locale: "host-locale",
+            themeMode: "host-theme",
+            darkMode: "host-dark",
+            firstVisit: "host-first-visit",
+            "nostr-accounts": "host-accounts",
+            "nostr-active-account": "host-active",
+            "__nostrlogin_accounts": "host-legacy",
+            "__nostrlogin_nip46": "host-session",
+            "nl-dark-mode": "host-nl-theme",
+        };
+        for (const [key, value] of Object.entries(sentinels)) {
+            hostStorage.setItem(key, value);
+        }
+        const scopedStorage = createWebComponentStorage(hostStorage);
+        scopedStorage.setItem("__nostrlogin_accounts", "component-legacy");
+        scopedStorage.removeItem("__nostrlogin_accounts");
+        scopedStorage.clear();
+
+        expect(EHAGAKI_WEB_COMPONENT_STORAGE_PREFIX).toBe(
+            "ehagaki.web-component.v1:",
+        );
+        for (const [key, value] of Object.entries(sentinels)) {
+            expect(hostStorage.getItem(key)).toBe(value);
+        }
+    });
 });

--- a/src/test/unit/playwrightWorktreePort.test.ts
+++ b/src/test/unit/playwrightWorktreePort.test.ts
@@ -107,10 +107,12 @@ describe('Playwright config connection values', () => {
             'desktop-chromium',
             'mobile-chromium',
             'mobile-webkit',
+            'desktop-firefox',
         ]);
-        expect(config.projects?.[2]?.testMatch).toBe(
+        expect(config.projects?.[2]?.testMatch).toEqual([
             '**/composerTargetDialog.spec.ts',
-        );
+            '**/webComponentEmbed.spec.ts',
+        ]);
     });
 
     it('builds all connection values from a supplied port', () => {

--- a/src/test/unit/webComponentIconAssets.test.ts
+++ b/src/test/unit/webComponentIconAssets.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+    applyWebComponentIconAssetUrls,
+    getWebComponentIconVariableName,
+} from "../../web-component/iconAssets";
+
+describe("Web Component icon assets", () => {
+    it("resolves transformed icon variables from the component asset base", () => {
+        const host = document.createElement("div");
+        const root = host.attachShadow({ mode: "open" });
+        const iconPath = "delete_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg";
+        const iconVariable = getWebComponentIconVariableName(iconPath);
+        const style = document.createElement("style");
+        style.textContent = `.icon { mask-image: var(${iconVariable}); }`;
+        root.append(style);
+
+        applyWebComponentIconAssetUrls(
+            root,
+            host,
+            new URL("https://component.example/"),
+        );
+
+        expect(host.style.getPropertyValue(iconVariable)).toBe(
+            `url("https://component.example/icons/${iconPath}")`,
+        );
+    });
+});

--- a/src/test/unit/webComponentNotificationPort.test.ts
+++ b/src/test/unit/webComponentNotificationPort.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import { createWebComponentNotificationPort } from "../../web-component/notificationPort";
+
+describe("Web Component notification port", () => {
+    it("uses composed bubbling CustomEvents and never needs postMessage", () => {
+        const dispatchSafeEvent = vi.fn(() => true);
+        const port = createWebComponentNotificationPort({ dispatchSafeEvent } as never);
+
+        port.notifyPostSuccess({ eventId: "event-id", quotedEventIds: ["quote"] });
+        port.notifyPostError({ code: "post_failed", message: "not exposed" });
+        port.notifyComposerContextUpdated({ reply: null, quotes: [], channel: null });
+
+        expect(dispatchSafeEvent).toHaveBeenNthCalledWith(1, "ehagaki-post-success", {
+            eventId: "event-id",
+            quotedEventIds: ["quote"],
+        });
+        expect(dispatchSafeEvent).toHaveBeenNthCalledWith(2, "ehagaki-post-error", {
+            code: "post_failed",
+        });
+        expect(dispatchSafeEvent).toHaveBeenNthCalledWith(
+            3,
+            "ehagaki-composer-context-updated",
+            { reply: null, quotes: [], channel: null },
+        );
+    });
+});

--- a/src/web-component/element.ts
+++ b/src/web-component/element.ts
@@ -1,4 +1,4 @@
-import { mount, tick, unmount } from "svelte";
+import { mount, unmount } from "svelte";
 import type { AppEmbedAppliedSettingKey } from "../lib/appEmbedController";
 import { configureAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
 import { createWebComponentStorage } from "../lib/appStorage";
@@ -103,6 +103,7 @@ export class EHagakiComposerElement extends HTMLElement {
     #readyState: "pending" | "resolved" | "rejected" = "pending";
     #operationQueue: Promise<void> = Promise.resolve();
     #connectionGeneration = 0;
+    #publicPartsObserver: MutationObserver | null = null;
 
     get assetBase(): string | null {
         return this.getAttribute("asset-base");
@@ -142,6 +143,8 @@ export class EHagakiComposerElement extends HTMLElement {
 
     disconnectedCallback(): void {
         this.#connectionGeneration += 1;
+        this.#publicPartsObserver?.disconnect();
+        this.#publicPartsObserver = null;
         if (activeInstance === this) activeInstance = null;
         if (this.#mountedApp) {
             unmount(this.#mountedApp);
@@ -193,7 +196,7 @@ export class EHagakiComposerElement extends HTMLElement {
             const shadowRoot = this.shadowRoot ?? this.attachShadow({ mode: "open" });
             shadowRoot.replaceChildren();
             const styles = document.createElement("style");
-            styles.textContent = `${transformAppCss(appCss)}\n${photoSwipeCss}\n:host { --bg: var(--ehagaki-background, hsl(0, 0%, 89%)); --text: var(--ehagaki-text, hsl(0, 0%, 24%)); --border: var(--ehagaki-border, hsl(0, 0%, 83%)); --link: var(--ehagaki-link, #1a0dab); --bg-input: var(--ehagaki-input-background, #fff); --bg-footer: var(--ehagaki-footer-background, hsl(0, 0%, 82%)); --dialog-bg: var(--ehagaki-dialog-background, #fff); font-family: var(--ehagaki-font-family, system-ui, sans-serif); } .ehagaki-web-component-shell { min-height: 0; }`;
+            styles.textContent = `${transformAppCss(appCss)}\n${photoSwipeCss}\n:host { --bg: var(--ehagaki-background, light-dark(hsl(0, 0%, 89%), hsl(0, 0%, 12%))); --text: var(--ehagaki-text, light-dark(hsl(0, 0%, 24%), hsl(0, 0%, 90%))); --border: var(--ehagaki-border, light-dark(hsl(0, 0%, 83%), dimgray)); --link: var(--ehagaki-link, light-dark(#1a0dab, #99c3ff)); --bg-input: var(--ehagaki-input-background, light-dark(#fff, hsl(0, 0%, 19%))); --bg-footer: var(--ehagaki-footer-background, light-dark(hsl(0, 0%, 82%), hsl(0, 0%, 10%))); --dialog-bg: var(--ehagaki-dialog-background, light-dark(#fff, hsl(0, 0%, 14%))); font-family: var(--ehagaki-font-family, system-ui, sans-serif); } .ehagaki-web-component-shell { min-height: 0; }`;
             const shell = document.createElement("div");
             shell.className = "ehagaki-web-component-shell";
             shell.part.add("shell");
@@ -231,8 +234,8 @@ export class EHagakiComposerElement extends HTMLElement {
                 props: { notificationPort: createWebComponentNotificationPort(this) },
             });
             this.#app = this.#mountedApp as AppInstance;
-            await tick();
-            this.applyPublicParts(shadowRoot);
+            await this.waitForPublicParts(shadowRoot, generation);
+            if (!this.isConnected || generation !== this.#connectionGeneration) return;
             this.#readyState = "resolved";
             this.#readyResolve?.();
             this.dispatchSafeEvent("ehagaki-ready", { apiVersion: EHAGAKI_COMPOSER_API_VERSION });
@@ -241,17 +244,40 @@ export class EHagakiComposerElement extends HTMLElement {
         }
     }
 
-    private applyPublicParts(root: ShadowRoot): void {
-        root.querySelector("header")?.part.add("header");
-        root.querySelector(".composer-scroll-region")?.part.add("composer");
-        root.querySelector(".footer-bar")?.part.add("footer");
-    }
-
     private requireApp(): AppInstance {
         if (!this.#app) {
             throw createError("initialization_failed", "eHagaki Composer is not ready.");
         }
         return this.#app;
+    }
+
+    private waitForPublicParts(root: ShadowRoot, generation: number): Promise<void> {
+        const requiredParts = ["header", "composer", "footer"];
+        const hasRequiredParts = () => requiredParts.every((part) =>
+            root.querySelector(`[part~="${part}"]`),
+        );
+        if (hasRequiredParts()) {
+            return Promise.resolve();
+        }
+
+        return new Promise((resolve) => {
+            const observer = new MutationObserver(() => {
+                if (
+                    generation !== this.#connectionGeneration
+                    || !this.isConnected
+                    || !hasRequiredParts()
+                ) {
+                    return;
+                }
+                observer.disconnect();
+                if (this.#publicPartsObserver === observer) {
+                    this.#publicPartsObserver = null;
+                }
+                resolve();
+            });
+            this.#publicPartsObserver = observer;
+            observer.observe(root, { childList: true, subtree: true });
+        });
     }
 
     private enqueue<T>(operation: () => Promise<T>): Promise<T> {

--- a/src/web-component/element.ts
+++ b/src/web-component/element.ts
@@ -1,0 +1,275 @@
+import { mount, tick, unmount } from "svelte";
+import type { AppEmbedAppliedSettingKey } from "../lib/appEmbedController";
+import { configureAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
+import { createWebComponentStorage } from "../lib/appStorage";
+import type {
+    EmbedComposerSetContextPayload,
+    EmbedSettingsSetPayload,
+} from "../lib/embedProtocol";
+import appCss from "../app.css?inline";
+import photoSwipeCss from "photoswipe/style.css?inline";
+import {
+    EHAGAKI_COMPOSER_API_VERSION,
+    type EHagakiComposerContext,
+    type EHagakiComposerInitializationErrorDetail,
+    type EHagakiComposerSettings,
+} from "./types";
+import { createWebComponentNotificationPort } from "./notificationPort";
+
+type AppInstance = {
+    setEmbedContext(payload: unknown): Promise<void>;
+    setEmbedSettings(
+        payload: EmbedSettingsSetPayload,
+    ): Promise<ReadonlyArray<AppEmbedAppliedSettingKey>>;
+};
+
+let activeInstance: EHagakiComposerElement | null = null;
+
+function createError(code: EHagakiComposerInitializationErrorDetail["code"], message: string): Error {
+    const error = new Error(message);
+    error.name = code;
+    return error;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateSettings(value: EHagakiComposerSettings): EmbedSettingsSetPayload {
+    if (!isRecord(value)) {
+        throw createError("initialization_failed", "Invalid settings payload.");
+    }
+    const validStrings = {
+        locale: new Set(["ja", "en"]),
+        themeMode: new Set(["system", "light", "dark"]),
+        imageQualityLevel: new Set(["none", "low", "medium", "high"]),
+        videoQualityLevel: new Set(["none", "low", "medium", "high"]),
+        imageCompressionLevel: new Set(["none", "low", "medium", "high"]),
+        videoCompressionLevel: new Set(["none", "low", "medium", "high"]),
+    } as const;
+    const validBooleanKeys = new Set([
+        "clientTagEnabled",
+        "quoteNotificationEnabled",
+        "replyNotificationEnabled",
+        "mediaFreePlacement",
+        "showMascot",
+        "showFlavorText",
+    ]);
+    const validKeys = new Set([
+        ...Object.keys(validStrings),
+        ...validBooleanKeys,
+        "uploadEndpoint",
+    ]);
+
+    for (const [key, setting] of Object.entries(value)) {
+        if (!validKeys.has(key)) {
+            throw createError("initialization_failed", "Invalid settings payload.");
+        }
+        if (key in validStrings) {
+            const choices = validStrings[key as keyof typeof validStrings];
+            if (typeof setting !== "string" || !choices.has(setting as never)) {
+                throw createError("initialization_failed", "Invalid settings payload.");
+            }
+        } else if (validBooleanKeys.has(key) && typeof setting !== "boolean") {
+            throw createError("initialization_failed", "Invalid settings payload.");
+        } else if (key === "uploadEndpoint" && typeof setting !== "string") {
+            throw createError("initialization_failed", "Invalid settings payload.");
+        }
+    }
+    return value;
+}
+
+function transformAppCss(css: string): string {
+    // app.css is authored for the document root. In this build it is copied
+    // into the component's open shadow tree instead of touching host styles.
+    return css
+        .replaceAll(":root", ":host")
+        .replace("html,\nbody,\n#app", ":host,\n.ehagaki-web-component-shell")
+        .replace("#app {", ".ehagaki-web-component-shell {")
+        .replace("body {", ".ehagaki-web-component-shell {");
+}
+
+export class EHagakiComposerElement extends HTMLElement {
+    static get observedAttributes(): string[] {
+        return ["asset-base"];
+    }
+
+    #app: AppInstance | null = null;
+    #mountedApp: ReturnType<typeof mount> | null = null;
+    #mountPromise: Promise<void> | null = null;
+    #readyResolve: (() => void) | null = null;
+    #readyReject: ((reason?: unknown) => void) | null = null;
+    #readyPromise: Promise<void> = this.createReadyPromise();
+    #readyState: "pending" | "resolved" | "rejected" = "pending";
+    #operationQueue: Promise<void> = Promise.resolve();
+    #connectionGeneration = 0;
+
+    get assetBase(): string | null {
+        return this.getAttribute("asset-base");
+    }
+
+    set assetBase(value: string | null) {
+        if (value === null || value === "") {
+            this.removeAttribute("asset-base");
+            return;
+        }
+        this.setAttribute("asset-base", value);
+    }
+
+    attributeChangedCallback(): void {
+        // The delivery base must be configured before the stateful app graph is
+        // imported. Changing it after connection applies on the next mount.
+    }
+
+    connectedCallback(): void {
+        if (this.#mountPromise) return;
+        if (activeInstance && activeInstance !== this) {
+            const error = createError(
+                "multiple_instances_unsupported",
+                "Only one ehagaki-composer can be connected in a document.",
+            );
+            this.fail("multiple_instances_unsupported", error.message, error);
+            return;
+        }
+
+        if (this.#readyState !== "pending") {
+            this.#readyPromise = this.createReadyPromise();
+            this.#readyState = "pending";
+        }
+        activeInstance = this;
+        this.#mountPromise = this.mountApp();
+    }
+
+    disconnectedCallback(): void {
+        this.#connectionGeneration += 1;
+        if (activeInstance === this) activeInstance = null;
+        if (this.#mountedApp) {
+            unmount(this.#mountedApp);
+            this.#mountedApp = null;
+        }
+        this.#app = null;
+        this.#mountPromise = null;
+        if (this.#readyState === "pending") {
+            this.#readyState = "rejected";
+            this.#readyReject?.(createError("disconnected", "Component was disconnected before it became ready."));
+        }
+    }
+
+    whenReady(): Promise<void> {
+        return this.#readyPromise;
+    }
+
+    setContext(context: EHagakiComposerContext): Promise<void> {
+        return this.enqueue(async () => {
+            await this.requireApp().setEmbedContext(context as EmbedComposerSetContextPayload);
+        });
+    }
+
+    setSettings(
+        settings: EHagakiComposerSettings,
+    ): Promise<ReadonlyArray<AppEmbedAppliedSettingKey>> {
+        return this.enqueue(async () =>
+            this.requireApp().setEmbedSettings(validateSettings(settings)));
+    }
+
+    dispatchSafeEvent(type: string, detail: Record<string, unknown>): boolean {
+        return this.dispatchEvent(new CustomEvent(type, {
+            bubbles: true,
+            composed: true,
+            detail,
+        }));
+    }
+
+    private createReadyPromise(): Promise<void> {
+        return new Promise<void>((resolve, reject) => {
+            this.#readyResolve = resolve;
+            this.#readyReject = reject;
+        });
+    }
+
+    private async mountApp(): Promise<void> {
+        const generation = ++this.#connectionGeneration;
+        try {
+            const shadowRoot = this.shadowRoot ?? this.attachShadow({ mode: "open" });
+            shadowRoot.replaceChildren();
+            const styles = document.createElement("style");
+            styles.textContent = `${transformAppCss(appCss)}\n${photoSwipeCss}\n:host { --bg: var(--ehagaki-background, hsl(0, 0%, 89%)); --text: var(--ehagaki-text, hsl(0, 0%, 24%)); --border: var(--ehagaki-border, hsl(0, 0%, 83%)); --link: var(--ehagaki-link, #1a0dab); --bg-input: var(--ehagaki-input-background, #fff); --bg-footer: var(--ehagaki-footer-background, hsl(0, 0%, 82%)); --dialog-bg: var(--ehagaki-dialog-background, #fff); font-family: var(--ehagaki-font-family, system-ui, sans-serif); } .ehagaki-web-component-shell { min-height: 0; }`;
+            const shell = document.createElement("div");
+            shell.className = "ehagaki-web-component-shell";
+            shell.part.add("shell");
+            const mountTarget = document.createElement("div");
+            mountTarget.className = "ehagaki-web-component-app";
+            const overlayTarget = document.createElement("div");
+            overlayTarget.className = "ehagaki-web-component-overlays";
+            overlayTarget.part.add("overlay-root");
+            shell.append(mountTarget, overlayTarget);
+            shadowRoot.append(styles, shell);
+
+            const assetBase = new URL(
+                this.assetBase ?? "./",
+                import.meta.url,
+            );
+            configureAppRuntimeEnvironment({
+                storage: createWebComponentStorage(window.localStorage),
+                window,
+                document,
+                domRoot: shadowRoot,
+                styleTarget: shell,
+                layoutTarget: shell,
+                overlayTarget,
+                themeTarget: this,
+                assetBase,
+                serviceWorkerEnabled: false,
+                externalInputEnabled: false,
+                historyEnabled: false,
+            });
+
+            const { default: App } = await import("../App.svelte");
+            if (!this.isConnected || generation !== this.#connectionGeneration) return;
+            this.#mountedApp = mount(App, {
+                target: mountTarget,
+                props: { notificationPort: createWebComponentNotificationPort(this) },
+            });
+            this.#app = this.#mountedApp as AppInstance;
+            await tick();
+            this.applyPublicParts(shadowRoot);
+            this.#readyState = "resolved";
+            this.#readyResolve?.();
+            this.dispatchSafeEvent("ehagaki-ready", { apiVersion: EHAGAKI_COMPOSER_API_VERSION });
+        } catch {
+            this.fail("initialization_failed", "eHagaki Composer could not be initialized.");
+        }
+    }
+
+    private applyPublicParts(root: ShadowRoot): void {
+        root.querySelector("header")?.part.add("header");
+        root.querySelector(".composer-scroll-region")?.part.add("composer");
+        root.querySelector(".footer-bar")?.part.add("footer");
+    }
+
+    private requireApp(): AppInstance {
+        if (!this.#app) {
+            throw createError("initialization_failed", "eHagaki Composer is not ready.");
+        }
+        return this.#app;
+    }
+
+    private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+        const queued = this.#operationQueue.then(async () => {
+            await this.whenReady();
+            return operation();
+        });
+        this.#operationQueue = queued.then(() => undefined, () => undefined);
+        return queued;
+    }
+
+    private fail(
+        code: EHagakiComposerInitializationErrorDetail["code"],
+        message: string,
+        reason: unknown = createError(code, message),
+    ): void {
+        this.#readyState = "rejected";
+        this.#readyReject?.(reason);
+        this.dispatchSafeEvent("ehagaki-initialization-error", { code, message });
+    }
+}

--- a/src/web-component/element.ts
+++ b/src/web-component/element.ts
@@ -15,6 +15,7 @@ import {
     type EHagakiComposerSettings,
 } from "./types";
 import { createWebComponentNotificationPort } from "./notificationPort";
+import { applyWebComponentIconAssetUrls } from "./iconAssets";
 
 type AppInstance = {
     setEmbedContext(payload: unknown): Promise<void>;
@@ -104,6 +105,7 @@ export class EHagakiComposerElement extends HTMLElement {
     #operationQueue: Promise<void> = Promise.resolve();
     #connectionGeneration = 0;
     #publicPartsObserver: MutationObserver | null = null;
+    #assetStyleObserver: MutationObserver | null = null;
 
     get assetBase(): string | null {
         return this.getAttribute("asset-base");
@@ -145,6 +147,8 @@ export class EHagakiComposerElement extends HTMLElement {
         this.#connectionGeneration += 1;
         this.#publicPartsObserver?.disconnect();
         this.#publicPartsObserver = null;
+        this.#assetStyleObserver?.disconnect();
+        this.#assetStyleObserver = null;
         if (activeInstance === this) activeInstance = null;
         if (this.#mountedApp) {
             unmount(this.#mountedApp);
@@ -203,7 +207,7 @@ export class EHagakiComposerElement extends HTMLElement {
             const mountTarget = document.createElement("div");
             mountTarget.className = "ehagaki-web-component-app";
             const overlayTarget = document.createElement("div");
-            overlayTarget.className = "ehagaki-web-component-overlays";
+            overlayTarget.className = "ehagaki-web-component-overlays ehagaki-app-root";
             overlayTarget.part.add("overlay-root");
             shell.append(mountTarget, overlayTarget);
             shadowRoot.append(styles, shell);
@@ -212,6 +216,13 @@ export class EHagakiComposerElement extends HTMLElement {
                 this.assetBase ?? "./",
                 import.meta.url,
             );
+            this.#assetStyleObserver = new MutationObserver(() => {
+                applyWebComponentIconAssetUrls(shadowRoot, shell, assetBase);
+            });
+            this.#assetStyleObserver.observe(shadowRoot, {
+                childList: true,
+                subtree: true,
+            });
             configureAppRuntimeEnvironment({
                 storage: createWebComponentStorage(window.localStorage),
                 window,
@@ -233,6 +244,7 @@ export class EHagakiComposerElement extends HTMLElement {
                 target: mountTarget,
                 props: { notificationPort: createWebComponentNotificationPort(this) },
             });
+            applyWebComponentIconAssetUrls(shadowRoot, shell, assetBase);
             this.#app = this.#mountedApp as AppInstance;
             await this.waitForPublicParts(shadowRoot, generation);
             if (!this.isConnected || generation !== this.#connectionGeneration) return;

--- a/src/web-component/entry.ts
+++ b/src/web-component/entry.ts
@@ -1,0 +1,9 @@
+import { EHagakiComposerElement } from "./element";
+import { EHAGAKI_COMPOSER_TAG_NAME } from "./types";
+
+export { EHagakiComposerElement, EHAGAKI_COMPOSER_TAG_NAME };
+export * from "./types";
+
+if (!customElements.get(EHAGAKI_COMPOSER_TAG_NAME)) {
+    customElements.define(EHAGAKI_COMPOSER_TAG_NAME, EHagakiComposerElement);
+}

--- a/src/web-component/iconAssets.ts
+++ b/src/web-component/iconAssets.ts
@@ -1,0 +1,49 @@
+const ICON_VARIABLE_PREFIX = "--ehagaki-icon-";
+const ICON_VARIABLE_PATTERN = /--ehagaki-icon-([0-9a-f]+)/g;
+
+function encodeIconPath(path: string): string {
+    return Array.from(
+        path,
+        (character) => character.charCodeAt(0).toString(16).padStart(2, "0"),
+    ).join("");
+}
+
+function decodeIconPath(encodedPath: string): string | null {
+    if (encodedPath.length === 0 || encodedPath.length % 2 !== 0) return null;
+    const path = Array.from({ length: encodedPath.length / 2 }, (_, index) =>
+        String.fromCharCode(
+            Number.parseInt(encodedPath.slice(index * 2, index * 2 + 2), 16),
+        ),
+    ).join("");
+    return /^[A-Za-z0-9._-]+\.svg$/.test(path) ? path : null;
+}
+
+/**
+ * A build-only transform uses this stable CSS property name in place of a
+ * document-root `/icons/...` URL. The property value is resolved once the
+ * Web Component knows its delivery `assetBase`.
+ */
+export function getWebComponentIconVariableName(iconPath: string): string {
+    return `${ICON_VARIABLE_PREFIX}${encodeIconPath(iconPath)}`;
+}
+
+export function applyWebComponentIconAssetUrls(
+    root: ShadowRoot,
+    target: HTMLElement,
+    assetBase: URL,
+): void {
+    const names = new Set<string>();
+    for (const style of root.querySelectorAll("style")) {
+        for (const match of style.textContent?.matchAll(ICON_VARIABLE_PATTERN) ?? []) {
+            names.add(match[0]);
+        }
+    }
+    for (const name of names) {
+        const iconPath = decodeIconPath(name.slice(ICON_VARIABLE_PREFIX.length));
+        if (!iconPath) continue;
+        target.style.setProperty(
+            name,
+            `url("${new URL(`icons/${iconPath}`, assetBase).href}")`,
+        );
+    }
+}

--- a/src/web-component/notificationPort.ts
+++ b/src/web-component/notificationPort.ts
@@ -1,0 +1,59 @@
+import type { AppEmbedNotificationPort } from "../lib/appEmbedController";
+import type { AppPostNotificationPort } from "../lib/appNotificationPort";
+import type { EHagakiComposerElement } from "./element";
+
+/**
+ * In-process notification adapter. It deliberately has no postMessage path:
+ * Web Components run in the host Window realm and communicate with their host
+ * through DOM events instead.
+ */
+export function createWebComponentNotificationPort(
+    element: EHagakiComposerElement,
+): AppPostNotificationPort & AppEmbedNotificationPort {
+    return {
+        notifyPostSuccess(options = {}) {
+            element.dispatchSafeEvent("ehagaki-post-success", {
+                ...options,
+                ...(options.quotedEventIds
+                    ? { quotedEventIds: [...options.quotedEventIds] }
+                    : {}),
+            });
+            return true;
+        },
+        notifyPostError(error) {
+            const code = typeof error === "object" && error?.code
+                ? error.code
+                : "post_failed";
+            element.dispatchSafeEvent("ehagaki-post-error", { code });
+            return true;
+        },
+        notifyComposerContextApplied() {
+            return true;
+        },
+        notifyComposerContextError(error) {
+            element.dispatchSafeEvent("ehagaki-initialization-error", {
+                code: error.code,
+                message: "Composer context could not be applied.",
+            });
+            return true;
+        },
+        notifyComposerContextUpdated(payload) {
+            element.dispatchSafeEvent("ehagaki-composer-context-updated", {
+                reply: payload.reply,
+                quotes: [...payload.quotes],
+                channel: payload.channel ?? null,
+            });
+            return true;
+        },
+        notifySettingsApplied() {
+            return true;
+        },
+        notifySettingsError(error) {
+            element.dispatchSafeEvent("ehagaki-initialization-error", {
+                code: error.code,
+                message: "Settings could not be applied.",
+            });
+            return true;
+        },
+    };
+}

--- a/src/web-component/types.ts
+++ b/src/web-component/types.ts
@@ -1,0 +1,30 @@
+import type {
+    EmbedComposerSetContextPayload,
+    EmbedSettingsSetPayload,
+} from "../lib/embedProtocol";
+
+export const EHAGAKI_COMPOSER_TAG_NAME = "ehagaki-composer";
+export const EHAGAKI_COMPOSER_API_VERSION = 1;
+
+export type EHagakiComposerContext = EmbedComposerSetContextPayload;
+export type EHagakiComposerSettings = EmbedSettingsSetPayload;
+
+export interface EHagakiComposerReadyDetail {
+    apiVersion: typeof EHAGAKI_COMPOSER_API_VERSION;
+}
+
+export interface EHagakiComposerInitializationErrorDetail {
+    code: "initialization_failed" | "multiple_instances_unsupported" | "disconnected";
+    message: string;
+}
+
+export interface EHagakiComposerPostSuccessDetail {
+    eventId?: string;
+    replyToEventId?: string;
+    quotedEventIds?: string[];
+}
+
+export interface EHagakiComposerPostErrorDetail {
+    code: string;
+    message?: string;
+}

--- a/vite.web-component.config.ts
+++ b/vite.web-component.config.ts
@@ -1,6 +1,29 @@
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { viteStaticCopy } from "vite-plugin-static-copy";
+import { getWebComponentIconVariableName } from "./src/web-component/iconAssets";
+
+const iconUrlPattern = /url\((["'])\/icons\/([^"'()]+)\1\)/g;
+
+function resolveWebComponentIconUrls() {
+    return {
+        name: "ehagaki-web-component-icon-urls",
+        enforce: "pre" as const,
+        transform(source: string, id: string) {
+            if (!id.endsWith(".svelte") || !source.includes("/icons/")) {
+                return null;
+            }
+            return {
+                code: source.replace(
+                    iconUrlPattern,
+                    (_match, _quote, iconPath: string) =>
+                        `var(${getWebComponentIconVariableName(iconPath)})`,
+                ),
+                map: null,
+            };
+        },
+    };
+}
 
 /**
  * Standalone Web Component distribution. It intentionally excludes the PWA
@@ -18,6 +41,7 @@ export default defineConfig({
     worker: { format: "es" },
     assetsInclude: ["**/*.wasm"],
     plugins: [
+        resolveWebComponentIconUrls(),
         svelte({ compilerOptions: { customElement: true } }),
         viteStaticCopy({
             targets: [

--- a/vite.web-component.config.ts
+++ b/vite.web-component.config.ts
@@ -1,0 +1,56 @@
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { viteStaticCopy } from "vite-plugin-static-copy";
+
+/**
+ * Standalone Web Component distribution. It intentionally excludes the PWA
+ * plugin, manifest, service worker registration, share target, and fixed
+ * iframe bridge used by the regular application build.
+ */
+export default defineConfig({
+    base: "./",
+    // Do not copy the PWA's public service worker or iframe sample. The small
+    // set of runtime assets used by the component is copied explicitly below.
+    publicDir: false,
+    optimizeDeps: {
+        exclude: ["@ffmpeg/ffmpeg", "@ffmpeg/util", "@jsquash/webp"],
+    },
+    worker: { format: "es" },
+    assetsInclude: ["**/*.wasm"],
+    plugins: [
+        svelte({ compilerOptions: { customElement: true } }),
+        viteStaticCopy({
+            targets: [
+                {
+                    src: "node_modules/@ffmpeg/core/dist/esm/*",
+                    dest: "ffmpeg-core",
+                },
+                {
+                    src: "public/icons/**/*",
+                    dest: "icons",
+                },
+                {
+                    src: "public/ehagaki_icon.svg",
+                    dest: ".",
+                },
+            ],
+        }),
+    ],
+    build: {
+        outDir: "dist-web-component",
+        emptyOutDir: true,
+        cssCodeSplit: false,
+        lib: {
+            entry: "src/web-component/entry.ts",
+            formats: ["es"],
+            fileName: "ehagaki-composer",
+        },
+        rollupOptions: {
+            output: {
+                entryFileNames: "ehagaki-composer.js",
+                chunkFileNames: "assets/[name]-[hash].js",
+                assetFileNames: "assets/[name]-[hash][extname]",
+            },
+        },
+    },
+});


### PR DESCRIPTION
## Summary
- add the standalone <ehagaki-composer> ES-module Web Component with ShadowRoot lifecycle, public API, events, and one-instance guard
- isolate component localStorage under ehagaki.web-component.v1:, disable eHagaki SW/external-input/history paths, and keep iframe/PWA behavior unchanged
- add a separate Web Component build, cross-origin browser coverage, and integration documentation

## Verification
- npm run check
- npm test
- npm run build
- npm run build:web-component
- npx playwright test src/test/e2e/webComponentEmbed.spec.ts --project=desktop-chromium --project=mobile-chromium --project=mobile-webkit --project=desktop-firefox
- npx playwright test src/test/e2e/iframeMessageGate.spec.ts
- git diff --check

## Related issue

Related to #89.

Web Component embedding is implemented by this PR. Browser-level proof of the relay WebSocket interception use case remains pending, so #89 should remain open.