### PR TITLE
fix: prevent Playground lifecycle button overflow

### DIFF
--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -115,6 +115,15 @@
         button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible { outline: 3px solid #92caaa; outline-offset: 2px; }
         .buttons { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px; }
         .buttons + .buttons { margin-top: 9px; }
+        .component-lifecycle-card { container-type: inline-size; }
+        .component-lifecycle-buttons button {
+            min-width: 0;
+            white-space: normal;
+            overflow-wrap: anywhere;
+        }
+        @container (max-width: 560px) {
+            .component-lifecycle-buttons { grid-template-columns: 1fr; }
+        }
         .preset-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
         .preset-button {
             display: grid;
@@ -246,12 +255,12 @@
                         <p class="small">外部モジュールはこのページと同じJavaScript権限で動作します。関連ファイルのURLにはworker/FFmpegなど実行可能なファイルも含まれるため、信頼できるURLだけを指定してください。asset-baseは作成・再作成時にelementへ設定されます。読み込み後は別モジュールへ切り替えられないため、試す場合はページを再読み込みしてください。</p>
                     </div>
 
-                    <div class="card stack">
+                    <div class="card stack component-lifecycle-card">
                         <h2>Componentを作成・削除・再作成</h2>
-                        <div class="buttons">
-                            <button id="create-component" type="button">作成して表示（Create / Mount）</button>
-                            <button id="destroy-component" type="button" class="secondary">削除して非表示（Destroy / Unmount）</button>
-                            <button id="recreate-component" type="button">作り直す（Recreate）</button>
+                        <div class="buttons component-lifecycle-buttons">
+                            <button id="create-component" type="button">作成して表示</button>
+                            <button id="destroy-component" type="button" class="secondary">削除して非表示</button>
+                            <button id="recreate-component" type="button">作り直す</button>
                             <button id="create-second" type="button" class="ghost">2個目を生成</button>
                         </div>
                         <p class="small">1つのページには接続できるComponentが1つだけという制約を確認できます。2個目は動作せず、<code>multiple_instances_unsupported</code> のerror eventと <code>whenReady()</code> のrejectionをログに記録します。1個目を削除すると、新しいComponentを作成できます。</p>

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -180,7 +180,7 @@ test("keeps the playground hierarchy and card stacks balanced across desktop and
                 bodyScrollWidth: document.body.scrollWidth,
                 themePanelCount: document.querySelectorAll(".theme-panel").length,
                 duplicateThemeHeadingCount: Array.from(document.querySelectorAll("h1, h2, h3")).filter((element) => element.textContent?.trim() === "Styling / Theme customization").length,
-                buttonWhiteSpace: Array.from(document.querySelectorAll("button:not(.preset-button)")).map((button) => getComputedStyle(button).whiteSpace),
+                buttonWhiteSpace: Array.from(document.querySelectorAll("button:not(.preset-button):not(#create-component):not(#destroy-component):not(#recreate-component):not(#create-second)")).map((button) => getComputedStyle(button).whiteSpace),
                 formBounds: Array.from(document.querySelectorAll<HTMLElement>("input, select, textarea")).map((element) => rect(element)),
                 clearLog: rect(clearLog),
                 eventHeader: rect(eventHeader),
@@ -254,6 +254,46 @@ test("keeps the playground hierarchy and card stacks balanced across desktop and
             expect(result.presetGrid.width).toBeGreaterThan(0);
             expect(result.customFields.width).toBeGreaterThan(0);
         }
+    }
+});
+
+test("keeps lifecycle buttons inside their card at desktop, intermediate, and mobile widths", async ({ page }) => {
+    for (const { label, viewport, expectedColumns } of [
+        { label: "desktop", viewport: { width: 1280, height: 900 }, expectedColumns: 2 },
+        { label: "intermediate", viewport: { width: 1024, height: 900 }, expectedColumns: 1 },
+        { label: "mobile", viewport: { width: 390, height: 844 }, expectedColumns: 1 },
+    ]) {
+        await page.setViewportSize(viewport);
+        await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
+        await expect(page.locator("#ready-status")).toHaveText("準備完了（whenReady(): resolved）");
+
+        const result = await page.locator(".component-lifecycle-card").evaluate((card) => {
+            const buttons = card.querySelector<HTMLElement>(".component-lifecycle-buttons")!;
+            const cardRect = card.getBoundingClientRect();
+            const buttonRects = Array.from(buttons.querySelectorAll<HTMLButtonElement>("button")).map((button) => ({
+                rect: button.getBoundingClientRect().toJSON(),
+                clientWidth: button.clientWidth,
+                scrollWidth: button.scrollWidth,
+            }));
+            return {
+                card: cardRect.toJSON(),
+                buttonGrid: getComputedStyle(buttons).gridTemplateColumns,
+                buttonRects,
+                documentScrollWidth: document.documentElement.scrollWidth,
+                bodyScrollWidth: document.body.scrollWidth,
+                viewportWidth: window.innerWidth,
+            };
+        });
+
+        expect(result.buttonRects, `${label}: four lifecycle buttons`).toHaveLength(4);
+        expect(result.buttonGrid.split(" "), `${label}: lifecycle button columns`).toHaveLength(expectedColumns);
+        for (const button of result.buttonRects) {
+            expect(button.rect.left, `${label}: button left edge`).toBeGreaterThanOrEqual(result.card.left - 1);
+            expect(button.rect.right, `${label}: button right edge`).toBeLessThanOrEqual(result.card.right + 1);
+            expect(button.scrollWidth, `${label}: button internal overflow`).toBeLessThanOrEqual(button.clientWidth + 1);
+        }
+        expect(result.documentScrollWidth, `${label}: document horizontal overflow`).toBeLessThanOrEqual(result.viewportWidth);
+        expect(result.bodyScrollWidth, `${label}: body horizontal overflow`).toBeLessThanOrEqual(result.viewportWidth);
     }
 });
 
