### PR TITLE
Remove part outline demo from Web Component sample

### DIFF
--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -115,10 +115,6 @@
         #component-mount { height: 580px; }
         ehagaki-composer { display: block; height: 100%; min-height: 0; background: white; }
 
-        /* Public parts demo: this selector is host CSS and crosses only the declared part boundary. */
-        ehagaki-composer::part(header) { outline: 3px solid var(--sample-part-outline, transparent); outline-offset: -3px; }
-        ehagaki-composer::part(composer) { box-shadow: inset 0 0 0 1px var(--sample-part-outline, transparent); }
-
         .comparison { width: 100%; table-layout: fixed; border-collapse: collapse; font-size: .84rem; }
         .comparison th, .comparison td { padding: 9px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; overflow-wrap: anywhere; }
         .comparison th { color: var(--muted); width: 25%; }
@@ -241,7 +237,7 @@
                 </div>
 
                 <div class="card stack">
-                    <h2>CSS Custom Properties / parts</h2>
+                    <h2>CSS Custom Properties</h2>
                     <p class="small">Create / Mount時はeHagaki本体のデフォルトCSSを使います。Accent / Baseは少数の指定でsurface群へ色味を付ける簡易テーマ、下段は個別tokenを指定する詳細overrideです。空欄は本体デフォルトを意味し、「入力したカスタムCSSを適用」を押したときだけ反映されます。</p>
                     <div class="buttons">
                         <button id="preset-mint" type="button" class="ghost">ミント</button>
@@ -260,12 +256,11 @@
                         <div class="field"><label for="style-dialog">dialog background</label><input id="style-dialog" placeholder="未指定 = eHagakiデフォルト"></div>
                         <div class="field"><label for="style-font">font family</label><input id="style-font" placeholder="未指定 = eHagakiデフォルト"></div>
                     </div>
-                    <div class="field"><label for="style-part-outline">::part(header/composer) outline</label><input id="style-part-outline" placeholder="未指定 = eHagakiデフォルト"></div>
                     <div class="buttons">
                         <button id="apply-styles" type="button" class="secondary">入力したカスタムCSSを適用</button>
                         <button id="reset-styles" type="button" class="ghost">デフォルトに戻す</button>
                     </div>
-                    <p class="small">Accent / Baseはsurface生成に使われ、backgroundやtextなどの個別overrideが指定されたtokenだけを上書きします。<code>ehagaki-composer::part(header)</code> と <code>::part(composer)</code> はレイアウトや局所調整用で、iframeではこのCSS境界を直接使えません。</p>
+                    <p class="small">Accent / Baseはsurface生成に使われ、backgroundやtextなどの個別overrideが指定されたtokenだけを上書きします。公開partの利用方法は <a href="https://github.com/Lokuyow/ehagaki/blob/main/docs/WEB_COMPONENT.md" target="_blank" rel="noreferrer noopener">Web Component guide</a> を参照してください。</p>
                 </div>
             </div>
         </section>

--- a/public/web-component-parent-client-example.js
+++ b/public/web-component-parent-client-example.js
@@ -43,17 +43,14 @@ const STYLE_PRESETS = {
     mint: {
         accent: "#28764f",
         base: "#dcefe4",
-        partOutline: "#28764f",
     },
     blue: {
         accent: "#1769aa",
         base: "#dfeaf3",
-        partOutline: "#1769aa",
     },
     dark: {
         accent: "#8ab4f8",
         base: "#242728",
-        partOutline: "#8ab4f8",
     },
 };
 
