### PR TITLE
Fix Web Component sample grid stretching

### DIFF
--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -36,6 +36,7 @@
             display: grid;
             grid-template-columns: minmax(320px, 450px) minmax(0, 1fr);
             gap: 20px;
+            align-items: start;
         }
 
         .column, .stack { display: grid; gap: 18px; min-width: 0; }
@@ -80,6 +81,9 @@
         button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible { outline: 3px solid #92caaa; outline-offset: 2px; }
         .buttons { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px; }
         .buttons + .buttons { margin-top: 9px; }
+        .event-monitor-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+        .event-monitor-header > div { min-width: 0; }
+        .event-monitor-header button { flex: 0 0 auto; }
         .full { grid-column: 1 / -1; }
         .grid-2 { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
         .grid-2 + .grid-2 { margin-top: 10px; }
@@ -273,7 +277,7 @@
             </div>
 
             <div class="panel stack">
-                <div class="buttons">
+                <div class="event-monitor-header">
                     <div><h2>Event monitor</h2><p class="small">秘密情報・署名要求payload・raw Errorは表示せず、安全なsummaryだけを記録します。</p></div>
                     <button id="clear-log" type="button" class="ghost">ログをクリア</button>
                 </div>

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -89,6 +89,54 @@ test.afterAll(async () => {
     await close(server);
 });
 
+test("keeps the sample columns and panels content-sized", async ({ page }) => {
+    for (const viewport of [{ width: 1280, height: 900 }, { width: 390, height: 844 }]) {
+        await page.setViewportSize(viewport);
+        await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
+
+        const result = await page.evaluate(() => {
+            const main = document.querySelector("main")!;
+            const columns = [...document.querySelectorAll<HTMLElement>("main > .column")];
+            const rightPanels = [...columns[1].querySelectorAll<HTMLElement>(":scope > .panel")];
+            const comparisonPanel = rightPanels[2];
+            const comparisonIntro = comparisonPanel.querySelector<HTMLElement>(":scope > div")!;
+            const comparisonTable = comparisonPanel.querySelector<HTMLTableElement>(".comparison")!;
+            const protocolPanel = rightPanels[3];
+            const protocolHeading = protocolPanel.querySelector<HTMLElement>("h2")!;
+            const protocolList = protocolPanel.querySelector<HTMLElement>(".api-list")!;
+            const clearLog = document.querySelector<HTMLButtonElement>("#clear-log")!;
+            const eventHeader = clearLog.parentElement!;
+            const rect = (element: Element) => element.getBoundingClientRect().toJSON();
+            return {
+                viewportWidth: window.innerWidth,
+                mainColumns: getComputedStyle(main).gridTemplateColumns,
+                mainAlignItems: getComputedStyle(main).alignItems,
+                columnHeights: columns.map((column) => column.getBoundingClientRect().height),
+                panelGaps: rightPanels.slice(1).map((panel, index) => panel.getBoundingClientRect().top - rightPanels[index].getBoundingClientRect().bottom),
+                comparisonGap: comparisonTable.getBoundingClientRect().top - comparisonIntro.getBoundingClientRect().bottom,
+                protocolGap: protocolList.getBoundingClientRect().top - protocolHeading.getBoundingClientRect().bottom,
+                clearLog: rect(clearLog),
+                eventHeader: rect(eventHeader),
+                eventPanel: rect(rightPanels[1]),
+            };
+        });
+
+        expect(result.mainAlignItems).toBe("start");
+        expect(result.columnHeights[1]).toBeLessThan(result.columnHeights[0]);
+        expect(result.panelGaps.every((gap) => gap <= 20.5)).toBe(true);
+        expect(result.comparisonGap).toBeLessThanOrEqual(20.5);
+        expect(result.protocolGap).toBeLessThanOrEqual(20.5);
+        expect(result.clearLog.width).toBeLessThan(result.eventPanel.width / 2);
+        expect(result.clearLog.height).toBeLessThanOrEqual(60);
+        expect(result.clearLog.top).toBeGreaterThanOrEqual(result.eventHeader.top - 1);
+        if (result.viewportWidth > 980) {
+            expect(result.mainColumns.split(" ")).toHaveLength(2);
+        } else {
+            expect(result.mainColumns.split(" ")).toHaveLength(1);
+        }
+    }
+});
+
 test("keeps the comparison table within the page viewport at mobile widths", async ({ page }) => {
     for (const width of [360, 390]) {
         await page.setViewportSize({ width, height: 844 });


### PR DESCRIPTION
## 変更概要
Web Component親ページサンプルの右カラムとEvent monitorのレイアウト崩れを修正しました。

## 原因
`main` の2カラムGridが既定の縦方向stretchで左カラムの高さを右カラムへ伝え、右側の`.column`/`.stack`のGridトラックへ余剰高が分配されていました。Event monitorは汎用`.buttons`（2列の1fr）を使っていたため、ログクリアボタンも不自然に拡大されていました。

## 修正内容
- `main` に`align-items: start`を追加し、縦方向のstretchだけを停止
- Event monitor専用ヘッダーをflex化し、ログクリアをcontent-drivenサイズで右上に配置
- 既存の汎用`.buttons`、2カラム/レスポンシブ閾値、textarea、Web Component本体の挙動は維持

## テスト
- 回帰E2Eを追加し、desktop/mobileの列数、パネル間gap、比較表/HTTP説明のgap、ボタン寸法を検証
- desktop Chromium / mobile Chromium / mobile WebKit: 27 passed
- `npm run check`: passed (0 errors, 0 warnings)
- `npm test`: 333 files / 3837 tests passed
- `npm run build`: passed
- `git diff --check`: passed

## 実ブラウザ確認
現在のワークツリーを別ポートで起動し、Desktop ChromeとiPhone 13相当でスクリーンショットを確認しました。Event monitor、iframeとの違い、HTTP / WebSocket / Service Workerが内容高で詰まり、狭幅でも重なりやはみ出しがないことを確認しています。

未実行の実端末（物理Android/iPhone）確認はありません。Playwrightのモバイルエミュレーションで確認しています。