### PR TITLE
fix: make web component sample styles opt-in

### DIFF
--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -237,7 +237,7 @@
 
                 <div class="card stack">
                     <h2>CSS Custom Properties / parts</h2>
-                    <p class="small">次のhost側style APIを変更できます。Shadow DOM内部へ直接入らず、custom propertyと公開partだけを使います。</p>
+                    <p class="small">Create / Mount時はeHagaki本体のデフォルトCSSを使い、入力欄の値は自動適用されません。「入力したカスタムCSSを適用」を押したときだけ反映し、「デフォルトに戻す」でsample側のoverrideを除去できます。</p>
                     <div class="grid-2">
                         <div class="field"><label for="style-background">background</label><input id="style-background" value="#f4f4f4"></div>
                         <div class="field"><label for="style-text">text</label><input id="style-text" value="#183028"></div>
@@ -249,8 +249,11 @@
                         <div class="field"><label for="style-font">font family</label><input id="style-font" value="system-ui, sans-serif"></div>
                     </div>
                     <div class="field"><label for="style-part-outline">::part(header/composer) outline</label><input id="style-part-outline" value="#28764f"></div>
-                    <button id="apply-styles" type="button" class="secondary">styleを適用</button>
-                    <p class="small"><code>ehagaki-composer::part(header)</code> と <code>::part(composer)</code> にoutlineを適用するhost stylesheetがこのページにあります。iframeではこのCSS境界を直接使えません。</p>
+                    <div class="buttons">
+                        <button id="apply-styles" type="button" class="secondary">入力したカスタムCSSを適用</button>
+                        <button id="reset-styles" type="button" class="ghost">デフォルトに戻す</button>
+                    </div>
+                    <p class="small"><code>ehagaki-composer::part(header)</code> と <code>::part(composer)</code> にoutlineを適用する、このページのスタイルがあります。iframeではこのCSS境界を直接使えません。</p>
                 </div>
             </div>
         </section>

--- a/public/web-component-parent-client-example.js
+++ b/public/web-component-parent-client-example.js
@@ -20,6 +20,17 @@ let secondaryComposer = null;
 let loadedModuleUrl = "";
 let moduleLoadPromise = null;
 
