### PR TITLE
Fix Web Component theme hover styles

### DIFF
--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -470,6 +470,46 @@ test("applies Button variants and host theme classes inside the Shadow DOM", asy
     expect(result.darkAppTextColor).not.toBe(result.lightAppTextColor);
 });
 
+test("applies the common desktop hover colors inside the Shadow DOM", async ({ page, isMobile }) => {
+    test.skip(isMobile, "Common hover styles are intentionally disabled on touch projects.");
+    await page.goto(hostOrigin);
+    await page.evaluate(async () => {
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+            setSettings(value: { themeMode: "light" }): Promise<string[]>;
+        };
+        document.body.append(composer);
+        await composer.whenReady();
+        await composer.setSettings({ themeMode: "light" });
+    });
+
+    const settingsButton = page.locator("ehagaki-composer").locator("button.settings-btn");
+    await expect(settingsButton).toBeVisible();
+    const before = await settingsButton.evaluate((button) => {
+        const icon = button.querySelector<HTMLElement>(".svg-icon")!;
+        const buttonStyle = getComputedStyle(button);
+        return {
+            background: buttonStyle.backgroundColor,
+            color: buttonStyle.color,
+            iconBackground: getComputedStyle(icon).backgroundColor,
+        };
+    });
+    await settingsButton.hover();
+    const after = await settingsButton.evaluate((button) => {
+        const icon = button.querySelector<HTMLElement>(".svg-icon")!;
+        const buttonStyle = getComputedStyle(button);
+        return {
+            background: buttonStyle.backgroundColor,
+            color: buttonStyle.color,
+            iconBackground: getComputedStyle(icon).backgroundColor,
+        };
+    });
+    expect(after.background).not.toBe(before.background);
+    expect(after.color).not.toBe(before.color);
+    expect(after.iconBackground).not.toBe(before.iconBackground);
+});
+
 test("applies Button styles inside a Portal dialog in the Shadow DOM", async ({ page }) => {
     await page.goto(hostOrigin);
     await page.evaluate(async () => {

--- a/src/web-component/element.ts
+++ b/src/web-component/element.ts
@@ -84,6 +84,7 @@ function transformAppCss(css: string): string {
     // app.css is authored for the document root. In this build it is copied
     // into the component's open shadow tree instead of touching host styles.
     return css
+        .replaceAll(/:root:is\(\s*\.light\s*,\s*\.dark\s*\)/g, ":host(:is(.light, .dark))")
         .replaceAll(":root", ":host")
         .replace("html,\nbody,\n#app", ":host,\n.ehagaki-web-component-shell")
         .replace("#app {", ".ehagaki-web-component-shell {")


### PR DESCRIPTION
## 原因

Web ComponentのShadow Rootへコピーする`app.css`で、`:root`を`:host`へ機械的に置換していました。テーマ付き共通hoverルールの`:root:is(.light, .dark)`は、生成時の空白正規化もありそのまま残り、テーマクラスを持つ`<ehagaki-composer>`ホストと一致していませんでした。その結果、desktopのbutton、SVGアイコンなどの共通hoverルールがShadow DOM内で適用されていませんでした。

## 修正内容

`transformAppCss()`で`:root:is(.light, .dark)`を空白差に依存しない正規表現で`:host(:is(.light, .dark))`へ変換してから、既存の一般的な`:root`変換を行うようにしました。通常版/PWAの`src/app.css`は変更していません。

## 責務と既存挙動

通常版/PWAは従来の`:root`ベースCSSを使用し、Web ComponentだけがShadow DOM用変換結果を使用します。テーマクラスは既存どおりruntimeの`themeTarget`でホストへ付与され、CSS Custom Properties、Shadow DOM、`::part()`、layout、storage、認証、Nostr、iframe経路は変更していません。`@media (hover: hover) and (pointer: fine)`、disabled、selected/active、light/dark/systemテーマの既存条件も維持しています。

## 回帰テスト

`webComponentEmbed.spec.ts`へ、desktop Chromiumで実際にWeb Componentをlightテーマでmountし、設定ボタンへマウスhoverを行って、hover前後のcomputed background/color/SVG background-colorが変化することを確認するE2Eを追加しました。mobile Chromium/WebKitではこのdesktop専用テストをskipし、既存のタッチ向けhover抑制を維持しています。

## 検証

- Web Component E2E desktop Chromium: 13 passed
- Web Component E2E mobile Chromium: 12 passed, desktop hover test 1 skipped
- Web Component E2E mobile WebKit: 12 passed, desktop hover test 1 skipped
- `npm run check`: passed, 0 errors / 0 warnings
- `npm test`: 333 files / 3,837 tests passed
- `npm run build`: passed
- `npm run build:web-component`: passed; standalone output verified
- `git diff --check`: passed

未実行: 実機のAndroid/iPhone、インストール済みPWA standalone、WebViewでの表示確認。今回の回帰はdesktop Chromiumの実ブラウザE2Eで確認し、touch projectの既存E2Eも実行しています。