@@ -271,7 +268,6 @@ function clearStyleInputs() {
     for (const [, id] of CUSTOM_STYLE_FIELDS) {
         getElement(id).value = "";
     }
-    getElement("style-part-outline").value = "";
 }
 
 function selectStylePreset(name) {
@@ -282,7 +278,6 @@ function selectStylePreset(name) {
     for (const [, id] of DETAIL_STYLE_FIELDS) {
         getElement(id).value = "";
     }
-    getElement("style-part-outline").value = preset.partOutline;
     appendLog(`styles preset selected: ${name}`);
 }
 
@@ -290,8 +285,6 @@ function removeCustomStyles(element) {
     for (const [property] of CUSTOM_STYLE_FIELDS) {
         element.style.removeProperty(property);
     }
-    element.style.removeProperty("--sample-part-outline");
-    document.documentElement.style.removeProperty("--sample-part-outline");
 }
 
 function configureElement(element) {
@@ -377,13 +370,7 @@ function applyStyles() {
         return;
     }
     applyCustomStyles(currentComposer);
-    const partOutline = getElement("style-part-outline").value.trim();
-    if (partOutline) {
-        currentComposer.style.setProperty("--sample-part-outline", partOutline);
-    } else {
-        currentComposer.style.removeProperty("--sample-part-outline");
-    }
-    appendLog("styles applied", { customProperties: 8, parts: ["header", "composer"] });
+    appendLog("styles applied", { customProperties: CUSTOM_STYLE_FIELDS.length });
 }
 
 function resetStyles() {
@@ -395,7 +382,7 @@ function resetStyles() {
     }
     removeCustomStyles(currentComposer);
     clearStyleInputs();
-    appendLog("styles reset", { customProperties: 8, parts: ["header", "composer"] });
+    appendLog("styles reset", { customProperties: CUSTOM_STYLE_FIELDS.length });
 }
 
 function refreshNip07Status() {

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -281,6 +281,7 @@ test("boots from production site output and exercises the public sample API", as
     await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
     await expect(page.locator("#component-status")).toHaveText("component mounted");
     await expect(page.locator("ehagaki-composer")).toHaveCount(1);
+    await expect(page.locator("#style-part-outline")).toHaveCount(0);
     for (const id of [
         "style-accent",
         "style-base",
@@ -292,7 +293,6 @@ test("boots from production site output and exercises the public sample API", as
         "style-footer",
         "style-dialog",
         "style-font",
-        "style-part-outline",
     ]) {
         await expect(page.locator(`#${id}`)).toHaveValue("");
     }
@@ -325,7 +325,6 @@ test("boots from production site output and exercises the public sample API", as
             "--ehagaki-footer-background",
             "--ehagaki-dialog-background",
             "--ehagaki-font-family",
-            "--sample-part-outline",
         ];
         return Object.fromEntries(properties.map((property) => [property, element.style.getPropertyValue(property)]));
     });
@@ -394,7 +393,6 @@ test("boots from production site output and exercises the public sample API", as
     ]) {
         await expect(page.locator(`#${id}`)).toHaveValue("");
     }
-    await expect(page.locator("#style-part-outline")).toHaveValue("#28764f");
     await page.getByRole("button", { name: "入力したカスタムCSSを適用" }).click();
     const afterPresetOnly = await page.locator("ehagaki-composer").evaluate((element) => {
         const shadow = element.shadowRoot!;
@@ -422,7 +420,6 @@ test("boots from production site output and exercises the public sample API", as
         "--ehagaki-footer-background",
         "--ehagaki-dialog-background",
         "--ehagaki-font-family",
-        "--sample-part-outline",
     ].map((property) => [property, element.style.getPropertyValue(property)])));
     expect(afterPresetInlineStyles["--ehagaki-accent-color"]).toBe("#28764f");
     expect(afterPresetInlineStyles["--ehagaki-base-color"]).toBe("#dcefe4");
@@ -430,10 +427,8 @@ test("boots from production site output and exercises the public sample API", as
 
     await page.locator("#style-text").fill("#102030");
     await page.locator("#style-border").fill("");
-    await page.locator("#style-part-outline").fill("rgb(1, 2, 3)");
     await page.getByRole("button", { name: "入力したカスタムCSSを適用" }).click();
     const partialStyleResult = await page.locator("ehagaki-composer").evaluate((element) => ({
-        outline: getComputedStyle(element.shadowRoot!.querySelector<HTMLElement>('[part~="header"]')!).outlineColor,
         accent: element.style.getPropertyValue("--ehagaki-accent-color"),
         base: element.style.getPropertyValue("--ehagaki-base-color"),
         background: element.style.getPropertyValue("--ehagaki-background"),
@@ -441,7 +436,6 @@ test("boots from production site output and exercises the public sample API", as
         border: element.style.getPropertyValue("--ehagaki-border"),
         appBackground: getComputedStyle(element.shadowRoot!.querySelector<HTMLElement>('[part~="shell"]')!).backgroundColor,
     }));
-    expect(partialStyleResult.outline).toBe("rgb(1, 2, 3)");
     expect(partialStyleResult.accent).toBe("#28764f");
     expect(partialStyleResult.base).toBe("#dcefe4");
     expect(partialStyleResult.background).toBe("");
@@ -462,15 +456,12 @@ test("boots from production site output and exercises the public sample API", as
             "--ehagaki-footer-background",
             "--ehagaki-dialog-background",
             "--ehagaki-font-family",
-            "--sample-part-outline",
         ];
         return {
             inlineProperties: Object.fromEntries(properties.map((property) => [property, element.style.getPropertyValue(property)])),
-            rootOutline: document.documentElement.style.getPropertyValue("--sample-part-outline"),
         };
     });
     expect(Object.values(resetStyleResult.inlineProperties).every((value) => value === "")).toBe(true);
-    expect(resetStyleResult.rootOutline).toBe("");
     for (const id of [
         "style-accent",
         "style-base",
@@ -482,7 +473,6 @@ test("boots from production site output and exercises the public sample API", as
         "style-footer",
         "style-dialog",
         "style-font",
-        "style-part-outline",
     ]) {
         await expect(page.locator(`#${id}`)).toHaveValue("");
     }
@@ -706,11 +696,10 @@ test("demonstrates second-instance rejection and recreation after destroy", asyn
     await expect(page.locator("ehagaki-composer")).toHaveCount(2);
     const secondInstanceStyles = await page.locator("ehagaki-composer").evaluateAll((elements) => elements.map((element) => ({
         background: element.style.getPropertyValue("--ehagaki-background"),
-        partOutline: element.style.getPropertyValue("--sample-part-outline"),
     })));
     expect(secondInstanceStyles).toEqual([
-        { background: "", partOutline: "" },
-        { background: "", partOutline: "" },
+        { background: "" },
+        { background: "" },
     ]);
 
     await page.getByRole("button", { name: "Destroy / Unmount" }).click();
@@ -729,9 +718,8 @@ test("demonstrates second-instance rejection and recreation after destroy", asyn
     await expect(page.locator("#component-status")).toHaveText("component mounted");
     const recreatedStyle = await page.locator("ehagaki-composer").evaluate((element) => ({
         background: element.style.getPropertyValue("--ehagaki-background"),
-        partOutline: element.style.getPropertyValue("--sample-part-outline"),
     }));
-    expect(recreatedStyle).toEqual({ background: "", partOutline: "" });
+    expect(recreatedStyle).toEqual({ background: "" });
 });
 
 test("does not auto-import query-selected modules outside manual mode", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Remove the interactive `::part(header/composer)` outline demo CSS, input, state, preset values, and apply/reset logging from the public Web Component sample.
- Keep Accent/Base themes, detailed `--ehagaki-*` overrides, reset, lifecycle behavior, the public `::part()` API, and the Web Component guide examples unchanged.

## Validation

- `npm run check` — passed with 0 errors and 0 warnings.
- `npm run build` — passed. Existing chunk-size and Svelte rest-props warnings remain.
- `npm test` — passed: 333 test files, 3837 tests.
- `npx playwright test src/test/e2e/webComponentParentClientExample.spec.ts --project=desktop-chromium --project=mobile-chromium --project=mobile-webkit` — 36 passed.
- `npx playwright test src/test/e2e/webComponentEmbed.spec.ts --project=desktop-chromium --project=mobile-chromium --project=mobile-webkit` — 40 passed, 2 skipped by existing hover conditions.
- Built preview opened in Desktop Chromium; screenshot and computed styles confirmed no sample part outline/inset shadow and no `style-part-outline` input.

## Not run

- Desktop Firefox project was not run because the requested sample and public-part coverage were run on Desktop Chromium plus the existing Mobile Chromium/Mobile WebKit projects; no Firefox-specific behavior is changed.
- Physical Android/iPhone browser verification was not run; Playwright mobile projects are device emulation.