@@ -653,7 +693,7 @@ test("does not create a second primary while auto-mount waits for the module", a
     try {
         await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`, { waitUntil: "commit" });
         await moduleRequestStarted;
-        await page.getByRole("button", { name: "作成して表示（Create / Mount）" }).click();
+        await page.getByRole("button", { name: "作成して表示" }).click();
         releaseModule();
 
         await expect(page.locator("#module-status")).toContainText("モジュールを読み込みました");
@@ -717,9 +757,9 @@ test("keeps the public sample container layout stable across destroy and recreat
         };
     });
     const first = await measure();
-    await page.getByRole("button", { name: "削除して非表示（Destroy / Unmount）" }).click();
+    await page.getByRole("button", { name: "削除して非表示" }).click();
     await expect(page.locator("ehagaki-composer")).toHaveCount(0);
-    await page.getByRole("button", { name: "作成して表示（Create / Mount）" }).click();
+    await page.getByRole("button", { name: "作成して表示" }).click();
     await expect(page.locator("#ready-status")).toHaveText("準備完了（whenReady(): resolved）");
     await expect.poll(() => page.locator("ehagaki-composer").evaluate((element) =>
         !!element.shadowRoot?.querySelector(".tiptap-editor"),
@@ -727,7 +767,7 @@ test("keeps the public sample container layout stable across destroy and recreat
     await waitForStableEditorSurface();
     const second = await measure();
 
-    await page.getByRole("button", { name: "作り直す（Recreate）" }).click();
+    await page.getByRole("button", { name: "作り直す" }).click();
     await expect(page.locator("#ready-status")).toHaveText("準備完了（whenReady(): resolved）");
     await expect.poll(() => page.locator("ehagaki-composer").evaluate((element) => {
         const shadow = element.shadowRoot;
@@ -776,16 +816,16 @@ test("preserves inherited Accent/Base theme across destroy and recreate", async 
         };
     });
 
-    await page.getByRole("button", { name: "作成して表示（Create / Mount）" }).click();
+    await page.getByRole("button", { name: "作成して表示" }).click();
     await expect(page.locator("#ready-status")).toHaveText("準備完了（whenReady(): resolved）");
     const first = await readTheme();
     expect(first.accent.toLowerCase()).toContain("#8a3ffc");
     expect(first.base.toLowerCase()).toContain("#e8dcff");
     expect(first.primaryBackground).not.toBe("rgba(0, 0, 0, 0)");
 
-    await page.getByRole("button", { name: "削除して非表示（Destroy / Unmount）" }).click();
+    await page.getByRole("button", { name: "削除して非表示" }).click();
     await expect(page.locator("ehagaki-composer")).toHaveCount(0);
-    await page.getByRole("button", { name: "作成して表示（Create / Mount）" }).click();
+    await page.getByRole("button", { name: "作成して表示" }).click();
     await expect(page.locator("#ready-status")).toHaveText("準備完了（whenReady(): resolved）");
     await expect.poll(readTheme).toEqual(first);
 });
@@ -806,20 +846,20 @@ test("demonstrates second-instance rejection and recreation after destroy", asyn
         { background: "" },
     ]);
 
-    await page.getByRole("button", { name: "削除して非表示（Destroy / Unmount）" }).click();
+    await page.getByRole("button", { name: "削除して非表示" }).click();
     await expect(page.locator("#component-status")).toContainText("設定は保持されています");
-    await page.getByRole("button", { name: "作成して表示（Create / Mount）" }).click();
+    await page.getByRole("button", { name: "作成して表示" }).click();
     await expect(page.locator("#component-status")).toHaveText("Componentを表示しました");
     await expect(page.locator("#ready-status")).toHaveText("準備完了（whenReady(): resolved）");
 
-    await page.getByRole("button", { name: "作り直す（Recreate）" }).click();
+    await page.getByRole("button", { name: "作り直す" }).click();
     await expect(page.locator("#component-status")).toHaveText("Componentを表示しました");
     await expect(page.locator("ehagaki-composer")).toHaveCount(1);
 
     await page.locator("details.advanced-settings summary").click();
     await page.locator("#style-background").fill("#fefefe");
     await page.getByRole("button", { name: "テーマカラーを適用" }).click();
-    await page.getByRole("button", { name: "作り直す（Recreate）" }).click();
+    await page.getByRole("button", { name: "作り直す" }).click();
     await expect(page.locator("#component-status")).toHaveText("Componentを表示しました");
     const recreatedStyle = await page.locator("ehagaki-composer").evaluate((element) => ({
         background: element.style.getPropertyValue("--ehagaki-background"),
@@ -853,7 +893,7 @@ test("keeps arbitrary module loading explicit in manual mode", async ({ page }) 
     await expect(page.locator("#event-log")).not.toHaveValue(/component_not_mounted/);
 
     await page.locator("#module-url").fill(`${origin}${securityFixturePath}`);
-    await page.getByRole("button", { name: "作成して表示（Create / Mount）" }).click();
+    await page.getByRole("button", { name: "作成して表示" }).click();
     await expect(page.locator("#module-status")).toContainText("モジュールを読み込みました");
     await expect(page.locator("#module-url")).toBeDisabled();
     await expect(page.locator("#component-status")).toHaveText("Componentを表示しました");


### PR DESCRIPTION
## 変更概要

Web Component PlaygroundのComponent作成・削除・再作成カードで、中間幅にボタンがカード外へはみ出す問題を修正しました。

## 変更内容

- ボタン文言を「作成して表示」「削除して非表示」「作り直す」に短縮
- 対象カードだけcontainer queryを使い、カード内幅が560px以下ではボタンを1列化
- 対象ボタンだけ文字の折り返しとmin-width: 0を適用
- DOM ID、Create / Destroy / Recreate処理、公開APIは変更なし

## 検証

- npm run check: 成功
- git diff --check: 成功
- npm test: 成功（333 files / 3,837 tests）
- Web Component Playground E2E: 39件成功（Desktop Chromium / Mobile Chromium / Mobile WebKit）
- 回帰テスト: 1280px、1024px、390pxでカード境界、button scrollWidth、ページ水平overflow、列数を確認
- 開発サーバーの実ブラウザ表示を1280px、1024px、390pxで確認。1024pxは対象カードが1列になり、横overflowなし

実機Android/iPhone確認は対象外です。