### PR TITLE
Fix Web Component preview height regression

### DIFF
--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -146,8 +146,8 @@
             line-height: 1.5;
         }
         .preview-panel { position: sticky; top: 18px; }
-        .component-frame { height: clamp(500px, 68vh, 620px); padding: 18px; background: #dce8df; border-radius: 18px; }
-        #component-mount { height: calc(100% - 36px); }
+        .component-frame { height: 640px; padding: 18px; background: #dce8df; border-radius: 18px; }
+        #component-mount { height: 580px; }
         ehagaki-composer { display: block; height: 100%; min-height: 0; background: white; }
 
         .comparison { width: 100%; table-layout: fixed; border-collapse: collapse; font-size: .84rem; }
@@ -162,6 +162,10 @@
             .preview-panel { position: static; }
             .component-frame { height: 520px; }
             #component-mount, ehagaki-composer { height: 484px; }
+        }
+
+        @media (min-width: 981px) and (max-height: 760px) {
+            .preview-panel { position: static; }
         }
 
         @media (max-width: 540px) {

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -90,9 +90,15 @@ test.afterAll(async () => {
 });
 
 test("keeps Theme Playground controls and preview together without mobile overflow", async ({ page }) => {
-    for (const viewport of [{ width: 1280, height: 900 }, { width: 390, height: 844 }]) {
+    for (const viewport of [
+        { width: 1280, height: 900 },
+        { width: 1280, height: 720 },
+        { width: 390, height: 844 },
+    ]) {
         await page.setViewportSize(viewport);
         await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
+        await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
+        await page.evaluate(() => window.scrollTo(0, 0));
 
         const result = await page.evaluate(() => {
             const playground = document.querySelector<HTMLElement>(".theme-playground")!;
@@ -111,7 +117,11 @@ test("keeps Theme Playground controls and preview together without mobile overfl
                 controls: rect(controls),
                 preview: rect(preview),
                 frame: rect(frame),
+                mount: rect(document.querySelector<HTMLElement>("#component-mount")!),
+                composer: rect(document.querySelector<HTMLElement>("ehagaki-composer")!),
                 referenceTop: reference.getBoundingClientRect().top,
+                documentScrollWidth: document.documentElement.scrollWidth,
+                sticky: getComputedStyle(preview).position,
                 clearLog: rect(clearLog),
                 eventHeader: rect(eventHeader),
             };
@@ -126,12 +136,20 @@ test("keeps Theme Playground controls and preview together without mobile overfl
             expect(result.playgroundColumns.split(" ")).toHaveLength(2);
             expect(result.controls.right).toBeLessThanOrEqual(result.preview.left);
             expect(result.preview.top).toBeLessThanOrEqual(result.frame.top);
-            expect(result.frame.bottom).toBeLessThanOrEqual(result.viewportHeight ?? 900);
+            expect(result.frame.height).toBeGreaterThanOrEqual(560);
+            expect(result.mount.height).toBeGreaterThanOrEqual(560);
+            expect(result.composer.height).toBeGreaterThanOrEqual(520);
+            expect(result.documentScrollWidth).toBeLessThanOrEqual(result.viewportWidth);
+            expect(result.sticky).toBe(result.viewportHeight >= 760 ? "sticky" : "static");
             await page.screenshot();
         } else {
             expect(result.playgroundColumns.split(" ")).toHaveLength(1);
             expect(result.preview.top).toBeGreaterThanOrEqual(result.controls.bottom - 1);
             expect(result.frame.right).toBeLessThanOrEqual(result.viewportWidth);
+            expect(result.frame.height).toBeCloseTo(484, 0);
+            expect(result.mount.height).toBeCloseTo(484, 0);
+            expect(result.sticky).toBe("static");
+            expect(result.documentScrollWidth).toBeLessThanOrEqual(result.viewportWidth);
         }
     }
 });


### PR DESCRIPTION
## Summary

- Restore the desktop Theme Playground preview to a practical 640px frame / 580px mount height.
- Unstick the preview on short desktop viewports instead of shrinking eHagaki to fit one viewport.
- Update layout E2E coverage for 1280x900, 1280x720, and mobile dimensions.

## Root cause

PR #124 applied `height: clamp(500px, 68vh, 620px)` to `.component-frame` and `height: calc(100% - 36px)` to `#component-mount`. The sample uses both selectors on the same element; the more-specific ID rule caused the mount height to resolve against an auto-height containing block, collapsing the frame to about 222px in the production preview.

## Measurements

Production preview DOMRect/computed-style measurements:

| viewport | preview panel | frame | mount | composer | editor | footer | sticky |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| Before, 1280x900 | 366px | 222px | 222px | 186px | 152px | 66px | sticky |
| Before, 1280x720 | 366px | 222px | 222px | 186px | 152px | 66px | sticky |
| After, 1280x900 | 688px | 580px | 580px | 544px | 358px | 66px | sticky |
| After, 1280x720 | 688px | 580px | 580px | 544px | 358px | 66px | static |

The short-desktop rule is `@media (min-width: 981px) and (max-height: 760px)`, so the page can scroll normally when the 688px preview cannot fit with its surrounding spacing. Mobile rules remain unchanged.

## Verification

- `npm run check` — passed, 0 errors / 0 warnings
- `npm test` — passed, 333 files / 3,837 tests
- `npm run build` — passed; existing Svelte/bundle informational warnings remain
- `webComponentParentClientExample.spec.ts` — 36 passed across Desktop Chromium, Mobile Chromium, Mobile WebKit
- `webComponentEmbed.spec.ts` — 40 passed, 2 existing skips across Desktop Chromium, Mobile Chromium, Mobile WebKit
- Production preview checked at 1280x900 and 1280x720 with DOMRect/computed style; Azure preset applied immediately in the short desktop case
- Physical Android/iPhone verification was not run