+const CUSTOM_STYLE_FIELDS = [
+    ["--ehagaki-background", "style-background"],
+    ["--ehagaki-text", "style-text"],
+    ["--ehagaki-border", "style-border"],
+    ["--ehagaki-link", "style-link"],
+    ["--ehagaki-input-background", "style-input"],
+    ["--ehagaki-footer-background", "style-footer"],
+    ["--ehagaki-dialog-background", "style-dialog"],
+    ["--ehagaki-font-family", "style-font"],
+];
+
 function getElement(id) {
     const element = document.getElementById(id);
     if (!element) throw new Error(`Missing sample element: ${id}`);
@@ -215,23 +226,21 @@ async function ensureModuleLoaded() {
 }
 
 function applyCustomStyles(element) {
-    for (const [property, id] of [
-        ["--ehagaki-background", "style-background"],
-        ["--ehagaki-text", "style-text"],
-        ["--ehagaki-border", "style-border"],
-        ["--ehagaki-link", "style-link"],
-        ["--ehagaki-input-background", "style-input"],
-        ["--ehagaki-footer-background", "style-footer"],
-        ["--ehagaki-dialog-background", "style-dialog"],
-        ["--ehagaki-font-family", "style-font"],
-    ]) {
+    for (const [property, id] of CUSTOM_STYLE_FIELDS) {
         element.style.setProperty(property, getElement(id).value);
     }
 }
 
+function removeCustomStyles(element) {
+    for (const [property] of CUSTOM_STYLE_FIELDS) {
+        element.style.removeProperty(property);
+    }
+    element.style.removeProperty("--sample-part-outline");
+    document.documentElement.style.removeProperty("--sample-part-outline");
+}
+
 function configureElement(element) {
     element.setAttribute("asset-base", normalizeDirectoryUrl(assetBaseInput.value));
-    applyCustomStyles(element);
 }
 
 async function createComposer() {
@@ -303,13 +312,24 @@ async function createSecondComposer() {
 }
 
 function applyStyles() {
-    if (!currentComposer) {
+    if (!currentComposer?.isConnected) {
+        setStatus(componentStatus, "componentを先にCreateしてください", "warn");
         appendLog("styles: component_not_mounted");
         return;
     }
     applyCustomStyles(currentComposer);
-    document.documentElement.style.setProperty("--sample-part-outline", getElement("style-part-outline").value);
+    currentComposer.style.setProperty("--sample-part-outline", getElement("style-part-outline").value);
     appendLog("styles applied", { customProperties: 8, parts: ["header", "composer"] });
+}
+
+function resetStyles() {
+    if (!currentComposer?.isConnected) {
+        setStatus(componentStatus, "componentを先にCreateしてください", "warn");
+        appendLog("styles: component_not_mounted");
+        return;
+    }
+    removeCustomStyles(currentComposer);
+    appendLog("styles reset", { customProperties: 8, parts: ["header", "composer"] });
 }
 
 function refreshNip07Status() {
@@ -343,6 +363,7 @@ function bindActions() {
     getElement("clear-context").addEventListener("click", () => applyContextToComposer({ content: null, reply: null, quotes: null, channel: null }, "clear context"));
     getElement("apply-invalid-context").addEventListener("click", () => applyContextToComposer({ content: "must not apply", reply: "invalid reference" }, "invalid context"));
     getElement("apply-styles").addEventListener("click", applyStyles);
+    getElement("reset-styles").addEventListener("click", resetStyles);
     getElement("clear-log").addEventListener("click", () => { eventLog.value = ""; });
 }
 

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -105,6 +105,65 @@ test("boots from production site output and exercises the public sample API", as
     expect(requests).toContain("/ehagaki/web-component/ehagaki-composer.js");
     expect([...requests].some((path) => path.startsWith("/ehagaki/web-component/assets/"))).toBe(true);
 
+    const initialStyleResult = await page.locator("ehagaki-composer").evaluate((element) => {
+        const properties = [
+            "--ehagaki-background",
+            "--ehagaki-text",
+            "--ehagaki-border",
+            "--ehagaki-link",
+            "--ehagaki-input-background",
+            "--ehagaki-footer-background",
+            "--ehagaki-dialog-background",
+            "--ehagaki-font-family",
+            "--sample-part-outline",
+        ];
+        return Object.fromEntries(properties.map((property) => [property, element.style.getPropertyValue(property)]));
+    });
+    expect(Object.values(initialStyleResult).every((value) => value === "")).toBe(true);
+
+    await page.locator("#theme-mode").selectOption("light");
+    await page.getByRole("button", { name: "実行中に適用" }).click();
+    await expect(page.locator("#component-status")).toContainText("themeMode");
+    const lightThemeResult = await page.locator("ehagaki-composer").evaluate((element) => {
+        const appRoot = element.shadowRoot!.querySelector<HTMLElement>(".ehagaki-app-root")!;
+        const appStyle = getComputedStyle(appRoot);
+        return {
+            lightHostClass: element.classList.contains("light"),
+            appColor: appStyle.color,
+            appBackground: appStyle.backgroundColor,
+        };
+    });
+    expect(lightThemeResult.lightHostClass).toBe(true);
+    expect(lightThemeResult.appColor).not.toBe("rgba(0, 0, 0, 0)");
+    expect(lightThemeResult.appColor).not.toBe(lightThemeResult.appBackground);
+
+    await page.locator("#theme-mode").selectOption("dark");
+    await page.getByRole("button", { name: "実行中に適用" }).click();
+    await expect(page.locator("#component-status")).toContainText("themeMode");
+    const darkThemeResult = await page.locator("ehagaki-composer").evaluate((element) => {
+        const shadow = element.shadowRoot!;
+        const appRoot = shadow.querySelector<HTMLElement>(".ehagaki-app-root")!;
+        const footer = shadow.querySelector<HTMLElement>(".footer-bar")!;
+        const footerButton = footer.querySelector<HTMLElement>("button")!;
+        const appStyle = getComputedStyle(appRoot);
+        const footerStyle = getComputedStyle(footer);
+        const buttonStyle = getComputedStyle(footerButton);
+        return {
+            darkHostClass: element.classList.contains("dark"),
+            appColor: appStyle.color,
+            appBackground: appStyle.backgroundColor,
+            footerColor: footerStyle.color,
+            footerBackground: footerStyle.backgroundColor,
+            buttonColor: buttonStyle.color,
+            buttonBackground: buttonStyle.backgroundColor,
+        };
+    });
+    expect(darkThemeResult.darkHostClass).toBe(true);
+    expect(darkThemeResult.appColor).not.toBe("rgba(0, 0, 0, 0)");
+    expect(darkThemeResult.appColor).not.toBe(darkThemeResult.appBackground);
+    expect(darkThemeResult.footerColor).not.toBe(darkThemeResult.footerBackground);
+    expect(darkThemeResult.buttonColor).not.toBe(darkThemeResult.buttonBackground);
+
     await page.getByRole("button", { name: "実行中に適用" }).click();
     await expect(page.locator("#component-status")).toContainText("locale");
 
@@ -126,18 +185,46 @@ test("boots from production site output and exercises the public sample API", as
     await expect(page.locator("#event-log")).toHaveValue(/ehagaki-composer-context-updated/);
 
     await page.locator("#style-background").fill("#fefefe");
+    await page.locator("#style-text").fill("#102030");
     await page.locator("#style-part-outline").fill("rgb(1, 2, 3)");
-    await page.getByRole("button", { name: "styleを適用" }).click();
+    await page.getByRole("button", { name: "入力したカスタムCSSを適用" }).click();
     const styleResult = await page.locator("ehagaki-composer").evaluate((element) => {
         const shadow = element.shadowRoot!;
         const header = shadow.querySelector<HTMLElement>('[part~="header"]')!;
         return {
             background: getComputedStyle(element).getPropertyValue("--ehagaki-background").trim(),
+            text: element.style.getPropertyValue("--ehagaki-text"),
             outline: getComputedStyle(header).outlineColor,
         };
     });
     expect(styleResult.background).toBe("#fefefe");
+    expect(styleResult.text).toBe("#102030");
     expect(styleResult.outline).toBe("rgb(1, 2, 3)");
+
+    await page.getByRole("button", { name: "デフォルトに戻す" }).click();
+    const resetStyleResult = await page.locator("ehagaki-composer").evaluate((element) => {
+        const properties = [
+            "--ehagaki-background",
+            "--ehagaki-text",
+            "--ehagaki-border",
+            "--ehagaki-link",
+            "--ehagaki-input-background",
+            "--ehagaki-footer-background",
+            "--ehagaki-dialog-background",
+            "--ehagaki-font-family",
+            "--sample-part-outline",
+        ];
+        const shadow = element.shadowRoot!;
+        const header = shadow.querySelector<HTMLElement>('[part~="header"]')!;
+        return {
+            inlineProperties: Object.fromEntries(properties.map((property) => [property, element.style.getPropertyValue(property)])),
+            outline: getComputedStyle(header).outlineColor,
+            rootOutline: document.documentElement.style.getPropertyValue("--sample-part-outline"),
+        };
+    });
+    expect(Object.values(resetStyleResult.inlineProperties).every((value) => value === "")).toBe(true);
+    expect(resetStyleResult.outline).not.toBe("rgb(1, 2, 3)");
+    expect(resetStyleResult.rootOutline).toBe("");
 });
 
 test("demonstrates second-instance rejection and recreation after destroy", async ({ page }) => {
@@ -149,6 +236,14 @@ test("demonstrates second-instance rejection and recreation after destroy", asyn
     await expect(page.locator("#component-status")).toHaveText("2個目は inert: multiple_instances_unsupported");
     await expect(page.locator("#event-log")).toHaveValue(/multiple_instances_unsupported/);
     await expect(page.locator("ehagaki-composer")).toHaveCount(2);
+    const secondInstanceStyles = await page.locator("ehagaki-composer").evaluateAll((elements) => elements.map((element) => ({
+        background: element.style.getPropertyValue("--ehagaki-background"),
+        partOutline: element.style.getPropertyValue("--sample-part-outline"),
+    })));
+    expect(secondInstanceStyles).toEqual([
+        { background: "", partOutline: "" },
+        { background: "", partOutline: "" },
+    ]);
 
     await page.getByRole("button", { name: "Destroy / Unmount" }).click();
     await expect(page.locator("#component-status")).toContainText("persistent settings remain");
@@ -159,6 +254,16 @@ test("demonstrates second-instance rejection and recreation after destroy", asyn
     await page.getByRole("button", { name: "Recreate" }).click();
     await expect(page.locator("#component-status")).toHaveText("component mounted");
     await expect(page.locator("ehagaki-composer")).toHaveCount(1);
+
+    await page.locator("#style-background").fill("#fefefe");
+    await page.getByRole("button", { name: "入力したカスタムCSSを適用" }).click();
+    await page.getByRole("button", { name: "Recreate" }).click();
+    await expect(page.locator("#component-status")).toHaveText("component mounted");
+    const recreatedStyle = await page.locator("ehagaki-composer").evaluate((element) => ({
+        background: element.style.getPropertyValue("--ehagaki-background"),
+        partOutline: element.style.getPropertyValue("--sample-part-outline"),
+    }));
+    expect(recreatedStyle).toEqual({ background: "", partOutline: "" });
 });
 
 test("does not import query-selected modules until an explicit Create action", async ({ page }) => {


### PR DESCRIPTION
## 概要

PR #109で整理したWeb Component公開sampleについて、カスタムCSSデモを明示適用型に修正します。

- Create / Mount、2個目の生成、RecreateではeHagaki本体のデフォルトCSSを使用
- 「入力したカスタムCSSを適用」を押したときだけ、現在のWeb Componentへ値を適用
- 「デフォルトに戻す」でsampleが設定したCSS Custom Propertiesとpart outlineを削除
- default light / dark、明示適用、リセット、Recreate後の未継承をsample E2Eで回帰確認
- 実装コードのWeb Component CSS、iframe、footer固定問題には変更なし

## 検証

- `npm run check`: 成功（0 errors / 0 warnings）
- `git diff --check`: 成功
- `npm run build`: 成功（sample E2E用のdist生成を含む）
- desktop Chromium sample E2E: 3 passed
- mobile Chromium sample E2E: 3 passed
- `npm test`: 未実行。sample HTML/JSと関連E2Eに限定した変更のため
