### PR TITLE
Add explicit LAN mode to Web Component dev server

### DIFF
--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -111,6 +111,17 @@ iframe 連携は含まれません。
 watchによる再buildの完了を待ってからページを再読み込みします。`vite.web-component.config.ts` などの
 build設定を変更した場合は、コマンドを再起動してください。
 
+Android ChromeやiPhone Safariなど、同じLAN上の実機から確認する場合は、明示的なLANモードを使います。
+
+```text
+npm run dev:web-component:lan
+```
+
+コンソールに表示された `http://<PCのLAN IP>:5173/ehagaki/web-component-parent-client-example.html`
+を実機で開いてください。PCと実機を同じWi-Fi/LANへ接続し、Windowsでは必要に応じてWindows Firewallで
+Node/ViteのPrivate networkアクセスを許可します。LANモードではViteのsample serverだけを公開し、
+Web Component assetの内部server（5174）は `127.0.0.1` のままです。実機から5174を直接開く必要はありません。
+
 ## `asset-base` / `assetBase`
 
 `asset-base` は、コンポーネントが配布物内のアセットを解決するための配信元です。実装では、

--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -121,6 +121,11 @@ npm run dev:web-component:lan
 を実機で開いてください。PCと実機を同じWi-Fi/LANへ接続し、Windowsでは必要に応じてWindows Firewallで
 Node/ViteのPrivate networkアクセスを許可します。LANモードではViteのsample serverだけを公開し、
 Web Component assetの内部server（5174）は `127.0.0.1` のままです。実機から5174を直接開く必要はありません。
+このLAN URLはHTTP originです。LAN内実機での一般的なlayout、Destroy/Create、host scroll、fallback keyboard behavior
+などの確認には利用できますが、secure context限定APIは本番HTTPSと同じ経路にならない場合があります。
+特にAndroid ChromeのVirtualKeyboard API経路（`navigator.virtualKeyboard`、`overlaysContent`、`boundingRect`、
+`geometrychange`）の最終確認は、PR previewなど利用可能なHTTPS deployment、または端末から信頼されるHTTPS originで行ってください。
+iPhone Safariを含む一般的な実機確認には、LAN mode自体を引き続き利用できます。
 
 ## `asset-base` / `assetBase`
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite --host",
     "dev:web-component": "node scripts/devWebComponentSample.mjs",
+    "dev:web-component:lan": "node scripts/devWebComponentSample.mjs --lan",
     "prebuild": "npx rimraf dist",
     "build": "vite build && node scripts/verifyLegacyBridgeBuild.mjs && npm run build:web-component && npm run assemble:web-component-site",
     "build:web-component": "node scripts/runWebComponentBuild.mjs",

