### PR TITLE
fix: add web component style presets

### DIFF
--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -237,18 +237,23 @@
 
                 <div class="card stack">
                     <h2>CSS Custom Properties / parts</h2>
-                    <p class="small">Create / Mount時はeHagaki本体のデフォルトCSSを使い、入力欄の値は自動適用されません。「入力したカスタムCSSを適用」を押したときだけ反映し、「デフォルトに戻す」でsample側のoverrideを除去できます。</p>
-                    <div class="grid-2">
-                        <div class="field"><label for="style-background">background</label><input id="style-background" value="#f4f4f4"></div>
-                        <div class="field"><label for="style-text">text</label><input id="style-text" value="#183028"></div>
-                        <div class="field"><label for="style-border">border</label><input id="style-border" value="#b8c7be"></div>
-                        <div class="field"><label for="style-link">link</label><input id="style-link" value="#28764f"></div>
-                        <div class="field"><label for="style-input">input background</label><input id="style-input" value="#ffffff"></div>
-                        <div class="field"><label for="style-footer">footer background</label><input id="style-footer" value="#e2ebe5"></div>
-                        <div class="field"><label for="style-dialog">dialog background</label><input id="style-dialog" value="#ffffff"></div>
-                        <div class="field"><label for="style-font">font family</label><input id="style-font" value="system-ui, sans-serif"></div>
+                    <p class="small">Create / Mount時はeHagaki本体のデフォルトCSSを使います。空欄は本体デフォルトを意味し、プリセットは入力欄へ値を入れるだけで表示は変えません。値は自由に編集でき、「入力したカスタムCSSを適用」を押したときだけ反映されます。「デフォルトに戻す」ではoverrideと入力欄をクリアします。</p>
+                    <div class="buttons">
+                        <button id="preset-mint" type="button" class="ghost">ミント</button>
+                        <button id="preset-blue" type="button" class="ghost">ブルー</button>
+                        <button id="preset-dark" type="button" class="ghost">ダーク</button>
                     </div>
-                    <div class="field"><label for="style-part-outline">::part(header/composer) outline</label><input id="style-part-outline" value="#28764f"></div>
+                    <div class="grid-2">
+                        <div class="field"><label for="style-background">background</label><input id="style-background" placeholder="未指定 = eHagakiデフォルト"></div>
+                        <div class="field"><label for="style-text">text</label><input id="style-text" placeholder="未指定 = eHagakiデフォルト"></div>
+                        <div class="field"><label for="style-border">border</label><input id="style-border" placeholder="未指定 = eHagakiデフォルト"></div>
+                        <div class="field"><label for="style-link">link</label><input id="style-link" placeholder="未指定 = eHagakiデフォルト"></div>
+                        <div class="field"><label for="style-input">input background</label><input id="style-input" placeholder="未指定 = eHagakiデフォルト"></div>
+                        <div class="field"><label for="style-footer">footer background</label><input id="style-footer" placeholder="未指定 = eHagakiデフォルト"></div>
+                        <div class="field"><label for="style-dialog">dialog background</label><input id="style-dialog" placeholder="未指定 = eHagakiデフォルト"></div>
+                        <div class="field"><label for="style-font">font family</label><input id="style-font" placeholder="未指定 = eHagakiデフォルト"></div>
+                    </div>
+                    <div class="field"><label for="style-part-outline">::part(header/composer) outline</label><input id="style-part-outline" placeholder="未指定 = eHagakiデフォルト"></div>
                     <div class="buttons">
                         <button id="apply-styles" type="button" class="secondary">入力したカスタムCSSを適用</button>
                         <button id="reset-styles" type="button" class="ghost">デフォルトに戻す</button>

--- a/public/web-component-parent-client-example.js
+++ b/public/web-component-parent-client-example.js
@@ -31,6 +31,53 @@ const CUSTOM_STYLE_FIELDS = [
     ["--ehagaki-font-family", "style-font"],
 ];
 
