### PR TITLE
fix: serve Web Component live sample static routes on Vercel

### DIFF
--- a/src/test/unit/vercelRouting.test.ts
+++ b/src/test/unit/vercelRouting.test.ts
@@ -15,13 +15,25 @@ const config = JSON.parse(
 ) as VercelConfig;
 
 describe("Vercel routing", () => {
-    it("assetsをSPA fallbackから除外する", () => {
+    it("static asset namespacesをSPA fallbackから除外する", () => {
         expect(config.rewrites).toEqual([
             {
-                source: "/((?!assets/).*)",
+                source: "/((?!assets/|web-component(?:/|$)|web-component-parent-client-example\\.(?:html|js)$).*)",
                 destination: "/index.html",
             },
         ]);
+
+        const fallback = new RegExp(`^${config.rewrites[0].source}`);
+        expect([
+            "/assets/app.js",
+            "/web-component-parent-client-example.html",
+            "/web-component-parent-client-example.js",
+            "/web-component/ehagaki-composer.js",
+            "/web-component/assets/entry.js",
+            "/web-component/icons/settings.svg",
+            "/web-component/ffmpeg-core/ffmpeg-core.wasm",
+        ].every((path) => !fallback.test(path))).toBe(true);
+        expect(fallback.test("/settings")).toBe(true);
     });
 
     it("Service Workerとnosniff headersを維持する", () => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/((?!assets/).*)",
+      "source": "/((?!assets/|web-component(?:/|$)|web-component-parent-client-example\\.(?:html|js)$).*)",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
## Summary

- Vercel の SPA fallback rewrite から Web Component の静的 namespace と live sample の HTML/JS を除外
- `/web-component/**` の entry、chunks、icons、FFmpeg core/WASM を filesystem 配信に任せる
- routing regression test で静的パスは fallback 対象外、通常の app route は `/index.html` fallback のままであることを固定

## Root cause

The existing catch-all rewrite only excluded `/assets/**`. Although Vercel's filesystem precedence served existing files, Web Component paths were still represented as SPA fallback candidates, so missing or mis-resolved component resources could receive `index.html` with a successful status instead of a real static response. The rewrite now excludes the complete `/web-component/**` namespace and both live-sample files while preserving the existing SPA fallback for app routes.

## Verification

- `npm run check`
- `npm test`
- `npm run build`
- `npm run build:web-component`
- Web Component sample E2E: desktop/mobile Chromium
- Existing Web Component E2E: 32 passed across Chromium/WebKit/Firefox
- iframe message gate: 3 passed
- Vercel `deploy --dry`: valid config
- Vercel Preview: Ready at https://ehagaki-5p4xymjtu-lokuyows-projects.vercel.app
- Preview route manifest confirmed the new rewrite and filesystem route; direct Preview content checks require the project's Vercel Authentication. The same public production host was browser-verified for sample mount, module/chunk/icon/WASM loading and Content-Type behavior.