### PR TITLE
feat: add Web Component parent client reference sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-web-component
 dist-ssr
 *.local
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ eHagaki（えはがき）は、画像・動画圧縮機能付きの投稿専用N
 - **リプライ・引用・チャンネル投稿**: 各種URLクエリや`nostr:` URIを通じたリプライ・引用投稿（NIP-10, NIP-18）に対応。パブリックチャット（NIP-28）のチャンネルへの投稿もサポート
 - **Content Warning (CW)**: センシティブなコンテンツ（NIP-36）に対する警告の設定が可能
 - **iframe埋め込み**: 他アプリの投稿フォームとして組み込んで利用するためのAPIを提供
+- **Web Component埋め込み**: 同一Window realmで利用できる `ehagaki-composer` と公開method/event/style APIを提供
 - **多言語対応**: 日本語・英語に対応（ブラウザ設定から自動判定）
 
 ## URLクエリ
@@ -72,6 +73,14 @@ eHagaki の iframe 埋め込み方法、親クライアント連携ログイン�
 - 親クライアント連携ログイン
 - `ehagaki.embed` envelope と `post.success` / `post.error` の受信方法
 - `auth.login` / `auth.request` / `auth.result` / `auth.error` / `rpc.request` の流れ
+
+## Web Component埋め込み
+
+Web Component版の公開API、lifecycle、context/settings、CustomEvent、CSS Custom Properties / `::part()`、storageとtrust boundaryは [docs/WEB_COMPONENT.md](docs/WEB_COMPONENT.md) にまとめています。
+
+実際に `Create / Mount`、`Destroy / Unmount`、再生成、設定・context更新、2個目instanceの拒否、event log、host側styleを操作するlive sampleは [https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html](https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html) から確認できます。
+
+Web Componentではiframeのparent-client auth/RPCや `postMessage` を使いません。ログインは埋め込まれたeHagakiの既存UIから行い、NIP-07はhostの `window.nostr` を直接利用します。host JavaScriptから秘密情報を隔離したい場合はiframe埋め込みを使用してください。
 
 ## 技術スタック
 

--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -3,7 +3,17 @@
 `npm run build:web-component` produces `dist-web-component/ehagaki-composer.js`.
 It is an ES module distribution and is deliberately separate from the PWA
 build: it does not contain a manifest, share target, eHagaki Service Worker
-registration, or the iframe bridge.
+registration, or the iframe bridge. The normal `npm run build` also assembles
+that standalone distribution under `dist/web-component/`, so the PWA site
+output can serve the live sample and component assets together. The standalone
+`dist-web-component/` output remains available for CDN or other distribution.
+
+操作できる公開リファレンスは
+[https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html](https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html)
+です。module URL / asset base、Create / Destroy / Recreate、`whenReady()`、
+initial/runtime settings、content/reply/quote/multiple quote/channel context、
+安全なevent log、2個目instanceの拒否、CSS Custom Propertiesと
+`::part()`を確認できます。
 
 ```html
 <script type="module" src="https://cdn.example/ehagaki-composer.js"></script>
@@ -39,6 +49,21 @@ All events bubble and are composed: `ehagaki-ready` (detail
 `ehagaki-composer-context-updated`, and `ehagaki-initialization-error`.
 Error details use a safe code/message only; they do not contain secret keys,
 authentication payloads, or raw errors.
+
+The component's authentication model is intentionally the existing eHagaki
+model. It does not add a Web Component signer callback/provider API. Because
+the component shares the host Window realm, NIP-07 uses the host's
+`window.nostr` directly; NIP-46 and nsec/managed-account login use eHagaki's
+own existing login UI inside the component. The sample displays only whether
+`window.nostr` and its known capabilities are present. It does not accept or
+persist an nsec and does not implement iframe `auth.*` / `rpc.*` messages.
+
+The sample's context controls call `element.setContext(...)` directly. The
+payload uses `content`, `reply`, `quotes`, and `channel`, where channel has a
+required `reference` and optional `relays`, `name`, `about`, and `picture`.
+Settings controls use the currently supported `locale`, `themeMode`, quality,
+notification, client-tag, media-placement, mascot, flavor-text, and upload
+endpoint keys; unsupported keys are rejected.
 
 The public CSS custom properties are `--ehagaki-background`,
 `--ehagaki-text`, `--ehagaki-border`, `--ehagaki-link`,
@@ -89,3 +114,11 @@ emulation does not prove its worker or CORS behavior.
 The component uses an open ShadowRoot. Dialogs, popovers, tooltips, suggestions,
 and PhotoSwipe are targeted at its overlay root, while browser-history and URL/
 share-target input handling are disabled.
+
+The host sample demonstrates the CSS custom properties `--ehagaki-background`,
+`--ehagaki-text`, `--ehagaki-border`, `--ehagaki-link`,
+`--ehagaki-input-background`, `--ehagaki-footer-background`,
+`--ehagaki-dialog-background`, and `--ehagaki-font-family`. It also styles the
+declared `shell`, `header`, `composer`, `footer`, and `overlay-root` parts from
+the host stylesheet. These are Web Component APIs; the iframe sample cannot
+reach the iframe's internal stylesheet in this way.

--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -13,7 +13,11 @@ output can serve the live sample and component assets together. The standalone
 です。module URL / asset base、Create / Destroy / Recreate、`whenReady()`、
 initial/runtime settings、content/reply/quote/multiple quote/channel context、
 安全なevent log、2個目instanceの拒否、CSS Custom Propertiesと
-`::part()`を確認できます。
+`::part()`を確認できます。ページロード時にはcomponentも任意moduleも
+自動実行せず、`Create / Mount`が明示的なimport・接続操作になります。
+外部moduleはhostと同じJavaScript権限で実行されるため、信頼できるURL
+だけを指定してください。module load後はCustom Elements Registryのため
+module URLを変更できず、別実装を試すにはページをreloadします。
 
 ```html
 <script type="module" src="https://cdn.example/ehagaki-composer.js"></script>

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "dev": "vite --host",
     "prebuild": "npx rimraf dist",
-    "build": "vite build && node scripts/verifyLegacyBridgeBuild.mjs",
+    "build": "vite build && node scripts/verifyLegacyBridgeBuild.mjs && npm run build:web-component && npm run assemble:web-component-site",
     "build:web-component": "vite build --config vite.web-component.config.ts && node scripts/verifyWebComponentBuild.mjs",
+    "assemble:web-component-site": "node scripts/assembleWebComponentSite.mjs",
     "verify:legacy-bridge-remote": "node scripts/verifyLegacyBridgeRemote.mjs",
     "preview": "vite preview --host",
     "check": "svelte-check --tsconfig ./tsconfig.json",

