### PR TITLE
fix: support web component sample in local dev

### DIFF
--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -76,6 +76,15 @@ iframe 連携は含まれません。
 との分離を保つため、Web Component 用ディレクトリへ PWA の Service Worker や manifest を
 追加しないでください。
 
+## ローカル開発
+
+通常のアプリ開発には `npm run dev` を使います。Web Component の公開サンプルをローカルで
+確認する場合は `npm run dev:web-component` を使い、
+`http://localhost:5173/ehagaki/web-component-parent-client-example.html` を開いてください。
+このコマンドは Web Component の初回buildとwatchを起動します。Web Component のソースを変更した後は、
+watchによる再buildの完了を待ってからページを再読み込みします。`vite.web-component.config.ts` などの
+build設定を変更した場合は、コマンドを再起動してください。
+
 ## `asset-base` / `assetBase`
 
 `asset-base` は、コンポーネントが配布物内のアセットを解決するための配信元です。実装では、

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host",
+    "dev:web-component": "node scripts/devWebComponentSample.mjs",
     "prebuild": "npx rimraf dist",
     "build": "vite build && node scripts/verifyLegacyBridgeBuild.mjs && npm run build:web-component && npm run assemble:web-component-site",
     "build:web-component": "vite build --config vite.web-component.config.ts && node scripts/verifyWebComponentBuild.mjs",

