### PR TITLE
fix: support web component builds from Windows unicode paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:web-component": "node scripts/devWebComponentSample.mjs",
     "prebuild": "npx rimraf dist",
     "build": "vite build && node scripts/verifyLegacyBridgeBuild.mjs && npm run build:web-component && npm run assemble:web-component-site",
-    "build:web-component": "vite build --config vite.web-component.config.ts && node scripts/verifyWebComponentBuild.mjs",
+    "build:web-component": "node scripts/runWebComponentBuild.mjs",
     "assemble:web-component-site": "node scripts/assembleWebComponentSite.mjs",
     "verify:legacy-bridge-remote": "node scripts/verifyLegacyBridgeRemote.mjs",
     "preview": "vite preview --host",

--- a/scripts/devWebComponentSample.mjs
+++ b/scripts/devWebComponentSample.mjs
@@ -4,15 +4,23 @@ import { stat } from "node:fs/promises";
 import { createServer } from "node:http";
 import { extname, isAbsolute, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createWebComponentBuildWorkingDirectory } from "./webComponentBuildWorkingDirectory.mjs";
+import {
+    createPhysicalViteDevServerCommand,
+    runWebComponentInitialBuild,
+    startNodeCommand,
+    startWebComponentBuild,
+} from "./webComponentBuildRunner.mjs";
 
-const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
-const webComponentDirectory = resolve(repositoryRoot, "dist-web-component");
-const viteCli = resolve(repositoryRoot, "node_modules", "vite", "bin", "vite.js");
+const physicalRepositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const webComponentDirectory = resolve(physicalRepositoryRoot, "dist-web-component");
 const host = "127.0.0.1";
 const appPort = parsePort(process.env.EHAGAKI_WEB_COMPONENT_DEV_APP_PORT, 5173, "EHAGAKI_WEB_COMPONENT_DEV_APP_PORT");
 const webComponentPort = parsePort(process.env.EHAGAKI_WEB_COMPONENT_DEV_PORT, 5174, "EHAGAKI_WEB_COMPONENT_DEV_PORT");
 
 let webComponentServer;
+let webComponentBuildWorkingDirectory;
+let initialBuild;
 let watcher;
 let viteServer;
 let shuttingDown = false;
@@ -103,35 +111,6 @@ function startWebComponentServer() {
     });
 }
 
