### PR TITLE
Add accent and base color theme API

### DIFF
--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -514,6 +514,22 @@ await replacement.whenReady();
 Shadow DOM の内部へ通常のホスト側 selector で直接 style を適用する代わりに、公開されている
 CSS Custom Properties を使用できます。
 
+まず、少数の指定で埋め込み先に合わせる簡易テーマとして、次の2色を指定できます。
+
+| CSS Custom Property | 用途 |
+| --- | --- |
+| `--ehagaki-accent-color` | 投稿ボタン、focus、選択状態などの主要アクセント |
+| `--ehagaki-base-color` | neutralな背景・入力欄・footer・button surface・borderなどへ混ぜる基準色 |
+
+Base Colorは指定色でsurfaceを直接塗りつぶさず、light/darkそれぞれの既定neutral色へ
+少量mixします。文字、アイコン、link、visited link、hashtag、danger、success、warningなどの
+意味色はBase Colorから生成されません。指定値は有効なCSS `<color>` としてください。任意の色の
+組み合わせについてコントラストを自動補正するAPIではないため、極端なAccent/Baseを指定する場合の
+可読性はhost側で確認してください。
+
+個別のtokenを調整したい場合は、従来の詳細overrideを使用できます。テーマ生成後に、指定された
+個別overrideのtokenだけが上書きされます。
+
 | CSS Custom Property | 用途 |
 | --- | --- |
 | `--ehagaki-background` | メイン背景 |
@@ -527,16 +543,18 @@ CSS Custom Properties を使用できます。
 
 ```css
 ehagaki-composer {
-  --ehagaki-background: #f4f4f4;
+  /* 簡易テーマ */
+  --ehagaki-accent-color: #28764f;
+  --ehagaki-base-color: #dcefe4;
+
+  /* 詳細override（必要なtokenだけ） */
   --ehagaki-text: #183028;
-  --ehagaki-border: #b8c7be;
-  --ehagaki-link: #28764f;
-  --ehagaki-input-background: #ffffff;
-  --ehagaki-footer-background: #e2ebe5;
-  --ehagaki-dialog-background: #ffffff;
   --ehagaki-font-family: system-ui, sans-serif;
 }
 ```
+
+Accent / Baseをどちらも指定しない場合は、現在のeHagakiの既定色が使われます。`themeMode` の
+`system` / `light` / `dark` とhostへ適用される `color-scheme` に応じてsurfaceが切り替わります。
 
 ## `::part()` によるスタイル調整
 

--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -241,13 +241,15 @@
 
                 <div class="card stack">
                     <h2>CSS Custom Properties / parts</h2>
-                    <p class="small">Create / Mount時はeHagaki本体のデフォルトCSSを使います。空欄は本体デフォルトを意味し、プリセットは入力欄へ値を入れるだけで表示は変えません。値は自由に編集でき、「入力したカスタムCSSを適用」を押したときだけ反映されます。「デフォルトに戻す」ではoverrideと入力欄をクリアします。</p>
+                    <p class="small">Create / Mount時はeHagaki本体のデフォルトCSSを使います。Accent / Baseは少数の指定でsurface群へ色味を付ける簡易テーマ、下段は個別tokenを指定する詳細overrideです。空欄は本体デフォルトを意味し、「入力したカスタムCSSを適用」を押したときだけ反映されます。</p>
                     <div class="buttons">
                         <button id="preset-mint" type="button" class="ghost">ミント</button>
                         <button id="preset-blue" type="button" class="ghost">ブルー</button>
                         <button id="preset-dark" type="button" class="ghost">ダーク</button>
                     </div>
                     <div class="grid-2">
+                        <div class="field"><label for="style-accent">accent color</label><input id="style-accent" placeholder="例: #28764f"></div>
+                        <div class="field"><label for="style-base">base color</label><input id="style-base" placeholder="例: #dcefe4"></div>
                         <div class="field"><label for="style-background">background</label><input id="style-background" placeholder="未指定 = eHagakiデフォルト"></div>
                         <div class="field"><label for="style-text">text</label><input id="style-text" placeholder="未指定 = eHagakiデフォルト"></div>
                         <div class="field"><label for="style-border">border</label><input id="style-border" placeholder="未指定 = eHagakiデフォルト"></div>
@@ -262,7 +264,7 @@
                         <button id="apply-styles" type="button" class="secondary">入力したカスタムCSSを適用</button>
                         <button id="reset-styles" type="button" class="ghost">デフォルトに戻す</button>
                     </div>
