### PR TITLE
Fix mobile Web Component preview overflow

### DIFF
--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -184,7 +184,7 @@
         @media (max-width: 980px) {
             .reference-columns, .theme-controls { grid-template-columns: 1fr; }
             .component-frame { height: 520px; }
-            #component-mount, ehagaki-composer { height: 484px; }
+            #component-mount { height: 520px; }
         }
 
         @media (max-width: 540px) {

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -158,8 +158,23 @@ test("keeps the playground hierarchy and card stacks balanced across desktop and
                 })),
                 preview: rect(preview),
                 frame: rect(frame),
-                mount: rect(document.querySelector<HTMLElement>("#component-mount")!),
-                composer: rect(document.querySelector<HTMLElement>("ehagaki-composer")!),
+                mount: (() => {
+                    const element = document.querySelector<HTMLElement>("#component-mount")!;
+                    const style = getComputedStyle(element);
+                    return {
+                        rect: rect(element),
+                        paddingTop: Number.parseFloat(style.paddingTop),
+                        paddingBottom: Number.parseFloat(style.paddingBottom),
+                        borderTop: Number.parseFloat(style.borderTopWidth),
+                        borderBottom: Number.parseFloat(style.borderBottomWidth),
+                        boxSizing: style.boxSizing,
+                    };
+                })(),
+                composer: (() => {
+                    const element = document.querySelector<HTMLElement>("ehagaki-composer")!;
+                    const style = getComputedStyle(element);
+                    return { rect: rect(element), height: style.height };
+                })(),
                 eventMonitor: rect(eventMonitor),
                 documentScrollWidth: document.documentElement.scrollWidth,
                 bodyScrollWidth: document.body.scrollWidth,
@@ -218,15 +233,24 @@ test("keeps the playground hierarchy and card stacks balanced across desktop and
             }
             expect(result.preview.top).toBeLessThanOrEqual(result.frame.top);
             expect(result.frame.height).toBeGreaterThanOrEqual(560);
-            expect(result.mount.height).toBeGreaterThanOrEqual(560);
-            expect(result.composer.height).toBeGreaterThanOrEqual(520);
+            expect(result.mount.rect.height).toBeGreaterThanOrEqual(560);
+            expect(result.composer.rect.height).toBeGreaterThanOrEqual(520);
             await page.screenshot();
         } else {
             expect(result.referenceColumns.template.split(" ")).toHaveLength(1);
             expect(result.themeControlsTemplate.split(" ")).toHaveLength(1);
             expect(result.frame.right).toBeLessThanOrEqual(result.viewportWidth);
-            expect(result.frame.height).toBeCloseTo(484, 0);
-            expect(result.mount.height).toBeCloseTo(484, 0);
+            expect(result.frame.height).toBeCloseTo(520, 0);
+            expect(result.mount.rect.height).toBeCloseTo(520, 0);
+            expect(result.mount.boxSizing).toBe("border-box");
+            expect(result.mount.paddingTop).toBeGreaterThan(0);
+            expect(result.mount.paddingBottom).toBeGreaterThan(0);
+            const mountContentTop = result.mount.rect.top + result.mount.borderTop + result.mount.paddingTop;
+            const mountContentBottom = result.mount.rect.bottom - result.mount.borderBottom - result.mount.paddingBottom;
+            expect(result.composer.rect.top).toBeGreaterThanOrEqual(mountContentTop - 1);
+            expect(result.composer.rect.bottom).toBeLessThanOrEqual(mountContentBottom + 1);
+            expect(result.composer.rect.bottom).toBeLessThanOrEqual(result.mount.rect.bottom + 1);
+            expect(Number.parseFloat(result.composer.height)).toBeCloseTo(mountContentBottom - mountContentTop, 0);
             expect(result.presetGrid.width).toBeGreaterThan(0);
             expect(result.customFields.width).toBeGreaterThan(0);
         }


### PR DESCRIPTION
## Summary

- Fix the mobile Live preview host sizing in `public/web-component-parent-client-example.html`.
- Add geometry-based Playwright regression coverage for 390px and 360px in Chromium and WebKit projects.

## Root cause

`#component-mount` and `.component-frame` are the same element, but the mobile rule assigned the mount `height: 484px` while the frame retained 18px top and bottom padding. Because the ID selector won, the 484px height included padding, while `ehagaki-composer` also received 484px and exceeded the mount content area.

## Fix

The mobile `#component-mount` now uses the intended outer `520px` height. The existing `ehagaki-composer { height: 100% }` then resolves to the 484px content area inside the preserved 18px padding, so the lower controls remain inside the preview without clipping.

## Regression test

The existing playground layout test now reads computed padding, box sizing, computed composer height, and mount/composer bounding boxes. At 390px and 360px it verifies that the composer stays within the mount content area; the same test continues to cover desktop Chromium and the mobile Chromium/WebKit projects.

## Verification

- `npx playwright test src/test/e2e/webComponentParentClientExample.spec.ts` — 36 passed (desktop Chromium, mobile Chromium, mobile WebKit)
- `npm run check` — passed, 0 errors / 0 warnings
- `npm test` — passed, 333 test files / 3,837 tests
- `npm run build` — passed
- `git diff --check` — passed

No required verification was omitted.
