### PR TITLE
Highlight Web Component resource links

### DIFF
--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -49,6 +49,25 @@
         }
         .page-intro, .live-preview { display: grid; gap: 18px; }
         .page-intro { gap: 10px; }
+        .intro-links { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 4px; }
+        .intro-link {
+            display: inline-flex;
+            align-items: center;
+            min-height: 42px;
+            padding: 9px 15px;
+            border: 1px solid var(--accent);
+            border-radius: 999px;
+            font-size: .88rem;
+            font-weight: 700;
+            text-decoration: none;
+            transition: background-color .15s ease, color .15s ease, transform .15s ease;
+        }
+        .intro-link.primary { background: var(--accent); color: #fff; }
+        .intro-link.secondary { background: var(--accent-soft); color: var(--text); }
+        .intro-link:hover { transform: translateY(-1px); }
+        .intro-link.primary:hover { background: #1d5d3d; }
+        .intro-link.secondary:hover { background: #c5e4d2; }
+        .intro-link:focus-visible { outline: 3px solid #92caaa; outline-offset: 2px; }
         .theme-panel { display: grid; gap: 18px; }
         .theme-panel-header, .theme-presets, .theme-custom-fields { display: grid; gap: 8px; }
         .theme-panel > details { grid-column: 1 / -1; }
@@ -180,7 +199,10 @@
         <header class="panel page-intro" aria-labelledby="page-heading">
             <h1 id="page-heading">eHagaki Web Component Playground</h1>
             <p class="lead">eHagaki Web Componentを実際にmountして、公開API・event・lifecycle・context・テーマカスタマイズを確認できるreference / playgroundです。</p>
-            <p class="small"><a href="https://github.com/Lokuyow/ehagaki/blob/main/docs/WEB_COMPONENT.md" target="_blank" rel="noreferrer noopener">Web Component guide</a> / <a href="./embed-parent-client-example.html">iframe sample</a></p>
+            <nav class="intro-links" aria-label="Web Component resources">
+                <a class="intro-link primary" href="https://github.com/Lokuyow/ehagaki/blob/main/docs/WEB_COMPONENT.md" target="_blank" rel="noreferrer noopener">Web Component guide</a>
+                <a class="intro-link secondary" href="./embed-parent-client-example.html">iframe sample</a>
+            </nav>
         </header>
 
         <section class="live-preview" aria-labelledby="live-preview-heading">

--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -127,12 +127,14 @@
             background: #fbfdfb;
             color: var(--text);
             text-align: left;
+            white-space: normal;
         }
         .preset-button[aria-pressed="true"] { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
         .preset-swatches { display: grid; grid-template-columns: repeat(2, 18px); gap: 3px; }
         .preset-swatch { width: 18px; height: 18px; border-radius: 5px; border: 1px solid rgba(24, 48, 40, .22); }
         .preset-name { font-weight: 700; }
-        .preset-values { color: var(--muted); font-size: .73rem; line-height: 1.35; }
+        .preset-button > span:last-child { min-width: 0; }
+        .preset-values { color: var(--muted); font-size: .73rem; line-height: 1.35; overflow-wrap: anywhere; }
         details.advanced-settings { border: 1px solid var(--line); border-radius: 12px; background: #f8fbf9; }
         details.advanced-settings summary { padding: 12px 14px; cursor: pointer; font-weight: 700; }
         details.advanced-settings[open] { padding-bottom: 14px; }

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -118,6 +118,7 @@ test("keeps the playground hierarchy and card stacks balanced across desktop and
             const customFields = document.querySelector<HTMLElement>(".theme-custom-fields")!;
             const details = document.querySelector<HTMLElement>("details.advanced-settings")!;
             const introLinks = Array.from(document.querySelectorAll<HTMLAnchorElement>(".intro-links a"));
+            const presetButtons = Array.from(document.querySelectorAll<HTMLButtonElement>(".preset-button"));
             const preview = document.querySelector<HTMLElement>(".preview-panel")!;
             const frame = document.querySelector<HTMLElement>(".component-frame")!;
             const eventMonitor = document.querySelector<HTMLElement>("[aria-labelledby=event-monitor-heading]")!;
@@ -150,6 +151,11 @@ test("keeps the playground hierarchy and card stacks balanced across desktop and
                     background: getComputedStyle(element).backgroundColor,
                     fontWeight: getComputedStyle(element).fontWeight,
                 })),
+                presetButtons: presetButtons.map((element) => ({
+                    rect: rect(element),
+                    clientWidth: element.clientWidth,
+                    scrollWidth: element.scrollWidth,
+                })),
                 preview: rect(preview),
                 frame: rect(frame),
                 mount: rect(document.querySelector<HTMLElement>("#component-mount")!),
@@ -159,7 +165,7 @@ test("keeps the playground hierarchy and card stacks balanced across desktop and
                 bodyScrollWidth: document.body.scrollWidth,
                 themePanelCount: document.querySelectorAll(".theme-panel").length,
                 duplicateThemeHeadingCount: Array.from(document.querySelectorAll("h1, h2, h3")).filter((element) => element.textContent?.trim() === "Styling / Theme customization").length,
-                buttonWhiteSpace: Array.from(document.querySelectorAll("button")).map((button) => getComputedStyle(button).whiteSpace),
+                buttonWhiteSpace: Array.from(document.querySelectorAll("button:not(.preset-button)")).map((button) => getComputedStyle(button).whiteSpace),
                 formBounds: Array.from(document.querySelectorAll<HTMLElement>("input, select, textarea")).map((element) => rect(element)),
                 clearLog: rect(clearLog),
                 eventHeader: rect(eventHeader),
@@ -194,6 +200,11 @@ test("keeps the playground hierarchy and card stacks balanced across desktop and
             expect(link.rect.right).toBeLessThanOrEqual(result.viewportWidth + 1);
             expect(Number(link.fontWeight)).toBeGreaterThanOrEqual(700);
             expect(link.background).not.toBe("rgba(0, 0, 0, 0)");
+        }
+        expect(result.presetButtons).toHaveLength(4);
+        for (const button of result.presetButtons) {
+            expect(button.rect.right).toBeLessThanOrEqual(result.viewportWidth + 1);
+            expect(button.scrollWidth).toBeLessThanOrEqual(button.clientWidth + 1);
         }
         for (const formBounds of result.formBounds) {
             expect(formBounds.right).toBeLessThanOrEqual(result.viewportWidth + 1);

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -100,6 +100,8 @@ test("keeps the playground hierarchy and card stacks balanced across desktop and
         await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
         await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
         await expect(page.getByRole("heading", { name: "eHagaki Web Component Playground", level: 1 })).toBeVisible();
+        await expect(page.getByRole("link", { name: "Web Component guide" })).toBeVisible();
+        await expect(page.getByRole("link", { name: "iframe sample" })).toBeVisible();
         await page.evaluate(() => window.scrollTo(0, 0));
 
         const result = await page.evaluate(() => {
@@ -115,6 +117,7 @@ test("keeps the playground hierarchy and card stacks balanced across desktop and
             const presetGrid = document.querySelector<HTMLElement>(".preset-grid")!;
             const customFields = document.querySelector<HTMLElement>(".theme-custom-fields")!;
             const details = document.querySelector<HTMLElement>("details.advanced-settings")!;
+            const introLinks = Array.from(document.querySelectorAll<HTMLAnchorElement>(".intro-links a"));
             const preview = document.querySelector<HTMLElement>(".preview-panel")!;
             const frame = document.querySelector<HTMLElement>(".component-frame")!;
             const eventMonitor = document.querySelector<HTMLElement>("[aria-labelledby=event-monitor-heading]")!;
@@ -141,6 +144,12 @@ test("keeps the playground hierarchy and card stacks balanced across desktop and
                 presetGrid: rect(presetGrid),
                 customFields: rect(customFields),
                 details: rect(details),
+                introLinks: introLinks.map((element) => ({
+                    rect: rect(element),
+                    href: element.href,
+                    background: getComputedStyle(element).backgroundColor,
+                    fontWeight: getComputedStyle(element).fontWeight,
+                })),
                 preview: rect(preview),
                 frame: rect(frame),
                 mount: rect(document.querySelector<HTMLElement>("#component-mount")!),
@@ -175,6 +184,17 @@ test("keeps the playground hierarchy and card stacks balanced across desktop and
         expect(result.bodyScrollWidth).toBeLessThanOrEqual(result.viewportWidth);
         expect(result.details.left).toBeGreaterThan(result.themePanel.left);
         expect(result.details.right).toBeLessThan(result.themePanel.right);
+        expect(result.introLinks).toHaveLength(2);
+        expect(result.introLinks.map((link) => link.href)).toEqual([
+            "https://github.com/Lokuyow/ehagaki/blob/main/docs/WEB_COMPONENT.md",
+            `${origin}/ehagaki/embed-parent-client-example.html`,
+        ]);
+        for (const link of result.introLinks) {
+            expect(link.rect.height).toBeGreaterThanOrEqual(40);
+            expect(link.rect.right).toBeLessThanOrEqual(result.viewportWidth + 1);
+            expect(Number(link.fontWeight)).toBeGreaterThanOrEqual(700);
+            expect(link.background).not.toBe("rgba(0, 0, 0, 0)");
+        }
         for (const formBounds of result.formBounds) {
             expect(formBounds.right).toBeLessThanOrEqual(result.viewportWidth + 1);
         }


### PR DESCRIPTION
## 概要

Web Component Playground の導入リンクを、目立つボタン型リンクとして表示します。

- `Web Component guide` をアクセントカラーの主要ボタンに変更
- `iframe sample` を補助ボタンとして並列表示
- 既存のURL、公開API、レスポンシブレイアウトは維持
- デスクトップ／モバイルで表示、URL、サイズ、背景、文字の太さをE2Eで検証

## 検証

- `npm run build`
- `npm run check`
- `npm test`
- `npx playwright test src/test/e2e/webComponentParentClientExample.spec.ts`（36 passed）