### PR TITLE
Auto-mount Web Component reference sample

### DIFF
--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -10,8 +10,9 @@ Window realm で動作し、ホストの JavaScript からは通常の要素・�
 DOM へ直接組み込みたい場合に適しています。
 
 実際に操作できる公開リファレンスは、[Web Component 親ページサンプル](https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html)
-です。ページを開いただけではコンポーネントを自動的に接続しません。ページを開いた後、
-`Create / Mount` を押すと Web Component が生成されます。サンプルでは、モジュールの読み込み、
+です。通常モードではページを開くと、既定の同梱モジュールとコンポーネントが自動的に接続されます。
+任意のモジュールを試す場合は URL に `?manual=1` を付けて manual mode に入り、module URL を編集してから
+`Create / Mount` を押してください。manual mode では明示的な操作までモジュールを読み込みません。サンプルでは、モジュールの読み込み、
 作成・破棄・再作成、設定、投稿コンテキスト、各種イベント、2 個目のインスタンスの拒否、
 CSS Custom Properties、`::part()` を確認できます。
 
@@ -662,8 +663,9 @@ CSP の `worker-src` では配信元オリジンと `blob:` の両方を許可�
 ## 実動サンプル
 
 公開サンプルは [https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html](https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html)
-です。ページを開いた後、`Create / Mount` を押すと Web Component が生成されます。ページロード時に
-モジュールやコンポーネントを自動的に接続することはありません。
+です。通常モードではページを開くと、既定の同梱モジュールとコンポーネントが自動的に接続されます。
+任意のモジュールを試す場合は URL に `?manual=1` を付けて manual mode に入り、module URL を編集してから
+`Create / Mount` を押してください。manual mode では明示的な操作までモジュールを読み込みません。
 
 サンプルでは次の操作を確認できます。
 