-                    <p class="small"><code>ehagaki-composer::part(header)</code> と <code>::part(composer)</code> にoutlineを適用する、このページのスタイルがあります。iframeではこのCSS境界を直接使えません。</p>
+                    <p class="small">Accent / Baseはsurface生成に使われ、backgroundやtextなどの個別overrideが指定されたtokenだけを上書きします。<code>ehagaki-composer::part(header)</code> と <code>::part(composer)</code> はレイアウトや局所調整用で、iframeではこのCSS境界を直接使えません。</p>
                 </div>
             </div>
         </section>

--- a/public/web-component-parent-client-example.js
+++ b/public/web-component-parent-client-example.js
@@ -20,7 +20,12 @@ let secondaryComposer = null;
 let loadedModuleUrl = "";
 let moduleLoadPromise = null;
 
-const CUSTOM_STYLE_FIELDS = [
+const THEME_STYLE_FIELDS = [
+    ["--ehagaki-accent-color", "style-accent"],
+    ["--ehagaki-base-color", "style-base"],
+];
+
+const DETAIL_STYLE_FIELDS = [
     ["--ehagaki-background", "style-background"],
     ["--ehagaki-text", "style-text"],
     ["--ehagaki-border", "style-border"],
@@ -31,51 +36,29 @@ const CUSTOM_STYLE_FIELDS = [
     ["--ehagaki-font-family", "style-font"],
 ];
 
+const CUSTOM_STYLE_FIELDS = [...THEME_STYLE_FIELDS, ...DETAIL_STYLE_FIELDS];
+
 const STYLE_PRESETS = {
     mint: {
-        background: "#f4f8f5",
-        text: "#183028",
-        border: "#b8c7be",
-        link: "#28764f",
-        input: "#ffffff",
-        footer: "#e2ebe5",
-        dialog: "#ffffff",
-        font: "system-ui, sans-serif",
+        accent: "#28764f",
+        base: "#dcefe4",
         partOutline: "#28764f",
     },
     blue: {
-        background: "#f3f7fb",
-        text: "#1d2a36",
-        border: "#b7c6d3",
-        link: "#1769aa",
-        input: "#ffffff",
-        footer: "#dfeaf3",
-        dialog: "#ffffff",
-        font: "system-ui, sans-serif",
+        accent: "#1769aa",
+        base: "#dfeaf3",
         partOutline: "#1769aa",
     },
     dark: {
-        background: "#181a1b",
-        text: "#e8e8e8",
-        border: "#4a4f52",
-        link: "#8ab4f8",
-        input: "#242728",
-        footer: "#202324",
-        dialog: "#242728",
-        font: "system-ui, sans-serif",
+        accent: "#8ab4f8",
+        base: "#242728",
         partOutline: "#8ab4f8",
     },
 };
 
 const STYLE_PRESET_FIELDS = [
-    ["style-background", "background"],
-    ["style-text", "text"],
-    ["style-border", "border"],
-    ["style-link", "link"],
-    ["style-input", "input"],
-    ["style-footer", "footer"],
-    ["style-dialog", "dialog"],
-    ["style-font", "font"],
+    ["style-accent", "accent"],
+    ["style-base", "base"],
 ];
 
 function getElement(id) {
@@ -294,6 +277,9 @@ function selectStylePreset(name) {
     const preset = STYLE_PRESETS[name];
     for (const [id, key] of STYLE_PRESET_FIELDS) {
         getElement(id).value = preset[key];
+    }
+    for (const [, id] of DETAIL_STYLE_FIELDS) {
+        getElement(id).value = "";
     }
     getElement("style-part-outline").value = preset.partOutline;
     appendLog(`styles preset selected: ${name}`);

--- a/src/app.css
+++ b/src/app.css
@@ -25,7 +25,11 @@
   --main-content-top-spacing: 6px;
   --composer-bottom-reserved-height: 116px;
 
-  --theme: hsl(152, 74%, 43%);
+  /* Theme inputs. --theme remains the compatibility name used by existing
+     components; --base-color is intentionally unset unless a host supplies it. */
+  --accent-color-default: hsl(152, 74%, 43%);
+  --accent-color: var(--accent-color-default);
+  --theme: var(--accent-color);
   --text-black: hsl(0, 0%, 24%);
   --nostr-bg: hsl(270, 100%, 98%);
   --yellow: hsl(50, 100%, 50%);
@@ -34,39 +38,93 @@
   --dark-gray: hsl(0, 0%, 66%);
   --light-gray: hsl(0, 0%, 83%);
 
-  /* ライトモード・ダークモード用カラー変数（デフォルト） */
-  --bg: light-dark(hsl(0, 0%, 89%), hsl(0, 0%, 12%));
-  --bg-input: light-dark(hsl(0, 0%, 100%), hsl(0, 0%, 19%));
-  --bg-footer: light-dark(hsl(0, 0%, 82%), hsl(0, 0%, 10%));
-  --bg-translucent: light-dark(#EDEDEDcc, #212121cc);
-  --bg-buttonbar: light-dark(hsl(0, 0%, 91%), hsl(0, 0%, 28%));
+  /* ライトモード・ダークモード用のneutral surface生成 */
+  --surface-bg: light-dark(
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 89%)) 8%, hsl(0, 0%, 89%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 12%)) 8%, hsl(0, 0%, 12%))
+  );
+  --surface-input: light-dark(
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 100%)) 5%, hsl(0, 0%, 100%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 19%)) 5%, hsl(0, 0%, 19%))
+  );
+  --surface-footer: light-dark(
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 82%)) 12%, hsl(0, 0%, 82%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 10%)) 12%, hsl(0, 0%, 10%))
+  );
+  --surface-buttonbar: light-dark(
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 91%)) 10%, hsl(0, 0%, 91%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 28%)) 10%, hsl(0, 0%, 28%))
+  );
 