-function runNode(args, environment = process.env) {
-    return spawn(process.execPath, args, {
-        cwd: repositoryRoot,
-        env: environment,
-        stdio: "inherit",
-        windowsHide: true,
-    });
-}
-
-function waitForExit(child) {
-    return new Promise((resolveExit, reject) => {
-        child.once("error", reject);
-        child.once("exit", (code, signal) => resolveExit({ code, signal }));
-    });
-}
-
-async function runInitialBuild() {
-    for (const [label, args] of [
-        ["Web Component build", [viteCli, "build", "--config", "vite.web-component.config.ts"]],
-        ["Web Component build verification", ["scripts/verifyWebComponentBuild.mjs"]],
-    ]) {
-        const build = runNode(args);
-        const { code, signal } = await waitForExit(build);
-        if (code !== 0) {
-            throw new Error(`${label} failed (${signal ?? code ?? "unknown"}).`);
-        }
-    }
-}
-
 function watchChild(label, child) {
     child.once("exit", (code, signal) => {
         if (!shuttingDown) {
@@ -175,10 +154,17 @@ async function shutdown(exitCode) {
     if (shuttingDown) return;
     shuttingDown = true;
     await Promise.all([
+        terminateChild(initialBuild),
         terminateChild(watcher),
         terminateChild(viteServer),
         closeServer(webComponentServer),
     ]);
+    try {
+        await webComponentBuildWorkingDirectory?.cleanup();
+    } catch (error) {
+        console.error(error instanceof Error ? error.message : error);
+        exitCode = 1;
+    }
     process.exitCode = exitCode;
 }
 
@@ -188,15 +174,22 @@ async function main() {
     }
 
     console.log("Building the Web Component for local development...");
-    await runInitialBuild();
+    webComponentBuildWorkingDirectory = await createWebComponentBuildWorkingDirectory({ physicalRepositoryRoot });
+    await runWebComponentInitialBuild(webComponentBuildWorkingDirectory.workingDirectory, {
+        onChildStarted: (child) => {
+            initialBuild = child;
+        },
+    });
 
     webComponentServer = await startWebComponentServer();
-    watcher = runNode([viteCli, "build", "--config", "vite.web-component.config.ts", "--watch"]);
-    viteServer = runNode([viteCli, "--host", host, "--port", String(appPort), "--strictPort"], {
-        ...process.env,
-        EHAGAKI_WEB_COMPONENT_DEV_PROXY: "true",
-        EHAGAKI_WEB_COMPONENT_DEV_PORT: String(webComponentPort),
+    watcher = startWebComponentBuild(webComponentBuildWorkingDirectory.workingDirectory, { watch: true });
+    console.log(`Vite dev server uses physical repository path ${physicalRepositoryRoot}`);
+    const viteDevServerCommand = createPhysicalViteDevServerCommand(physicalRepositoryRoot, {
+        host,
+        appPort,
+        webComponentPort,
     });
+    viteServer = startNodeCommand(viteDevServerCommand, { environment: viteDevServerCommand.environment });
     watchChild("Web Component watcher", watcher);
     watchChild("Vite dev server", viteServer);
 

--- a/scripts/runWebComponentBuild.mjs
+++ b/scripts/runWebComponentBuild.mjs
@@ -1,0 +1,49 @@
+import { createWebComponentBuildWorkingDirectory } from "./webComponentBuildWorkingDirectory.mjs";
+import { runWebComponentInitialBuild } from "./webComponentBuildRunner.mjs";
+import { fileURLToPath } from "node:url";
+
+const physicalRepositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+
+let workingDirectoryHandle;
+let activeChild;
+let shuttingDown = false;
+
+function waitForExit(child) {
+    return new Promise((resolve) => child.once("exit", resolve));
+}
+
+async function shutdown(exitCode) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    if (activeChild?.exitCode === null) {
+        const exited = waitForExit(activeChild);
+        activeChild.kill("SIGTERM");
+        await exited;
+    }
+    try {
+        await workingDirectoryHandle?.cleanup();
+    } catch (error) {
+        console.error(error instanceof Error ? error.message : error);
+        exitCode = 1;
+    }
+    process.exitCode = exitCode;
+}
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.once(signal, () => {
+        void shutdown(0);
+    });
+}
+
+try {
+    workingDirectoryHandle = await createWebComponentBuildWorkingDirectory({ physicalRepositoryRoot });
+    await runWebComponentInitialBuild(workingDirectoryHandle.workingDirectory, {
+        onChildStarted: (child) => {
+            activeChild = child;
+        },
+    });
+    await shutdown(0);
+} catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    await shutdown(1);
+}

--- a/scripts/webComponentBuildRunner.mjs
+++ b/scripts/webComponentBuildRunner.mjs
@@ -1,0 +1,120 @@
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+
+/**
+ * @typedef {object} NodeCommand
+ * @property {string} command
+ * @property {string[]} args
+ * @property {string} cwd
+ */
+
+/** @typedef {{ watch?: boolean }} WebComponentBuildOptions */
+
+/**
+ * @typedef {object} StartNodeCommandOptions
+ * @property {NodeJS.ProcessEnv} [environment]
+ * @property {import("node:child_process").StdioOptions} [stdio]
+ */
+
+/**
+ * @typedef {object} PhysicalViteDevServerOptions
+ * @property {string} host
+ * @property {number} appPort
+ * @property {number} webComponentPort
+ * @property {NodeJS.ProcessEnv} [environment]
+ */
+
+/** @param {string} workingDirectory @param {WebComponentBuildOptions} [options] @returns {NodeCommand} */
+export function createWebComponentBuildCommand(workingDirectory, { watch = false } = {}) {
+    const viteCli = resolve(workingDirectory, "node_modules", "vite", "bin", "vite.js");
+    return {
+        command: process.execPath,
+        args: [viteCli, "build", "--config", "vite.web-component.config.ts", ...(watch ? ["--watch"] : [])],
+        cwd: workingDirectory,
+    };
+}
+
+/** @param {string} physicalRepositoryRoot @param {PhysicalViteDevServerOptions} options */
+export function createPhysicalViteDevServerCommand(physicalRepositoryRoot, {
+    host,
+    appPort,
+    webComponentPort,
+    environment = process.env,
+}) {
+    return {
+        command: process.execPath,
+        args: [
+            resolve(physicalRepositoryRoot, "node_modules", "vite", "bin", "vite.js"),
+            "--host",
+            host,
+            "--port",
+            String(appPort),
+            "--strictPort",
+        ],
+        cwd: physicalRepositoryRoot,
+        environment: {
+            ...environment,
+            EHAGAKI_WEB_COMPONENT_DEV_PROXY: "true",
+            EHAGAKI_WEB_COMPONENT_DEV_PORT: String(webComponentPort),
+        },
+    };
+}
+
+/** @param {string} workingDirectory @returns {NodeCommand} */
+function createWebComponentBuildVerificationCommand(workingDirectory) {
+    return {
+        command: process.execPath,
+        args: [resolve(workingDirectory, "scripts", "verifyWebComponentBuild.mjs")],
+        cwd: workingDirectory,
+    };
+}
+
+/** @param {NodeCommand} command @param {StartNodeCommandOptions} [options] */
+export function startNodeCommand(command, { environment = process.env, stdio = "inherit" } = {}) {
+    return spawn(command.command, command.args, {
+        cwd: command.cwd,
+        env: environment,
+        stdio,
+        windowsHide: true,
+    });
+}
+
+/** @param {string} workingDirectory @param {WebComponentBuildOptions & StartNodeCommandOptions} [options] */
+export function startWebComponentBuild(workingDirectory, options) {
+    return startNodeCommand(createWebComponentBuildCommand(workingDirectory, options), options);
+}
+
+/** @param {string} label @param {import("node:child_process").ChildProcess} child @returns {Promise<void>} */
+function waitForSuccessfulExit(label, child) {
+    return new Promise((resolveExit, reject) => {
+        child.once("error", reject);
+        child.once("exit", (code, signal) => {
+            if (code === 0) {
+                resolveExit();
+                return;
+            }
+            reject(new Error(`${label} failed (${signal ?? code ?? "unknown"}).`));
+        });
+    });
+}
+
+/**
+ * @param {string} workingDirectory
+ * @param {{ onChildStarted?: (child: import("node:child_process").ChildProcess | undefined) => void }} [options]
+ */
+export async function runWebComponentInitialBuild(workingDirectory, { onChildStarted } = {}) {
+    /** @type {[string, NodeCommand][]} */
+    const commands = [
+        ["Web Component build", createWebComponentBuildCommand(workingDirectory)],
+        ["Web Component build verification", createWebComponentBuildVerificationCommand(workingDirectory)],
+    ];
+    for (const [label, command] of commands) {
+        const child = startNodeCommand(command);
+        onChildStarted?.(child);
+        try {
+            await waitForSuccessfulExit(label, child);
+        } finally {
+            onChildStarted?.(undefined);
+        }
+    }
+}

--- a/scripts/webComponentBuildWorkingDirectory.mjs
+++ b/scripts/webComponentBuildWorkingDirectory.mjs
@@ -1,0 +1,91 @@
+import { existsSync } from "node:fs";
+import { spawn } from "node:child_process";
+
+const candidateDriveLetters = "ZYXWVUTSRQPONMLKJIHGFED";
+
+/** @param {string} repositoryRoot @param {NodeJS.Platform} [platform] */
+export function needsWindowsAsciiWorkingDirectory(repositoryRoot, platform = process.platform) {
+    return platform === "win32" && /[^\x00-\x7F]/.test(repositoryRoot);
+}
+
+/** @param {(path: string) => boolean} [pathExists] */
+export function findAvailableSubstDriveLetter(pathExists = existsSync) {
+    for (const driveLetter of candidateDriveLetters) {
+        if (!pathExists(`${driveLetter}:\\`)) {
+            return driveLetter;
+        }
+    }
+    throw new Error("Could not find an unused Windows drive letter for the temporary Web Component build path.");
+}
+
+/** @param {string[]} args @returns {Promise<void>} */
+function runSubst(args) {
+    return new Promise((resolve, reject) => {
+        const child = spawn("subst", args, {
+            stdio: ["ignore", "pipe", "pipe"],
+            windowsHide: true,
+        });
+        let output = "";
+        child.stdout.on("data", (chunk) => {
+            output += String(chunk);
+        });
+        child.stderr.on("data", (chunk) => {
+            output += String(chunk);
+        });
+        child.once("error", reject);
+        child.once("exit", (code) => {
+            if (code === 0) {
+                resolve();
+                return;
+            }
+            reject(new Error(`subst ${args.join(" ")} failed (${code ?? "unknown"})${output ? `: ${output.trim()}` : ""}`));
+        });
+    });
+}
+
+/**
+ * @typedef {object} WebComponentBuildWorkingDirectoryOptions
+ * @property {string} physicalRepositoryRoot
+ * @property {NodeJS.Platform} [platform]
+ * @property {(path: string) => boolean} [pathExists]
+ * @property {(args: string[]) => Promise<void>} [executeSubst]
+ * @property {(message: string) => void} [log]
+ */
+
+/** @param {WebComponentBuildWorkingDirectoryOptions} options */
+export async function createWebComponentBuildWorkingDirectory({
+    physicalRepositoryRoot,
+    platform = process.platform,
+    pathExists = existsSync,
+    executeSubst = runSubst,
+    log = console.log,
+}) {
+    if (!needsWindowsAsciiWorkingDirectory(physicalRepositoryRoot, platform)) {
+        return {
+            workingDirectory: physicalRepositoryRoot,
+            usesTemporaryWindowsPath: false,
+            cleanup: async () => {},
+        };
+    }
+
+    const driveLetter = findAvailableSubstDriveLetter(pathExists);
+    const drive = `${driveLetter}:`;
+    try {
+        await executeSubst([drive, physicalRepositoryRoot]);
+    } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(`Could not create a temporary Windows path for the Web Component build: ${detail}`);
+    }
+
+    let cleanedUp = false;
+    log(`Web Component build uses temporary Windows path ${drive}\\`);
+    return {
+        workingDirectory: `${drive}\\`,
+        usesTemporaryWindowsPath: true,
+        cleanup: async () => {
+            if (cleanedUp) return;
+            cleanedUp = true;
+            await executeSubst([drive, "/D"]);
+        },
+    };
+}

--- a/src/test/e2e/webComponentDevServer.spec.ts
+++ b/src/test/e2e/webComponentDevServer.spec.ts
@@ -102,6 +102,9 @@ test("serves the Web Component sample through the local dev proxy", async ({ pag
             () => requestStatus(`${origin}/ehagaki/web-component/ehagaki-composer.js`),
             { timeout: 30_000 },
         ).toBe(200);
+        await expect.poll(() => output.join(""), { timeout: 30_000 }).toContain(
+            `Vite dev server uses physical repository path ${process.cwd()}`,
+        );
 
         await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
         await expect(page.locator("#module-url")).toHaveValue(`${origin}/ehagaki/web-component/ehagaki-composer.js`);

--- a/src/test/unit/webComponentBuildWorkingDirectory.test.ts
+++ b/src/test/unit/webComponentBuildWorkingDirectory.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+    createWebComponentBuildWorkingDirectory,
+    findAvailableSubstDriveLetter,
+    needsWindowsAsciiWorkingDirectory,
+} from "../../../scripts/webComponentBuildWorkingDirectory.mjs";
+import {
+    createPhysicalViteDevServerCommand,
+    createWebComponentBuildCommand,
+} from "../../../scripts/webComponentBuildRunner.mjs";
+
+describe("Web Component build working directory", () => {
+    it("uses the physical repository path unless Windows has a non-ASCII path", () => {
+        expect(needsWindowsAsciiWorkingDirectory("C:\\work\\ehagaki", "win32")).toBe(false);
+        expect(needsWindowsAsciiWorkingDirectory("D:\\ドキュメント\\ehagaki", "linux")).toBe(false);
+        expect(needsWindowsAsciiWorkingDirectory("D:\\ドキュメント\\ehagaki", "win32")).toBe(true);
+    });
+
+    it("selects an unused drive letter without replacing an existing mapping", () => {
+        expect(findAvailableSubstDriveLetter((path) => path === "Z:\\" || path === "Y:\\")).toBe("X");
+    });
+
+    it("creates and removes only its temporary mapping for a Windows non-ASCII path", async () => {
+        const executeSubst = vi.fn().mockResolvedValue(undefined);
+        const log = vi.fn();
+        const workingDirectory = await createWebComponentBuildWorkingDirectory({
+            physicalRepositoryRoot: "D:\\ドキュメント\\GitHub\\ehagaki",
+            platform: "win32",
+            pathExists: (path) => path === "Z:\\",
+            executeSubst,
+            log,
+        });
+
+        expect(workingDirectory.workingDirectory).toBe("Y:\\");
+        expect(workingDirectory.usesTemporaryWindowsPath).toBe(true);
+        expect(executeSubst).toHaveBeenCalledWith(["Y:", "D:\\ドキュメント\\GitHub\\ehagaki"]);
+        expect(log).toHaveBeenCalledWith("Web Component build uses temporary Windows path Y:\\");
+
+        await workingDirectory.cleanup();
+        await workingDirectory.cleanup();
+        expect(executeSubst).toHaveBeenLastCalledWith(["Y:", "/D"]);
+        expect(executeSubst).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps the Web Component build command on the selected safe path", () => {
+        expect(createWebComponentBuildCommand("Y:\\", { watch: true })).toEqual({
+            command: process.execPath,
+            args: [
+                "Y:\\node_modules\\vite\\bin\\vite.js",
+                "build",
+                "--config",
+                "vite.web-component.config.ts",
+                "--watch",
+            ],
+            cwd: "Y:\\",
+        });
+    });
+
+    it("keeps the normal Vite dev server on the physical repository path", () => {
+        const physicalRepositoryRoot = "D:\\ドキュメント\\GitHub\\ehagaki";
+        const command = createPhysicalViteDevServerCommand(physicalRepositoryRoot, {
+            host: "127.0.0.1",
+            appPort: 5173,
+            webComponentPort: 5174,
+            environment: { PATH: "test" },
+        });
+
+        expect(command.cwd).toBe(physicalRepositoryRoot);
+        expect(command.args[0]).toBe("D:\\ドキュメント\\GitHub\\ehagaki\\node_modules\\vite\\bin\\vite.js");
+        expect(command.environment).toMatchObject({
+            PATH: "test",
+            EHAGAKI_WEB_COMPONENT_DEV_PROXY: "true",
+            EHAGAKI_WEB_COMPONENT_DEV_PORT: "5174",
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Windowsでリポジトリの実パスに非ASCII文字が含まれる場合だけ、Web Componentの初回buildとwatch buildを一時的な未使用`subst`ドライブから実行するようにしました。
- 通常のVite dev serverは常にphysical repository pathから起動し、`EHAGAKI_WEB_COMPONENT_DEV_PROXY`による既存の開発専用proxyを維持します。
- `build:web-component`を共通runnerへ移し、`npm run build`からのWeb Component buildも同じ経路を通します。

## Safety
- 一時ドライブはD-Zを降順に検査して未使用のものだけを選択し、作成に成功したmappingだけを通常終了・SIGINT/SIGTERM・build失敗時に解除します。
- Web Component API、sample、production URL、Vercel/GitHub Pages routingには変更を加えていません。

## Validation
- `npm run test -- src/test/unit/webComponentBuildWorkingDirectory.test.ts`
- `npx playwright test src/test/e2e/webComponentDevServer.spec.ts src/test/e2e/webComponentParentClientExample.spec.ts --project=desktop-chromium`
- `npm run check`
- `npm test` (331 files, 3829 tests)
- `npm run build:web-component`
- `npm run build`
- `git diff --check`

The Codex worktree path is ASCII-only, so an actual non-ASCII Windows CWD was not run here. The path selection, process CWD split, and created-mapping-only cleanup are covered by unit tests.