--- a/scripts/devWebComponentSample.mjs
+++ b/scripts/devWebComponentSample.mjs
@@ -209,6 +209,7 @@ async function main() {
 
     if (lanMode) {
         console.log("LAN mode enabled: the Vite development server is exposed to the trusted local network.");
+        console.log("LAN mode uses HTTP. Secure-context-only browser APIs may be unavailable; use HTTPS for final production-path verification.");
         const lanUrls = createLanSampleUrls(appPort, getLanIPv4Addresses());
         if (lanUrls.length > 0) {
             for (const url of lanUrls) console.log(`Web Component sample (LAN): ${url}`);

--- a/scripts/devWebComponentSample.mjs
+++ b/scripts/devWebComponentSample.mjs
@@ -11,10 +11,16 @@ import {
     startNodeCommand,
     startWebComponentBuild,
 } from "./webComponentBuildRunner.mjs";
+import {
+    createLanSampleUrls,
+    getLanIPv4Addresses,
+    resolveWebComponentDevHosts,
+} from "./webComponentDevServerConfig.mjs";
 
 const physicalRepositoryRoot = fileURLToPath(new URL("..", import.meta.url));
 const webComponentDirectory = resolve(physicalRepositoryRoot, "dist-web-component");
-const host = "127.0.0.1";
+const lanMode = parseArguments(process.argv.slice(2));
+const { appHost, webComponentHost } = resolveWebComponentDevHosts(lanMode);
 const appPort = parsePort(process.env.EHAGAKI_WEB_COMPONENT_DEV_APP_PORT, 5173, "EHAGAKI_WEB_COMPONENT_DEV_APP_PORT");
 const webComponentPort = parsePort(process.env.EHAGAKI_WEB_COMPONENT_DEV_PORT, 5174, "EHAGAKI_WEB_COMPONENT_DEV_PORT");
 
@@ -37,6 +43,14 @@ function parsePort(value, fallback, variableName) {
     return port;
 }
 
+function parseArguments(args) {
+    const unknownArgument = args.find((argument) => argument !== "--lan");
+    if (unknownArgument) {
+        throw new Error(`Unknown argument: ${unknownArgument}`);
+    }
+    return args.includes("--lan");
+}
+
 function contentType(filePath) {
     switch (extname(filePath)) {
         case ".js": return "text/javascript; charset=utf-8";
@@ -54,7 +68,7 @@ function contentType(filePath) {
 }
 
 function resolveAssetPath(requestUrl) {
-    const pathname = decodeURIComponent(new URL(requestUrl ?? "/", `http://${host}`).pathname);
+    const pathname = decodeURIComponent(new URL(requestUrl ?? "/", `http://${webComponentHost}`).pathname);
     const filePath = resolve(webComponentDirectory, `.${pathname}`);
     const pathFromRoot = relative(webComponentDirectory, filePath);
     if (pathFromRoot.startsWith("..") || isAbsolute(pathFromRoot)) {
@@ -104,7 +118,7 @@ function startWebComponentServer() {
             }
         });
         server.once("error", reject);
-        server.listen(webComponentPort, host, () => {
+        server.listen(webComponentPort, webComponentHost, () => {
             server.off("error", reject);
             resolveServer(server);
         });
@@ -185,7 +199,7 @@ async function main() {
     watcher = startWebComponentBuild(webComponentBuildWorkingDirectory.workingDirectory, { watch: true });
     console.log(`Vite dev server uses physical repository path ${physicalRepositoryRoot}`);
     const viteDevServerCommand = createPhysicalViteDevServerCommand(physicalRepositoryRoot, {
-        host,
+        host: appHost,
         appPort,
         webComponentPort,
     });
@@ -193,7 +207,17 @@ async function main() {
     watchChild("Web Component watcher", watcher);
     watchChild("Vite dev server", viteServer);
 
-    console.log(`Web Component sample: http://localhost:${appPort}/ehagaki/web-component-parent-client-example.html`);
+    if (lanMode) {
+        console.log("LAN mode enabled: the Vite development server is exposed to the trusted local network.");
+        const lanUrls = createLanSampleUrls(appPort, getLanIPv4Addresses());
+        if (lanUrls.length > 0) {
+            for (const url of lanUrls) console.log(`Web Component sample (LAN): ${url}`);
+        } else {
+            console.log("No non-internal LAN IPv4 address was found; use Vite's Network URL or the PC's LAN IP.");
+        }
+    } else {
+        console.log(`Web Component sample: http://localhost:${appPort}/ehagaki/web-component-parent-client-example.html`);
+    }
 }
 
 for (const signal of ["SIGINT", "SIGTERM"]) {

--- a/scripts/webComponentDevServerConfig.mjs
+++ b/scripts/webComponentDevServerConfig.mjs
@@ -1,0 +1,28 @@
+import { networkInterfaces } from "node:os";
+
+export const LOCALHOST = "127.0.0.1";
+export const LAN_HOST = "0.0.0.0";
+
+/** @param {boolean} lanMode */
+export function resolveWebComponentDevHosts(lanMode) {
+    return {
+        appHost: lanMode ? LAN_HOST : LOCALHOST,
+        webComponentHost: LOCALHOST,
+    };
+}
+
+/** @param {NodeJS.Dict<import("node:os").NetworkInterfaceInfo[] | undefined>} [interfaces] */
+export function getLanIPv4Addresses(interfaces = networkInterfaces()) {
+    return [...new Set(Object.values(interfaces).flatMap((entries) =>
+        (entries ?? [])
+            .filter((entry) => !entry.internal && (entry.family === "IPv4" || String(entry.family) === "4"))
+            .map((entry) => entry.address),
+    ))];
+}
+
+/** @param {number} appPort @param {string[]} addresses */
+export function createLanSampleUrls(appPort, addresses) {
+    return addresses.map((address) =>
+        `http://${address}:${appPort}/ehagaki/web-component-parent-client-example.html`,
+    );
+}

--- a/src/test/unit/webComponentBuildWorkingDirectory.test.ts
+++ b/src/test/unit/webComponentBuildWorkingDirectory.test.ts
@@ -73,4 +73,18 @@ describe("Web Component build working directory", () => {
             EHAGAKI_WEB_COMPONENT_DEV_PORT: "5174",
         });
     });
+
+    it("can expose only the Vite app server while preserving the loopback proxy target", () => {
+        const command = createPhysicalViteDevServerCommand("D:\\ドキュメント\\GitHub\\ehagaki", {
+            host: "0.0.0.0",
+            appPort: 5173,
+            webComponentPort: 5174,
+        });
+
+        expect(command.args).toContain("0.0.0.0");
+        expect(command.environment).toMatchObject({
+            EHAGAKI_WEB_COMPONENT_DEV_PROXY: "true",
+            EHAGAKI_WEB_COMPONENT_DEV_PORT: "5174",
+        });
+    });
 });

--- a/src/test/unit/webComponentDevServerConfig.test.ts
+++ b/src/test/unit/webComponentDevServerConfig.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+    createLanSampleUrls,
+    getLanIPv4Addresses,
+    resolveWebComponentDevHosts,
+} from "../../../scripts/webComponentDevServerConfig.mjs";
+
+describe("Web Component dev server host configuration", () => {
+    it("keeps both servers on loopback in normal mode", () => {
+        expect(resolveWebComponentDevHosts(false)).toEqual({
+            appHost: "127.0.0.1",
+            webComponentHost: "127.0.0.1",
+        });
+    });
+
+    it("publishes only the app server in LAN mode", () => {
+        expect(resolveWebComponentDevHosts(true)).toEqual({
+            appHost: "0.0.0.0",
+            webComponentHost: "127.0.0.1",
+        });
+    });
+
+    it("returns unique non-internal IPv4 candidates and sample URLs", () => {
+        expect(getLanIPv4Addresses({
+            WiFi: [
+                { address: "192.168.1.20", netmask: "", family: "IPv4", mac: "", internal: false, cidr: "" },
+                { address: "192.168.1.20", netmask: "", family: "IPv4", mac: "", internal: false, cidr: "" },
+            ],
+            Loopback: [
+                { address: "127.0.0.1", netmask: "", family: "IPv4", mac: "", internal: true, cidr: "" },
+            ],
+        })).toEqual(["192.168.1.20"]);
+        expect(createLanSampleUrls(5173, ["192.168.1.20"])).toEqual([
+            "http://192.168.1.20:5173/ehagaki/web-component-parent-client-example.html",
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary

- Add `npm run dev:web-component:lan` for explicit LAN-device testing.
- Keep the default `npm run dev:web-component` loopback-only.
- In LAN mode, bind only the Vite sample server to `0.0.0.0`.
- Keep the internal Web Component asset server on `127.0.0.1:5174`.
- Keep the Vite proxy target at `127.0.0.1:5174`.
- Display non-internal LAN IPv4 candidates and sample URLs.
- Add documentation and tests for host separation, URL generation, and the existing lifecycle.

## Validation

- Targeted Web Component dev-server unit tests: passed
- `npm test`: 333 files / 3837 tests passed
- `npm run check`: passed with 0 errors and 0 warnings
- `npm run build`: passed
- Web Component dev-server E2E: desktop Chromium and mobile Chromium passed
- `git diff --check`: passed

## Manual verification

- Real Android/iPhone connection was not performed from the development environment.
- LAN mode serves an HTTP origin. Secure-context-only browser APIs may be unavailable or may use a different path than production HTTPS.
- LAN HTTP remains useful for general device layout, Destroy/Create, host scroll, and fallback keyboard behavior checks.
- Final Android Chrome VirtualKeyboard API production-path verification must use an available HTTPS deployment, such as a PR preview, or another HTTPS origin trusted by the device.
- iPhone Safari and general physical-device checks can continue to use LAN mode.

This PR remains Draft pending physical-device verification.
