### PR TITLE
chore: remove second component playground control

### DIFF
--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -261,9 +261,8 @@
                             <button id="create-component" type="button">作成して表示</button>
                             <button id="destroy-component" type="button" class="secondary">削除して非表示</button>
                             <button id="recreate-component" type="button">作り直す</button>
-                            <button id="create-second" type="button" class="ghost">2個目を生成</button>
                         </div>
-                        <p class="small">1つのページには接続できるComponentが1つだけという制約を確認できます。2個目は動作せず、<code>multiple_instances_unsupported</code> のerror eventと <code>whenReady()</code> のrejectionをログに記録します。1個目を削除すると、新しいComponentを作成できます。</p>
+                        <p class="small">Componentの作成、削除、再作成という基本的なライフサイクル操作を確認できます。削除後は、新しいComponentを作成できます。</p>
                     </div>
 
                     <div class="card stack">

--- a/public/web-component-parent-client-example.js
+++ b/public/web-component-parent-client-example.js
@@ -17,7 +17,6 @@ const eventLog = document.querySelector("#event-log");
 const isManualMode = new URLSearchParams(window.location.search).get("manual") === "1";
 
 let currentComposer = null;
-let secondaryComposer = null;
 let loadedModuleUrl = "";
 let moduleLoadPromise = null;
 