--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>eHagaki Web Component Reference</title>
+    <link rel="icon" href="./favicon.ico">
     <style>
         :root {
             color-scheme: light;
@@ -170,7 +171,7 @@
                         <label for="asset-base">asset base</label>
                         <input id="asset-base" type="url" spellcheck="false">
                     </div>
-                    <p class="small">公開sampleの既定値は <code>./web-component/</code> です。GitHub Pagesの <code>/ehagaki/</code> baseを壊さないためroot-relative URLは使いません。module importは明示的なCreate操作でのみ発生します。</p>
+                    <p class="small">通常モードでは既定の同梱moduleをページ初期化時に自動読み込みしてeHagakiを表示します。任意moduleを試す場合はURL末尾に <code>?manual=1</code> を付けてmanual modeに入り、module URLを編集してから <code>Create / Mount</code> を押してください。manual modeでは明示的なCreate操作までmoduleを読み込みません。<code>moduleUrl</code> などのqueryだけで任意moduleを自動実行することはありません。</p>
                     <p class="small">外部moduleはhostページと同じJavaScript権限で実行されます。asset baseもworker/FFmpeg等の実行可能resourceに使われるため、信頼できるURLだけを指定してください。asset baseはCreate / Recreate時にelementへ設定されます。module load後はCustom Elements Registryのため実装を切り替えられず、別moduleを試すにはページをreloadしてください。</p>
                 </div>
 

--- a/public/web-component-parent-client-example.js
+++ b/public/web-component-parent-client-example.js
@@ -14,6 +14,7 @@ const readyStatus = document.querySelector("#ready-status");
 const nip07Status = document.querySelector("#nip07-status");
 const componentMount = document.querySelector("#component-mount");
 const eventLog = document.querySelector("#event-log");
+const isManualMode = new URLSearchParams(window.location.search).get("manual") === "1";
 
 let currentComposer = null;
 let secondaryComposer = null;
@@ -453,4 +454,11 @@ appendLog("sample ready", {
     sameWindowRealm: true,
     eventTransport: "CustomEvent bubbles+composed",
     secretLogging: false,
+    mode: isManualMode ? "manual" : "auto",
 });
+
+if (!isManualMode) {
+    void createComposer().catch((error) => appendLog("initial create failed", { code: safeErrorCode(error) }));
+} else {
+    appendLog("manual mode: waiting for explicit Create / Mount");
+}

--- a/public/web-component-parent-client-example.js
+++ b/public/web-component-parent-client-example.js
@@ -318,6 +318,10 @@ async function createComposer() {
         return;
     }
     await ensureModuleLoaded();
+    if (currentComposer?.isConnected) {
+        setStatus(componentStatus, "componentは既にmount済みです", "warn");
+        return;
+    }
     const element = document.createElement("ehagaki-composer");
     configureElement(element);
     installEventListeners(element, "primary");

--- a/src/test/e2e/webComponentDevServer.spec.ts
+++ b/src/test/e2e/webComponentDevServer.spec.ts
@@ -109,7 +109,6 @@ test("serves the Web Component sample through the local dev proxy", async ({ pag
         await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
         await expect(page.locator("#module-url")).toHaveValue(`${origin}/ehagaki/web-component/ehagaki-composer.js`);
         await expect(page.locator("#asset-base")).toHaveValue(`${origin}/ehagaki/web-component/`);
-        await page.getByRole("button", { name: "Create / Mount" }).click();
         await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
         await page.waitForFunction(() => document.querySelector("ehagaki-composer")?.shadowRoot?.querySelector(".footer-bar"));
 

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -107,7 +107,6 @@ test("keeps the comparison table within the page viewport at mobile widths", asy
 
 test("uses the internal theme surface even when the host forces a white background", async ({ page }) => {
     await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
-    await page.getByRole("button", { name: "Create / Mount" }).click();
     await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
     const result = await page.locator("ehagaki-composer").evaluate(async (element) => {
         const composer = element as HTMLElement & { setSettings(value: { themeMode: "light" | "dark" }): Promise<string[]> };
@@ -167,7 +166,6 @@ test("keeps Web Component header controls responsive to component width", async 
         await page.locator("#component-mount").evaluate((mount, width) => {
             (mount as HTMLElement).style.width = width;
         }, mountWidth);
-        await page.getByRole("button", { name: "Create / Mount" }).click();
         await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
 
         const geometry = await page.locator("ehagaki-composer").evaluate((element) => {
@@ -231,8 +229,10 @@ test("boots from production site output and exercises the public sample API", as
 
     await expect(page.locator("#module-url")).toHaveValue(`${origin}/ehagaki/web-component/ehagaki-composer.js`);
     await expect(page.locator("#asset-base")).toHaveValue(`${origin}/ehagaki/web-component/`);
-    await expect(page.locator("#module-status")).toHaveText("module 未読み込み");
-    await expect(page.locator("ehagaki-composer")).toHaveCount(0);
+    await expect(page.locator("#module-status")).toHaveText("module loaded; reload to choose another implementation");
+    await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
+    await expect(page.locator("#component-status")).toHaveText("component mounted");
+    await expect(page.locator("ehagaki-composer")).toHaveCount(1);
     for (const id of [
         "style-background",
         "style-text",
@@ -246,12 +246,7 @@ test("boots from production site output and exercises the public sample API", as
     ]) {
         await expect(page.locator(`#${id}`)).toHaveValue("");
     }
-    await page.getByRole("button", { name: "Create / Mount" }).click();
-    await expect(page.locator("#module-status")).toContainText("module loaded");
-    await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
-    await expect(page.locator("#component-status")).toHaveText("component mounted");
     await expect(page.locator("#module-url")).toBeDisabled();
-    await expect(page.locator("ehagaki-composer")).toHaveCount(1);
     expect(requests).toContain("/ehagaki/web-component/ehagaki-composer.js");
     expect([...requests].some((path) => path.startsWith("/ehagaki/web-component/assets/"))).toBe(true);
 
@@ -459,7 +454,6 @@ test("keeps the public sample container layout stable across destroy and recreat
     const pageErrors: string[] = [];
     page.on("pageerror", (error) => pageErrors.push(error.message));
     await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
-    await page.getByRole("button", { name: "Create / Mount" }).click();
     await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
     await expect.poll(() => page.locator("ehagaki-composer").evaluate((element) =>
         !!element.shadowRoot?.querySelector(".tiptap-editor"),
@@ -543,7 +537,6 @@ test("keeps the public sample container layout stable across destroy and recreat
 
 test("demonstrates second-instance rejection and recreation after destroy", async ({ page }) => {
     await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
-    await page.getByRole("button", { name: "Create / Mount" }).click();
     await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
 
     await page.getByRole("button", { name: "2個目を生成" }).click();
@@ -580,12 +573,24 @@ test("demonstrates second-instance rejection and recreation after destroy", asyn
     expect(recreatedStyle).toEqual({ background: "", partOutline: "" });
 });
 
-test("does not import query-selected modules until an explicit Create action", async ({ page }) => {
+test("does not auto-import query-selected modules outside manual mode", async ({ page }) => {
     await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html?moduleUrl=${encodeURIComponent(`${origin}${securityFixturePath}`)}`);
 
     await expect(page.locator("#module-url")).toHaveValue(`${origin}/ehagaki/web-component/ehagaki-composer.js`);
-    await expect(page.locator("ehagaki-composer")).toHaveCount(0);
+    await expect(page.locator("#module-status")).toContainText("module loaded");
+    await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
+    await expect(page.locator("ehagaki-composer")).toHaveCount(1);
     expect(requests).not.toContain(securityFixturePath);
+    expect(await page.evaluate(() => window.__securityFixtureLoaded === true)).toBe(false);
+});
+
+test("keeps arbitrary module loading explicit in manual mode", async ({ page }) => {
+    await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html?manual=1`);
+
+    await expect(page.locator("#module-status")).toHaveText("module 未読み込み");
+    await expect(page.locator("ehagaki-composer")).toHaveCount(0);
+    await expect(page.locator("#module-url")).toBeEditable();
+    expect(requests).not.toContain("/ehagaki/web-component/ehagaki-composer.js");
     expect(await page.evaluate(() => window.__securityFixtureLoaded === true)).toBe(false);
 
     await page.locator("#module-url").fill(`${origin}${securityFixturePath}`);

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -450,6 +450,45 @@ test("boots from production site output and exercises the public sample API", as
 
 });
 
+test("does not create a second primary while auto-mount waits for the module", async ({ page }) => {
+    const moduleUrl = `${origin}/ehagaki/web-component/ehagaki-composer.js`;
+    let releaseModule: () => void = () => undefined;
+    let resolveModuleRequestStarted: () => void = () => undefined;
+    const moduleRequestStarted = new Promise<void>((resolve) => {
+        resolveModuleRequestStarted = resolve;
+    });
+    const moduleGate = new Promise<void>((resolve) => {
+        releaseModule = resolve;
+    });
+
+    await page.route(moduleUrl, async (route) => {
+        resolveModuleRequestStarted();
+        await moduleGate;
+        await route.continue();
+    });
+
+    try {
+        await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`, { waitUntil: "commit" });
+        await moduleRequestStarted;
+        await page.getByRole("button", { name: "Create / Mount" }).click();
+        releaseModule();
+
+        await expect(page.locator("#module-status")).toContainText("module loaded");
+        await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
+        await expect(page.locator("#component-status")).toHaveText("component mounted");
+        await expect(page.locator("ehagaki-composer")).toHaveCount(1);
+        await expect(page.locator("#event-log")).not.toHaveValue(/multiple_instances_unsupported/);
+
+        await page.locator("#theme-mode").selectOption("light");
+        await page.getByRole("button", { name: "実行中に適用" }).click();
+        await expect(page.locator("#component-status")).toContainText("themeMode");
+        await expect(page.locator("ehagaki-composer")).toHaveCount(1);
+    } finally {
+        releaseModule();
+        await page.unroute(moduleUrl);
+    }
+});
+
 test("keeps the public sample container layout stable across destroy and recreate", async ({ page }) => {
     const pageErrors: string[] = [];
     page.on("pageerror", (error) => pageErrors.push(error.message));


### PR DESCRIPTION
## 変更概要
公開Web Componentサンプルを、通常アクセスだけで既定の同梱moduleを読み込み、eHagakiを表示する初期UXへ変更しました。今回、初回auto-mountのmodule読込中にCreate / Mountが重なった場合の二重primary生成競合も修正しました。

## 挙動
- 通常モードは既存の `createComposer()` を初期化末尾から呼び出し、初期settings/context、`whenReady()`、asset-base、既存lifecycle guardをそのまま利用します。
- `createComposer()` はmodule load後にもconnected primaryを再確認し、auto-mountとCreate / Recreateが同じmodule loadを待っても新しいelementを生成しません。
- `?manual=1` のmanual modeでは初期importとcomponent生成を行わず、module URLの編集と明示的な `Create / Mount` 後だけ任意moduleを読み込みます。
- Destroy / Create / Recreate、2個目のinstance拒否、persistent settings、settings/context、CSS Custom Properties / `::part()`、event logを維持しました。

## セキュリティ境界
`moduleUrl`などのqueryだけでは任意moduleを自動importしません。通常モードで自動読み込みするのは既定の同梱moduleだけです。Web Componentがhostと同じJavaScript権限で動作する説明も更新しました。

## 検証
- `npm run build:web-component` 成功
- `npm run build` 成功
- `npm run check`（0 errors / 0 warnings）
- `npx playwright test src/test/e2e/webComponentParentClientExample.spec.ts --project=desktop-chromium`（10 passed）
- 同 `mobile-chromium`（10 passed）
- 同 `mobile-webkit`（10 passed）
- `npx playwright test src/test/e2e/webComponentDevServer.spec.ts --project=desktop-chromium`（1 passed）
- `npm test`（333 files / 3837 tests passed）
- module requestをrouteで停止してからCreateを押す決定的なauto-mount競合回帰テストを追加し、1 instance・resolved/mounted・runtime settings適用・multiple拒否なしを確認

## 未実行
実Android/iPhone端末での確認は未実行です。Playwrightのmobile Chromium/WebKitは端末OSやPWA standalone UIの代替ではありません。