### PR TITLE
Fix Web Component sample edge clipping

### DIFF
--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -108,7 +108,7 @@
         }
         .component-frame { height: 640px; padding: 18px; background: #dce8df; border-radius: 18px; }
         #component-mount { height: 580px; }
-        ehagaki-composer { display: block; height: 100%; min-height: 0; background: white; border-radius: 14px; overflow: hidden; }
+        ehagaki-composer { display: block; height: 100%; min-height: 0; background: white; }
 
         /* Public parts demo: this selector is host CSS and crosses only the declared part boundary. */
         ehagaki-composer::part(header) { outline: 3px solid var(--sample-part-outline, transparent); outline-offset: -3px; }

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -164,6 +164,21 @@ test("boots from production site output and exercises the public sample API", as
     expect(requests).toContain("/ehagaki/web-component/ehagaki-composer.js");
     expect([...requests].some((path) => path.startsWith("/ehagaki/web-component/assets/"))).toBe(true);
 
+    const edgeClippingStyles = await page.locator("ehagaki-composer").evaluate((element) => {
+        const hostStyle = getComputedStyle(element);
+        const frameStyle = getComputedStyle(element.parentElement!);
+        return {
+            hostOverflowX: hostStyle.overflowX,
+            hostOverflowY: hostStyle.overflowY,
+            hostBorderRadius: hostStyle.borderRadius,
+            frameBorderRadius: frameStyle.borderRadius,
+        };
+    });
+    expect(edgeClippingStyles.hostOverflowX).toBe("visible");
+    expect(edgeClippingStyles.hostOverflowY).toBe("visible");
+    expect(edgeClippingStyles.hostBorderRadius).toBe("0px");
+    expect(edgeClippingStyles.frameBorderRadius).toBe("18px");
+
     const initialStyleResult = await page.locator("ehagaki-composer").evaluate((element) => {
         const properties = [
             "--ehagaki-background",


### PR DESCRIPTION
## Summary

- Remove host-side border-radius and overflow clipping from the public Web Component sample.
- Add a computed-style regression assertion for unclipped host edges and preserved frame radius.

## Root cause

The sample host clipped the component Shadow DOM at its own rounded corners, trimming edge UI. The outer component frame already provides the intended rounded design and padding.

## Checks

- npx playwright test src/test/e2e/webComponentParentClientExample.spec.ts --project=desktop-chromium --project=mobile-chromium --project=mobile-webkit
- npm run check
- git diff --check
- npm run build