+const STYLE_PRESETS = {
+    mint: {
+        background: "#f4f8f5",
+        text: "#183028",
+        border: "#b8c7be",
+        link: "#28764f",
+        input: "#ffffff",
+        footer: "#e2ebe5",
+        dialog: "#ffffff",
+        font: "system-ui, sans-serif",
+        partOutline: "#28764f",
+    },
+    blue: {
+        background: "#f3f7fb",
+        text: "#1d2a36",
+        border: "#b7c6d3",
+        link: "#1769aa",
+        input: "#ffffff",
+        footer: "#dfeaf3",
+        dialog: "#ffffff",
+        font: "system-ui, sans-serif",
+        partOutline: "#1769aa",
+    },
+    dark: {
+        background: "#181a1b",
+        text: "#e8e8e8",
+        border: "#4a4f52",
+        link: "#8ab4f8",
+        input: "#242728",
+        footer: "#202324",
+        dialog: "#242728",
+        font: "system-ui, sans-serif",
+        partOutline: "#8ab4f8",
+    },
+};
+
+const STYLE_PRESET_FIELDS = [
+    ["style-background", "background"],
+    ["style-text", "text"],
+    ["style-border", "border"],
+    ["style-link", "link"],
+    ["style-input", "input"],
+    ["style-footer", "footer"],
+    ["style-dialog", "dialog"],
+    ["style-font", "font"],
+];
+
 function getElement(id) {
     const element = document.getElementById(id);
     if (!element) throw new Error(`Missing sample element: ${id}`);
@@ -227,8 +274,29 @@ async function ensureModuleLoaded() {
 
 function applyCustomStyles(element) {
     for (const [property, id] of CUSTOM_STYLE_FIELDS) {
-        element.style.setProperty(property, getElement(id).value);
+        const value = getElement(id).value.trim();
+        if (value) {
+            element.style.setProperty(property, value);
+        } else {
+            element.style.removeProperty(property);
+        }
     }
+}
+
+function clearStyleInputs() {
+    for (const [, id] of CUSTOM_STYLE_FIELDS) {
+        getElement(id).value = "";
+    }
+    getElement("style-part-outline").value = "";
+}
+
+function selectStylePreset(name) {
+    const preset = STYLE_PRESETS[name];
+    for (const [id, key] of STYLE_PRESET_FIELDS) {
+        getElement(id).value = preset[key];
+    }
+    getElement("style-part-outline").value = preset.partOutline;
+    appendLog(`styles preset selected: ${name}`);
 }
 
 function removeCustomStyles(element) {
@@ -318,17 +386,24 @@ function applyStyles() {
         return;
     }
     applyCustomStyles(currentComposer);
-    currentComposer.style.setProperty("--sample-part-outline", getElement("style-part-outline").value);
+    const partOutline = getElement("style-part-outline").value.trim();
+    if (partOutline) {
+        currentComposer.style.setProperty("--sample-part-outline", partOutline);
+    } else {
+        currentComposer.style.removeProperty("--sample-part-outline");
+    }
     appendLog("styles applied", { customProperties: 8, parts: ["header", "composer"] });
 }
 
 function resetStyles() {
     if (!currentComposer?.isConnected) {
+        clearStyleInputs();
         setStatus(componentStatus, "componentを先にCreateしてください", "warn");
-        appendLog("styles: component_not_mounted");
+        appendLog("styles reset: component_not_mounted");
         return;
     }
     removeCustomStyles(currentComposer);
+    clearStyleInputs();
     appendLog("styles reset", { customProperties: 8, parts: ["header", "composer"] });
 }
 
@@ -364,6 +439,9 @@ function bindActions() {
     getElement("apply-invalid-context").addEventListener("click", () => applyContextToComposer({ content: "must not apply", reply: "invalid reference" }, "invalid context"));
     getElement("apply-styles").addEventListener("click", applyStyles);
     getElement("reset-styles").addEventListener("click", resetStyles);
+    getElement("preset-mint").addEventListener("click", () => selectStylePreset("mint"));
+    getElement("preset-blue").addEventListener("click", () => selectStylePreset("blue"));
+    getElement("preset-dark").addEventListener("click", () => selectStylePreset("dark"));
     getElement("clear-log").addEventListener("click", () => { eventLog.value = ""; });
 }
 

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -96,6 +96,19 @@ test("boots from production site output and exercises the public sample API", as
     await expect(page.locator("#asset-base")).toHaveValue(`${origin}/ehagaki/web-component/`);
     await expect(page.locator("#module-status")).toHaveText("module 未読み込み");
     await expect(page.locator("ehagaki-composer")).toHaveCount(0);
+    for (const id of [
+        "style-background",
+        "style-text",
+        "style-border",
+        "style-link",
+        "style-input",
+        "style-footer",
+        "style-dialog",
+        "style-font",
+        "style-part-outline",
+    ]) {
+        await expect(page.locator(`#${id}`)).toHaveValue("");
+    }
     await page.getByRole("button", { name: "Create / Mount" }).click();
     await expect(page.locator("#module-status")).toContainText("module loaded");
     await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
@@ -164,6 +177,110 @@ test("boots from production site output and exercises the public sample API", as
     expect(darkThemeResult.footerColor).not.toBe(darkThemeResult.footerBackground);
     expect(darkThemeResult.buttonColor).not.toBe(darkThemeResult.buttonBackground);
 
+    await page.getByRole("button", { name: "ブルー" }).click();
+    await expect(page.locator("#style-background")).toHaveValue("#f3f7fb");
+    await expect(page.locator("#style-text")).toHaveValue("#1d2a36");
+    const afterBluePresetOnly = await page.locator("ehagaki-composer").evaluate((element) => element.style.getPropertyValue("--ehagaki-background"));
+    expect(afterBluePresetOnly).toBe("");
+
+    await page.getByRole("button", { name: "ミント" }).click();
+    await expect(page.locator("#style-background")).toHaveValue("#f4f8f5");
+    await expect(page.locator("#style-text")).toHaveValue("#183028");
+    await expect(page.locator("#style-border")).toHaveValue("#b8c7be");
+    await expect(page.locator("#style-link")).toHaveValue("#28764f");
+    await expect(page.locator("#style-input")).toHaveValue("#ffffff");
+    await expect(page.locator("#style-footer")).toHaveValue("#e2ebe5");
+    await expect(page.locator("#style-dialog")).toHaveValue("#ffffff");
+    await expect(page.locator("#style-font")).toHaveValue("system-ui, sans-serif");
+    await expect(page.locator("#style-part-outline")).toHaveValue("#28764f");
+    const afterPresetOnly = await page.locator("ehagaki-composer").evaluate((element) => Object.fromEntries([
+        "--ehagaki-background",
+        "--ehagaki-text",
+        "--ehagaki-border",
+        "--ehagaki-link",
+        "--ehagaki-input-background",
+        "--ehagaki-footer-background",
+        "--ehagaki-dialog-background",
+        "--ehagaki-font-family",
+        "--sample-part-outline",
+    ].map((property) => [property, element.style.getPropertyValue(property)])));
+    expect(Object.values(afterPresetOnly).every((value) => value === "")).toBe(true);
+
+    await page.locator("#style-text").fill("#102030");
+    await page.locator("#style-border").fill("");
+    await page.locator("#style-part-outline").fill("rgb(1, 2, 3)");
+    await page.getByRole("button", { name: "入力したカスタムCSSを適用" }).click();
+    const partialStyleResult = await page.locator("ehagaki-composer").evaluate((element) => ({
+        outline: getComputedStyle(element.shadowRoot!.querySelector<HTMLElement>('[part~="header"]')!).outlineColor,
+        background: element.style.getPropertyValue("--ehagaki-background"),
+        text: element.style.getPropertyValue("--ehagaki-text"),
+        border: element.style.getPropertyValue("--ehagaki-border"),
+        computedBackground: getComputedStyle(element).getPropertyValue("--ehagaki-background").trim(),
+    }));
+    expect(partialStyleResult.outline).toBe("rgb(1, 2, 3)");
+    expect(partialStyleResult.background).toBe("#f4f8f5");
+    expect(partialStyleResult.text).toBe("#102030");
+    expect(partialStyleResult.border).toBe("");
+    expect(partialStyleResult.computedBackground).toBe("#f4f8f5");
+
+    await page.getByRole("button", { name: "デフォルトに戻す" }).click();
+    const resetStyleResult = await page.locator("ehagaki-composer").evaluate((element) => {
+        const properties = [
+            "--ehagaki-background",
+            "--ehagaki-text",
+            "--ehagaki-border",
+            "--ehagaki-link",
+            "--ehagaki-input-background",
+            "--ehagaki-footer-background",
+            "--ehagaki-dialog-background",
+            "--ehagaki-font-family",
+            "--sample-part-outline",
+        ];
+        return {
+            inlineProperties: Object.fromEntries(properties.map((property) => [property, element.style.getPropertyValue(property)])),
+            rootOutline: document.documentElement.style.getPropertyValue("--sample-part-outline"),
+        };
+    });
+    expect(Object.values(resetStyleResult.inlineProperties).every((value) => value === "")).toBe(true);
+    expect(resetStyleResult.rootOutline).toBe("");
+    for (const id of [
+        "style-background",
+        "style-text",
+        "style-border",
+        "style-link",
+        "style-input",
+        "style-footer",
+        "style-dialog",
+        "style-font",
+        "style-part-outline",
+    ]) {
+        await expect(page.locator(`#${id}`)).toHaveValue("");
+    }
+
+    await page.getByRole("button", { name: "ダーク" }).click();
+    await expect(page.locator("#style-background")).toHaveValue("#181a1b");
+    await expect(page.locator("#style-text")).toHaveValue("#e8e8e8");
+    const darkPresetOnly = await page.locator("ehagaki-composer").evaluate((element) => ({
+        background: element.style.getPropertyValue("--ehagaki-background"),
+        text: element.style.getPropertyValue("--ehagaki-text"),
+    }));
+    expect(darkPresetOnly).toEqual({ background: "", text: "" });
+    await page.getByRole("button", { name: "入力したカスタムCSSを適用" }).click();
+    const darkPresetResult = await page.locator("ehagaki-composer").evaluate((element) => {
+        const appRoot = element.shadowRoot!.querySelector<HTMLElement>(".ehagaki-app-root")!;
+        const style = getComputedStyle(appRoot);
+        return {
+            background: element.style.getPropertyValue("--ehagaki-background"),
+            text: element.style.getPropertyValue("--ehagaki-text"),
+            appColor: style.color,
+            appBackground: style.backgroundColor,
+        };
+    });
+    expect(darkPresetResult.background).toBe("#181a1b");
+    expect(darkPresetResult.text).toBe("#e8e8e8");
+    expect(darkPresetResult.appColor).not.toBe(darkPresetResult.appBackground);
+    await page.getByRole("button", { name: "デフォルトに戻す" }).click();
+
     await page.getByRole("button", { name: "実行中に適用" }).click();
     await expect(page.locator("#component-status")).toContainText("locale");
 
@@ -184,47 +301,6 @@ test("boots from production site output and exercises the public sample API", as
     await expect(page.locator("#component-status")).toContainText("invalid context: rejected");
     await expect(page.locator("#event-log")).toHaveValue(/ehagaki-composer-context-updated/);
 
-    await page.locator("#style-background").fill("#fefefe");
-    await page.locator("#style-text").fill("#102030");
-    await page.locator("#style-part-outline").fill("rgb(1, 2, 3)");
-    await page.getByRole("button", { name: "入力したカスタムCSSを適用" }).click();
-    const styleResult = await page.locator("ehagaki-composer").evaluate((element) => {
-        const shadow = element.shadowRoot!;
-        const header = shadow.querySelector<HTMLElement>('[part~="header"]')!;
-        return {
-            background: getComputedStyle(element).getPropertyValue("--ehagaki-background").trim(),
-            text: element.style.getPropertyValue("--ehagaki-text"),
-            outline: getComputedStyle(header).outlineColor,
-        };
-    });
-    expect(styleResult.background).toBe("#fefefe");
-    expect(styleResult.text).toBe("#102030");
-    expect(styleResult.outline).toBe("rgb(1, 2, 3)");
-
-    await page.getByRole("button", { name: "デフォルトに戻す" }).click();
-    const resetStyleResult = await page.locator("ehagaki-composer").evaluate((element) => {
-        const properties = [
-            "--ehagaki-background",
-            "--ehagaki-text",
-            "--ehagaki-border",
-            "--ehagaki-link",
-            "--ehagaki-input-background",
-            "--ehagaki-footer-background",
-            "--ehagaki-dialog-background",
-            "--ehagaki-font-family",
-            "--sample-part-outline",
-        ];
-        const shadow = element.shadowRoot!;
-        const header = shadow.querySelector<HTMLElement>('[part~="header"]')!;
-        return {
-            inlineProperties: Object.fromEntries(properties.map((property) => [property, element.style.getPropertyValue(property)])),
-            outline: getComputedStyle(header).outlineColor,
-            rootOutline: document.documentElement.style.getPropertyValue("--sample-part-outline"),
-        };
-    });
-    expect(Object.values(resetStyleResult.inlineProperties).every((value) => value === "")).toBe(true);
-    expect(resetStyleResult.outline).not.toBe("rgb(1, 2, 3)");
-    expect(resetStyleResult.rootOutline).toBe("");
 });
 
 test("demonstrates second-instance rejection and recreation after destroy", async ({ page }) => {


### PR DESCRIPTION
## 概要

Web Component公開sampleのCSS Custom Properties UIを拡充しました。

- CSS入力欄の初期値を空欄化（空欄はeHagaki本体デフォルト）
- ミント、ブルー、ダークの3プリセットを追加
- プリセットは入力欄だけを更新し、適用ボタン押下までWeb Componentへ反映しない
- 空欄の項目は`removeProperty()`で部分指定に対応
- デフォルト復元時にoverrideと全入力欄をクリア
- Recreate時の自動再適用なしを維持
- Web Component本体、CSS、footer固定問題は変更なし

## 検証

- `npm run build`: 成功
- desktop Chromium sample E2E: 3 passed
- mobile Chromium sample E2E: 3 passed
- `npm run check`: 成功（0 errors / 0 warnings）
- `git diff --check`: 成功
- `npm test`: 未実行（sampleと関連E2Eに限定した変更のため）