-  --btn-bg: light-dark(hsl(0, 0%, 92%), hsl(0, 0%, 25%));
+  --surface-button: light-dark(
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 92%)) 8%, hsl(0, 0%, 92%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 25%)) 8%, hsl(0, 0%, 25%))
+  );
+  --surface-button-border: light-dark(
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 75%)) 14%, hsl(0, 0%, 75%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 14%, hsl(0, 0%, 30%))
+  );
+  --surface-button-preview-action: light-dark(
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 74%)) 12%, hsl(0, 0%, 74%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 36%)) 12%, hsl(0, 0%, 36%))
+  );
+
+  --surface-border: light-dark(
+    color-mix(in srgb, var(--base-color, var(--light-gray)) 14%, var(--light-gray)),
+    color-mix(in srgb, var(--base-color, dimgray) 14%, dimgray)
+  );
+  --surface-border-hr: light-dark(
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 84%)) 10%, hsl(0, 0%, 84%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 10%, hsl(0, 0%, 30%))
+  );
+  --surface-border-hr-light: light-dark(
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 92%)) 7%, hsl(0, 0%, 92%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 20%)) 7%, hsl(0, 0%, 20%))
+  );
+
+  --surface-dialog: light-dark(
+    color-mix(in srgb, var(--base-color, white) 5%, white),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 5%, hsl(0, 0%, 14%))
+  );
+  --surface-window: light-dark(
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 95%)) 5%, hsl(0, 0%, 95%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 5%, hsl(0, 0%, 14%))
+  );
+
+  --bg: var(--surface-bg);
+  --bg-input: var(--surface-input);
+  --bg-footer: var(--surface-footer);
+  --bg-translucent: light-dark(#EDEDEDcc, #212121cc);
+  --bg-buttonbar: var(--surface-buttonbar);
+
+  --btn-bg: var(--surface-button);
   --btn-bg2: light-dark(color-mix(in srgb, var(--btn-bg), black 6%), color-mix(in srgb, var(--btn-bg), white 10%));
   --btn-bg3: light-dark(color-mix(in srgb, var(--btn-bg), black 11%), color-mix(in srgb, var(--btn-bg), white 20%));
-  --btn-border: light-dark(hsl(0, 0%, 75%), hsl(0, 0%, 30%));
+  --btn-border: var(--surface-button-border);
   --btn-hover-bg: light-dark(rgba(50, 50, 50, 0.12), rgba(255, 255, 255, 0.12));
-  --btn-post-preview-action: light-dark(hsl(0, 0%, 74%), hsl(0, 0%, 36%));
+  --btn-post-preview-action: var(--surface-button-preview-action);
 
-  --border: light-dark(var(--light-gray), dimgray);
-  --border-hr: light-dark(hsl(0, 0%, 84%), hsl(0, 0%, 30%));
-  --border-hr-light: light-dark(hsl(0, 0%, 92%), hsl(0, 0%, 20%));
+  --border: var(--surface-border);
+  --border-hr: var(--surface-border-hr);
+  --border-hr-light: var(--surface-border-hr-light);
 
-  --text: light-dark(hsl(0, 0%, 24%), hsl(0, 0%, 90%));
+  --semantic-text: light-dark(hsl(0, 0%, 24%), hsl(0, 0%, 90%));
+  --text: var(--semantic-text);
   --text-light: light-dark(hsl(0, 0%, 46%), hsl(0, 0%, 75%));
   --text-muted: light-dark(hsl(0, 0%, 60%), hsl(0, 0%, 55%));
   --text-red: light-dark(hsl(0, 99%, 45%), hsl(0, 99%, 69%));
   --text-r: light-dark(#e6e6e6, #3D3D3D);
 
-  --link: light-dark(#1a0dab, #99c3ff);
+  --semantic-link: light-dark(#1a0dab, #99c3ff);
+  --link: var(--semantic-link);
   --link-visited: light-dark(#681da8, #c58af9);
 
-  --dialog-bg: light-dark(white, hsl(0, 0%, 14%));
+  --dialog-bg: var(--surface-dialog);
   --dialog-bg2: light-dark(color-mix(in srgb, var(--dialog-bg), black 6%), color-mix(in srgb, var(--dialog-bg), white 10%));
   --dialog-bg3: light-dark(color-mix(in srgb, var(--dialog-bg), black 11%), color-mix(in srgb, var(--dialog-bg), white 16%));
   --dialog-bg-overlay: light-dark(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.8));
 
-  --window: light-dark(hsl(0, 0%, 95%), hsl(0, 0%, 14%));
+  --window: var(--surface-window);
 
   --svg: light-dark(hsl(0, 0%, 36%), hsl(0, 0%, 90%));
   --svg-light: var(--text-light);

--- a/src/components/PostHistoryImportDialog.svelte
+++ b/src/components/PostHistoryImportDialog.svelte
@@ -466,8 +466,8 @@
     }
 
     .import-drop-zone-active {
-        border-color: var(--accent-color, var(--primary-color));
-        background: color-mix(in srgb, var(--accent-color, var(--primary-color)), transparent 90%);
+        border-color: var(--accent-color);
+        background: color-mix(in srgb, var(--accent-color), transparent 90%);
     }
 
     .import-drop-hint {

--- a/src/components/SettingsDialog.svelte
+++ b/src/components/SettingsDialog.svelte
@@ -1027,7 +1027,7 @@
 
     .sw-update-section {
         border-radius: 8px;
-        background: rgba(var(--theme-rgb), 0.05);
+        background: color-mix(in srgb, var(--theme) 5%, transparent);
     }
 
     .sw-update-label {

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -176,6 +176,101 @@ test("mounts across origins without touching host storage or registering an eHag
     await expect(page.locator("#host")).toHaveText("host surface");
 });
 
+test("applies Accent/Base themes while preserving default and meaning colors", async ({ page }) => {
+    await page.goto(hostOrigin);
+    await page.evaluate(async () => {
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+            setSettings(value: { themeMode: "light" | "dark" }): Promise<string[]>;
+        };
+        document.body.append(composer);
+        await composer.whenReady();
+        await composer.setSettings({ themeMode: "light" });
+    });
+
+    const readTheme = () => page.locator("ehagaki-composer").evaluate((element) => {
+        const shadow = element.shadowRoot!;
+        const shell = shadow.querySelector<HTMLElement>('[part~="shell"]')!;
+        const appRoot = shadow.querySelector<HTMLElement>(".ehagaki-app-root")!;
+        const primary = shadow.querySelector<HTMLElement>("button.primary")!;
+        const colorToPixel = (color: string) => {
+            const canvas = document.createElement("canvas");
+            canvas.width = 1;
+            canvas.height = 1;
+            const context = canvas.getContext("2d")!;
+            context.fillStyle = color;
+            context.fillRect(0, 0, 1, 1);
+            return Array.from(context.getImageData(0, 0, 1, 1).data);
+        };
+        const style = getComputedStyle(element);
+        return {
+            accent: style.getPropertyValue("--accent-color").trim(),
+            base: style.getPropertyValue("--base-color").trim(),
+            shellBackground: getComputedStyle(shell).backgroundColor,
+            shellPixel: colorToPixel(getComputedStyle(shell).backgroundColor),
+            primaryBackground: getComputedStyle(primary).backgroundColor,
+            textColor: getComputedStyle(appRoot).color,
+            text: style.getPropertyValue("--text").trim(),
+            link: style.getPropertyValue("--link").trim(),
+            danger: style.getPropertyValue("--danger").trim(),
+        };
+    });
+
+    const defaultLight = await readTheme();
+    expect(defaultLight.shellPixel).toEqual([227, 227, 227, 255]);
+    expect(defaultLight.primaryBackground).not.toBe("rgba(0, 0, 0, 0)");
+
+    await page.locator("ehagaki-composer").evaluate(async (element) => {
+        await (element as HTMLElement & { setSettings(value: { themeMode: "dark" }): Promise<string[]> })
+            .setSettings({ themeMode: "dark" });
+    });
+    const defaultDark = await readTheme();
+    expect(defaultDark.shellPixel).toEqual([31, 31, 31, 255]);
+    await page.locator("ehagaki-composer").evaluate(async (element) => {
+        await (element as HTMLElement & { setSettings(value: { themeMode: "light" }): Promise<string[]> })
+            .setSettings({ themeMode: "light" });
+    });
+
+    await page.locator("ehagaki-composer").evaluate((element) => {
+        element.style.setProperty("--ehagaki-accent-color", "#c04444");
+        element.style.setProperty("--ehagaki-base-color", "#d9e8f2");
+    });
+    const themedLight = await readTheme();
+    expect(themedLight.accent.toLowerCase()).toContain("#c04444");
+    expect(themedLight.base.toLowerCase()).toContain("#d9e8f2");
+    expect(themedLight.shellPixel).not.toEqual(defaultLight.shellPixel);
+    expect(themedLight.primaryBackground).not.toBe(defaultLight.primaryBackground);
+    expect(themedLight.text).toBe(defaultLight.text);
+    expect(themedLight.link).toBe(defaultLight.link);
+    expect(themedLight.danger).toBe(defaultLight.danger);
+
+    await page.locator("ehagaki-composer").evaluate((element) => {
+        element.style.setProperty("--ehagaki-background", "rgb(1, 2, 3)");
+    });
+    await expect.poll(() => page.locator("ehagaki-composer").evaluate((element) =>
+        getComputedStyle(element.shadowRoot!.querySelector<HTMLElement>('[part~="shell"]')!).backgroundColor,
+    )).toBe("rgb(1, 2, 3)");
+
+    await page.locator("ehagaki-composer").evaluate((element) => {
+        element.style.removeProperty("--ehagaki-background");
+    });
+    await expect.poll(readTheme).toMatchObject({
+        accent: "#c04444",
+        base: "#d9e8f2",
+    });
+
+    const composer = page.locator("ehagaki-composer");
+    await composer.evaluate(async (element) => {
+        await (element as HTMLElement & { setSettings(value: { themeMode: "dark" }): Promise<string[]> })
+            .setSettings({ themeMode: "dark" });
+    });
+    const themedDark = await readTheme();
+    expect(themedDark.shellPixel).not.toEqual(themedLight.shellPixel);
+    expect(themedDark.textColor).not.toBe(themedLight.textColor);
+    expect(themedDark.danger).toBe(themedLight.danger);
+});
+
 test("keeps bounded container layout inside the component while host page scrolls", async ({ page }) => {
     await page.goto(hostOrigin);
     const result = await page.evaluate(async () => {

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -282,6 +282,8 @@ test("boots from production site output and exercises the public sample API", as
     await expect(page.locator("#module-status")).toHaveText("module 未読み込み");
     await expect(page.locator("ehagaki-composer")).toHaveCount(0);
     for (const id of [
+        "style-accent",
+        "style-base",
         "style-background",
         "style-text",
         "style-border",
@@ -378,22 +380,45 @@ test("boots from production site output and exercises the public sample API", as
     expect(darkThemeResult.buttonColor).not.toBe(darkThemeResult.buttonBackground);
 
     await page.getByRole("button", { name: "ブルー" }).click();
-    await expect(page.locator("#style-background")).toHaveValue("#f3f7fb");
-    await expect(page.locator("#style-text")).toHaveValue("#1d2a36");
-    const afterBluePresetOnly = await page.locator("ehagaki-composer").evaluate((element) => element.style.getPropertyValue("--ehagaki-background"));
-    expect(afterBluePresetOnly).toBe("");
+    await expect(page.locator("#style-accent")).toHaveValue("#1769aa");
+    await expect(page.locator("#style-base")).toHaveValue("#dfeaf3");
+    await expect(page.locator("#style-background")).toHaveValue("");
 
     await page.getByRole("button", { name: "ミント" }).click();
-    await expect(page.locator("#style-background")).toHaveValue("#f4f8f5");
-    await expect(page.locator("#style-text")).toHaveValue("#183028");
-    await expect(page.locator("#style-border")).toHaveValue("#b8c7be");
-    await expect(page.locator("#style-link")).toHaveValue("#28764f");
-    await expect(page.locator("#style-input")).toHaveValue("#ffffff");
-    await expect(page.locator("#style-footer")).toHaveValue("#e2ebe5");
-    await expect(page.locator("#style-dialog")).toHaveValue("#ffffff");
-    await expect(page.locator("#style-font")).toHaveValue("system-ui, sans-serif");
+    await expect(page.locator("#style-accent")).toHaveValue("#28764f");
+    await expect(page.locator("#style-base")).toHaveValue("#dcefe4");
+    for (const id of [
+        "style-background",
+        "style-text",
+        "style-border",
+        "style-link",
+        "style-input",
+        "style-footer",
+        "style-dialog",
+        "style-font",
+    ]) {
+        await expect(page.locator(`#${id}`)).toHaveValue("");
+    }
     await expect(page.locator("#style-part-outline")).toHaveValue("#28764f");
-    const afterPresetOnly = await page.locator("ehagaki-composer").evaluate((element) => Object.fromEntries([
+    await page.getByRole("button", { name: "入力したカスタムCSSを適用" }).click();
+    const afterPresetOnly = await page.locator("ehagaki-composer").evaluate((element) => {
+        const shadow = element.shadowRoot!;
+        const shell = shadow.querySelector<HTMLElement>('[part~="shell"]')!;
+        const primary = shadow.querySelector<HTMLElement>("button.primary")!;
+        return {
+            accent: element.style.getPropertyValue("--ehagaki-accent-color"),
+            base: element.style.getPropertyValue("--ehagaki-base-color"),
+            surface: getComputedStyle(shell).backgroundColor,
+            primaryBackground: getComputedStyle(primary).backgroundColor,
+        };
+    });
+    expect(afterPresetOnly.accent).toBe("#28764f");
+    expect(afterPresetOnly.base).toBe("#dcefe4");
+    expect(afterPresetOnly.surface).not.toBe("rgba(0, 0, 0, 0)");
+    expect(afterPresetOnly.primaryBackground).not.toBe("rgba(0, 0, 0, 0)");
+    const afterPresetInlineStyles = await page.locator("ehagaki-composer").evaluate((element) => Object.fromEntries([
+        "--ehagaki-accent-color",
+        "--ehagaki-base-color",
         "--ehagaki-background",
         "--ehagaki-text",
         "--ehagaki-border",
@@ -404,7 +429,9 @@ test("boots from production site output and exercises the public sample API", as
         "--ehagaki-font-family",
         "--sample-part-outline",
     ].map((property) => [property, element.style.getPropertyValue(property)])));
-    expect(Object.values(afterPresetOnly).every((value) => value === "")).toBe(true);
+    expect(afterPresetInlineStyles["--ehagaki-accent-color"]).toBe("#28764f");
+    expect(afterPresetInlineStyles["--ehagaki-base-color"]).toBe("#dcefe4");
+    expect(afterPresetInlineStyles["--ehagaki-background"]).toBe("");
 
     await page.locator("#style-text").fill("#102030");
     await page.locator("#style-border").fill("");
@@ -412,20 +439,26 @@ test("boots from production site output and exercises the public sample API", as
     await page.getByRole("button", { name: "入力したカスタムCSSを適用" }).click();
     const partialStyleResult = await page.locator("ehagaki-composer").evaluate((element) => ({
         outline: getComputedStyle(element.shadowRoot!.querySelector<HTMLElement>('[part~="header"]')!).outlineColor,
+        accent: element.style.getPropertyValue("--ehagaki-accent-color"),
+        base: element.style.getPropertyValue("--ehagaki-base-color"),
         background: element.style.getPropertyValue("--ehagaki-background"),
         text: element.style.getPropertyValue("--ehagaki-text"),
         border: element.style.getPropertyValue("--ehagaki-border"),
-        computedBackground: getComputedStyle(element).getPropertyValue("--ehagaki-background").trim(),
+        appBackground: getComputedStyle(element.shadowRoot!.querySelector<HTMLElement>('[part~="shell"]')!).backgroundColor,
     }));
     expect(partialStyleResult.outline).toBe("rgb(1, 2, 3)");
-    expect(partialStyleResult.background).toBe("#f4f8f5");
+    expect(partialStyleResult.accent).toBe("#28764f");
+    expect(partialStyleResult.base).toBe("#dcefe4");
+    expect(partialStyleResult.background).toBe("");
     expect(partialStyleResult.text).toBe("#102030");
     expect(partialStyleResult.border).toBe("");
-    expect(partialStyleResult.computedBackground).toBe("#f4f8f5");
+    expect(partialStyleResult.appBackground).not.toBe("rgba(0, 0, 0, 0)");
 
     await page.getByRole("button", { name: "デフォルトに戻す" }).click();
     const resetStyleResult = await page.locator("ehagaki-composer").evaluate((element) => {
         const properties = [
+            "--ehagaki-accent-color",
+            "--ehagaki-base-color",
             "--ehagaki-background",
             "--ehagaki-text",
             "--ehagaki-border",
@@ -444,6 +477,8 @@ test("boots from production site output and exercises the public sample API", as
     expect(Object.values(resetStyleResult.inlineProperties).every((value) => value === "")).toBe(true);
     expect(resetStyleResult.rootOutline).toBe("");
     for (const id of [
+        "style-accent",
+        "style-base",
         "style-background",
         "style-text",
         "style-border",
@@ -458,26 +493,32 @@ test("boots from production site output and exercises the public sample API", as
     }
 
     await page.getByRole("button", { name: "ダーク" }).click();
-    await expect(page.locator("#style-background")).toHaveValue("#181a1b");
-    await expect(page.locator("#style-text")).toHaveValue("#e8e8e8");
+    await expect(page.locator("#style-accent")).toHaveValue("#8ab4f8");
+    await expect(page.locator("#style-base")).toHaveValue("#242728");
     const darkPresetOnly = await page.locator("ehagaki-composer").evaluate((element) => ({
+        accent: element.style.getPropertyValue("--ehagaki-accent-color"),
+        base: element.style.getPropertyValue("--ehagaki-base-color"),
         background: element.style.getPropertyValue("--ehagaki-background"),
         text: element.style.getPropertyValue("--ehagaki-text"),
     }));
-    expect(darkPresetOnly).toEqual({ background: "", text: "" });
+    expect(darkPresetOnly).toEqual({ accent: "", base: "", background: "", text: "" });
     await page.getByRole("button", { name: "入力したカスタムCSSを適用" }).click();
     const darkPresetResult = await page.locator("ehagaki-composer").evaluate((element) => {
         const appRoot = element.shadowRoot!.querySelector<HTMLElement>(".ehagaki-app-root")!;
         const style = getComputedStyle(appRoot);
         return {
+            accent: element.style.getPropertyValue("--ehagaki-accent-color"),
+            base: element.style.getPropertyValue("--ehagaki-base-color"),
             background: element.style.getPropertyValue("--ehagaki-background"),
             text: element.style.getPropertyValue("--ehagaki-text"),
             appColor: style.color,
             appBackground: style.backgroundColor,
         };
     });
-    expect(darkPresetResult.background).toBe("#181a1b");
-    expect(darkPresetResult.text).toBe("#e8e8e8");
+    expect(darkPresetResult.accent).toBe("#8ab4f8");
+    expect(darkPresetResult.base).toBe("#242728");
+    expect(darkPresetResult.background).toBe("");
+    expect(darkPresetResult.text).toBe("");
     expect(darkPresetResult.appColor).not.toBe(darkPresetResult.appBackground);
     await page.getByRole("button", { name: "デフォルトに戻す" }).click();
 
@@ -587,6 +628,39 @@ test("keeps the public sample container layout stable across destroy and recreat
     expect(second.editorSurface.height).toBeCloseTo(first.editorSurface.height, 0);
     expect(third.editorSurface.height).toBeCloseTo(first.editorSurface.height, 0);
     expect(pageErrors).toEqual([]);
+});
+
+test("preserves inherited Accent/Base theme across destroy and recreate", async ({ page }) => {
+    await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
+    await page.locator("#component-mount").evaluate((mount) => {
+        mount.style.setProperty("--ehagaki-accent-color", "#8a3ffc");
+        mount.style.setProperty("--ehagaki-base-color", "#e8dcff");
+    });
+
+    const readTheme = () => page.locator("ehagaki-composer").evaluate((element) => {
+        const shadow = element.shadowRoot!;
+        const shell = shadow.querySelector<HTMLElement>('[part~="shell"]')!;
+        const primary = shadow.querySelector<HTMLElement>("button.primary")!;
+        return {
+            accent: getComputedStyle(element).getPropertyValue("--accent-color").trim(),
+            base: getComputedStyle(element).getPropertyValue("--base-color").trim(),
+            shellBackground: getComputedStyle(shell).backgroundColor,
+            primaryBackground: getComputedStyle(primary).backgroundColor,
+        };
+    });
+
+    await page.getByRole("button", { name: "Create / Mount" }).click();
+    await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
+    const first = await readTheme();
+    expect(first.accent.toLowerCase()).toContain("#8a3ffc");
+    expect(first.base.toLowerCase()).toContain("#e8dcff");
+    expect(first.primaryBackground).not.toBe("rgba(0, 0, 0, 0)");
+
+    await page.getByRole("button", { name: "Destroy / Unmount" }).click();
+    await expect(page.locator("ehagaki-composer")).toHaveCount(0);
+    await page.getByRole("button", { name: "Create / Mount" }).click();
+    await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
+    await expect.poll(readTheme).toEqual(first);
 });
 
 test("demonstrates second-instance rejection and recreation after destroy", async ({ page }) => {

--- a/src/web-component/element.ts
+++ b/src/web-component/element.ts
@@ -91,6 +91,35 @@ function transformAppCss(css: string): string {
         .replace("body {", ".ehagaki-web-component-shell {");
 }
 
+function getWebComponentThemeCss(): string {
+    return `:host {
+        display: block;
+        --accent-color: var(--ehagaki-accent-color, var(--accent-color-default));
+        --base-color: var(--ehagaki-base-color);
+        --bg: var(--ehagaki-background, var(--surface-bg));
+        --text: var(--ehagaki-text, var(--semantic-text));
+        --border: var(--ehagaki-border, var(--surface-border));
+        --link: var(--ehagaki-link, var(--semantic-link));
+        --bg-input: var(--ehagaki-input-background, var(--surface-input));
+        --bg-footer: var(--ehagaki-footer-background, var(--surface-footer));
+        --dialog-bg: var(--ehagaki-dialog-background, var(--surface-dialog));
+        font-family: var(--ehagaki-font-family, system-ui, sans-serif);
+    }
+
+    .ehagaki-web-component-shell {
+        position: relative;
+        container-type: inline-size;
+        background: var(--bg);
+    }
+
+    .ehagaki-web-component-shell,
+    .ehagaki-web-component-app {
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+    }`;
+}
+
 export class EHagakiComposerElement extends HTMLElement {
     static get observedAttributes(): string[] {
         return ["asset-base"];
@@ -201,7 +230,7 @@ export class EHagakiComposerElement extends HTMLElement {
             const shadowRoot = this.shadowRoot ?? this.attachShadow({ mode: "open" });
             shadowRoot.replaceChildren();
             const styles = document.createElement("style");
-            styles.textContent = `${transformAppCss(appCss)}\n${photoSwipeCss}\n:host { display: block; --bg: var(--ehagaki-background, light-dark(hsl(0, 0%, 89%), hsl(0, 0%, 12%))); --text: var(--ehagaki-text, light-dark(hsl(0, 0%, 24%), hsl(0, 0%, 90%))); --border: var(--ehagaki-border, light-dark(hsl(0, 0%, 83%), dimgray)); --link: var(--ehagaki-link, light-dark(#1a0dab, #99c3ff)); --bg-input: var(--ehagaki-input-background, light-dark(#fff, hsl(0, 0%, 19%))); --bg-footer: var(--ehagaki-footer-background, light-dark(hsl(0, 0%, 82%), hsl(0, 0%, 10%))); --dialog-bg: var(--ehagaki-dialog-background, light-dark(#fff, hsl(0, 0%, 14%))); font-family: var(--ehagaki-font-family, system-ui, sans-serif); } .ehagaki-web-component-shell { position: relative; container-type: inline-size; background: var(--bg); } .ehagaki-web-component-shell, .ehagaki-web-component-app { width: 100%; height: 100%; min-height: 0; }`;
+            styles.textContent = `${transformAppCss(appCss)}\n${photoSwipeCss}\n${getWebComponentThemeCss()}`;
             const shell = document.createElement("div");
             shell.className = "ehagaki-web-component-shell";
             shell.part.add("shell");


### PR DESCRIPTION
## Summary

- Add shared Accent/Base color inputs and semantic neutral surface tokens.
- Expose `--ehagaki-accent-color` and `--ehagaki-base-color` for Web Component embeds.
- Preserve existing detailed `--ehagaki-*` overrides and public `::part()` API.
- Update the reference sample, documentation, and browser coverage.

## Behavior

Accent continues to drive the existing `--theme` compatibility path. Base colors are mixed into neutral backgrounds, inputs, footers, button surfaces, borders, dialogs, and windows; meaning colors such as danger, success, warning, links, hashtags, and status colors remain independent. Detailed overrides win for only the token they target.

## Validation

- `npm test` (333 files, 3,837 tests)
- `npm run check`
- `npm run build`
- Web Component E2E: desktop Chromium, mobile Chromium, mobile WebKit, and desktop Firefox theme coverage
- Public sample E2E: desktop Chromium, mobile Chromium, and mobile WebKit

## Desktop Firefox comparison

The exact `keeps the normal app Portal Button scope` test was run twice with the configured `desktop-firefox` project in isolated worktrees:

- PR HEAD `7bcb1930121f9a8853ff481840b88a4e01956f73`: 2/2 passed.
- Base `b3448e3144e01b73dcfcc64e6c27dfa1137e73df`: 2/2 passed.

The previously reported Welcome Dialog timeout was not reproducible in this comparison, and no PR-specific regression was established. No code change was made for it. Physical Android/iOS devices were not verified.