@@ -349,28 +348,7 @@ function destroyComposer() {
 
 async function recreateComposer() {
     destroyComposer();
-    if (secondaryComposer?.isConnected) secondaryComposer.remove();
-    secondaryComposer = null;
     await createComposer();
-}
-
-async function createSecondComposer() {
-    if (secondaryComposer?.isConnected) {
-        appendLog("secondary: already connected");
-        return;
-    }
-    await ensureModuleLoaded();
-    const element = document.createElement("ehagaki-composer");
-    configureElement(element);
-    installEventListeners(element, "secondary");
-    secondaryComposer = element;
-    componentMount.append(element);
-    void element.whenReady().then(() => {
-        appendLog("secondary: unexpected ready");
-    }).catch((error) => {
-        appendLog("secondary: whenReady rejected", { code: safeErrorCode(error) });
-        setStatus(componentStatus, "2個目は動作しません（inert: multiple_instances_unsupported）", "error");
-    });
 }
 
 function applyStyles() {
@@ -416,7 +394,6 @@ function bindActions() {
     getElement("create-component").addEventListener("click", () => void createComposer().catch((error) => appendLog("create failed", { code: safeErrorCode(error) })));
     getElement("destroy-component").addEventListener("click", destroyComposer);
     getElement("recreate-component").addEventListener("click", () => void recreateComposer().catch((error) => appendLog("recreate failed", { code: safeErrorCode(error) })));
-    getElement("create-second").addEventListener("click", () => void createSecondComposer().catch((error) => appendLog("secondary create failed", { code: safeErrorCode(error) })));
     getElement("apply-runtime-settings").addEventListener("click", () => applySettingsToComposer(getSettings(), "runtime setSettings"));
     getElement("apply-invalid-settings").addEventListener("click", () => applySettingsToComposer({ unsupportedKey: true }, "invalid setSettings"));
     getElement("apply-content").addEventListener("click", () => applyContextToComposer({ content: getElement("context-content").value }, "content context", "投稿内容を反映"));

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -495,15 +495,19 @@ test("rejects a second connected component and releases the slot after disconnec
         const errors: string[] = [];
         second.addEventListener("ehagaki-initialization-error", (event) => errors.push((event as CustomEvent).detail.code));
         document.body.append(second);
-        await second.whenReady().then(() => "resolved", (error) => error.name);
+        const secondReady = await second.whenReady().then(
+            () => ({ resolved: true, errorName: null }),
+            (error) => ({ resolved: false, errorName: error.name }),
+        );
         first.remove();
         const replacement = document.createElement("ehagaki-composer") as HTMLElement & { whenReady(): Promise<void> };
         document.body.append(replacement);
         await replacement.whenReady();
-        return { errors, replacementReady: !!replacement.shadowRoot };
+        return { errors, secondReady, replacementReady: !!replacement.shadowRoot };
     });
 
     expect(result.errors).toEqual(["multiple_instances_unsupported"]);
+    expect(result.secondReady).toEqual({ resolved: false, errorName: "multiple_instances_unsupported" });
     expect(result.replacementReady).toBe(true);
 });
 

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -180,7 +180,7 @@ test("keeps the playground hierarchy and card stacks balanced across desktop and
                 bodyScrollWidth: document.body.scrollWidth,
                 themePanelCount: document.querySelectorAll(".theme-panel").length,
                 duplicateThemeHeadingCount: Array.from(document.querySelectorAll("h1, h2, h3")).filter((element) => element.textContent?.trim() === "Styling / Theme customization").length,
-                buttonWhiteSpace: Array.from(document.querySelectorAll("button:not(.preset-button):not(#create-component):not(#destroy-component):not(#recreate-component):not(#create-second)")).map((button) => getComputedStyle(button).whiteSpace),
+                buttonWhiteSpace: Array.from(document.querySelectorAll("button:not(.preset-button):not(#create-component):not(#destroy-component):not(#recreate-component)")).map((button) => getComputedStyle(button).whiteSpace),
                 formBounds: Array.from(document.querySelectorAll<HTMLElement>("input, select, textarea")).map((element) => rect(element)),
                 clearLog: rect(clearLog),
                 eventHeader: rect(eventHeader),
@@ -266,6 +266,7 @@ test("keeps lifecycle buttons inside their card at desktop, intermediate, and mo
         await page.setViewportSize(viewport);
         await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
         await expect(page.locator("#ready-status")).toHaveText("準備完了（whenReady(): resolved）");
+        await expect(page.getByRole("button", { name: "2個目を生成" })).toHaveCount(0);
 
         const result = await page.locator(".component-lifecycle-card").evaluate((card) => {
             const buttons = card.querySelector<HTMLElement>(".component-lifecycle-buttons")!;
@@ -285,7 +286,7 @@ test("keeps lifecycle buttons inside their card at desktop, intermediate, and mo
             };
         });
 
-        expect(result.buttonRects, `${label}: four lifecycle buttons`).toHaveLength(4);
+        expect(result.buttonRects, `${label}: three lifecycle buttons`).toHaveLength(3);
         expect(result.buttonGrid.split(" "), `${label}: lifecycle button columns`).toHaveLength(expectedColumns);
         for (const button of result.buttonRects) {
             expect(button.rect.left, `${label}: button left edge`).toBeGreaterThanOrEqual(result.card.left - 1);
@@ -828,43 +829,6 @@ test("preserves inherited Accent/Base theme across destroy and recreate", async 
     await page.getByRole("button", { name: "作成して表示" }).click();
     await expect(page.locator("#ready-status")).toHaveText("準備完了（whenReady(): resolved）");
     await expect.poll(readTheme).toEqual(first);
-});
-
-test("demonstrates second-instance rejection and recreation after destroy", async ({ page }) => {
-    await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
-    await expect(page.locator("#ready-status")).toHaveText("準備完了（whenReady(): resolved）");
-
-    await page.getByRole("button", { name: "2個目を生成" }).click();
-    await expect(page.locator("#component-status")).toHaveText("2個目は動作しません（inert: multiple_instances_unsupported）");
-    await expect(page.locator("#event-log")).toHaveValue(/multiple_instances_unsupported/);
-    await expect(page.locator("ehagaki-composer")).toHaveCount(2);
-    const secondInstanceStyles = await page.locator("ehagaki-composer").evaluateAll((elements) => elements.map((element) => ({
-        background: element.style.getPropertyValue("--ehagaki-background"),
-    })));
-    expect(secondInstanceStyles).toEqual([
-        { background: "" },
-        { background: "" },
-    ]);
-
-    await page.getByRole("button", { name: "削除して非表示" }).click();
-    await expect(page.locator("#component-status")).toContainText("設定は保持されています");
-    await page.getByRole("button", { name: "作成して表示" }).click();
-    await expect(page.locator("#component-status")).toHaveText("Componentを表示しました");
-    await expect(page.locator("#ready-status")).toHaveText("準備完了（whenReady(): resolved）");
-
-    await page.getByRole("button", { name: "作り直す" }).click();
-    await expect(page.locator("#component-status")).toHaveText("Componentを表示しました");
-    await expect(page.locator("ehagaki-composer")).toHaveCount(1);
-
-    await page.locator("details.advanced-settings summary").click();
-    await page.locator("#style-background").fill("#fefefe");
-    await page.getByRole("button", { name: "テーマカラーを適用" }).click();
-    await page.getByRole("button", { name: "作り直す" }).click();
-    await expect(page.locator("#component-status")).toHaveText("Componentを表示しました");
-    const recreatedStyle = await page.locator("ehagaki-composer").evaluate((element) => ({
-        background: element.style.getPropertyValue("--ehagaki-background"),
-    }));
-    expect(recreatedStyle).toEqual({ background: "" });
 });
 
 test("does not auto-import query-selected modules outside manual mode", async ({ page }) => {


### PR DESCRIPTION
## 変更概要

eHagaki Web Component Playgroundのライフサイクルセクションから、通常利用には不要な「2個目を生成」操作を削除しました。

## 変更内容

- 「2個目を生成」ボタンと、その説明を削除し、作成・削除・再作成の説明へ整理
- ボタン専用のsecondary component参照、生成処理、イベント登録、再作成時の専用後始末を削除
- Playground E2Eを3操作前提に更新し、削除済みボタンが表示されないことを追加確認
- singleton制約の公開仕様ドキュメントとWeb Component本体は変更なし

## singleton制約のテスト

`src/test/e2e/webComponentEmbed.spec.ts` の `rejects a second connected component and releases the slot after disconnect` を維持しています。Playgroundボタンに依存せず、テスト内で2個目のComponentを直接生成し、`multiple_instances_unsupported` のerror event、`whenReady()` のrejection、1個目切断後の再接続を検証します。

## 検証

成功:
- `npm run check`
- `npm test`（333 files / 3837 tests）
- `npm run build`
- `git diff --check`
- Playground/Web Component Playwright E2E（Playground関連全件、singleton制約テストを含む）

未成功・未実行:
- 結合したPlaywright 26件中、既存の色ピクセル期待値テスト1件が失敗（期待 `[227,227,227,255]`、実測 `[240,240,240,255]`）。単独再実行でも同じ結果で、今回の変更箇所とは無関係です。
- 上記以外のPlaywright 25件は成功しました。
- 実端末（Android/iPhone）確認は実行していません。Chromiumの実ブラウザE2EでPlaygroundの表示、作成・削除・再作成、レイアウトを確認しています。