### PR TITLE
Improve Web Component Theme Playground

### DIFF
--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -35,12 +35,22 @@
             width: min(1440px, calc(100vw - 32px));
             margin: 24px auto 48px;
             display: grid;
+            gap: 24px;
+        }
+
+        .column, .stack { display: grid; gap: 18px; min-width: 0; }
+        .theme-playground, .reference-grid {
+            display: grid;
             grid-template-columns: minmax(320px, 450px) minmax(0, 1fr);
             gap: 20px;
             align-items: start;
         }
-
-        .column, .stack { display: grid; gap: 18px; min-width: 0; }
+        .theme-controls { display: grid; gap: 16px; min-width: 0; }
+        .theme-controls > header { display: grid; gap: 10px; }
+        .theme-panel { display: grid; gap: 18px; }
+        .theme-panel > header { display: grid; gap: 6px; }
+        .reference-grid { padding-top: 2px; }
+        .reference-heading { display: grid; gap: 6px; }
         .panel, .card { background: var(--panel); border: 1px solid var(--line); border-radius: 18px; box-shadow: var(--shadow); }
         .panel { padding: 22px; }
         .card { padding: 16px; box-shadow: none; }
@@ -82,6 +92,30 @@
         button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible { outline: 3px solid #92caaa; outline-offset: 2px; }
         .buttons { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px; }
         .buttons + .buttons { margin-top: 9px; }
+        .preset-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+        .preset-button {
+            display: grid;
+            grid-template-columns: auto 1fr;
+            align-items: center;
+            gap: 10px;
+            min-height: 58px;
+            border: 1px solid var(--line);
+            border-radius: 12px;
+            background: #fbfdfb;
+            color: var(--text);
+            text-align: left;
+        }
+        .preset-button[aria-pressed="true"] { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
+        .preset-swatches { display: grid; grid-template-columns: repeat(2, 18px); gap: 3px; }
+        .preset-swatch { width: 18px; height: 18px; border-radius: 5px; border: 1px solid rgba(24, 48, 40, .22); }
+        .preset-name { font-weight: 700; }
+        .preset-values { color: var(--muted); font-size: .73rem; line-height: 1.35; }
+        .theme-divider { border: 0; border-top: 1px solid var(--line); margin: 0; }
+        details.advanced-settings { border: 1px solid var(--line); border-radius: 12px; background: #f8fbf9; }
+        details.advanced-settings summary { padding: 12px 14px; cursor: pointer; font-weight: 700; }
+        details.advanced-settings[open] { padding-bottom: 14px; }
+        details.advanced-settings[open] summary { margin-bottom: 14px; border-bottom: 1px solid var(--line); }
+        .advanced-content { display: grid; gap: 14px; padding: 0 14px; }
         .event-monitor-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
         .event-monitor-header > div { min-width: 0; }
         .event-monitor-header button { flex: 0 0 auto; }
@@ -111,8 +145,9 @@
             font-size: .78rem;
             line-height: 1.5;
         }
-        .component-frame { height: 640px; padding: 18px; background: #dce8df; border-radius: 18px; }
-        #component-mount { height: 580px; }
+        .preview-panel { position: sticky; top: 18px; }
+        .component-frame { height: clamp(500px, 68vh, 620px); padding: 18px; background: #dce8df; border-radius: 18px; }
+        #component-mount { height: calc(100% - 36px); }
         ehagaki-composer { display: block; height: 100%; min-height: 0; background: white; }
 
         .comparison { width: 100%; table-layout: fixed; border-collapse: collapse; font-size: .84rem; }
@@ -123,9 +158,10 @@
         .check input { width: auto; }
 
         @media (max-width: 980px) {
-            main { grid-template-columns: 1fr; }
+            .theme-playground, .reference-grid { grid-template-columns: 1fr; }
+            .preview-panel { position: static; }
             .component-frame { height: 520px; }
-            #component-mount, ehagaki-composer { height: 480px; }
+            #component-mount, ehagaki-composer { height: 484px; }
         }
 
         @media (max-width: 540px) {
@@ -139,15 +175,83 @@
 
 <body>
     <main>
-        <section class="column">
-            <div class="panel stack">
-                <header class="stack">
-                    <div>
-                        <h1>eHagaki Web Component</h1>
-                        <p class="lead">外部サイトのhostから、公開API・lifecycle・event・security modelを実際に操作するリファレンスです。</p>
-                    </div>
+        <section class="theme-playground" aria-labelledby="theme-playground-heading">
+            <div class="theme-controls">
+                <header>
+                    <h1 id="theme-playground-heading">Theme Playground</h1>
+                    <p class="lead">プリセットやテーマカラーを試しながら、右側のeHagaki Web Componentの見た目を確認できます。</p>
                     <p class="small"><a href="https://github.com/Lokuyow/ehagaki/blob/main/docs/WEB_COMPONENT.md" target="_blank" rel="noreferrer noopener">Web Component guide</a> / <a href="./embed-parent-client-example.html">iframe sample</a></p>
                 </header>
+
+                <div class="panel theme-panel">
+                    <header>
+                        <h2>簡単設定</h2>
+                        <p class="small">プリセット、accent、baseだけでsurface全体の色味を試せます。Base Colorはneutral surfaceへmixされる色味のseedです。</p>
+                    </header>
+                    <div class="preset-grid" aria-label="Theme presets">
+                        <button id="preset-azure" type="button" class="preset-button" aria-pressed="false">
+                            <span class="preset-swatches" aria-hidden="true"><span class="preset-swatch" style="background: #005FCC"></span><span class="preset-swatch" style="background: #0077FF"></span></span>
+                            <span><span class="preset-name">Azure</span><br><span class="preset-values">#005FCC / #0077FF</span></span>
+                        </button>
+                        <button id="preset-rose" type="button" class="preset-button" aria-pressed="false">
+                            <span class="preset-swatches" aria-hidden="true"><span class="preset-swatch" style="background: #B4233C"></span><span class="preset-swatch" style="background: #FF3B5C"></span></span>
+                            <span><span class="preset-name">Rose</span><br><span class="preset-values">#B4233C / #FF3B5C</span></span>
+                        </button>
+                        <button id="preset-forest" type="button" class="preset-button" aria-pressed="false">
+                            <span class="preset-swatches" aria-hidden="true"><span class="preset-swatch" style="background: #1F7A4D"></span><span class="preset-swatch" style="background: #00A86B"></span></span>
+                            <span><span class="preset-name">Forest</span><br><span class="preset-values">#1F7A4D / #00A86B</span></span>
+                        </button>
+                        <button id="preset-amber" type="button" class="preset-button" aria-pressed="false">
+                            <span class="preset-swatches" aria-hidden="true"><span class="preset-swatch" style="background: #8A5700"></span><span class="preset-swatch" style="background: #F2B000"></span></span>
+                            <span><span class="preset-name">Amber</span><br><span class="preset-values">#8A5700 / #F2B000</span></span>
+                        </button>
+                    </div>
+                    <hr class="theme-divider">
+                    <div class="grid-2">
+                        <div class="field"><label for="style-accent">accent color</label><input id="style-accent" placeholder="#005FCC"></div>
+                        <div class="field"><label for="style-base">base color</label><input id="style-base" placeholder="#0077FF"></div>
+                    </div>
+                    <p class="small">空欄はeHagakiデフォルトです。プリセットはmount済みなら選択直後に反映され、手入力値は「テーマカラーを適用」で反映されます。</p>
+                    <div class="buttons">
+                        <button id="apply-styles" type="button" class="secondary">テーマカラーを適用</button>
+                        <button id="reset-styles" type="button" class="ghost">デフォルトに戻す</button>
+                    </div>
+
+                    <details class="advanced-settings">
+                        <summary>詳細設定</summary>
+                        <div class="advanced-content">
+                            <p class="small">個別tokenを指定すると、指定した項目だけを上書きします。空欄はeHagakiデフォルトです。</p>
+                            <div class="grid-2">
+                                <div class="field"><label for="style-background">background</label><input id="style-background"></div>
+                                <div class="field"><label for="style-text">text</label><input id="style-text"></div>
+                                <div class="field"><label for="style-border">border</label><input id="style-border"></div>
+                                <div class="field"><label for="style-link">link</label><input id="style-link"></div>
+                                <div class="field"><label for="style-input">input background</label><input id="style-input"></div>
+                                <div class="field"><label for="style-footer">footer background</label><input id="style-footer"></div>
+                                <div class="field"><label for="style-dialog">dialog background</label><input id="style-dialog"></div>
+                                <div class="field"><label for="style-font">font family</label><input id="style-font"></div>
+                            </div>
+                            <p class="small">Accent / Baseはsurface生成に使われます。公開partの利用方法は <a href="https://github.com/Lokuyow/ehagaki/blob/main/docs/WEB_COMPONENT.md" target="_blank" rel="noreferrer noopener">Web Component guide</a> を参照してください。</p>
+                        </div>
+                    </details>
+                </div>
+            </div>
+
+            <div class="panel stack preview-panel">
+                <div>
+                    <h2>Component surface</h2>
+                    <p class="small">プリセットを押すと、mount済みのcomponentへCSS Custom Propertiesがその場で反映されます。</p>
+                </div>
+                <div id="component-mount" class="component-frame" aria-label="eHagaki Web Component mount point"></div>
+            </div>
+        </section>
+
+        <section class="reference-grid" aria-labelledby="reference-heading">
+            <div class="column">
+                <div class="panel stack reference-heading">
+                    <h2 id="reference-heading">Web Component reference</h2>
+                    <p class="small">公開API・lifecycle・event・security modelを実際に操作するリファレンスです。</p>
+                </div>
 
                 <div class="notice">
                     <strong>認証とtrust boundary</strong>
@@ -235,77 +339,42 @@
                         <button id="apply-invalid-context" type="button" class="ghost full">invalid contextを試す</button>
                     </div>
                 </div>
+            </div>
 
-                <div class="card stack">
-                    <h2>CSS Custom Properties</h2>
-                    <p class="small">Create / Mount時はeHagaki本体のデフォルトCSSを使います。Accent / Baseは少数の指定でsurface群へ色味を付ける簡易テーマ、下段は個別tokenを指定する詳細overrideです。空欄は本体デフォルトを意味し、「入力したカスタムCSSを適用」を押したときだけ反映されます。</p>
-                    <div class="buttons">
-                        <button id="preset-mint" type="button" class="ghost">ミント</button>
-                        <button id="preset-blue" type="button" class="ghost">ブルー</button>
-                        <button id="preset-dark" type="button" class="ghost">ダーク</button>
+            <div class="column">
+                <div class="panel stack">
+                    <div class="event-monitor-header">
+                        <div><h2>Event monitor</h2><p class="small">秘密情報・署名要求payload・raw Errorは表示せず、安全なsummaryだけを記録します。</p></div>
+                        <button id="clear-log" type="button" class="ghost">ログをクリア</button>
                     </div>
-                    <div class="grid-2">
-                        <div class="field"><label for="style-accent">accent color</label><input id="style-accent" placeholder="例: #28764f"></div>
-                        <div class="field"><label for="style-base">base color</label><input id="style-base" placeholder="例: #dcefe4"></div>
-                        <div class="field"><label for="style-background">background</label><input id="style-background" placeholder="未指定 = eHagakiデフォルト"></div>
-                        <div class="field"><label for="style-text">text</label><input id="style-text" placeholder="未指定 = eHagakiデフォルト"></div>
-                        <div class="field"><label for="style-border">border</label><input id="style-border" placeholder="未指定 = eHagakiデフォルト"></div>
-                        <div class="field"><label for="style-link">link</label><input id="style-link" placeholder="未指定 = eHagakiデフォルト"></div>
-                        <div class="field"><label for="style-input">input background</label><input id="style-input" placeholder="未指定 = eHagakiデフォルト"></div>
-                        <div class="field"><label for="style-footer">footer background</label><input id="style-footer" placeholder="未指定 = eHagakiデフォルト"></div>
-                        <div class="field"><label for="style-dialog">dialog background</label><input id="style-dialog" placeholder="未指定 = eHagakiデフォルト"></div>
-                        <div class="field"><label for="style-font">font family</label><input id="style-font" placeholder="未指定 = eHagakiデフォルト"></div>
+                    <textarea id="event-log" class="log" readonly aria-label="Web Component event log"></textarea>
+                </div>
+
+                <div class="panel stack">
+                    <div>
+                        <h2>iframeとの違い</h2>
+                        <p class="small">Web Componentが常に安全という意味ではありません。host JavaScriptから秘密情報を隔離したい場合はiframeを使ってください。</p>
                     </div>
-                    <div class="buttons">
-                        <button id="apply-styles" type="button" class="secondary">入力したカスタムCSSを適用</button>
-                        <button id="reset-styles" type="button" class="ghost">デフォルトに戻す</button>
-                    </div>
-                    <p class="small">Accent / Baseはsurface生成に使われ、backgroundやtextなどの個別overrideが指定されたtokenだけを上書きします。公開partの利用方法は <a href="https://github.com/Lokuyow/ehagaki/blob/main/docs/WEB_COMPONENT.md" target="_blank" rel="noreferrer noopener">Web Component guide</a> を参照してください。</p>
+                    <table class="comparison">
+                        <thead><tr><th>項目</th><th>iframe</th><th>Web Component</th></tr></thead>
+                        <tbody>
+                            <tr><th>境界 / API</th><td>origin isolation、postMessage protocol、handshake</td><td>同じWindow realm、method/property/CustomEvent、element create/destroy/recreate</td></tr>
+                            <tr><th>認証</th><td>parent-client auth/RPCを利用可能</td><td>parent-client auth/RPCは使用しない。NIP-07はhostのwindow.nostrを直接利用し、NIP-46/nsecはeHagaki UI</td></tr>
+                            <tr><th>保存</th><td>storage/IndexedDBの親委譲が可能</td><td>localStorageは <code>ehagaki.web-component.v1:</code> namespace、IndexedDBはhost originの <code>eHagakiDB</code></td></tr>
+                            <tr><th>更新 / style</th><td>iframe reloadまたはpostMessage</td><td>setSettings()/setContext()、CSS Custom Properties / <code>::part()</code></td></tr>
+                            <tr><th>trust</th><td>iframe originとの境界を設計可能</td><td>trusted hostのみ正式サポート。hostは同一realmのコード・storageを観測可能</td></tr>
+                        </tbody>
+                    </table>
                 </div>
-            </div>
-        </section>
 
-        <section class="column">
-            <div class="panel stack">
-                <div>
-                    <h2>Component surface</h2>
-                    <p class="small">listenerはelement生成前に登録され、ready eventの取りこぼしを避けます。イベントはbubbles/composedのCustomEventとしてhostへ届きます。</p>
+                <div class="panel stack">
+                    <h2>HTTP / WebSocket / Service Worker</h2>
+                    <ul class="api-list small">
+                        <li>HTTP requestはhost Service Workerが観測可能です。</li>
+                        <li>Nostr relayはWebSocketです。Service Workerのfetch interceptionはrelay interceptionの証拠ではありません。</li>
+                        <li>host <code>window.WebSocket</code> wrapperについてbrowser-level proofは現在未完了です。今回relay interceptor fixture/APIは追加していません。</li>
+                    </ul>
                 </div>
-                <div id="component-mount" class="component-frame" aria-label="eHagaki Web Component mount point"></div>
-            </div>
-
-            <div class="panel stack">
-                <div class="event-monitor-header">
-                    <div><h2>Event monitor</h2><p class="small">秘密情報・署名要求payload・raw Errorは表示せず、安全なsummaryだけを記録します。</p></div>
-                    <button id="clear-log" type="button" class="ghost">ログをクリア</button>
-                </div>
-                <textarea id="event-log" class="log" readonly aria-label="Web Component event log"></textarea>
-            </div>
-
-            <div class="panel stack">
-                <div>
-                    <h2>iframeとの違い</h2>
-                    <p class="small">Web Componentが常に安全という意味ではありません。host JavaScriptから秘密情報を隔離したい場合はiframeを使ってください。</p>
-                </div>
-                <table class="comparison">
-                    <thead><tr><th>項目</th><th>iframe</th><th>Web Component</th></tr></thead>
-                    <tbody>
-                        <tr><th>境界 / API</th><td>origin isolation、postMessage protocol、handshake</td><td>同じWindow realm、method/property/CustomEvent、element create/destroy/recreate</td></tr>
-                        <tr><th>認証</th><td>parent-client auth/RPCを利用可能</td><td>parent-client auth/RPCは使用しない。NIP-07はhostのwindow.nostrを直接利用し、NIP-46/nsecはeHagaki UI</td></tr>
-                        <tr><th>保存</th><td>storage/IndexedDBの親委譲が可能</td><td>localStorageは <code>ehagaki.web-component.v1:</code> namespace、IndexedDBはhost originの <code>eHagakiDB</code></td></tr>
-                        <tr><th>更新 / style</th><td>iframe reloadまたはpostMessage</td><td>setSettings()/setContext()、CSS Custom Properties / <code>::part()</code></td></tr>
-                        <tr><th>trust</th><td>iframe originとの境界を設計可能</td><td>trusted hostのみ正式サポート。hostは同一realmのコード・storageを観測可能</td></tr>
-                    </tbody>
-                </table>
-            </div>
-
-            <div class="panel stack">
-                <h2>HTTP / WebSocket / Service Worker</h2>
-                <ul class="api-list small">
-                    <li>HTTP requestはhost Service Workerが観測可能です。</li>
-                    <li>Nostr relayはWebSocketです。Service Workerのfetch interceptionはrelay interceptionの証拠ではありません。</li>
-                    <li>host <code>window.WebSocket</code> wrapperについてbrowser-level proofは現在未完了です。今回relay interceptor fixture/APIは追加していません。</li>
-                </ul>
             </div>
         </section>
     </main>

--- a/public/web-component-parent-client-example.js
+++ b/public/web-component-parent-client-example.js
@@ -40,17 +40,21 @@ const DETAIL_STYLE_FIELDS = [
 const CUSTOM_STYLE_FIELDS = [...THEME_STYLE_FIELDS, ...DETAIL_STYLE_FIELDS];
 
 const STYLE_PRESETS = {
-    mint: {
-        accent: "#28764f",
-        base: "#dcefe4",
+    azure: {
+        accent: "#005FCC",
+        base: "#0077FF",
     },
-    blue: {
-        accent: "#1769aa",
-        base: "#dfeaf3",
+    rose: {
+        accent: "#B4233C",
+        base: "#FF3B5C",
     },
-    dark: {
-        accent: "#8ab4f8",
-        base: "#242728",
+    forest: {
+        accent: "#1F7A4D",
+        base: "#00A86B",
+    },
+    amber: {
+        accent: "#8A5700",
+        base: "#F2B000",
     },
 };
 
@@ -278,7 +282,13 @@ function selectStylePreset(name) {
     for (const [, id] of DETAIL_STYLE_FIELDS) {
         getElement(id).value = "";
     }
-    appendLog(`styles preset selected: ${name}`);
+    for (const presetName of Object.keys(STYLE_PRESETS)) {
+        const button = document.querySelector(`#preset-${presetName}`);
+        if (button) button.setAttribute("aria-pressed", String(presetName === name));
+    }
+    const isMounted = !!currentComposer?.isConnected;
+    if (isMounted) applyCustomStyles(currentComposer);
+    appendLog(`styles preset selected: ${name}`, { applied: isMounted });
 }
 
 function removeCustomStyles(element) {
@@ -374,6 +384,10 @@ function applyStyles() {
 }
 
 function resetStyles() {
+    for (const presetName of Object.keys(STYLE_PRESETS)) {
+        const button = document.querySelector(`#preset-${presetName}`);
+        if (button) button.setAttribute("aria-pressed", "false");
+    }
     if (!currentComposer?.isConnected) {
         clearStyleInputs();
         setStatus(componentStatus, "componentを先にCreateしてください", "warn");
@@ -417,9 +431,10 @@ function bindActions() {
     getElement("apply-invalid-context").addEventListener("click", () => applyContextToComposer({ content: "must not apply", reply: "invalid reference" }, "invalid context"));
     getElement("apply-styles").addEventListener("click", applyStyles);
     getElement("reset-styles").addEventListener("click", resetStyles);
-    getElement("preset-mint").addEventListener("click", () => selectStylePreset("mint"));
-    getElement("preset-blue").addEventListener("click", () => selectStylePreset("blue"));
-    getElement("preset-dark").addEventListener("click", () => selectStylePreset("dark"));
+    getElement("preset-azure").addEventListener("click", () => selectStylePreset("azure"));
+    getElement("preset-rose").addEventListener("click", () => selectStylePreset("rose"));
+    getElement("preset-forest").addEventListener("click", () => selectStylePreset("forest"));
+    getElement("preset-amber").addEventListener("click", () => selectStylePreset("amber"));
     getElement("clear-log").addEventListener("click", () => { eventLog.value = ""; });
 }
 

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -89,50 +89,49 @@ test.afterAll(async () => {
     await close(server);
 });
 
-test("keeps the sample columns and panels content-sized", async ({ page }) => {
+test("keeps Theme Playground controls and preview together without mobile overflow", async ({ page }) => {
     for (const viewport of [{ width: 1280, height: 900 }, { width: 390, height: 844 }]) {
         await page.setViewportSize(viewport);
         await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
 
         const result = await page.evaluate(() => {
-            const main = document.querySelector("main")!;
-            const columns = [...document.querySelectorAll<HTMLElement>("main > .column")];
-            const rightPanels = [...columns[1].querySelectorAll<HTMLElement>(":scope > .panel")];
-            const comparisonPanel = rightPanels[2];
-            const comparisonIntro = comparisonPanel.querySelector<HTMLElement>(":scope > div")!;
-            const comparisonTable = comparisonPanel.querySelector<HTMLTableElement>(".comparison")!;
-            const protocolPanel = rightPanels[3];
-            const protocolHeading = protocolPanel.querySelector<HTMLElement>("h2")!;
-            const protocolList = protocolPanel.querySelector<HTMLElement>(".api-list")!;
+            const playground = document.querySelector<HTMLElement>(".theme-playground")!;
+            const controls = document.querySelector<HTMLElement>(".theme-controls")!;
+            const preview = document.querySelector<HTMLElement>(".preview-panel")!;
+            const frame = document.querySelector<HTMLElement>(".component-frame")!;
+            const reference = document.querySelector<HTMLElement>(".reference-grid")!;
             const clearLog = document.querySelector<HTMLButtonElement>("#clear-log")!;
             const eventHeader = clearLog.parentElement!;
             const rect = (element: Element) => element.getBoundingClientRect().toJSON();
             return {
                 viewportWidth: window.innerWidth,
-                mainColumns: getComputedStyle(main).gridTemplateColumns,
-                mainAlignItems: getComputedStyle(main).alignItems,
-                columnHeights: columns.map((column) => column.getBoundingClientRect().height),
-                panelGaps: rightPanels.slice(1).map((panel, index) => panel.getBoundingClientRect().top - rightPanels[index].getBoundingClientRect().bottom),
-                comparisonGap: comparisonTable.getBoundingClientRect().top - comparisonIntro.getBoundingClientRect().bottom,
-                protocolGap: protocolList.getBoundingClientRect().top - protocolHeading.getBoundingClientRect().bottom,
+                viewportHeight: window.innerHeight,
+                playgroundColumns: getComputedStyle(playground).gridTemplateColumns,
+                playgroundTop: playground.getBoundingClientRect().top,
+                controls: rect(controls),
+                preview: rect(preview),
+                frame: rect(frame),
+                referenceTop: reference.getBoundingClientRect().top,
                 clearLog: rect(clearLog),
                 eventHeader: rect(eventHeader),
-                eventPanel: rect(rightPanels[1]),
             };
         });
 
-        expect(result.mainAlignItems).toBe("start");
-        expect(result.columnHeights[1]).toBeLessThan(result.columnHeights[0]);
-        expect(result.panelGaps.every((gap) => gap <= 20.5)).toBe(true);
-        expect(result.comparisonGap).toBeLessThanOrEqual(20.5);
-        expect(result.protocolGap).toBeLessThanOrEqual(20.5);
-        expect(result.clearLog.width).toBeLessThan(result.eventPanel.width / 2);
+        expect(result.playgroundTop).toBeGreaterThanOrEqual(0);
+        expect(result.referenceTop).toBeGreaterThan(result.preview.bottom);
+        expect(result.clearLog.width).toBeLessThan(result.preview.width / 2);
         expect(result.clearLog.height).toBeLessThanOrEqual(60);
         expect(result.clearLog.top).toBeGreaterThanOrEqual(result.eventHeader.top - 1);
         if (result.viewportWidth > 980) {
-            expect(result.mainColumns.split(" ")).toHaveLength(2);
+            expect(result.playgroundColumns.split(" ")).toHaveLength(2);
+            expect(result.controls.right).toBeLessThanOrEqual(result.preview.left);
+            expect(result.preview.top).toBeLessThanOrEqual(result.frame.top);
+            expect(result.frame.bottom).toBeLessThanOrEqual(result.viewportHeight ?? 900);
+            await page.screenshot();
         } else {
-            expect(result.mainColumns.split(" ")).toHaveLength(1);
+            expect(result.playgroundColumns.split(" ")).toHaveLength(1);
+            expect(result.preview.top).toBeGreaterThanOrEqual(result.controls.bottom - 1);
+            expect(result.frame.right).toBeLessThanOrEqual(result.viewportWidth);
         }
     }
 });
@@ -373,14 +372,13 @@ test("boots from production site output and exercises the public sample API", as
     expect(darkThemeResult.footerColor).not.toBe(darkThemeResult.footerBackground);
     expect(darkThemeResult.buttonColor).not.toBe(darkThemeResult.buttonBackground);
 
-    await page.getByRole("button", { name: "ブルー" }).click();
-    await expect(page.locator("#style-accent")).toHaveValue("#1769aa");
-    await expect(page.locator("#style-base")).toHaveValue("#dfeaf3");
-    await expect(page.locator("#style-background")).toHaveValue("");
-
-    await page.getByRole("button", { name: "ミント" }).click();
-    await expect(page.locator("#style-accent")).toHaveValue("#28764f");
-    await expect(page.locator("#style-base")).toHaveValue("#dcefe4");
+    await expect(page.locator(".preset-button")).toHaveCount(4);
+    for (const name of ["Azure", "Rose", "Forest", "Amber"]) {
+        await expect(page.getByRole("button", { name: new RegExp(name) })).toBeVisible();
+    }
+    await expect(page.getByRole("button", { name: "ミント" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "ブルー" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "ダーク" })).toHaveCount(0);
     for (const id of [
         "style-background",
         "style-text",
@@ -391,57 +389,64 @@ test("boots from production site output and exercises the public sample API", as
         "style-dialog",
         "style-font",
     ]) {
-        await expect(page.locator(`#${id}`)).toHaveValue("");
+        await expect(page.locator(`#${id}`)).not.toHaveAttribute("placeholder", "未指定 = eHagakiデフォルト");
     }
-    await page.getByRole("button", { name: "入力したカスタムCSSを適用" }).click();
-    const afterPresetOnly = await page.locator("ehagaki-composer").evaluate((element) => {
+
+    const readTheme = () => page.locator("ehagaki-composer").evaluate((element) => {
         const shadow = element.shadowRoot!;
         const shell = shadow.querySelector<HTMLElement>('[part~="shell"]')!;
         const primary = shadow.querySelector<HTMLElement>("button.primary")!;
         return {
             accent: element.style.getPropertyValue("--ehagaki-accent-color"),
             base: element.style.getPropertyValue("--ehagaki-base-color"),
+            background: element.style.getPropertyValue("--ehagaki-background"),
+            text: element.style.getPropertyValue("--ehagaki-text"),
             surface: getComputedStyle(shell).backgroundColor,
             primaryBackground: getComputedStyle(primary).backgroundColor,
         };
     });
-    expect(afterPresetOnly.accent).toBe("#28764f");
-    expect(afterPresetOnly.base).toBe("#dcefe4");
-    expect(afterPresetOnly.surface).not.toBe("rgba(0, 0, 0, 0)");
-    expect(afterPresetOnly.primaryBackground).not.toBe("rgba(0, 0, 0, 0)");
-    const afterPresetInlineStyles = await page.locator("ehagaki-composer").evaluate((element) => Object.fromEntries([
-        "--ehagaki-accent-color",
-        "--ehagaki-base-color",
-        "--ehagaki-background",
-        "--ehagaki-text",
-        "--ehagaki-border",
-        "--ehagaki-link",
-        "--ehagaki-input-background",
-        "--ehagaki-footer-background",
-        "--ehagaki-dialog-background",
-        "--ehagaki-font-family",
-    ].map((property) => [property, element.style.getPropertyValue(property)])));
-    expect(afterPresetInlineStyles["--ehagaki-accent-color"]).toBe("#28764f");
-    expect(afterPresetInlineStyles["--ehagaki-base-color"]).toBe("#dcefe4");
-    expect(afterPresetInlineStyles["--ehagaki-background"]).toBe("");
 
+    const presetValues = [
+        ["Azure", "#005FCC", "#0077FF"],
+        ["Rose", "#B4233C", "#FF3B5C"],
+        ["Forest", "#1F7A4D", "#00A86B"],
+        ["Amber", "#8A5700", "#F2B000"],
+    ] as const;
+    let previousSurface = "";
+    for (const [name, accent, base] of presetValues) {
+        await page.getByRole("button", { name: new RegExp(name) }).click();
+        await expect(page.locator("#style-accent")).toHaveValue(accent);
+        await expect(page.locator("#style-base")).toHaveValue(base);
+        await expect(page.locator("#style-text")).toHaveValue("");
+        const result = await readTheme();
+        expect(result.accent).toBe(accent);
+        expect(result.base).toBe(base);
+        expect(result.background).toBe("");
+        expect(result.text).toBe("");
+        expect(result.surface).not.toBe("rgba(0, 0, 0, 0)");
+        expect(result.primaryBackground).not.toBe("rgba(0, 0, 0, 0)");
+        if (previousSurface) expect(result.surface).not.toBe(previousSurface);
+        previousSurface = result.surface;
+    }
+
+    await page.locator("#style-accent").fill("#123456");
+    await page.locator("#style-base").fill("#ABCDEF");
+    await page.getByRole("button", { name: "テーマカラーを適用" }).click();
+    await expect.poll(readTheme).toMatchObject({
+        accent: "#123456",
+        base: "#ABCDEF",
+    });
+
+    await page.locator("details.advanced-settings summary").click();
     await page.locator("#style-text").fill("#102030");
-    await page.locator("#style-border").fill("");
-    await page.getByRole("button", { name: "入力したカスタムCSSを適用" }).click();
-    const partialStyleResult = await page.locator("ehagaki-composer").evaluate((element) => ({
-        accent: element.style.getPropertyValue("--ehagaki-accent-color"),
-        base: element.style.getPropertyValue("--ehagaki-base-color"),
-        background: element.style.getPropertyValue("--ehagaki-background"),
-        text: element.style.getPropertyValue("--ehagaki-text"),
-        border: element.style.getPropertyValue("--ehagaki-border"),
-        appBackground: getComputedStyle(element.shadowRoot!.querySelector<HTMLElement>('[part~="shell"]')!).backgroundColor,
-    }));
-    expect(partialStyleResult.accent).toBe("#28764f");
-    expect(partialStyleResult.base).toBe("#dcefe4");
-    expect(partialStyleResult.background).toBe("");
-    expect(partialStyleResult.text).toBe("#102030");
-    expect(partialStyleResult.border).toBe("");
-    expect(partialStyleResult.appBackground).not.toBe("rgba(0, 0, 0, 0)");
+    await page.locator("#style-border").fill("#203040");
+    await page.getByRole("button", { name: "テーマカラーを適用" }).click();
+    await expect.poll(readTheme).toMatchObject({
+        accent: "#123456",
+        base: "#ABCDEF",
+        text: "#102030",
+        background: "",
+    });
 
     await page.getByRole("button", { name: "デフォルトに戻す" }).click();
     const resetStyleResult = await page.locator("ehagaki-composer").evaluate((element) => {
@@ -457,11 +462,9 @@ test("boots from production site output and exercises the public sample API", as
             "--ehagaki-dialog-background",
             "--ehagaki-font-family",
         ];
-        return {
-            inlineProperties: Object.fromEntries(properties.map((property) => [property, element.style.getPropertyValue(property)])),
-        };
+        return Object.fromEntries(properties.map((property) => [property, element.style.getPropertyValue(property)]));
     });
-    expect(Object.values(resetStyleResult.inlineProperties).every((value) => value === "")).toBe(true);
+    expect(Object.values(resetStyleResult).every((value) => value === "")).toBe(true);
     for (const id of [
         "style-accent",
         "style-base",
@@ -476,36 +479,6 @@ test("boots from production site output and exercises the public sample API", as
     ]) {
         await expect(page.locator(`#${id}`)).toHaveValue("");
     }
-
-    await page.getByRole("button", { name: "ダーク" }).click();
-    await expect(page.locator("#style-accent")).toHaveValue("#8ab4f8");
-    await expect(page.locator("#style-base")).toHaveValue("#242728");
-    const darkPresetOnly = await page.locator("ehagaki-composer").evaluate((element) => ({
-        accent: element.style.getPropertyValue("--ehagaki-accent-color"),
-        base: element.style.getPropertyValue("--ehagaki-base-color"),
-        background: element.style.getPropertyValue("--ehagaki-background"),
-        text: element.style.getPropertyValue("--ehagaki-text"),
-    }));
-    expect(darkPresetOnly).toEqual({ accent: "", base: "", background: "", text: "" });
-    await page.getByRole("button", { name: "入力したカスタムCSSを適用" }).click();
-    const darkPresetResult = await page.locator("ehagaki-composer").evaluate((element) => {
-        const appRoot = element.shadowRoot!.querySelector<HTMLElement>(".ehagaki-app-root")!;
-        const style = getComputedStyle(appRoot);
-        return {
-            accent: element.style.getPropertyValue("--ehagaki-accent-color"),
-            base: element.style.getPropertyValue("--ehagaki-base-color"),
-            background: element.style.getPropertyValue("--ehagaki-background"),
-            text: element.style.getPropertyValue("--ehagaki-text"),
-            appColor: style.color,
-            appBackground: style.backgroundColor,
-        };
-    });
-    expect(darkPresetResult.accent).toBe("#8ab4f8");
-    expect(darkPresetResult.base).toBe("#242728");
-    expect(darkPresetResult.background).toBe("");
-    expect(darkPresetResult.text).toBe("");
-    expect(darkPresetResult.appColor).not.toBe(darkPresetResult.appBackground);
-    await page.getByRole("button", { name: "デフォルトに戻す" }).click();
 
     await page.getByRole("button", { name: "実行中に適用" }).click();
     await expect(page.locator("#component-status")).toContainText("locale");
@@ -712,8 +685,9 @@ test("demonstrates second-instance rejection and recreation after destroy", asyn
     await expect(page.locator("#component-status")).toHaveText("component mounted");
     await expect(page.locator("ehagaki-composer")).toHaveCount(1);
 
+    await page.locator("details.advanced-settings summary").click();
     await page.locator("#style-background").fill("#fefefe");
-    await page.getByRole("button", { name: "入力したカスタムCSSを適用" }).click();
+    await page.getByRole("button", { name: "テーマカラーを適用" }).click();
     await page.getByRole("button", { name: "Recreate" }).click();
     await expect(page.locator("#component-status")).toHaveText("component mounted");
     const recreatedStyle = await page.locator("ehagaki-composer").evaluate((element) => ({
@@ -741,6 +715,11 @@ test("keeps arbitrary module loading explicit in manual mode", async ({ page }) 
     await expect(page.locator("#module-url")).toBeEditable();
     expect(requests).not.toContain("/ehagaki/web-component/ehagaki-composer.js");
     expect(await page.evaluate(() => window.__securityFixtureLoaded === true)).toBe(false);
+
+    await page.getByRole("button", { name: /Azure/ }).click();
+    await expect(page.locator("#style-accent")).toHaveValue("#005FCC");
+    await expect(page.locator("#style-base")).toHaveValue("#0077FF");
+    await expect(page.locator("#event-log")).not.toHaveValue(/component_not_mounted/);
 
     await page.locator("#module-url").fill(`${origin}${securityFixturePath}`);
     await page.getByRole("button", { name: "Create / Mount" }).click();


### PR DESCRIPTION
## Summary

- Reorganized the public Web Component sample around a top-level Theme Playground with theme controls on the left and a sticky eHagaki preview on the right on desktop.
- Added four high-saturation Base Color seed presets and visual Accent/Base swatches:
  - Azure: accent `#005FCC`, base `#0077FF`
  - Rose: accent `#B4233C`, base `#FF3B5C`
  - Forest: accent `#1F7A4D`, base `#00A86B`
  - Amber: accent `#8A5700`, base `#F2B000`
- The Base values are intentionally vivid seeds so the existing neutral-surface mix produces a visible theme tint. The application theme generation and mix ratio are unchanged.
- Preset selection now clears detail overrides and immediately applies Accent/Base to a mounted Web Component. In manual mode before mount, it updates only the inputs and selection state without an error.
- Separated simple Accent/Base controls from the collapsed advanced overrides, removed the repeated default-value placeholders, and preserved the existing apply/reset, lifecycle, CSS Custom Properties, and `::part()` behavior.

## Validation

- `npm run check` — passed with 0 errors and 0 warnings
- `npm test` — 333 test files / 3,837 tests passed
- `npm run build` — passed; existing bundle-size and Svelte rest-prop warnings remain informational
- Public sample E2E — 36 passed across Desktop Chromium, Mobile Chromium, and Mobile WebKit
- `webComponentEmbed.spec.ts` — 40 passed, 2 existing conditional hover tests skipped, across Desktop Chromium, Mobile Chromium, and Mobile WebKit
- Production preview browser check — clicked Azure, Rose, Forest, and Amber in sequence; verified immediate preview color changes; checked Azure in light mode and Rose in dark mode; checked 390px one-column layout and no horizontal overflow

Physical Android/iPhone hardware verification was not run; the mobile browser projects and desktop production preview were used instead.