--- a/scripts/devWebComponentSample.mjs
+++ b/scripts/devWebComponentSample.mjs
@@ -1,0 +1,215 @@
+import { spawn } from "node:child_process";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import { extname, isAbsolute, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const webComponentDirectory = resolve(repositoryRoot, "dist-web-component");
+const viteCli = resolve(repositoryRoot, "node_modules", "vite", "bin", "vite.js");
+const host = "127.0.0.1";
+const appPort = parsePort(process.env.EHAGAKI_WEB_COMPONENT_DEV_APP_PORT, 5173, "EHAGAKI_WEB_COMPONENT_DEV_APP_PORT");
+const webComponentPort = parsePort(process.env.EHAGAKI_WEB_COMPONENT_DEV_PORT, 5174, "EHAGAKI_WEB_COMPONENT_DEV_PORT");
+
+let webComponentServer;
+let watcher;
+let viteServer;
+let shuttingDown = false;
+
+function parsePort(value, fallback, variableName) {
+    if (value === undefined) return fallback;
+    if (!/^[0-9]+$/.test(value)) {
+        throw new Error(`${variableName} must be a valid TCP port.`);
+    }
+    const port = Number(value);
+    if (!Number.isSafeInteger(port) || port < 1024 || port > 65535) {
+        throw new Error(`${variableName} must be a valid TCP port.`);
+    }
+    return port;
+}
+
+function contentType(filePath) {
+    switch (extname(filePath)) {
+        case ".js": return "text/javascript; charset=utf-8";
+        case ".css": return "text/css; charset=utf-8";
+        case ".json": return "application/json; charset=utf-8";
+        case ".svg": return "image/svg+xml";
+        case ".wasm": return "application/wasm";
+        case ".png": return "image/png";
+        case ".jpg":
+        case ".jpeg": return "image/jpeg";
+        case ".webp": return "image/webp";
+        case ".ico": return "image/x-icon";
+        default: return "application/octet-stream";
+    }
+}
+
+function resolveAssetPath(requestUrl) {
+    const pathname = decodeURIComponent(new URL(requestUrl ?? "/", `http://${host}`).pathname);
+    const filePath = resolve(webComponentDirectory, `.${pathname}`);
+    const pathFromRoot = relative(webComponentDirectory, filePath);
+    if (pathFromRoot.startsWith("..") || isAbsolute(pathFromRoot)) {
+        return null;
+    }
+    return filePath;
+}
+
+function startWebComponentServer() {
+    return new Promise((resolveServer, reject) => {
+        const server = createServer(async (request, response) => {
+            if (request.method !== "GET" && request.method !== "HEAD") {
+                response.writeHead(405, { Allow: "GET, HEAD" }).end();
+                return;
+            }
+
+            let filePath;
+            try {
+                filePath = resolveAssetPath(request.url);
+            } catch {
+                response.writeHead(400).end();
+                return;
+            }
+            if (!filePath) {
+                response.writeHead(400).end();
+                return;
+            }
+
+            try {
+                const file = await stat(filePath);
+                if (!file.isFile()) {
+                    response.writeHead(404).end();
+                    return;
+                }
+                response.writeHead(200, {
+                    "Content-Length": file.size,
+                    "Content-Type": contentType(filePath),
+                    "Cache-Control": "no-store",
+                });
+                if (request.method === "HEAD") {
+                    response.end();
+                    return;
+                }
+                createReadStream(filePath).pipe(response);
+            } catch {
+                response.writeHead(404).end();
+            }
+        });
+        server.once("error", reject);
+        server.listen(webComponentPort, host, () => {
+            server.off("error", reject);
+            resolveServer(server);
+        });
+    });
+}
+
+function runNode(args, environment = process.env) {
+    return spawn(process.execPath, args, {
+        cwd: repositoryRoot,
+        env: environment,
+        stdio: "inherit",
+        windowsHide: true,
+    });
+}
+
+function waitForExit(child) {
+    return new Promise((resolveExit, reject) => {
+        child.once("error", reject);
+        child.once("exit", (code, signal) => resolveExit({ code, signal }));
+    });
+}
+
+async function runInitialBuild() {
+    for (const [label, args] of [
+        ["Web Component build", [viteCli, "build", "--config", "vite.web-component.config.ts"]],
+        ["Web Component build verification", ["scripts/verifyWebComponentBuild.mjs"]],
+    ]) {
+        const build = runNode(args);
+        const { code, signal } = await waitForExit(build);
+        if (code !== 0) {
+            throw new Error(`${label} failed (${signal ?? code ?? "unknown"}).`);
+        }
+    }
+}
+
+function watchChild(label, child) {
+    child.once("exit", (code, signal) => {
+        if (!shuttingDown) {
+            console.error(`${label} stopped unexpectedly (${signal ?? code ?? "unknown"}).`);
+            void shutdown(code ?? 1);
+        }
+    });
+}
+
+function closeServer(server) {
+    return new Promise((resolveClose) => {
+        if (!server) {
+            resolveClose();
+            return;
+        }
+        server.close(() => resolveClose());
+    });
+}
+
+function terminateChild(child) {
+    return new Promise((resolveTerminate) => {
+        if (!child?.pid || child.exitCode !== null) {
+            resolveTerminate();
+            return;
+        }
+        if (process.platform === "win32") {
+            const taskkill = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+                stdio: "ignore",
+                windowsHide: true,
+            });
+            taskkill.once("error", resolveTerminate);
+            taskkill.once("exit", resolveTerminate);
+            return;
+        }
+        child.once("exit", resolveTerminate);
+        child.kill("SIGTERM");
+    });
+}
+
+async function shutdown(exitCode) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    await Promise.all([
+        terminateChild(watcher),
+        terminateChild(viteServer),
+        closeServer(webComponentServer),
+    ]);
+    process.exitCode = exitCode;
+}
+
+async function main() {
+    if (appPort === webComponentPort) {
+        throw new Error("The app and Web Component dev server ports must be different.");
+    }
+
+    console.log("Building the Web Component for local development...");
+    await runInitialBuild();
+
+    webComponentServer = await startWebComponentServer();
+    watcher = runNode([viteCli, "build", "--config", "vite.web-component.config.ts", "--watch"]);
+    viteServer = runNode([viteCli, "--host", host, "--port", String(appPort), "--strictPort"], {
+        ...process.env,
+        EHAGAKI_WEB_COMPONENT_DEV_PROXY: "true",
+        EHAGAKI_WEB_COMPONENT_DEV_PORT: String(webComponentPort),
+    });
+    watchChild("Web Component watcher", watcher);
+    watchChild("Vite dev server", viteServer);
+
+    console.log(`Web Component sample: http://localhost:${appPort}/ehagaki/web-component-parent-client-example.html`);
+}
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.once(signal, () => {
+        void shutdown(0);
+    });
+}
+
+main().catch(async (error) => {
+    console.error(error instanceof Error ? error.message : error);
+    await shutdown(1);
+});