--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -1,0 +1,304 @@
+<!doctype html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>eHagaki Web Component Reference</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --page-bg: #edf3ef;
+            --panel: #ffffff;
+            --line: #cbd8d0;
+            --text: #183028;
+            --muted: #5d7067;
+            --accent: #28764f;
+            --accent-soft: #dcefe4;
+            --ok: #207346;
+            --warn: #8a5b12;
+            --error: #9f2d2d;
+            --shadow: 0 18px 42px rgba(24, 48, 40, 0.12);
+            font-family: "Segoe UI", "Hiragino Sans", sans-serif;
+        }
+
+        * { box-sizing: border-box; }
+
+        body {
+            margin: 0;
+            background: radial-gradient(circle at top left, #d9eee2, transparent 32%), var(--page-bg);
+            color: var(--text);
+        }
+
+        main {
+            width: min(1440px, calc(100vw - 32px));
+            margin: 24px auto 48px;
+            display: grid;
+            grid-template-columns: minmax(320px, 450px) minmax(0, 1fr);
+            gap: 20px;
+        }
+
+        .column, .stack { display: grid; gap: 18px; min-width: 0; }
+        .panel, .card { background: var(--panel); border: 1px solid var(--line); border-radius: 18px; box-shadow: var(--shadow); }
+        .panel { padding: 22px; }
+        .card { padding: 16px; box-shadow: none; }
+        h1, h2, h3 { margin: 0; }
+        h1 { font-size: 1.8rem; line-height: 1.2; }
+        h2 { font-size: 1.08rem; }
+        h3 { font-size: .94rem; color: var(--muted); }
+        p { margin: 0; line-height: 1.6; }
+        .lead, .small { color: var(--muted); }
+        .small { font-size: .84rem; }
+        code { overflow-wrap: anywhere; }
+        a { color: var(--accent); }
+
+        .field { display: grid; gap: 7px; }
+        .field + .field { margin-top: 12px; }
+        label { font-size: .86rem; font-weight: 650; color: var(--muted); }
+        input, select, textarea, button { font: inherit; }
+        input, select, textarea {
+            width: 100%;
+            border: 1px solid var(--line);
+            border-radius: 10px;
+            padding: 10px 12px;
+            background: #fbfdfb;
+            color: var(--text);
+        }
+        textarea { min-height: 86px; resize: vertical; }
+        button {
+            min-height: 42px;
+            padding: 9px 13px;
+            border: 0;
+            border-radius: 999px;
+            background: var(--accent);
+            color: white;
+            cursor: pointer;
+        }
+        button.secondary { background: #5d7067; }
+        button.ghost { background: transparent; border: 1px solid var(--line); color: var(--text); }
+        button:disabled { opacity: .55; cursor: not-allowed; }
+        button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible { outline: 3px solid #92caaa; outline-offset: 2px; }
+        .buttons { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px; }
+        .buttons + .buttons { margin-top: 9px; }
+        .full { grid-column: 1 / -1; }
+        .grid-2 { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+        .grid-2 + .grid-2 { margin-top: 10px; }
+        .status-list { display: grid; gap: 8px; }
+        .status {
+            min-height: 34px;
+            display: flex;
+            align-items: center;
+            padding: 7px 11px;
+            border-radius: 999px;
+            background: #edf4ef;
+            color: var(--muted);
+            font-size: .86rem;
+        }
+        .status.ok { background: #dff2e6; color: var(--ok); }
+        .status.warn { background: #fff0d5; color: var(--warn); }
+        .status.error { background: #fbe2e2; color: var(--error); }
+        .notice { display: grid; gap: 8px; padding: 13px; border-left: 4px solid var(--accent); background: var(--accent-soft); border-radius: 10px; }
+        .log {
+            min-height: 190px;
+            max-height: 320px;
+            resize: vertical;
+            font-family: Consolas, "Courier New", monospace;
+            font-size: .78rem;
+            line-height: 1.5;
+        }
+        .component-frame { min-height: 640px; padding: 18px; background: #dce8df; border-radius: 18px; }
+        #component-mount { min-height: 580px; }
+        ehagaki-composer { display: block; min-height: 580px; background: white; border-radius: 14px; overflow: hidden; }
+
+        /* Public parts demo: this selector is host CSS and crosses only the declared part boundary. */
+        ehagaki-composer::part(header) { outline: 3px solid var(--sample-part-outline, transparent); outline-offset: -3px; }
+        ehagaki-composer::part(composer) { box-shadow: inset 0 0 0 1px var(--sample-part-outline, transparent); }
+
+        .comparison { width: 100%; border-collapse: collapse; font-size: .84rem; }
+        .comparison th, .comparison td { padding: 9px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+        .comparison th { color: var(--muted); width: 25%; }
+        .api-list { margin: 0; padding-left: 18px; line-height: 1.7; }
+        .check { display: inline-flex; align-items: center; gap: 8px; color: var(--text); font-size: .86rem; }
+        .check input { width: auto; }
+
+        @media (max-width: 980px) {
+            main { grid-template-columns: 1fr; }
+            .component-frame { min-height: 520px; }
+            #component-mount, ehagaki-composer { min-height: 480px; }
+        }
+
+        @media (max-width: 540px) {
+            main { width: min(100% - 18px, 680px); margin-top: 10px; }
+            .panel { padding: 15px; }
+            .grid-2, .buttons { grid-template-columns: 1fr; }
+            .full { grid-column: auto; }
+        }
+    </style>
+</head>
+
+<body>
+    <main>
+        <section class="column">
+            <div class="panel stack">
+                <header class="stack">
+                    <div>
+                        <h1>eHagaki Web Component</h1>
+                        <p class="lead">外部サイトのhostから、公開API・lifecycle・event・security modelを実際に操作するリファレンスです。</p>
+                    </div>
+                    <p class="small"><a href="https://github.com/Lokuyow/ehagaki/blob/main/docs/WEB_COMPONENT.md" target="_blank" rel="noreferrer noopener">Web Component guide</a> / <a href="./embed-parent-client-example.html">iframe sample</a></p>
+                </header>
+
+                <div class="notice">
+                    <strong>認証とtrust boundary</strong>
+                    <p class="small">Web Componentはhostと同じWindow realmで動作します。ログイン操作は埋め込まれたeHagaki内の既存UIから行い、NIP-07はhostの <code>window.nostr</code> を直接利用します。NIP-46・nsec/managed accountもeHagaki自身の既存経路です。このsampleはsigner callbackを追加せず、nsecを保存しません。</p>
+                </div>
+
+                <div class="status-list">
+                    <div id="module-status" class="status" role="status" aria-live="polite">module 未読み込み</div>
+                    <div id="component-status" class="status" role="status" aria-live="polite">component 未作成</div>
+                    <div id="ready-status" class="status" role="status" aria-live="polite">whenReady(): pending</div>
+                    <div id="nip07-status" class="status warn" role="status" aria-live="polite">NIP-07 capabilityを確認中</div>
+                </div>
+
+                <div class="card stack">
+                    <h2>Module / asset base</h2>
+                    <div class="field">
+                        <label for="module-url">Web Component module URL</label>
+                        <input id="module-url" type="url" spellcheck="false">
+                    </div>
+                    <div class="field">
+                        <label for="asset-base">asset base</label>
+                        <input id="asset-base" type="url" spellcheck="false">
+                    </div>
+                    <p class="small">公開sampleの既定値は <code>./web-component/</code> です。GitHub Pagesの <code>/ehagaki/</code> baseを壊さないためroot-relative URLは使いません。ローカルE2Eや別originのbundleはここで上書きできます。</p>
+                </div>
+
+                <div class="card stack">
+                    <h2>Create / destroy / recreate</h2>
+                    <div class="buttons">
+                        <button id="create-component" type="button">Create / Mount</button>
+                        <button id="destroy-component" type="button" class="secondary">Destroy / Unmount</button>
+                        <button id="recreate-component" type="button">Recreate</button>
+                        <button id="create-second" type="button" class="ghost">2個目を生成</button>
+                    </div>
+                    <p class="small">1 document 1 connected instance制約を確認できます。2個目は inert、<code>multiple_instances_unsupported</code> のerror eventと <code>whenReady()</code> rejectionをlogします。1個目をdestroy後は新しいinstanceを生成できます。</p>
+                </div>
+
+                <div class="card stack">
+                    <h2>Initial / runtime settings</h2>
+                    <p class="small">Create前に入力した設定は、element接続前に <code>setSettings()</code> をqueueしてready後に適用します。下のボタンは同じ公開APIを実行中に呼び出します。</p>
+                    <div class="grid-2">
+                        <div class="field"><label for="locale">locale</label><select id="locale"><option value="ja">ja</option><option value="en">en</option></select></div>
+                        <div class="field"><label for="theme-mode">themeMode</label><select id="theme-mode"><option value="system">system</option><option value="light">light</option><option value="dark">dark</option></select></div>
+                        <div class="field"><label for="image-quality">imageQualityLevel</label><select id="image-quality"><option value="medium">medium</option><option value="none">none</option><option value="low">low</option><option value="high">high</option></select></div>
+                        <div class="field"><label for="video-quality">videoQualityLevel</label><select id="video-quality"><option value="medium">medium</option><option value="none">none</option><option value="low">low</option><option value="high">high</option></select></div>
+                    </div>
+                    <div class="grid-2">
+                        <label class="check"><input id="client-tag" type="checkbox" checked> clientTagEnabled</label>
+                        <label class="check"><input id="quote-notification" type="checkbox"> quoteNotificationEnabled</label>
+                        <label class="check"><input id="reply-notification" type="checkbox"> replyNotificationEnabled</label>
+                        <label class="check"><input id="media-free-placement" type="checkbox"> mediaFreePlacement</label>
+                        <label class="check"><input id="show-mascot" type="checkbox" checked> showMascot</label>
+                        <label class="check"><input id="show-flavor-text" type="checkbox" checked> showFlavorText</label>
+                    </div>
+                    <div class="buttons">
+                        <button id="apply-runtime-settings" type="button" class="secondary">実行中に適用</button>
+                        <button id="apply-invalid-settings" type="button" class="ghost">invalid settings</button>
+                    </div>
+                </div>
+
+                <div class="card stack">
+                    <h2>Composer context</h2>
+                    <p class="small">入力したNIP-19 <code>note1...</code> / <code>nevent1...</code> を、iframe protocolではなく直接 <code>element.setContext(...)</code> に渡します。channelのpayloadは <code>reference</code>、任意の <code>relays/name/about/picture</code> です。</p>
+                    <div class="field"><label for="context-content">content</label><textarea id="context-content">Web Componentからの初期コンテンツ</textarea></div>
+                    <div class="field"><label for="context-reply">reply</label><input id="context-reply" type="text" placeholder="note1... / nevent1..."></div>
+                    <div class="grid-2">
+                        <div class="field"><label for="context-quote-one">quote</label><input id="context-quote-one" type="text" placeholder="note1... / nevent1..."></div>
+                        <div class="field"><label for="context-quote-two">quote 2</label><input id="context-quote-two" type="text" placeholder="複数quote用"></div>
+                    </div>
+                    <div class="buttons">
+                        <button id="apply-content" type="button">contentを適用</button>
+                        <button id="apply-reply" type="button">replyを適用</button>
+                        <button id="apply-quote" type="button">quoteを適用</button>
+                        <button id="apply-multiple-quotes" type="button">multiple quote</button>
+                    </div>
+                    <div class="field"><label for="context-channel-reference">channel.reference</label><input id="context-channel-reference" type="text" placeholder="note1... / nevent1..."></div>
+                    <div class="grid-2">
+                        <div class="field"><label for="context-channel-relays">channel.relays (CSV)</label><input id="context-channel-relays" type="text" placeholder="wss://relay.example"></div>
+                        <div class="field"><label for="context-channel-name">channel.name</label><input id="context-channel-name" type="text"></div>
+                    </div>
+                    <div class="buttons">
+                        <button id="apply-channel" type="button">channelを適用</button>
+                        <button id="clear-context" type="button" class="secondary">contextをclear</button>
+                        <button id="apply-invalid-context" type="button" class="ghost full">invalid contextを試す</button>
+                    </div>
+                </div>
+
+                <div class="card stack">
+                    <h2>CSS Custom Properties / parts</h2>
+                    <p class="small">次のhost側style APIを変更できます。Shadow DOM内部へ直接入らず、custom propertyと公開partだけを使います。</p>
+                    <div class="grid-2">
+                        <div class="field"><label for="style-background">background</label><input id="style-background" value="#f4f4f4"></div>
+                        <div class="field"><label for="style-text">text</label><input id="style-text" value="#183028"></div>
+                        <div class="field"><label for="style-border">border</label><input id="style-border" value="#b8c7be"></div>
+                        <div class="field"><label for="style-link">link</label><input id="style-link" value="#28764f"></div>
+                        <div class="field"><label for="style-input">input background</label><input id="style-input" value="#ffffff"></div>
+                        <div class="field"><label for="style-footer">footer background</label><input id="style-footer" value="#e2ebe5"></div>
+                        <div class="field"><label for="style-dialog">dialog background</label><input id="style-dialog" value="#ffffff"></div>
+                        <div class="field"><label for="style-font">font family</label><input id="style-font" value="system-ui, sans-serif"></div>
+                    </div>
+                    <div class="field"><label for="style-part-outline">::part(header/composer) outline</label><input id="style-part-outline" value="#28764f"></div>
+                    <button id="apply-styles" type="button" class="secondary">styleを適用</button>
+                    <p class="small"><code>ehagaki-composer::part(header)</code> と <code>::part(composer)</code> にoutlineを適用するhost stylesheetがこのページにあります。iframeではこのCSS境界を直接使えません。</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="column">
+            <div class="panel stack">
+                <div>
+                    <h2>Component surface</h2>
+                    <p class="small">listenerはelement生成前に登録され、ready eventの取りこぼしを避けます。イベントはbubbles/composedのCustomEventとしてhostへ届きます。</p>
+                </div>
+                <div id="component-mount" class="component-frame" aria-label="eHagaki Web Component mount point"></div>
+            </div>
+
+            <div class="panel stack">
+                <div class="buttons">
+                    <div><h2>Event monitor</h2><p class="small">秘密情報・署名要求payload・raw Errorは表示せず、安全なsummaryだけを記録します。</p></div>
+                    <button id="clear-log" type="button" class="ghost">ログをクリア</button>
+                </div>
+                <textarea id="event-log" class="log" readonly aria-label="Web Component event log"></textarea>
+            </div>
+
+            <div class="panel stack">
+                <div>
+                    <h2>iframeとの違い</h2>
+                    <p class="small">Web Componentが常に安全という意味ではありません。host JavaScriptから秘密情報を隔離したい場合はiframeを使ってください。</p>
+                </div>
+                <table class="comparison">
+                    <thead><tr><th>項目</th><th>iframe</th><th>Web Component</th></tr></thead>
+                    <tbody>
+                        <tr><th>境界 / API</th><td>origin isolation、postMessage protocol、handshake</td><td>同じWindow realm、method/property/CustomEvent、element create/destroy/recreate</td></tr>
+                        <tr><th>認証</th><td>parent-client auth/RPCを利用可能</td><td>parent-client auth/RPCは使用しない。NIP-07はhostのwindow.nostrを直接利用し、NIP-46/nsecはeHagaki UI</td></tr>
+                        <tr><th>保存</th><td>storage/IndexedDBの親委譲が可能</td><td>localStorageは <code>ehagaki.web-component.v1:</code> namespace、IndexedDBはhost originの <code>eHagakiDB</code></td></tr>
+                        <tr><th>更新 / style</th><td>iframe reloadまたはpostMessage</td><td>setSettings()/setContext()、CSS Custom Properties / <code>::part()</code></td></tr>
+                        <tr><th>trust</th><td>iframe originとの境界を設計可能</td><td>trusted hostのみ正式サポート。hostは同一realmのコード・storageを観測可能</td></tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="panel stack">
+                <h2>HTTP / WebSocket / Service Worker</h2>
+                <ul class="api-list small">
+                    <li>HTTP requestはhost Service Workerが観測可能です。</li>
+                    <li>Nostr relayはWebSocketです。Service Workerのfetch interceptionはrelay interceptionの証拠ではありません。</li>
+                    <li>host <code>window.WebSocket</code> wrapperについてbrowser-level proofは現在未完了です。今回relay interceptor fixture/APIは追加していません。</li>
+                </ul>
+            </div>
+        </section>
+    </main>
+    <script type="module" src="./web-component-parent-client-example.js"></script>
+</body>
+
+</html>

--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -170,7 +170,8 @@
                         <label for="asset-base">asset base</label>
                         <input id="asset-base" type="url" spellcheck="false">
                     </div>
-                    <p class="small">公開sampleの既定値は <code>./web-component/</code> です。GitHub Pagesの <code>/ehagaki/</code> baseを壊さないためroot-relative URLは使いません。ローカルE2Eや別originのbundleはここで上書きできます。</p>
+                    <p class="small">公開sampleの既定値は <code>./web-component/</code> です。GitHub Pagesの <code>/ehagaki/</code> baseを壊さないためroot-relative URLは使いません。module importは明示的なCreate操作でのみ発生します。</p>
+                    <p class="small">外部moduleはhostページと同じJavaScript権限で実行されます。asset baseもworker/FFmpeg等の実行可能resourceに使われるため、信頼できるURLだけを指定してください。asset baseはCreate / Recreate時にelementへ設定されます。module load後はCustom Elements Registryのため実装を切り替えられず、別moduleを試すにはページをreloadしてください。</p>
                 </div>
 
                 <div class="card stack">

--- a/public/web-component-parent-client-example.js
+++ b/public/web-component-parent-client-example.js
@@ -1,0 +1,353 @@
+const EVENT_TYPES = [
+    "ehagaki-ready",
+    "ehagaki-post-success",
+    "ehagaki-post-error",
+    "ehagaki-composer-context-updated",
+    "ehagaki-initialization-error",
+];
+
+const moduleUrlInput = document.querySelector("#module-url");
+const assetBaseInput = document.querySelector("#asset-base");
+const moduleStatus = document.querySelector("#module-status");
+const componentStatus = document.querySelector("#component-status");
+const readyStatus = document.querySelector("#ready-status");
+const nip07Status = document.querySelector("#nip07-status");
+const componentMount = document.querySelector("#component-mount");
+const eventLog = document.querySelector("#event-log");
+
+let currentComposer = null;
+let secondaryComposer = null;
+let loadedModuleUrl = "";
+let moduleLoadPromise = null;
+
+function getElement(id) {
+    const element = document.getElementById(id);
+    if (!element) throw new Error(`Missing sample element: ${id}`);
+    return element;
+}
+
+function setStatus(element, message, tone = "") {
+    element.textContent = message;
+    element.className = `status${tone ? ` ${tone}` : ""}`;
+}
+
+function formatTime() {
+    return new Intl.DateTimeFormat(undefined, {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+    }).format(new Date());
+}
+
+function appendLog(message, detail) {
+    const line = `[${formatTime()}] ${message}${detail ? ` ${JSON.stringify(detail)}` : ""}`;
+    eventLog.value = `${eventLog.value}${eventLog.value ? "\n" : ""}${line}`;
+    eventLog.scrollTop = eventLog.scrollHeight;
+}
+
+function safeErrorCode(error) {
+    if (error && typeof error.name === "string" && /^[A-Za-z0-9_-]+$/.test(error.name)) {
+        return error.name;
+    }
+    return "operation_failed";
+}
+
+function safeEventDetail(type, detail) {
+    if (!detail || typeof detail !== "object") return {};
+    switch (type) {
+        case "ehagaki-ready":
+            return { apiVersion: detail.apiVersion };
+        case "ehagaki-post-success":
+            return {
+                hasEventId: typeof detail.eventId === "string",
+                hasReplyToEventId: typeof detail.replyToEventId === "string",
+                quotedEventCount: Array.isArray(detail.quotedEventIds) ? detail.quotedEventIds.length : 0,
+            };
+        case "ehagaki-post-error":
+            return { code: typeof detail.code === "string" ? detail.code : "post_failed" };
+        case "ehagaki-composer-context-updated":
+            return {
+                hasReply: typeof detail.reply === "string",
+                quoteCount: Array.isArray(detail.quotes) ? detail.quotes.length : 0,
+                hasChannel: !!detail.channel,
+            };
+        case "ehagaki-initialization-error":
+            return {
+                code: typeof detail.code === "string" ? detail.code : "initialization_failed",
+                message: typeof detail.message === "string" ? detail.message : "safe initialization error",
+            };
+        default:
+            return {};
+    }
+}
+
+function installEventListeners(element, label) {
+    for (const type of EVENT_TYPES) {
+        // Listen on the host mount point, not inside ShadowRoot. This makes the
+        // sample exercise the component's bubbles+composed event boundary.
+        componentMount.addEventListener(type, (event) => {
+            if (event.target !== element) return;
+            const detail = safeEventDetail(type, event.detail);
+            appendLog(`${label}: ${type}`, detail);
+            if (type === "ehagaki-ready" && element === currentComposer) {
+                setStatus(readyStatus, "whenReady(): resolved", "ok");
+            }
+            if (type === "ehagaki-initialization-error") {
+                const code = detail.code ?? "initialization_failed";
+                setStatus(readyStatus, `whenReady(): rejected (${code})`, "error");
+            }
+        });
+    }
+}
+
+function normalizeDirectoryUrl(value) {
+    const resolved = new URL(value || "./web-component/", document.baseURI);
+    if (!resolved.pathname.endsWith("/")) resolved.pathname += "/";
+    return resolved.href;
+}
+
+function getDefaultModuleUrl() {
+    return new URL("./web-component/ehagaki-composer.js", document.baseURI).href;
+}
+
+function getDefaultAssetBase() {
+    return new URL("./web-component/", document.baseURI).href;
+}
+
+function getSettings() {
+    return {
+        locale: getElement("locale").value,
+        themeMode: getElement("theme-mode").value,
+        imageQualityLevel: getElement("image-quality").value,
+        videoQualityLevel: getElement("video-quality").value,
+        clientTagEnabled: getElement("client-tag").checked,
+        quoteNotificationEnabled: getElement("quote-notification").checked,
+        replyNotificationEnabled: getElement("reply-notification").checked,
+        mediaFreePlacement: getElement("media-free-placement").checked,
+        showMascot: getElement("show-mascot").checked,
+        showFlavorText: getElement("show-flavor-text").checked,
+    };
+}
+
+function getOptionalValue(id) {
+    const value = getElement(id).value.trim();
+    return value || undefined;
+}
+
+function getContext() {
+    const context = {};
+    const content = getOptionalValue("context-content");
+    const reply = getOptionalValue("context-reply");
+    const quoteOne = getOptionalValue("context-quote-one");
+    const quoteTwo = getOptionalValue("context-quote-two");
+    const channelReference = getOptionalValue("context-channel-reference");
+    if (content !== undefined) context.content = content;
+    if (reply !== undefined) context.reply = reply;
+    if (quoteOne !== undefined || quoteTwo !== undefined) {
+        context.quotes = [quoteOne, quoteTwo].filter((value) => value !== undefined);
+    }
+    if (channelReference !== undefined) {
+        const relays = getOptionalValue("context-channel-relays");
+        const channel = { reference: channelReference };
+        if (relays !== undefined) channel.relays = relays.split(",").map((relay) => relay.trim()).filter(Boolean);
+        for (const [key, id] of [["name", "context-channel-name"]]) {
+            const value = getOptionalValue(id);
+            if (value !== undefined) channel[key] = value;
+        }
+        context.channel = channel;
+    }
+    return context;
+}
+
+function applySettingsToComposer(settings, label) {
+    if (!currentComposer) {
+        setStatus(componentStatus, "componentを先にCreateしてください", "warn");
+        appendLog(`${label}: component_not_mounted`);
+        return;
+    }
+    void currentComposer.setSettings(settings).then((applied) => {
+        appendLog(`${label}: settings applied`, { keys: [...applied] });
+        setStatus(componentStatus, `${label}: ${[...applied].join(", ") || "no keys"}`, "ok");
+    }).catch((error) => {
+        const code = safeErrorCode(error);
+        appendLog(`${label}: settings rejected`, { code });
+        setStatus(componentStatus, `${label}: rejected (${code})`, "error");
+    });
+}
+
+function applyContextToComposer(context, label) {
+    if (!currentComposer) {
+        setStatus(componentStatus, "componentを先にCreateしてください", "warn");
+        appendLog(`${label}: component_not_mounted`);
+        return;
+    }
+    void currentComposer.setContext(context).then(() => {
+        appendLog(`${label}: context applied`, {
+            hasContent: typeof context.content === "string",
+            hasReply: typeof context.reply === "string",
+            quoteCount: Array.isArray(context.quotes) ? context.quotes.length : 0,
+            hasChannel: !!context.channel,
+        });
+        setStatus(componentStatus, `${label}: applied`, "ok");
+    }).catch((error) => {
+        const code = safeErrorCode(error);
+        appendLog(`${label}: context rejected`, { code });
+        setStatus(componentStatus, `${label}: rejected (${code})`, "error");
+    });
+}
+
+async function ensureModuleLoaded() {
+    const moduleUrl = moduleUrlInput.value.trim() || getDefaultModuleUrl();
+    if (loadedModuleUrl === moduleUrl && moduleLoadPromise) return moduleLoadPromise;
+    loadedModuleUrl = moduleUrl;
+    moduleLoadPromise = import(moduleUrl).then(() => {
+        setStatus(moduleStatus, `module loaded: ${moduleUrl}`, "ok");
+    }).catch((error) => {
+        moduleLoadPromise = null;
+        setStatus(moduleStatus, `module failed (${safeErrorCode(error)})`, "error");
+        appendLog("module load failed", { code: safeErrorCode(error) });
+        throw error;
+    });
+    return moduleLoadPromise;
+}
+
+function configureElement(element) {
+    element.setAttribute("asset-base", normalizeDirectoryUrl(assetBaseInput.value));
+    for (const [property, id] of [
+        ["--ehagaki-background", "style-background"],
+        ["--ehagaki-text", "style-text"],
+        ["--ehagaki-border", "style-border"],
+        ["--ehagaki-link", "style-link"],
+        ["--ehagaki-input-background", "style-input"],
+        ["--ehagaki-footer-background", "style-footer"],
+        ["--ehagaki-dialog-background", "style-dialog"],
+        ["--ehagaki-font-family", "style-font"],
+    ]) {
+        element.style.setProperty(property, getElement(id).value);
+    }
+}
+
+async function createComposer() {
+    if (currentComposer?.isConnected) {
+        setStatus(componentStatus, "componentは既にmount済みです", "warn");
+        return;
+    }
+    await ensureModuleLoaded();
+    const element = document.createElement("ehagaki-composer");
+    configureElement(element);
+    installEventListeners(element, "primary");
+    currentComposer = element;
+    setStatus(componentStatus, "component created / connecting", "warn");
+    setStatus(readyStatus, "whenReady(): pending (queued settings/context)", "warn");
+
+    // These calls intentionally happen before connection. The element queues them until ready.
+    const initialSettings = element.setSettings(getSettings());
+    const initialContext = element.setContext(getContext());
+    componentMount.append(element);
+
+    void element.whenReady().then(() => {
+        setStatus(readyStatus, "whenReady(): resolved", "ok");
+        setStatus(componentStatus, "component mounted", "ok");
+    }).catch((error) => {
+        setStatus(readyStatus, `whenReady(): rejected (${safeErrorCode(error)})`, "error");
+    });
+    void initialSettings.then((applied) => appendLog("initial setSettings applied", { keys: [...applied] }))
+        .catch((error) => appendLog("initial setSettings rejected", { code: safeErrorCode(error) }));
+    void initialContext.then(() => appendLog("initial setContext applied", { queuedBeforeConnection: true }))
+        .catch((error) => appendLog("initial setContext rejected", { code: safeErrorCode(error) }));
+}
+
+function destroyComposer() {
+    if (!currentComposer?.isConnected) {
+        setStatus(componentStatus, "primary componentはmountされていません", "warn");
+        return;
+    }
+    currentComposer.remove();
+    currentComposer = null;
+    setStatus(componentStatus, "primary component destroyed; persistent settings remain", "ok");
+    setStatus(readyStatus, "whenReady(): not connected", "warn");
+    appendLog("primary: disconnected", { persistentSettingsRemain: true });
+}
+
+async function recreateComposer() {
+    destroyComposer();
+    if (secondaryComposer?.isConnected) secondaryComposer.remove();
+    secondaryComposer = null;
+    await createComposer();
+}
+
+async function createSecondComposer() {
+    if (secondaryComposer?.isConnected) {
+        appendLog("secondary: already connected");
+        return;
+    }
+    await ensureModuleLoaded();
+    const element = document.createElement("ehagaki-composer");
+    configureElement(element);
+    installEventListeners(element, "secondary");
+    secondaryComposer = element;
+    componentMount.append(element);
+    void element.whenReady().then(() => {
+        appendLog("secondary: unexpected ready");
+    }).catch((error) => {
+        appendLog("secondary: whenReady rejected", { code: safeErrorCode(error) });
+        setStatus(componentStatus, "2個目は inert: multiple_instances_unsupported", "error");
+    });
+}
+
+function applyStyles() {
+    if (!currentComposer) {
+        appendLog("styles: component_not_mounted");
+        return;
+    }
+    configureElement(currentComposer);
+    document.documentElement.style.setProperty("--sample-part-outline", getElement("style-part-outline").value);
+    appendLog("styles applied", { customProperties: 8, parts: ["header", "composer"] });
+}
+
+function refreshNip07Status() {
+    const signer = window.nostr;
+    if (!signer) {
+        setStatus(nip07Status, "NIP-07: window.nostr not available", "warn");
+        return;
+    }
+    const capabilities = ["getPublicKey", "signEvent", "nip04", "nip44"].filter((key) => {
+        if (key === "nip04" || key === "nip44") return signer[key] && typeof signer[key] === "object";
+        return typeof signer[key] === "function";
+    });
+    setStatus(nip07Status, `NIP-07: available (${capabilities.join(", ") || "no known capability"})`, "ok");
+}
+
+function bindActions() {
+    getElement("create-component").addEventListener("click", () => void createComposer().catch((error) => appendLog("create failed", { code: safeErrorCode(error) })));
+    getElement("destroy-component").addEventListener("click", destroyComposer);
+    getElement("recreate-component").addEventListener("click", () => void recreateComposer().catch((error) => appendLog("recreate failed", { code: safeErrorCode(error) })));
+    getElement("create-second").addEventListener("click", () => void createSecondComposer().catch((error) => appendLog("secondary create failed", { code: safeErrorCode(error) })));
+    getElement("apply-runtime-settings").addEventListener("click", () => applySettingsToComposer(getSettings(), "runtime setSettings"));
+    getElement("apply-invalid-settings").addEventListener("click", () => applySettingsToComposer({ unsupportedKey: true }, "invalid setSettings"));
+    getElement("apply-content").addEventListener("click", () => applyContextToComposer({ content: getElement("context-content").value }, "content context"));
+    getElement("apply-reply").addEventListener("click", () => applyContextToComposer({ reply: getElement("context-reply").value.trim() }, "reply context"));
+    getElement("apply-quote").addEventListener("click", () => applyContextToComposer({ quotes: [getElement("context-quote-one").value.trim()] }, "quote context"));
+    getElement("apply-multiple-quotes").addEventListener("click", () => applyContextToComposer({ quotes: [getElement("context-quote-one").value.trim(), getElement("context-quote-two").value.trim()] }, "multiple quote context"));
+    getElement("apply-channel").addEventListener("click", () => {
+        const context = getContext();
+        applyContextToComposer({ channel: context.channel }, "channel context");
+    });
+    getElement("clear-context").addEventListener("click", () => applyContextToComposer({ content: null, reply: null, quotes: null, channel: null }, "clear context"));
+    getElement("apply-invalid-context").addEventListener("click", () => applyContextToComposer({ content: "must not apply", reply: "invalid reference" }, "invalid context"));
+    getElement("apply-styles").addEventListener("click", applyStyles);
+    getElement("clear-log").addEventListener("click", () => { eventLog.value = ""; });
+}
+
+moduleUrlInput.value = new URL(new URLSearchParams(location.search).get("moduleUrl") || getDefaultModuleUrl(), document.baseURI).href;
+assetBaseInput.value = normalizeDirectoryUrl(new URLSearchParams(location.search).get("assetBase") || getDefaultAssetBase());
+bindActions();
+refreshNip07Status();
+appendLog("sample ready", {
+    sameWindowRealm: true,
+    eventTransport: "CustomEvent bubbles+composed",
+    secretLogging: false,
+});
+
+// Boot the reference page automatically, while keeping Create / Mount available for recreation.
+void createComposer().catch((error) => appendLog("sample boot failed", { code: safeErrorCode(error) }));

--- a/public/web-component-parent-client-example.js
+++ b/public/web-component-parent-client-example.js
@@ -201,9 +201,12 @@ async function ensureModuleLoaded() {
     if (loadedModuleUrl === moduleUrl && moduleLoadPromise) return moduleLoadPromise;
     loadedModuleUrl = moduleUrl;
     moduleLoadPromise = import(moduleUrl).then(() => {
-        setStatus(moduleStatus, `module loaded: ${moduleUrl}`, "ok");
+        moduleUrlInput.disabled = true;
+        moduleUrlInput.setAttribute("aria-disabled", "true");
+        setStatus(moduleStatus, "module loaded; reload to choose another implementation", "ok");
     }).catch((error) => {
         moduleLoadPromise = null;
+        loadedModuleUrl = "";
         setStatus(moduleStatus, `module failed (${safeErrorCode(error)})`, "error");
         appendLog("module load failed", { code: safeErrorCode(error) });
         throw error;
@@ -211,8 +214,7 @@ async function ensureModuleLoaded() {
     return moduleLoadPromise;
 }
 
-function configureElement(element) {
-    element.setAttribute("asset-base", normalizeDirectoryUrl(assetBaseInput.value));
+function applyCustomStyles(element) {
     for (const [property, id] of [
         ["--ehagaki-background", "style-background"],
         ["--ehagaki-text", "style-text"],
@@ -225,6 +227,11 @@ function configureElement(element) {
     ]) {
         element.style.setProperty(property, getElement(id).value);
     }
+}
+
+function configureElement(element) {
+    element.setAttribute("asset-base", normalizeDirectoryUrl(assetBaseInput.value));
+    applyCustomStyles(element);
 }
 
 async function createComposer() {
@@ -300,7 +307,7 @@ function applyStyles() {
         appendLog("styles: component_not_mounted");
         return;
     }
-    configureElement(currentComposer);
+    applyCustomStyles(currentComposer);
     document.documentElement.style.setProperty("--sample-part-outline", getElement("style-part-outline").value);
     appendLog("styles applied", { customProperties: 8, parts: ["header", "composer"] });
 }
@@ -339,8 +346,8 @@ function bindActions() {
     getElement("clear-log").addEventListener("click", () => { eventLog.value = ""; });
 }
 
-moduleUrlInput.value = new URL(new URLSearchParams(location.search).get("moduleUrl") || getDefaultModuleUrl(), document.baseURI).href;
-assetBaseInput.value = normalizeDirectoryUrl(new URLSearchParams(location.search).get("assetBase") || getDefaultAssetBase());
+moduleUrlInput.value = getDefaultModuleUrl();
+assetBaseInput.value = getDefaultAssetBase();
 bindActions();
 refreshNip07Status();
 appendLog("sample ready", {
@@ -348,6 +355,3 @@ appendLog("sample ready", {
     eventTransport: "CustomEvent bubbles+composed",
     secretLogging: false,
 });
-
-// Boot the reference page automatically, while keeping Create / Mount available for recreation.
-void createComposer().catch((error) => appendLog("sample boot failed", { code: safeErrorCode(error) }));

--- a/scripts/assembleWebComponentSite.mjs
+++ b/scripts/assembleWebComponentSite.mjs
@@ -1,0 +1,14 @@
+import { access, cp, mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const sourceDirectory = join(repositoryRoot, "dist-web-component");
+const siteDirectory = join(repositoryRoot, "dist", "web-component");
+
+await access(join(sourceDirectory, "ehagaki-composer.js"));
+await rm(siteDirectory, { recursive: true, force: true });
+await mkdir(siteDirectory, { recursive: true });
+await cp(sourceDirectory, siteDirectory, { recursive: true });
+
+console.log(`Assembled Web Component distribution at ${siteDirectory}`);

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -7,6 +7,13 @@ import { nip19 } from "nostr-tools";
 let server: Server;
 let origin = "";
 const requests = new Set<string>();
+const securityFixturePath = "/ehagaki/security-fixture.js";
+
+declare global {
+    interface Window {
+        __securityFixtureLoaded?: boolean;
+    }
+}
 
 function contentType(filePath: string): string {
     switch (extname(filePath)) {
@@ -38,6 +45,22 @@ test.beforeAll(async () => {
     server = createServer(async (request, response) => {
         const pathname = new URL(request.url ?? "/", origin).pathname;
         requests.add(pathname);
+        if (pathname === securityFixturePath) {
+            response.writeHead(200, { "Content-Type": "text/javascript; charset=utf-8" });
+            response.end(`
+                window.__securityFixtureLoaded = true;
+                class SecurityFixtureComposer extends HTMLElement {
+                    whenReady() { return Promise.resolve(); }
+                    setSettings() { return Promise.resolve([]); }
+                    setContext() { return Promise.resolve(); }
+                    connectedCallback() {
+                        this.dispatchEvent(new CustomEvent("ehagaki-ready", { bubbles: true, composed: true, detail: { apiVersion: 999 } }));
+                    }
+                }
+                customElements.define("ehagaki-composer", SecurityFixtureComposer);
+            `);
+            return;
+        }
         if (!pathname.startsWith("/ehagaki/")) {
             response.writeHead(404).end();
             return;
@@ -69,9 +92,15 @@ test.afterAll(async () => {
 test("boots from production site output and exercises the public sample API", async ({ page }) => {
     await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
 
+    await expect(page.locator("#module-url")).toHaveValue(`${origin}/ehagaki/web-component/ehagaki-composer.js`);
+    await expect(page.locator("#asset-base")).toHaveValue(`${origin}/ehagaki/web-component/`);
+    await expect(page.locator("#module-status")).toHaveText("module 未読み込み");
+    await expect(page.locator("ehagaki-composer")).toHaveCount(0);
+    await page.getByRole("button", { name: "Create / Mount" }).click();
     await expect(page.locator("#module-status")).toContainText("module loaded");
     await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
     await expect(page.locator("#component-status")).toHaveText("component mounted");
+    await expect(page.locator("#module-url")).toBeDisabled();
     await expect(page.locator("ehagaki-composer")).toHaveCount(1);
     expect(requests).toContain("/ehagaki/web-component/ehagaki-composer.js");
     expect([...requests].some((path) => path.startsWith("/ehagaki/web-component/assets/"))).toBe(true);
@@ -113,6 +142,7 @@ test("boots from production site output and exercises the public sample API", as
 
 test("demonstrates second-instance rejection and recreation after destroy", async ({ page }) => {
     await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
+    await page.getByRole("button", { name: "Create / Mount" }).click();
     await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
 
     await page.getByRole("button", { name: "2個目を生成" }).click();
@@ -129,4 +159,21 @@ test("demonstrates second-instance rejection and recreation after destroy", asyn
     await page.getByRole("button", { name: "Recreate" }).click();
     await expect(page.locator("#component-status")).toHaveText("component mounted");
     await expect(page.locator("ehagaki-composer")).toHaveCount(1);
+});
+
+test("does not import query-selected modules until an explicit Create action", async ({ page }) => {
+    await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html?moduleUrl=${encodeURIComponent(`${origin}${securityFixturePath}`)}`);
+
+    await expect(page.locator("#module-url")).toHaveValue(`${origin}/ehagaki/web-component/ehagaki-composer.js`);
+    await expect(page.locator("ehagaki-composer")).toHaveCount(0);
+    expect(requests).not.toContain(securityFixturePath);
+    expect(await page.evaluate(() => window.__securityFixtureLoaded === true)).toBe(false);
+
+    await page.locator("#module-url").fill(`${origin}${securityFixturePath}`);
+    await page.getByRole("button", { name: "Create / Mount" }).click();
+    await expect(page.locator("#module-status")).toContainText("module loaded");
+    await expect(page.locator("#module-url")).toBeDisabled();
+    await expect(page.locator("#component-status")).toHaveText("component mounted");
+    expect(requests).toContain(securityFixturePath);
+    expect(await page.evaluate(() => window.__securityFixtureLoaded === true)).toBe(true);
 });

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "@playwright/test";
+import { createServer, type Server } from "node:http";
+import { extname, join, normalize } from "node:path";
+import { access, readFile } from "node:fs/promises";
+import { nip19 } from "nostr-tools";
+
+let server: Server;
+let origin = "";
+const requests = new Set<string>();
+
+function contentType(filePath: string): string {
+    switch (extname(filePath)) {
+        case ".html": return "text/html; charset=utf-8";
+        case ".js": return "text/javascript; charset=utf-8";
+        case ".css": return "text/css; charset=utf-8";
+        case ".svg": return "image/svg+xml";
+        case ".wasm": return "application/wasm";
+        case ".png": return "image/png";
+        default: return "application/octet-stream";
+    }
+}
+
+function listen(value: Server): Promise<number> {
+    return new Promise((resolve) => {
+        value.listen(0, "127.0.0.1", () => {
+            const address = value.address();
+            resolve(typeof address === "object" && address ? address.port : 0);
+        });
+    });
+}
+
+function close(value: Server): Promise<void> {
+    return new Promise((resolve, reject) => value.close((error) => error ? reject(error) : resolve()));
+}
+
+test.beforeAll(async () => {
+    await access(join(process.cwd(), "dist", "web-component", "ehagaki-composer.js"));
+    server = createServer(async (request, response) => {
+        const pathname = new URL(request.url ?? "/", origin).pathname;
+        requests.add(pathname);
+        if (!pathname.startsWith("/ehagaki/")) {
+            response.writeHead(404).end();
+            return;
+        }
+        const relativePath = pathname.slice("/ehagaki/".length) || "index.html";
+        const siteRoot = normalize(join(process.cwd(), "dist"));
+        const filePath = normalize(join(siteRoot, relativePath));
+        if (!filePath.startsWith(siteRoot)) {
+            response.writeHead(400).end();
+            return;
+        }
+        try {
+            const body = await readFile(filePath);
+            response.writeHead(200, { "Content-Type": contentType(filePath) });
+            response.end(body);
+        } catch {
+            response.writeHead(404).end();
+        }
+    });
+    origin = `http://127.0.0.1:${await listen(server)}`;
+});
+
+test.beforeEach(() => requests.clear());
+
+test.afterAll(async () => {
+    await close(server);
+});
+
+test("boots from production site output and exercises the public sample API", async ({ page }) => {
+    await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
+
+    await expect(page.locator("#module-status")).toContainText("module loaded");
+    await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
+    await expect(page.locator("#component-status")).toHaveText("component mounted");
+    await expect(page.locator("ehagaki-composer")).toHaveCount(1);
+    expect(requests).toContain("/ehagaki/web-component/ehagaki-composer.js");
+    expect([...requests].some((path) => path.startsWith("/ehagaki/web-component/assets/"))).toBe(true);
+
+    await page.getByRole("button", { name: "実行中に適用" }).click();
+    await expect(page.locator("#component-status")).toContainText("locale");
+
+    const reply = nip19.noteEncode("a".repeat(64));
+    const quote = nip19.noteEncode("b".repeat(64));
+    const secondQuote = nip19.noteEncode("c".repeat(64));
+    await page.locator("#context-reply").fill(reply);
+    await page.getByRole("button", { name: "replyを適用" }).click();
+    await expect(page.locator("#component-status")).toHaveText("reply context: applied");
+    await page.locator("#context-quote-one").fill(quote);
+    await page.getByRole("button", { name: "quoteを適用" }).click();
+    await expect(page.locator("#component-status")).toHaveText("quote context: applied");
+    await page.locator("#context-quote-two").fill(secondQuote);
+    await page.getByRole("button", { name: "multiple quote" }).click();
+    await expect(page.locator("#component-status")).toHaveText("multiple quote context: applied");
+
+    await page.getByRole("button", { name: "invalid contextを試す" }).click();
+    await expect(page.locator("#component-status")).toContainText("invalid context: rejected");
+    await expect(page.locator("#event-log")).toHaveValue(/ehagaki-composer-context-updated/);
+
+    await page.locator("#style-background").fill("#fefefe");
+    await page.locator("#style-part-outline").fill("rgb(1, 2, 3)");
+    await page.getByRole("button", { name: "styleを適用" }).click();
+    const styleResult = await page.locator("ehagaki-composer").evaluate((element) => {
+        const shadow = element.shadowRoot!;
+        const header = shadow.querySelector<HTMLElement>('[part~="header"]')!;
+        return {
+            background: getComputedStyle(element).getPropertyValue("--ehagaki-background").trim(),
+            outline: getComputedStyle(header).outlineColor,
+        };
+    });
+    expect(styleResult.background).toBe("#fefefe");
+    expect(styleResult.outline).toBe("rgb(1, 2, 3)");
+});
+
+test("demonstrates second-instance rejection and recreation after destroy", async ({ page }) => {
+    await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
+    await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
+
+    await page.getByRole("button", { name: "2個目を生成" }).click();
+    await expect(page.locator("#component-status")).toHaveText("2個目は inert: multiple_instances_unsupported");
+    await expect(page.locator("#event-log")).toHaveValue(/multiple_instances_unsupported/);
+    await expect(page.locator("ehagaki-composer")).toHaveCount(2);
+
+    await page.getByRole("button", { name: "Destroy / Unmount" }).click();
+    await expect(page.locator("#component-status")).toContainText("persistent settings remain");
+    await page.getByRole("button", { name: "Create / Mount" }).click();
+    await expect(page.locator("#component-status")).toHaveText("component mounted");
+    await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
+
+    await page.getByRole("button", { name: "Recreate" }).click();
+    await expect(page.locator("#component-status")).toHaveText("component mounted");
+    await expect(page.locator("ehagaki-composer")).toHaveCount(1);
+});


### PR DESCRIPTION
## Summary

- add a production-reference Web Component parent-client sample at `web-component-parent-client-example.html`
- exercise the public `ehagaki-composer` lifecycle, `whenReady()`, settings/context methods, safe CustomEvent monitoring, single-instance rejection, and CSS custom properties/`::part()`
- assemble the standalone Web Component distribution under `dist/web-component/` during the normal site build so the GitHub Pages output is self-contained
- add deterministic production-output Playwright coverage for desktop/mobile Chromium
- document the Web Component guide and live sample in the README and guide

The sample intentionally does not add signer callbacks, iframe auth/RPC, nsec storage, relay interception APIs, or browser-level WebSocket proof. It explains that NIP-07 uses the trusted host's `window.nostr` in the shared realm and that iframe is the boundary for isolating secrets from host JavaScript.

Related to #89

## Verification

- `npm run check`
- `npm test`
- `npm run build`
- `npm run build:web-component`
- `git diff --check`
- sample Playwright: desktop Chromium and mobile Chromium
- existing `webComponentEmbed.spec.ts`: desktop/mobile Chromium, mobile WebKit, desktop Firefox
- existing `iframeMessageGate.spec.ts`: desktop/mobile Chromium