### PR TITLE
docs: organize and translate embedding guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ https://lokuyow.github.io/ehagaki/?quote=note1...
 
 eHagaki の iframe 埋め込み方法、親クライアント連携ログイン、`postMessage` 仕様は公開ガイドに分離しました。
 
-[IFRAME_EMBEDDING.md](IFRAME_EMBEDDING.md) を参照してください。
+[docs/IFRAME_EMBEDDING.md](docs/IFRAME_EMBEDDING.md) を参照してください。
 
 親ページ連携の動作確認用サンプルは [https://lokuyow.github.io/ehagaki/embed-parent-client-example.html](https://lokuyow.github.io/ehagaki/embed-parent-client-example.html) からも直接アクセスできます。
 

--- a/docs/IFRAME_EMBEDDING.md
+++ b/docs/IFRAME_EMBEDDING.md
@@ -163,7 +163,7 @@ eHagaki のテーマ設定は初回起動時の既定値が `system` です。�
 
 - `embedTheme=system` は iframe 起動ごとに system へ戻したい場合に使えます
 - `defaultTheme=light|dark` は eHagaki 側にテーマ保存がない時だけ初期値を指定したい場合に使ってください
-- 既存の [public/embed-parent-client-example.html](public/embed-parent-client-example.html) は、`embed~` / `default~` と実行中の `settings.set` を切り替えて試せます
+- 既存の [public/embed-parent-client-example.html](../public/embed-parent-client-example.html) は、`embed~` / `default~` と実行中の `settings.set` を切り替えて試せます
 
 ## 2. リプライ / 複数引用 / パブリックチャット状態で起動する
 
@@ -579,7 +579,7 @@ iframe.contentWindow.postMessage({
 }, 'https://lokuyow.github.io');
 ```
 
-既存の [public/embed-parent-client-example.html](public/embed-parent-client-example.html) は、localStorage 委譲と `uploadDestinations` の IndexedDB 委譲に対応しています。
+既存の [public/embed-parent-client-example.html](../public/embed-parent-client-example.html) は、localStorage 委譲と `uploadDestinations` の IndexedDB 委譲に対応しています。
 
 ### 都度生成 iframe の設定注入
 
@@ -598,8 +598,8 @@ iframe.contentWindow.postMessage({
 
 リポジトリ内には実際に親ページとして動かせるサンプルを追加しています。
 
-- [public/embed-parent-client-example.html](public/embed-parent-client-example.html)
-- [public/embed-parent-client-example.js](public/embed-parent-client-example.js)
+- [public/embed-parent-client-example.html](../public/embed-parent-client-example.html)
+- [public/embed-parent-client-example.js](../public/embed-parent-client-example.js)
 
 オンラインで直接確認するには [https://lokuyow.github.io/ehagaki/embed-parent-client-example.html](https://lokuyow.github.io/ehagaki/embed-parent-client-example.html) を開いてください。
 

--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -103,8 +103,8 @@ API は提供せず、Issue #89 の relay-interceptor の証明も未完了で�
 付きで配信するか、`asset-base` からアクセスできる配信基準を指定してください。
 クロスオリジン埋め込みでは、FFmpeg は `asset-base` から同梱の class-worker モジュール
 を取得し、ホストオリジンの Blob URL をそのワーカー用に作成した後、`asset-base` から
-`ffmpeg-core.js` と `ffmpeg-core.wasm` を読み込みます。`worker-src` では delivery
-配信元オリジンと `blob:` の両方を許可してください。この経路のプロキシをホストの Service
+`ffmpeg-core.js` と `ffmpeg-core.wasm` を読み込みます。`worker-src` では配信元オリジンと
+`blob:` の両方を許可してください。この経路のプロキシをホストの Service
 Worker に依存しないでください。同一オリジンの PWA 配信では、生成されたワーカー用
 アセットを引き続き直接利用します。iOS Safari は実際の配信元オリジンで確認して
 ください。モバイルエミュレーションではワーカーや CORS の動作は検証できません。

--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -1,18 +1,18 @@
 # eHagaki Composer Web Component ガイド
 
 `npm run build:web-component` は `dist-web-component/ehagaki-composer.js` を生成します。
-これは ES module 形式の配布物で、PWA のビルドとは意図的に分離されています。manifest、share target、eHagaki Service Worker の登録、iframe bridge は含みません。通常の `npm run build` では、この standalone 配布物を `dist/web-component/` にも組み立てるため、PWA site の出力から live sample と component asset をまとめて配信できます。standalone の `dist-web-component/` 出力は、CDN など別の配布方法にも利用できます。
+これは ES module 形式の配布物で、PWA のビルドとは意図的に分離されています。manifest、共有ターゲット、eHagaki Service Worker の登録、iframe 連携は含みません。通常の `npm run build` では、この単独配布物を `dist/web-component/` にも組み立てるため、PWA サイトの出力から実動サンプルとコンポーネント用アセットをまとめて配信できます。単独配布物の `dist-web-component/` 出力は、CDN など別の配布方法にも利用できます。
 
 操作できる公開リファレンスは
 [https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html](https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html)
-です。module URL / asset base、Create / Destroy / Recreate、`whenReady()`、
-initial/runtime settings、content/reply/quote/multiple quote/channel context、
-安全な event log、2 個目の instance の拒否、CSS Custom Properties と
-`::part()` を確認できます。ページロード時には component も任意の module も
+です。モジュール URL / アセットの基準、作成 / 破棄 / 再作成、`whenReady()`、
+初期設定 / 実行時設定、本文 / 返信 / 引用 / 複数引用 / チャンネルのコンテキスト、
+安全なイベントログ、2 個目のインスタンスの拒否、CSS Custom Properties と
+`::part()` を確認できます。ページロード時にはコンポーネントも任意のモジュールも
 自動実行せず、`Create / Mount` が明示的な import・接続操作になります。
-外部 module は host と同じ JavaScript 権限で実行されるため、信頼できる URL
-だけを指定してください。module load 後は Custom Elements Registry の制約により
-module URL を変更できず、別実装を試すにはページを reload します。
+外部モジュールはホストと同じ JavaScript 権限で実行されるため、信頼できる URL
+だけを指定してください。モジュールの読み込み後は Custom Elements Registry の制約により
+モジュール URL を変更できず、別実装を試すにはページを再読み込みします。
 
 ```html
 <script type="module" src="https://cdn.example/ehagaki-composer.js"></script>
@@ -29,94 +29,94 @@ module URL を変更できず、別実装を試すにはページを reload し�
 ```
 
 1 つの document で接続できる `ehagaki-composer` は 1 個だけです。2 個目の
-element は inert のままになり、`multiple_instances_unsupported` を付けた
-`ehagaki-initialization-error` を発生させ、`whenReady()` を reject します。最初の
-element を disconnect すると、その slot は解放されます。disconnect しても保存済み
+要素は非活性のままになり、`multiple_instances_unsupported` を付けた
+`ehagaki-initialization-error` を発生させ、`whenReady()` を拒否します。最初の
+要素を切断すると、その枠は解放されます。切断しても保存済み
 データは削除されません。
 
-## API と event
+## APIとイベント
 
-- `whenReady(): Promise<void>` は component の mount 完了後に resolve します。
+- `whenReady(): Promise<void>` はコンポーネントの mount 完了後に解決します。
 - `setContext(context)` は iframe の `composer.setContext` と同じ reply、quote、
-  channel、content の validation/apply ロジックを使います。
-- `setSettings(settings)` は対応している settings を適用し、適用された key とともに
-  resolve します。
-- `assetBase` property / `asset-base` attribute は、chunk、worker、WASM、FFmpeg
-  asset を配信する base を選択します。connection 前に設定してください。
+  channel、content の検証・適用ロジックを使います。
+- `setSettings(settings)` は対応している設定を適用し、適用された key とともに
+  解決します。
+- `assetBase` プロパティ / `asset-base` 属性は、チャンク、ワーカー、WASM、FFmpeg
+  アセットを配信する基準を選択します。接続前に設定してください。
 
-すべての event は bubble し、composed です。対象は `ehagaki-ready`（detail は
+すべてのイベントは bubble し、composed です。対象は `ehagaki-ready`（detail は
 `{ apiVersion: 1 }`）、`ehagaki-post-success`、`ehagaki-post-error`、
 `ehagaki-composer-context-updated`、`ehagaki-initialization-error` です。
-Error detail には安全な code/message だけを使用し、secret key、authentication
-payload、raw error は含めません。
+エラーの detail には安全な code/message だけを使用し、秘密鍵、認証 payload、
+生のエラーは含めません。
 
-component の authentication model は、意図的に既存の eHagaki の model を使います。
-Web Component 専用の signer callback/provider API は追加していません。component は
-host の Window realm を共有するため、NIP-07 では host の `window.nostr` を直接利用
-します。NIP-46 と nsec/managed-account の login には、component 内の eHagaki 既存
-login UI を使います。sample が表示するのは `window.nostr` と既知の capability の
+コンポーネントの認証モデルは、意図的に既存の eHagaki のモデルを使います。
+Web Component 専用の signer callback/provider API は追加していません。コンポーネントは
+ホストの Window realm を共有するため、NIP-07 ではホストの `window.nostr` を直接利用
+します。NIP-46 と nsec/managed-account の login には、コンポーネント内の eHagaki 既存
+ログイン UI を使います。サンプルが表示するのは `window.nostr` と既知の対応機能の
 有無だけです。nsec を受け取ったり保存したりせず、iframe の `auth.*` / `rpc.*`
-message も実装していません。
+メッセージも実装していません。
 
-sample の context controls は `element.setContext(...)` を直接呼び出します。
+サンプルのコンテキスト操作は `element.setContext(...)` を直接呼び出します。
 payload には `content`、`reply`、`quotes`、`channel` を使います。channel には必須の
-`reference` と、任意の `relays`、`name`、`about`、`picture` があります。settings
-controls では、現在対応している `locale`、`themeMode`、quality、notification、
-client-tag、media-placement、mascot、flavor-text、upload endpoint の key を使い、
-未対応の key は reject します。
+`reference` と、任意の `relays`、`name`、`about`、`picture` があります。設定
+操作では、現在対応している `locale`、`themeMode`、品質、通知、クライアントタグ、
+メディア配置、マスコット、フレーバーテキスト、アップロード先の key を使い、
+未対応の key は拒否します。
 
 公開している CSS Custom Properties は `--ehagaki-background`、
 `--ehagaki-text`、`--ehagaki-border`、`--ehagaki-link`、
 `--ehagaki-input-background`、`--ehagaki-footer-background`、
-`--ehagaki-dialog-background`、`--ehagaki-font-family` です。component は
+`--ehagaki-dialog-background`、`--ehagaki-font-family` です。コンポーネントは
 `shell`、`header`、`composer`、`footer`、`overlay-root` の part も公開しています。
 
-## Storage、origin、trust boundary
+## ストレージ、オリジン、信頼境界
 
-component は host の Window realm で動作し、host origin に直接保存します。ただし、
-eHagaki の localStorage key はすべて `ehagaki.web-component.v1:` namespace に限定
-されます。対象には account、nsec、NIP-46、relay、settings、legacy-cleanup の path
-が含まれます。host の raw key を読み取り、上書き、削除することはありません。この
-first release には migration がありません。iframe parent-storage protocol を通じて
-以前に委譲されていた data は、Web Component へ切り替えても自動移行されません。
+コンポーネントはホストの Window realm で動作し、ホストオリジンに直接保存します。ただし、
+eHagaki の localStorage key はすべて `ehagaki.web-component.v1:` 名前空間に限定
+されます。対象にはアカウント、nsec、NIP-46、リレー、設定、legacy-cleanup の経路
+が含まれます。ホストの生の key を読み取り、上書き、削除することはありません。この
+初回リリースには移行がありません。iframe parent-storage プロトコルを通じて
+以前に委譲されていたデータは、Web Component へ切り替えても自動移行されません。
 
-IndexedDB は host origin の app-specific な `eHagakiDB` のままです。schema や
-database name の migration はありません。host は component を実行する trusted
-環境であり、same-origin storage を検査できます。namespace は衝突防止のためのもの
-であり、secret boundary ではありません。
+IndexedDB はホストオリジンの eHagaki 専用 `eHagakiDB` のままです。schema や
+データベース名の移行はありません。ホストはコンポーネントを実行する信頼された
+環境であり、同一オリジンのストレージを検査できます。名前空間は衝突防止のためのもの
+であり、秘密の境界ではありません。
 
-## Service Worker、relay、FFmpeg、CSP
+## Service Worker、リレー、FFmpeg、CSP
 
-component 自身は eHagaki Service Worker を register せず、message も送りません。host
-Service Worker は通常の HTTP fetch、image、upload を観測できますが、その `fetch`
-event だけでは Nostr WebSocket relay traffic の interception を示せません。component
-は host の Window realm を共有し、現在の `initializeNostrSession()` path は
-`websocketCtor` なしで rx-nostr を生成します。そのため rx-nostr は relay を開くとき
-`globalThis.WebSocket` を使います。この module の import 前に host が wrapper を
-install した場合、その wrapper が適用される boundary になります。
-この release は browser-level の relay-interceptor 保証をうたいません。通常の app
-relay path には authenticated session が必要で、既存 application には credential-free
-で deterministic な local-relay route が見つかっていません。専用の relay-interceptor
-API は提供せず、Issue #89 の relay-interceptor proof も未完了です。
+コンポーネント自身は eHagaki Service Worker を登録せず、メッセージも送りません。ホストの
+Service Worker は通常の HTTP fetch、画像、アップロードを観測できますが、その `fetch`
+イベントだけでは Nostr WebSocket のリレー通信を傍受できることの証明にはなりません。コンポーネント
+はホストの Window realm を共有し、現在の `initializeNostrSession()` 経路は
+`websocketCtor` なしで rx-nostr を生成します。そのため rx-nostr はリレーを開くとき
+`globalThis.WebSocket` を使います。このモジュールの import 前にホストがラッパーを
+導入した場合、そのラッパーが適用される境界になります。
+このリリースはブラウザレベルの relay-interceptor 保証をうたいません。通常のアプリの
+リレー経路には認証済みセッションが必要で、既存アプリケーションには認証情報不要で
+決定的なローカルリレー経路が見つかっていません。専用の relay-interceptor
+API は提供せず、Issue #89 の relay-interceptor の証明も未完了です。
 
-module、chunk、worker、FFmpeg file、WASM は、埋め込み元 origin を許可する CORS header
-付きで配信するか、`asset-base` にアクセス可能な delivery base を指定してください。
-cross-origin embedding では、FFmpeg は `asset-base` から bundled class-worker module
-を取得し、host origin の Blob URL をその worker 用に作成した後、`asset-base` から
+モジュール、チャンク、ワーカー、FFmpeg ファイル、WASM は、埋め込み元オリジンを許可する CORS ヘッダー
+付きで配信するか、`asset-base` からアクセスできる配信基準を指定してください。
+クロスオリジン埋め込みでは、FFmpeg は `asset-base` から同梱の class-worker モジュール
+を取得し、ホストオリジンの Blob URL をそのワーカー用に作成した後、`asset-base` から
 `ffmpeg-core.js` と `ffmpeg-core.wasm` を読み込みます。`worker-src` では delivery
-origin と `blob:` の両方を許可してください。この path の proxy を host Service
-Worker に依存しないでください。同一 origin の PWA 配信では、生成された worker
-asset を引き続き直接利用します。iOS Safari は実際の delivery origin で確認して
-ください。mobile emulation では worker や CORS の動作は検証できません。
+配信元オリジンと `blob:` の両方を許可してください。この経路のプロキシをホストの Service
+Worker に依存しないでください。同一オリジンの PWA 配信では、生成されたワーカー用
+アセットを引き続き直接利用します。iOS Safari は実際の配信元オリジンで確認して
+ください。モバイルエミュレーションではワーカーや CORS の動作は検証できません。
 
-component は open ShadowRoot を使います。Dialog、popover、tooltip、suggestion、
-PhotoSwipe は component の overlay root を対象にします。一方、browser-history と
-URL/share-target input handling は無効化されています。
+コンポーネントは open ShadowRoot を使います。Dialog、popover、tooltip、suggestion、
+PhotoSwipe はコンポーネントの overlay root を対象にします。一方、ブラウザ履歴と
+URL/share-target の入力処理は無効化されています。
 
-host sample では CSS Custom Properties `--ehagaki-background`,
+ホストのサンプルでは CSS Custom Properties `--ehagaki-background`,
 `--ehagaki-text`, `--ehagaki-border`, `--ehagaki-link`,
 `--ehagaki-input-background`, `--ehagaki-footer-background`,
-`--ehagaki-dialog-background`、`--ehagaki-font-family` を確認できます。また、host
-stylesheet から宣言済みの `shell`、`header`、`composer`、`footer`、`overlay-root`
-part を style できます。これらは Web Component API であり、iframe sample からは
-この方法で iframe 内部の stylesheet にアクセスできません。
+`--ehagaki-dialog-background`、`--ehagaki-font-family` を確認できます。また、ホストの
+スタイルシートから宣言済みの `shell`、`header`、`composer`、`footer`、`overlay-root`
+part をスタイル設定できます。これらは Web Component API であり、iframe のサンプルからは
+この方法で iframe 内部のスタイルシートにアクセスできません。

--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -1,23 +1,18 @@
-# eHagaki Composer Web Component
+# eHagaki Composer Web Component ガイド
 
-`npm run build:web-component` produces `dist-web-component/ehagaki-composer.js`.
-It is an ES module distribution and is deliberately separate from the PWA
-build: it does not contain a manifest, share target, eHagaki Service Worker
-registration, or the iframe bridge. The normal `npm run build` also assembles
-that standalone distribution under `dist/web-component/`, so the PWA site
-output can serve the live sample and component assets together. The standalone
-`dist-web-component/` output remains available for CDN or other distribution.
+`npm run build:web-component` は `dist-web-component/ehagaki-composer.js` を生成します。
+これは ES module 形式の配布物で、PWA のビルドとは意図的に分離されています。manifest、share target、eHagaki Service Worker の登録、iframe bridge は含みません。通常の `npm run build` では、この standalone 配布物を `dist/web-component/` にも組み立てるため、PWA site の出力から live sample と component asset をまとめて配信できます。standalone の `dist-web-component/` 出力は、CDN など別の配布方法にも利用できます。
 
 操作できる公開リファレンスは
 [https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html](https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html)
 です。module URL / asset base、Create / Destroy / Recreate、`whenReady()`、
 initial/runtime settings、content/reply/quote/multiple quote/channel context、
-安全なevent log、2個目instanceの拒否、CSS Custom Propertiesと
-`::part()`を確認できます。ページロード時にはcomponentも任意moduleも
-自動実行せず、`Create / Mount`が明示的なimport・接続操作になります。
-外部moduleはhostと同じJavaScript権限で実行されるため、信頼できるURL
-だけを指定してください。module load後はCustom Elements Registryのため
-module URLを変更できず、別実装を試すにはページをreloadします。
+安全な event log、2 個目の instance の拒否、CSS Custom Properties と
+`::part()` を確認できます。ページロード時には component も任意の module も
+自動実行せず、`Create / Mount` が明示的な import・接続操作になります。
+外部 module は host と同じ JavaScript 権限で実行されるため、信頼できる URL
+だけを指定してください。module load 後は Custom Elements Registry の制約により
+module URL を変更できず、別実装を試すにはページを reload します。
 
 ```html
 <script type="module" src="https://cdn.example/ehagaki-composer.js"></script>
@@ -33,96 +28,95 @@ module URLを変更できず、別実装を試すにはページをreloadしま�
 </script>
 ```
 
-Only one connected `ehagaki-composer` is supported in a document. A second
-element remains inert, emits `ehagaki-initialization-error` with
-`multiple_instances_unsupported`, and rejects `whenReady()`. Disconnecting the
-first element releases that slot. Disconnecting does not delete persisted data.
+1 つの document で接続できる `ehagaki-composer` は 1 個だけです。2 個目の
+element は inert のままになり、`multiple_instances_unsupported` を付けた
+`ehagaki-initialization-error` を発生させ、`whenReady()` を reject します。最初の
+element を disconnect すると、その slot は解放されます。disconnect しても保存済み
+データは削除されません。
 
-## API and events
+## API と event
 
-- `whenReady(): Promise<void>` resolves after the component mounts.
-- `setContext(context)` uses the same reply, quote, channel, and content
-  validation/apply logic as iframe `composer.setContext`.
-- `setSettings(settings)` applies supported settings and resolves with the
-  applied keys.
-- `assetBase` property / `asset-base` attribute selects the component-delivery
-  base for chunks, workers, WASM, and FFmpeg assets. Set it before connection.
+- `whenReady(): Promise<void>` は component の mount 完了後に resolve します。
+- `setContext(context)` は iframe の `composer.setContext` と同じ reply、quote、
+  channel、content の validation/apply ロジックを使います。
+- `setSettings(settings)` は対応している settings を適用し、適用された key とともに
+  resolve します。
+- `assetBase` property / `asset-base` attribute は、chunk、worker、WASM、FFmpeg
+  asset を配信する base を選択します。connection 前に設定してください。
 
-All events bubble and are composed: `ehagaki-ready` (detail
-`{ apiVersion: 1 }`), `ehagaki-post-success`, `ehagaki-post-error`,
-`ehagaki-composer-context-updated`, and `ehagaki-initialization-error`.
-Error details use a safe code/message only; they do not contain secret keys,
-authentication payloads, or raw errors.
+すべての event は bubble し、composed です。対象は `ehagaki-ready`（detail は
+`{ apiVersion: 1 }`）、`ehagaki-post-success`、`ehagaki-post-error`、
+`ehagaki-composer-context-updated`、`ehagaki-initialization-error` です。
+Error detail には安全な code/message だけを使用し、secret key、authentication
+payload、raw error は含めません。
 
-The component's authentication model is intentionally the existing eHagaki
-model. It does not add a Web Component signer callback/provider API. Because
-the component shares the host Window realm, NIP-07 uses the host's
-`window.nostr` directly; NIP-46 and nsec/managed-account login use eHagaki's
-own existing login UI inside the component. The sample displays only whether
-`window.nostr` and its known capabilities are present. It does not accept or
-persist an nsec and does not implement iframe `auth.*` / `rpc.*` messages.
+component の authentication model は、意図的に既存の eHagaki の model を使います。
+Web Component 専用の signer callback/provider API は追加していません。component は
+host の Window realm を共有するため、NIP-07 では host の `window.nostr` を直接利用
+します。NIP-46 と nsec/managed-account の login には、component 内の eHagaki 既存
+login UI を使います。sample が表示するのは `window.nostr` と既知の capability の
+有無だけです。nsec を受け取ったり保存したりせず、iframe の `auth.*` / `rpc.*`
+message も実装していません。
 
-The sample's context controls call `element.setContext(...)` directly. The
-payload uses `content`, `reply`, `quotes`, and `channel`, where channel has a
-required `reference` and optional `relays`, `name`, `about`, and `picture`.
-Settings controls use the currently supported `locale`, `themeMode`, quality,
-notification, client-tag, media-placement, mascot, flavor-text, and upload
-endpoint keys; unsupported keys are rejected.
+sample の context controls は `element.setContext(...)` を直接呼び出します。
+payload には `content`、`reply`、`quotes`、`channel` を使います。channel には必須の
+`reference` と、任意の `relays`、`name`、`about`、`picture` があります。settings
+controls では、現在対応している `locale`、`themeMode`、quality、notification、
+client-tag、media-placement、mascot、flavor-text、upload endpoint の key を使い、
+未対応の key は reject します。
 
-The public CSS custom properties are `--ehagaki-background`,
+公開している CSS Custom Properties は `--ehagaki-background`、
+`--ehagaki-text`、`--ehagaki-border`、`--ehagaki-link`、
+`--ehagaki-input-background`、`--ehagaki-footer-background`、
+`--ehagaki-dialog-background`、`--ehagaki-font-family` です。component は
+`shell`、`header`、`composer`、`footer`、`overlay-root` の part も公開しています。
+
+## Storage、origin、trust boundary
+
+component は host の Window realm で動作し、host origin に直接保存します。ただし、
+eHagaki の localStorage key はすべて `ehagaki.web-component.v1:` namespace に限定
+されます。対象には account、nsec、NIP-46、relay、settings、legacy-cleanup の path
+が含まれます。host の raw key を読み取り、上書き、削除することはありません。この
+first release には migration がありません。iframe parent-storage protocol を通じて
+以前に委譲されていた data は、Web Component へ切り替えても自動移行されません。
+
+IndexedDB は host origin の app-specific な `eHagakiDB` のままです。schema や
+database name の migration はありません。host は component を実行する trusted
+環境であり、same-origin storage を検査できます。namespace は衝突防止のためのもの
+であり、secret boundary ではありません。
+
+## Service Worker、relay、FFmpeg、CSP
+
+component 自身は eHagaki Service Worker を register せず、message も送りません。host
+Service Worker は通常の HTTP fetch、image、upload を観測できますが、その `fetch`
+event だけでは Nostr WebSocket relay traffic の interception を示せません。component
+は host の Window realm を共有し、現在の `initializeNostrSession()` path は
+`websocketCtor` なしで rx-nostr を生成します。そのため rx-nostr は relay を開くとき
+`globalThis.WebSocket` を使います。この module の import 前に host が wrapper を
+install した場合、その wrapper が適用される boundary になります。
+この release は browser-level の relay-interceptor 保証をうたいません。通常の app
+relay path には authenticated session が必要で、既存 application には credential-free
+で deterministic な local-relay route が見つかっていません。専用の relay-interceptor
+API は提供せず、Issue #89 の relay-interceptor proof も未完了です。
+
+module、chunk、worker、FFmpeg file、WASM は、埋め込み元 origin を許可する CORS header
+付きで配信するか、`asset-base` にアクセス可能な delivery base を指定してください。
+cross-origin embedding では、FFmpeg は `asset-base` から bundled class-worker module
+を取得し、host origin の Blob URL をその worker 用に作成した後、`asset-base` から
+`ffmpeg-core.js` と `ffmpeg-core.wasm` を読み込みます。`worker-src` では delivery
+origin と `blob:` の両方を許可してください。この path の proxy を host Service
+Worker に依存しないでください。同一 origin の PWA 配信では、生成された worker
+asset を引き続き直接利用します。iOS Safari は実際の delivery origin で確認して
+ください。mobile emulation では worker や CORS の動作は検証できません。
+
+component は open ShadowRoot を使います。Dialog、popover、tooltip、suggestion、
+PhotoSwipe は component の overlay root を対象にします。一方、browser-history と
+URL/share-target input handling は無効化されています。
+
+host sample では CSS Custom Properties `--ehagaki-background`,
 `--ehagaki-text`, `--ehagaki-border`, `--ehagaki-link`,
 `--ehagaki-input-background`, `--ehagaki-footer-background`,
-`--ehagaki-dialog-background`, and `--ehagaki-font-family`. The component
-also exposes `shell`, `header`, `composer`, `footer`, and `overlay-root` parts.
-
-## Storage, origin, and trust boundary
-
-The component runs in the host Window realm and stores directly in the host
-origin, but every eHagaki localStorage key is confined to
-`ehagaki.web-component.v1:`. This includes account, nsec, NIP-46, relay,
-settings, and legacy-cleanup paths; raw host keys are not read, overwritten, or
-removed. This first release has no migration. Data previously delegated through
-the iframe parent-storage protocol is not automatically moved when switching to
-the Web Component.
-
-IndexedDB remains the app-specific `eHagakiDB` at the host origin. There is no
-schema or database-name migration. The host is trusted to execute the component
-and can inspect same-origin storage; the namespace is collision protection, not
-a secret boundary.
-
-## Service Workers, relays, FFmpeg, and CSP
-
-The component neither registers nor messages an eHagaki Service Worker. A host
-Service Worker may observe ordinary HTTP fetches, images, and uploads, but its
-`fetch` event does not demonstrate interception of Nostr WebSocket relay
-traffic. The component shares the host Window realm, and the current
-`initializeNostrSession()` path creates rx-nostr without a `websocketCtor`;
-rx-nostr therefore uses `globalThis.WebSocket` when it opens a relay. A host
-wrapper installed before this module is imported is the applicable boundary.
-This release does not claim a browser-level relay-interceptor guarantee: the
-normal app relay path requires an authenticated session and no deterministic,
-credential-free local-relay route was found in the existing application. No
-special relay-interceptor API is provided, and Issue #89's relay-interceptor
-proof remains incomplete.
-
-Serve the module, chunks, workers, FFmpeg files, and WASM with CORS headers
-that permit the embedding origin, or set `asset-base` to an accessible delivery
-base. In a cross-origin embedding, FFmpeg fetches its bundled class-worker
-module from `asset-base`, creates a host-origin Blob URL for that worker, then
-loads `ffmpeg-core.js` and `ffmpeg-core.wasm` from `asset-base`. Permit both
-the delivery origin and `blob:` in `worker-src`; do not rely on a host Service
-Worker to proxy this path. Same-origin PWA delivery continues to use the emitted
-worker asset directly. Test iOS Safari with the actual delivery origin: mobile
-emulation does not prove its worker or CORS behavior.
-
-The component uses an open ShadowRoot. Dialogs, popovers, tooltips, suggestions,
-and PhotoSwipe are targeted at its overlay root, while browser-history and URL/
-share-target input handling are disabled.
-
-The host sample demonstrates the CSS custom properties `--ehagaki-background`,
-`--ehagaki-text`, `--ehagaki-border`, `--ehagaki-link`,
-`--ehagaki-input-background`, `--ehagaki-footer-background`,
-`--ehagaki-dialog-background`, and `--ehagaki-font-family`. It also styles the
-declared `shell`, `header`, `composer`, `footer`, and `overlay-root` parts from
-the host stylesheet. These are Web Component APIs; the iframe sample cannot
-reach the iframe's internal stylesheet in this way.
+`--ehagaki-dialog-background`、`--ehagaki-font-family` を確認できます。また、host
+stylesheet から宣言済みの `shell`、`header`、`composer`、`footer`、`overlay-root`
+part を style できます。これらは Web Component API であり、iframe sample からは
+この方法で iframe 内部の stylesheet にアクセスできません。

--- a/public/embed-parent-client-example.html
+++ b/public/embed-parent-client-example.html
@@ -427,7 +427,7 @@
             <header>
                 <h1>Parent Client Sample</h1>
                 <p class="lead">親ページ側で NIP-07 または秘密鍵を使ってログインし、eHagaki の embed protocol v1 を中継する実動サンプルです。</p>
-                <p class="help-link"><a href="https://github.com/Lokuyow/ehagaki/blob/main/IFRAME_EMBEDDING.md"
+                <p class="help-link"><a href="https://github.com/Lokuyow/ehagaki/blob/main/docs/IFRAME_EMBEDDING.md"
                         target="_blank" rel="noreferrer noopener">埋め込みガイドを開く</a>（iframe 埋め込みの仕様と親ページ向けメッセージ形式を確認できます）
                 </p>
             </header>


### PR DESCRIPTION
## 概要

- `IFRAME_EMBEDDING.md` を `docs/IFRAME_EMBEDDING.md` へ移動
- iframe / Web Component の公開ガイドを `docs/` に統一
- Web Component ガイドの説明文・見出しを日本語化
- README、iframe live sample、移動後の相対リンクを更新

## 仕様・実装への影響

コード、公開 API、sample の UI / 機能、build / deploy、Vercel、Service Worker、storage、protocol は変更していません。コードブロック内のコマンド、API 名、property / attribute、event、error code、settings key、context field、URL は維持しています。

## 検証

- `npm run check`: 成功（0 errors / 0 warnings）
- `git diff --check`: 成功
- `docs/IFRAME_EMBEDDING.md` のリポジトリ内 Markdown link 4 件を検証
- ルート直下の旧 `IFRAME_EMBEDDING.md` 参照がないことを確認
- `docs/IFRAME_EMBEDDING.md` と `docs/WEB_COMPONENT.md` の存在を確認