--- a/src/test/e2e/webComponentDevServer.spec.ts
+++ b/src/test/e2e/webComponentDevServer.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from "@playwright/test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { rm, stat, utimes } from "node:fs/promises";
+import { createServer } from "node:net";
+import { join } from "node:path";
+
+const host = "127.0.0.1";
+
+async function reservePort(): Promise<number> {
+    const server = createServer();
+    await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, host, () => resolve());
+    });
+    const address = server.address();
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    if (!address || typeof address === "string") {
+        throw new Error("Could not reserve a TCP port for the Web Component dev server test.");
+    }
+    return address.port;
+}
+
+async function requestStatus(url: string): Promise<number> {
+    try {
+        return (await fetch(url)).status;
+    } catch {
+        return 0;
+    }
+}
+
+function waitForExit(child: ChildProcess): Promise<void> {
+    return new Promise((resolve) => child.once("exit", () => resolve()));
+}
+
+async function stopDevServer(child: ChildProcess): Promise<void> {
+    if (child.exitCode !== null) return;
+    const exited = waitForExit(child);
+    child.kill("SIGINT");
+    await Promise.race([
+        exited,
+        new Promise<void>((resolve) => setTimeout(resolve, 10_000)),
+    ]);
+    if (child.exitCode !== null) return;
+
+    if (process.platform === "win32" && child.pid) {
+        const taskkill = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+            stdio: "ignore",
+            windowsHide: true,
+        });
+        await new Promise<void>((resolve) => taskkill.once("exit", () => resolve()));
+        return;
+    }
+    child.kill("SIGTERM");
+    await exited;
+}
+
+test("serves the Web Component sample through the local dev proxy", async ({ page }) => {
+    test.setTimeout(180_000);
+    const appPort = await reservePort();
+    const webComponentPort = await reservePort();
+    const origin = `http://${host}:${appPort}`;
+    const output: string[] = [];
+    await rm(join(process.cwd(), "dist-web-component"), { recursive: true, force: true });
+    const devServer = spawn(process.execPath, ["scripts/devWebComponentSample.mjs"], {
+        cwd: process.cwd(),
+        env: {
+            ...process.env,
+            EHAGAKI_WEB_COMPONENT_DEV_APP_PORT: String(appPort),
+            EHAGAKI_WEB_COMPONENT_DEV_PORT: String(webComponentPort),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+    });
+    devServer.stdout?.on("data", (chunk) => output.push(String(chunk)));
+    devServer.stderr?.on("data", (chunk) => output.push(String(chunk)));
+
+    const webComponentResponses: Array<{ path: string; status: number }> = [];
+    const failedWebComponentRequests: string[] = [];
+    const consoleErrors: string[] = [];
+    page.on("response", (response) => {
+        const url = new URL(response.url());
+        if (url.origin === origin && url.pathname.startsWith("/ehagaki/web-component/")) {
+            webComponentResponses.push({ path: url.pathname, status: response.status() });
+        }
+    });
+    page.on("requestfailed", (request) => {
+        const url = new URL(request.url());
+        if (url.origin === origin && url.pathname.startsWith("/ehagaki/web-component/")) {
+            failedWebComponentRequests.push(url.pathname);
+        }
+    });
+    page.on("console", (message) => {
+        if (message.type() === "error") consoleErrors.push(message.text());
+    });
+
+    try {
+        await expect.poll(
+            () => requestStatus(`${origin}/ehagaki/web-component-parent-client-example.html`),
+            { timeout: 120_000 },
+        ).toBe(200);
+        await expect.poll(
+            () => requestStatus(`${origin}/ehagaki/web-component/ehagaki-composer.js`),
+            { timeout: 30_000 },
+        ).toBe(200);
+
+        await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
+        await expect(page.locator("#module-url")).toHaveValue(`${origin}/ehagaki/web-component/ehagaki-composer.js`);
+        await expect(page.locator("#asset-base")).toHaveValue(`${origin}/ehagaki/web-component/`);
+        await page.getByRole("button", { name: "Create / Mount" }).click();
+        await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
+        await page.waitForFunction(() => document.querySelector("ehagaki-composer")?.shadowRoot?.querySelector(".footer-bar"));
+
+        const iconStatus = await page.evaluate(async () => (
+            await fetch("./web-component/icons/add_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg")
+        ).status);
+        expect(iconStatus).toBe(200);
+        expect(webComponentResponses.some(({ path, status }) => path.endsWith("/ehagaki-composer.js") && status === 200)).toBe(true);
+        expect(webComponentResponses.some(({ path, status }) => path.includes("/assets/") && status === 200)).toBe(true);
+        expect(webComponentResponses.some(({ path, status }) => path.includes("/icons/") && status === 200)).toBe(true);
+        expect(webComponentResponses.some(({ status }) => status === 404)).toBe(false);
+        expect(failedWebComponentRequests).toEqual([]);
+        expect(consoleErrors.filter((message) => /404|module/i.test(message))).toEqual([]);
+
+        const entryPath = join(process.cwd(), "src", "web-component", "entry.ts");
+        const entryStat = await stat(entryPath);
+        await expect.poll(() => (output.join("").match(/built in/g) ?? []).length, {
+            timeout: 30_000,
+        }).toBeGreaterThanOrEqual(2);
+        const completedBuilds = (output.join("").match(/built in/g) ?? []).length;
+        try {
+            await utimes(entryPath, entryStat.atime, new Date(Date.now() + 2_000));
+            await expect.poll(() => (output.join("").match(/built in/g) ?? []).length, {
+                timeout: 60_000,
+            }).toBeGreaterThan(completedBuilds);
+        } finally {
+            await utimes(entryPath, entryStat.atime, entryStat.mtime);
+        }
+    } finally {
+        await stopDevServer(devServer);
+        await expect.poll(() => requestStatus(`${origin}/ehagaki/web-component-parent-client-example.html`), {
+            timeout: 10_000,
+        }).toBe(0);
+        if (devServer.exitCode !== 0 && devServer.exitCode !== null) {
+            throw new Error(`dev:web-component exited unexpectedly: ${output.join("").slice(-4000)}`);
+        }
+    }
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,18 @@ const isPreview = process.argv.some(arg => arg.includes('preview')) ||
 
 // Vercel環境ではルートパス、それ以外では /ehagaki/ を使用
 const baseUrl = process.env.VERCEL ? '/' : '/ehagaki/';
+const webComponentDevProxyEnabled = process.env.EHAGAKI_WEB_COMPONENT_DEV_PROXY === 'true';
+const webComponentDevServerPort = process.env.EHAGAKI_WEB_COMPONENT_DEV_PORT;
+const webComponentDevProxyPath = `${baseUrl}web-component/`;
+const webComponentDevProxy = webComponentDevProxyEnabled && webComponentDevServerPort
+  ? {
+      [webComponentDevProxyPath]: {
+        target: `http://127.0.0.1:${webComponentDevServerPort}`,
+        changeOrigin: true,
+        rewrite: (requestPath: string) => requestPath.slice(webComponentDevProxyPath.length - 1),
+      },
+    }
+  : undefined;
 const fixedLegacyBridgeManifest = loadFixedLegacyBridgeManifest();
 const fixedLegacyBridgePaths = fixedLegacyBridgeManifest.assets.map(asset => asset.path);
 
@@ -195,6 +207,7 @@ export default defineConfig({
   server: {
     allowedHosts: [
       '.ngrok-free.app'
-    ]
+    ],
+    proxy: webComponentDevProxy,
   }
 });


### PR DESCRIPTION
## 概要

Web Component公開sampleをローカル開発時にも同一オリジンURLで動作させる`npm run dev:web-component`を追加します。

- 既存の`vite.web-component.config.ts`で初回buildとwatchを実行
- `dist-web-component/`をloopbackの内部静的サーバーから配信
- 新コマンド時だけ通常Viteが`/ehagaki/web-component/`を内部サーバーへproxy
- sample HTML/JSのmodule URL・asset-base・security境界には変更なし
- 空の`dist-web-component/`から起動、watch再build、Ctrl+C/SIGTERMの子プロセスcleanupを確認するsmoke testを追加
- 通常`npm run dev`、production build、配布/assembly構成は維持

## 検証

- dev Web Component smoke E2E (desktop Chromium): 1 passed
- 既存Web Component parent sample E2E (desktop Chromium): 3 passed
- `npm run check`: 成功（0 errors / 0 warnings）
- `npm test`: 330 files / 3824 tests passed
- `npm run build`: 成功
- `git diff --check`: 成功
