### PR TITLE
Disable local nsec auth in Direct Web Component

### DIFF
--- a/.agents/skills/ehagaki-browser-debug/references/browser-debug-map.md
+++ b/.agents/skills/ehagaki-browser-debug/references/browser-debug-map.md
@@ -76,7 +76,7 @@
 - **Event source:** open state、`onOpenAutoFocus/onCloseAutoFocus`、pointer outside、Escape、`popstate`、trigger click/tap。
 - **StateまたはCSS変数:** `contentRef`、`trapFocus`、`initialFocus`、`--bits-dialog-depth`、`.dialog-overlay`、`.dialog`、`.popover-content`、application dialog stateは`src/stores/dialogStore.svelte.ts`。
 - **Cleanup所有者:** bits-ui Root/Portalがprimitiveのlistenerを所有する。`useDialogHistory()`はcomponent lifecycleで`popstate`を解除する。caller固有のfocus callbackはcallerが所有する。
-- **関連テスト:** `src/test/unit/confirmDialog.test.ts`、`src/test/unit/useDialogHistory.test.ts`、`src/test/unit/composerTargetDialog.test.ts`、`src/test/unit/postHistoryDialog*.test.ts`、`src/test/e2e/composerTargetDialog.spec.ts`、`src/test/e2e/postHistoryDialog.spec.ts`。
+- **関連テスト:** `src/test/unit/confirmDialog.test.ts`、`src/test/unit/useDialogHistory.test.ts`、`src/test/unit/loginDialog.test.ts`、`src/test/unit/composerTargetDialog.test.ts`、`src/test/unit/postHistoryDialog*.test.ts`、`src/test/e2e/composerTargetDialog.spec.ts`、`src/test/e2e/postHistoryDialog.spec.ts`、`src/test/e2e/webComponentEmbed.spec.ts`。
 - **Playwrightまたは実端末確認が必要になる条件:** focus trap、portal z-order、overlay click、Escape、nested dialog、戻る操作、mobile viewport内配置はPlaywright。
 - **注意点:** `DialogWrapper`はclose時の自動focus復元を抑止している。focus defectを隠すためにtrapやopen autofocusを無条件停止しない。
 
@@ -186,7 +186,7 @@
 - **Cleanup所有者:** Playwright runnerがpage/contextを破棄し、route/popupはtestがcloseする。temporary artifactは調査完了時に削除する。
 - **関連テスト:** `src/test/e2e/composerTargetDialog.spec.ts`と`src/test/e2e/postHistoryDialog.spec.ts`。unit/component mock基盤は`src/test/setup.ts`と`src/test/mocks/`。
 - **Playwrightまたは実端末確認が必要になる条件:** config上の全projectは実browser engineでDOMを描画するが、IME/browser chrome/PWA standalone/WebViewは実端末確認を別途行う。
-- **注意点:** `desktop-chromium`は`Desktop Chrome` descriptor。`mobile-chromium`は`iPhone 13` descriptorをChromiumのdefault engineで実行する。`mobile-webkit`だけが`browserName: 'webkit'`を明示し、`composerTargetDialog.spec.ts`だけに限定される。base URL、Vite command、post-history harness ready URLは同じresolved portを使用し、Vite commandは`--strictPort`で自動移動を禁止する。worktree rootごとにportが異なるため、通常の複数worktreeが固定`4173`を共有しない。`reuseExistingServer: false`で古いserverを再利用せず、常に現在checkoutのViteを起動する。
+- **注意点:** `desktop-chromium`は`Desktop Chrome` descriptor。`mobile-chromium`は`iPhone 13` descriptorをChromiumのdefault engineで実行する。`mobile-webkit`だけが`browserName: 'webkit'`を明示し、`composerTargetDialog.spec.ts`、`webComponentEmbed.spec.ts`、`webComponentParentClientExample.spec.ts`に限定される。`desktop-firefox`は`webComponentEmbed.spec.ts`に限定される。base URL、Vite command、post-history harness ready URLは同じresolved portを使用し、Vite commandは`--strictPort`で自動移動を禁止する。worktree rootごとにportが異なるため、通常の複数worktreeが固定`4173`を共有しない。`reuseExistingServer: false`で古いserverを再利用せず、常に現在checkoutのViteを起動する。
 
 ## 関連テストの選択
 

--- a/.agents/skills/ehagaki-nostr/references/implementation-map.md
+++ b/.agents/skills/ehagaki-nostr/references/implementation-map.md
@@ -125,9 +125,9 @@
 - 機能: 旧single-accountの`nostr-secret-key`を、nsec自身から導出したpubkeyのcredential、`nsec` account record、activation policyに沿うactive pointerへ安全に移行する。
 - 関連NIP: nsecのdecode/identity導出はNIP-19。migrationはrelay eventを生成・取得しない。
 - 主な実装ファイル: `src/lib/legacyNsecMigration.ts`、`src/lib/authService.ts`、`src/lib/keyManager.svelte.ts`、`src/lib/accountManager.ts`。
-- 主な関数または責務: `captureLegacyNsecMigrationSnapshot`がaccount listとactive pointerをstrictに取得し、`migrateLegacyNsec`がcredential readback、account record readback、activation policy、legacy削除を順に所有する。`AuthService.initializeAuth`はsnapshot後にNIP-07/NIP-46の旧single-account移行を必要時だけ実行し、nsec migrationの後に既存managed restoreへ進む。
-- 関連テスト: `src/test/unit/legacyNsecMigration.test.ts`、`src/test/unit/keyManager.test.ts`、`src/test/unit/accountManager.test.ts`、`src/test/unit/authService.initialize.test.ts`。
-- 注意点: profile/relay storage keyのsuffixをidentity根拠に使わない。legacy credentialはすべての永続条件をreadbackで確認するまで削除しない。既存の有効なactive pointerはtypeにかかわらずmigration中に維持し、Parent clientは起動時managed restore候補へ追加しない。
+- 主な関数または責務: `captureLegacyNsecMigrationSnapshot`がaccount listとactive pointerをstrictに取得し、`migrateLegacyNsec`がcredential readback、account record readback、activation policy、legacy削除を順に所有する。`AuthService.initializeAuth`はsnapshot後にNIP-07/NIP-46の旧single-account移行を必要時だけ実行し、nsec migrationの後に既存managed restoreへ進む。Direct Web Componentでは`AppRuntimeEnvironment.localNsecAuthEnabled=false`を認証serviceへ伝え、`AccountManager.cleanupLocalNsecAuthData`がWeb Component namespace内の旧nsec credential/account/active pointerだけを整理してから、NIP-07/NIP-46候補のrestoreへ進む。
+- 関連テスト: `src/test/unit/legacyNsecMigration.test.ts`、`src/test/unit/keyManager.test.ts`、`src/test/unit/accountManager.test.ts`、`src/test/unit/authService.initialize.test.ts`、`src/test/unit/authService.authenticate.test.ts`、`src/test/unit/authService.restore.test.ts`、`src/test/e2e/webComponentEmbed.spec.ts`。
+- 注意点: profile/relay storage keyのsuffixをidentity根拠に使わない。legacy credentialはすべての永続条件をreadbackで確認するまで削除しない。既存の有効なactive pointerはtypeにかかわらずmigration中に維持し、Parent clientは起動時managed restore候補へ追加しない。Direct Web Component以外ではlocal nsec capabilityを有効のまま維持する。
 
 ## NIP-07
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Web Component版の公開API、lifecycle、context/settings、CustomEvent、CSS 
 
 実際に `Create / Mount`、`Destroy / Unmount`、再生成、設定・context更新、2個目instanceの拒否、event log、host側styleを操作するlive sampleは [https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html](https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html) から確認できます。
 
-Web Componentではiframeのparent-client auth/RPCや `postMessage` を使いません。ログインは埋め込まれたeHagakiの既存UIから行い、NIP-07はhostの `window.nostr` を直接利用します。host JavaScriptから秘密情報を隔離したい場合はiframe埋め込みを使用してください。
+Web Componentではiframeのparent-client auth/RPCや `postMessage` を使いません。ホストと同じWindow realm / originで動作するためローカルnsec認証には対応せず、NIP-07はhostの `window.nostr` を直接利用し、NIP-46は埋め込まれたeHagakiのUIから利用します。通常版/PWAとiframe版では従来どおりnsec認証を利用できます。
 
 ## 技術スタック
 

--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -582,9 +582,14 @@ Web Component 専用の signer callback/provider API はありません。
 
 - NIP-07 では、コンポーネントと同じ Window realm にあるホストの `window.nostr` を直接利用します。
 - NIP-46 は、コンポーネント内の既存 eHagaki UI からログインします。
-- nsec / managed account も、コンポーネント内の既存 eHagaki UI から利用します。
+- ローカル秘密鍵（nsec）の入力、保存、保存済みアカウントの復元には対応しません。
 - iframe の `auth.*` / `rpc.*` メッセージは Web Component では使いません。
 - ホスト側から nsec をコンポーネントへ渡す API はありません。
+
+Web Component はホストページと同じ Window realm / origin で動作します。信頼できない埋め込み元の
+JavaScript から入力・保存された秘密鍵を取得されることを防ぐため、認証には NIP-07 や NIP-46 など、
+秘密鍵そのものを Web Component へ入力しない方式を使用してください。この制限は Direct Web Component
+固有であり、通常版/PWA と iframe 版では従来どおりローカル nsec 認証を利用できます。
 
 NIP-07 の有無をホストから確認するだけなら、`window.nostr` と必要な method の存在を
 確認します。これは signer を Web Component へ渡すコードではありません。実際の署名処理は
@@ -610,6 +615,7 @@ console.log('NIP-07 available:', nip07Available);
 | スタイル | iframe 内 document の CSS 境界 | ShadowRoot。CSS Custom Properties / `::part()` を公開 |
 | Window realm | ホストとは分離 | ホストと共有 |
 | NIP-07 | iframe の認証経路または parent-client 連携 | ホストの `window.nostr` を直接利用 |
+| ローカル nsec | 利用可能 | 利用不可 |
 | parent-client auth/RPC | 利用可能 | 使用しない |
 | `postMessage` | 使用する | 使用しない |
 | 保存 | 親側の storage / IndexedDB 委譲を構成可能 | ホストオリジンに保存。専用 localStorage namespace を使用 |
@@ -624,7 +630,9 @@ iframe の通信、parent storage、parent-client auth/RPC が必要な場合は
 Web Component はホストの Window realm で動作し、ホストオリジンへ直接保存します。
 
 - localStorage の key は `ehagaki.web-component.v1:` namespace に限定されます。
-- アカウント、nsec、NIP-46、リレー、設定、legacy-cleanup などの eHagaki 管理値も、この namespace の対象です。
+- アカウント、NIP-46、リレー、設定、legacy-cleanup などの eHagaki 管理値も、この namespace の対象です。
+- 旧 Web Component 版がこの namespace 内へ保存した nsec credential、nsec 型 account record、対応する
+  active-account 状態は起動時に整理され、再利用されません。NIP-07/NIP-46 の account/session は保持されます。
 - ホストの namespace なしの生の key を読み取り、上書き、削除することはありません。
 - この namespace は衝突防止のためのものであり、秘密情報の隔離境界ではありません。
 - iframe の parent-storage プロトコルを通じて以前に委譲されていたデータは、Web Component へ

--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -292,7 +292,7 @@
                 <div class="column">
                     <div class="notice">
                         <strong>認証と安全な利用範囲</strong>
-                        <p class="small">Web Componentは、このページと同じWindow realmで動作します。ログインは埋め込まれたeHagakiの画面から行い、NIP-07はページの <code>window.nostr</code> を直接利用します。NIP-46・nsec/managed accountもeHagakiの既存経路を使います。このサンプルはsigner callbackを追加せず、nsecを保存しません。</p>
+                        <p class="small">Web Componentは、このページと同じWindow realm / originで動作します。ローカル秘密鍵（nsec）の入力・保存・復元には対応しません。ログインには、秘密鍵自体を入力しないNIP-07（ページの <code>window.nostr</code>）またはNIP-46を利用してください。</p>
                     </div>
 
                     <div class="card stack">
@@ -331,7 +331,7 @@
                             <thead><tr><th>項目</th><th>iframe</th><th>Web Component</th></tr></thead>
                             <tbody>
                                 <tr><th>分離方法 / API</th><td>originを分け、postMessage protocolとhandshakeで通信</td><td>同じWindow realmでmethod/property/CustomEventを使い、elementを作成・削除・再作成</td></tr>
-                                <tr><th>認証</th><td>parent-client auth/RPCを利用可能</td><td>parent-client auth/RPCは使用しない。NIP-07はhostのwindow.nostrを直接利用し、NIP-46/nsecはeHagaki UIを利用</td></tr>
+                                <tr><th>認証</th><td>parent-client auth/RPCやローカルnsecを利用可能</td><td>parent-client auth/RPCとローカルnsecは使用しない。NIP-07はhostのwindow.nostrを直接利用し、NIP-46はeHagaki UIを利用</td></tr>
                                 <tr><th>データの保存</th><td>storage/IndexedDBを親ページに委ねられる</td><td>localStorageは <code>ehagaki.web-component.v1:</code> namespace、IndexedDBはhost originの <code>eHagakiDB</code></td></tr>
                                 <tr><th>更新 / 見た目</th><td>iframeのreloadまたはpostMessage</td><td>setSettings()/setContext()、CSS Custom Properties / <code>::part()</code></td></tr>
                                 <tr><th>安全な範囲</th><td>iframeとは別のoriginとして分離可能</td><td>trusted hostのみ正式サポート。hostは同じrealmのコードやstorageを確認可能</td></tr>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2021,6 +2021,7 @@
           nip46NostrConnectUri={pendingNip46ConnectionUri}
           {nip46NostrConnectErrorMessage}
           initialNostrConnectRelayCandidates={getInitialNip46ConnectRelayCandidates()}
+          localNsecAuthEnabled={appRuntimeEnvironment.localNsecAuthEnabled}
         />
       {/if}
       {#if showTransitionOverlay}
@@ -2052,6 +2053,7 @@
           {nip46NostrConnectErrorMessage}
           initialNostrConnectRelayCandidates={getInitialNip46ConnectRelayCandidates()}
           isAddAccountMode={true}
+          localNsecAuthEnabled={appRuntimeEnvironment.localNsecAuthEnabled}
         />
       {/if}
       {#if showLogoutDialogStore.value && ProfileComponent}

--- a/src/components/LoginDialog.svelte
+++ b/src/components/LoginDialog.svelte
@@ -44,6 +44,7 @@
         nip46NostrConnectErrorMessage?: string;
         initialNostrConnectRelayCandidates?: string[];
         isAddAccountMode?: boolean;
+        localNsecAuthEnabled?: boolean;
     }
 
     let {
@@ -68,6 +69,7 @@
         nip46NostrConnectErrorMessage = "",
         initialNostrConnectRelayCandidates = [],
         isAddAccountMode = false,
+        localNsecAuthEnabled = true,
     }: Props = $props();
 
     // ダイアログを閉じるハンドラ
@@ -634,10 +636,14 @@
     onOpenChange={(open) => !open && handleClose()}
     title={isAddAccountMode
         ? $_("loginDialog.add_account_title")
-        : $_("loginDialog.input_secret")}
+        : localNsecAuthEnabled
+          ? $_("loginDialog.input_secret")
+          : $_("common.login")}
     description={isAddAccountMode
         ? $_("loginDialog.add_account_hint")
-        : $_("loginDialog.hint_input_secret")}
+        : localNsecAuthEnabled
+          ? $_("loginDialog.hint_input_secret")
+          : $_("loginDialog.login_methods_hint")}
     contentClass="login-dialog"
     footerVariant="close-button"
 >
@@ -1072,63 +1078,65 @@
         </details>
     </div>
 
-    <div class="divider">
-        <span>{$_("common.or")}</span>
-    </div>
-
-    <div class="secret-key-section">
-        <div class="secret-heading-row">
-            <div class="secret-icon svg-icon"></div>
-            <h3>{$_("loginDialog.input_secret")}</h3>
+    {#if localNsecAuthEnabled}
+        <div class="divider">
+            <span>{$_("common.or")}</span>
         </div>
 
-        <form novalidate onsubmit={handleFormSubmit}>
-            <div class="secret-input-row">
-                <div class="input-shell">
-                    <input
-                        bind:value={secretKey}
-                        type="password"
-                        placeholder="nsec1..."
-                        class="secret-input u-control"
-                        id="secretKey"
-                        name="secretKey"
-                        autocomplete="current-password"
-                        required
-                        minlength="63"
-                        maxlength="63"
-                        bind:this={inputEl}
-                        title={$_("loginDialog.hint_input_secret")}
-                        oninput={() => inputEl?.setCustomValidity("")}
-                    />
-                    {#if secretKey.length > 0}
-                        <Button
-                            variant="secondary"
-                            type="button"
-                            className="clear-input-btn"
-                            ariaLabel={clearInputLabel}
-                            onClick={handleClearSecretKey}
-                            onmousedown={preventKeyboardFocusChange}
-                            ontouchstart={preventKeyboardFocusChange}
-                        >
-                            <div
-                                class="clear-input-icon svg-icon"
-                                aria-hidden="true"
-                            ></div>
-                        </Button>
-                    {/if}
-                </div>
- 
-                <Button
-                    variant="primary"
-                    shape="square"
-                    type="submit"
-                    className="save-btn u-control"
-                >
-                    {$_("loginDialog.save")}
-                </Button>
+        <div class="secret-key-section">
+            <div class="secret-heading-row">
+                <div class="secret-icon svg-icon"></div>
+                <h3>{$_("loginDialog.input_secret")}</h3>
             </div>
-        </form>
-    </div>
+
+            <form novalidate onsubmit={handleFormSubmit}>
+                <div class="secret-input-row">
+                    <div class="input-shell">
+                        <input
+                            bind:value={secretKey}
+                            type="password"
+                            placeholder="nsec1..."
+                            class="secret-input u-control"
+                            id="secretKey"
+                            name="secretKey"
+                            autocomplete="current-password"
+                            required
+                            minlength="63"
+                            maxlength="63"
+                            bind:this={inputEl}
+                            title={$_("loginDialog.hint_input_secret")}
+                            oninput={() => inputEl?.setCustomValidity("")}
+                        />
+                        {#if secretKey.length > 0}
+                            <Button
+                                variant="secondary"
+                                type="button"
+                                className="clear-input-btn"
+                                ariaLabel={clearInputLabel}
+                                onClick={handleClearSecretKey}
+                                onmousedown={preventKeyboardFocusChange}
+                                ontouchstart={preventKeyboardFocusChange}
+                            >
+                                <div
+                                    class="clear-input-icon svg-icon"
+                                    aria-hidden="true"
+                                ></div>
+                            </Button>
+                        {/if}
+                    </div>
+
+                    <Button
+                        variant="primary"
+                        shape="square"
+                        type="submit"
+                        className="save-btn u-control"
+                    >
+                        {$_("loginDialog.save")}
+                    </Button>
+                </div>
+            </form>
+        </div>
+    {/if}
 
     {#snippet footer()}
         <Dialog.Close>

--- a/src/lib/accountManager.ts
+++ b/src/lib/accountManager.ts
@@ -59,6 +59,112 @@ export class AccountManager {
         this.clearActiveAccountPubkey();
     }
 
+    /**
+     * Removes only local nsec credentials and nsec account records.
+     * The configured Storage boundary decides the namespace; the Direct Web
+     * Component passes its scoped facade, so host keys remain unreachable.
+     */
+    cleanupLocalNsecAuthData(): void {
+        let remainingAccounts: unknown[] | null = null;
+        const removedPubkeys = new Set<string>();
+
+        try {
+            const rawAccounts = this.localStorage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS);
+            if (rawAccounts !== null) {
+                const parsed = JSON.parse(rawAccounts) as unknown;
+                if (Array.isArray(parsed)) {
+                    remainingAccounts = parsed.filter((account) => {
+                        if (
+                            typeof account === 'object'
+                            && account !== null
+                            && (account as Partial<StoredAccount>).type === 'nsec'
+                        ) {
+                            const pubkeyHex = (account as Partial<StoredAccount>).pubkeyHex;
+                            if (typeof pubkeyHex === 'string') {
+                                removedPubkeys.add(pubkeyHex);
+                            }
+                            return false;
+                        }
+                        return true;
+                    });
+
+                    if (remainingAccounts.length !== parsed.length) {
+                        this.localStorage.setItem(
+                            STORAGE_KEYS.NOSTR_ACCOUNTS,
+                            JSON.stringify(remainingAccounts),
+                        );
+                    }
+                }
+            }
+        } catch {
+            this.console.error('ローカルnsecアカウントデータ削除に失敗しました', {
+                stage: 'account-records',
+                reason: 'unexpected',
+            });
+            remainingAccounts = null;
+            removedPubkeys.clear();
+        }
+
+        if (remainingAccounts && removedPubkeys.size > 0) {
+            try {
+                const activePubkey = this.getActiveAccountPubkey();
+                const activeStillExists = remainingAccounts.some(
+                    (account) => typeof account === 'object'
+                        && account !== null
+                        && (account as Partial<StoredAccount>).pubkeyHex === activePubkey,
+                );
+                if (activePubkey && removedPubkeys.has(activePubkey) && !activeStillExists) {
+                    const nextActiveAccount = remainingAccounts.find((account) =>
+                        typeof account === 'object'
+                        && account !== null
+                        && typeof (account as Partial<StoredAccount>).pubkeyHex === 'string'
+                        && (account as Partial<StoredAccount>).pubkeyHex,
+                    ) as Partial<StoredAccount> | undefined;
+                    const nextActivePubkey = nextActiveAccount?.pubkeyHex;
+                    if (nextActivePubkey) {
+                        this.saveActiveAccountPubkey(nextActivePubkey);
+                    } else {
+                        this.clearActiveAccountPubkey();
+                    }
+                }
+            } catch {
+                this.console.error('ローカルnsecアカウントデータ削除に失敗しました', {
+                    stage: 'active-account',
+                    reason: 'unexpected',
+                });
+            }
+        }
+
+        const credentialKeys = new Set<string>([
+            STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY,
+            ...[...removedPubkeys].map((pubkeyHex) => getNsecStorageKey(pubkeyHex)),
+        ]);
+        try {
+            for (let index = 0; index < this.localStorage.length; index += 1) {
+                const key = this.localStorage.key(index);
+                if (key?.startsWith(STORAGE_KEYS.NOSTR_SECRET_KEY_PREFIX)) {
+                    credentialKeys.add(key);
+                }
+            }
+        } catch {
+            this.console.error('ローカルnsecアカウントデータ削除に失敗しました', {
+                stage: 'credential-list',
+                reason: 'unexpected',
+            });
+        }
+
+        for (const key of credentialKeys) {
+            try {
+                this.localStorage.removeItem(key);
+            } catch {
+                this.console.error('ローカルnsecアカウントデータ削除に失敗しました', {
+                    stage: 'credential-remove',
+                    reason: 'unexpected',
+                });
+            }
+        }
+    }
+
     addAccount(pubkeyHex: string, type: StoredAccount['type']): void {
         const accounts = this.getAccounts();
         const existing = accounts.find(a => a.pubkeyHex === pubkeyHex);

--- a/src/lib/appRuntimeEnvironment.ts
+++ b/src/lib/appRuntimeEnvironment.ts
@@ -19,6 +19,7 @@ export interface AppRuntimeEnvironment {
     serviceWorkerEnabled: boolean;
     externalInputEnabled: boolean;
     historyEnabled: boolean;
+    localNsecAuthEnabled: boolean;
 }
 
 function createFallbackElement(): HTMLElement {
@@ -55,6 +56,7 @@ function createDefaultEnvironment(): AppRuntimeEnvironment {
         serviceWorkerEnabled: true,
         externalInputEnabled: true,
         historyEnabled: true,
+        localNsecAuthEnabled: true,
     };
 }
 

--- a/src/lib/authRestoreUtils.ts
+++ b/src/lib/authRestoreUtils.ts
@@ -14,6 +14,7 @@ const LEGACY_NIP07_STORAGE_KEY = 'nostr-nip07-pubkey';
 export type RestoreResult = { hasAuth: boolean; pubkeyHex?: string };
 export type ManagedRestoreFailureReason =
     | 'invalid-requested-pubkey'
+    | 'local-nsec-auth-disabled'
     | 'account-record-mismatch'
     | 'credential-missing'
     | 'credential-read-failed'
@@ -102,7 +103,9 @@ interface ManagedAccountRestoreDependencies {
     restoreAccount(pubkeyHex: string, type: AccountAuthType): Promise<RestoreResult>;
 }
 
-export interface LegacyAuthCheckDependencies extends LegacyNsecDependencies, LegacyNip07Dependencies, LegacyNip46Dependencies { }
+export interface LegacyAuthCheckDependencies extends LegacyNsecDependencies, LegacyNip07Dependencies, LegacyNip46Dependencies {
+    localNsecAuthEnabled: boolean;
+}
 
 function createProfileRefs(pubkeyHex: string): { npub: string; nprofile: string } {
     return {
@@ -399,10 +402,10 @@ export async function runLegacyAuthChecks(
     dependencies: LegacyAuthCheckDependencies,
 ): Promise<RestoreResult> {
     const checks = [
-        checkLegacyNsecAuth,
+        ...(dependencies.localNsecAuthEnabled ? [checkLegacyNsecAuth] : []),
         checkLegacyNip07Auth,
         checkLegacyNip46Auth,
-    ] as const;
+    ];
 
     for (const check of checks) {
         const result = await check(dependencies as never);

--- a/src/lib/authService.ts
+++ b/src/lib/authService.ts
@@ -47,6 +47,10 @@ export class AuthService {
     // --- nsec認証 ---
 
     async authenticateWithNsec(secretKey: string): Promise<AuthResult> {
+        if (!this.runtime.localNsecAuthEnabled) {
+            return { success: false, error: 'local-nsec-auth-disabled' };
+        }
+
         if (!this.runtime.keyManager.isValidNsec(secretKey)) {
             return { success: false, error: 'invalid_secret' };
         }
@@ -253,6 +257,9 @@ export class AuthService {
     async initializeAuth(): Promise<RestoreResult> {
         try {
             if (this.accountManager) {
+                if (!this.runtime.localNsecAuthEnabled) {
+                    this.accountManager.cleanupLocalNsecAuthData();
+                }
                 const snapshotResult = captureLegacyNsecMigrationSnapshot(this.runtime.localStorage);
                 if (snapshotResult.status === 'failed') {
                     return { hasAuth: false };
@@ -323,6 +330,10 @@ export class AuthService {
         pubkeyHex: string,
         type: 'nsec' | 'nip07' | 'nip46' | 'parentClient',
     ): Promise<ManagedRestoreResult> {
+        if (type === 'nsec' && !this.runtime.localNsecAuthEnabled) {
+            return { hasAuth: false, reason: 'local-nsec-auth-disabled' };
+        }
+
         if (!/^[0-9a-fA-F]{64}$/.test(pubkeyHex)) {
             return { hasAuth: false, reason: 'invalid-requested-pubkey' };
         }

--- a/src/lib/authServiceRuntime.ts
+++ b/src/lib/authServiceRuntime.ts
@@ -52,6 +52,7 @@ export interface AuthServiceRuntime {
     caches: CacheStorage;
     navigator: Navigator;
     serviceWorkerEnabled: boolean;
+    localNsecAuthEnabled: boolean;
     console: Console;
     nip46Svc: Nip46Service;
     parentClientSvc: ParentClientAuthService;
@@ -76,6 +77,9 @@ export function createAuthServiceRuntime(dependencies: AuthServiceDependencies =
     const serviceWorkerEnabled =
         dependencies.serviceWorkerEnabled ??
         getAppRuntimeEnvironment().serviceWorkerEnabled;
+    const localNsecAuthEnabled =
+        dependencies.localNsecAuthEnabled ??
+        getAppRuntimeEnvironment().localNsecAuthEnabled;
     const consoleObj = dependencies.console ?? (typeof window !== 'undefined' ? window.console : {} as Console);
     const indexedDB =
         dependencies.indexedDB ??
@@ -94,6 +98,7 @@ export function createAuthServiceRuntime(dependencies: AuthServiceDependencies =
         caches,
         navigator,
         serviceWorkerEnabled,
+        localNsecAuthEnabled,
         console: consoleObj,
         keyManager,
         nip46Svc: nip46Service,

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -26,6 +26,7 @@
     "get_started": "Get Started"
   },
   "loginDialog": {
+    "login_methods_hint": "Choose a login method",
     "input_secret": "Secret Key",
     "hint_input_secret": "Enter a secret key starting with nsec1",
     "save": "Save",

--- a/src/lib/i18n/ja.json
+++ b/src/lib/i18n/ja.json
@@ -26,6 +26,7 @@
     "get_started": "はじめる"
   },
   "loginDialog": {
+    "login_methods_hint": "ログイン方法を選択",
     "input_secret": "秘密鍵",
     "hint_input_secret": "nsec1から始まる秘密鍵を入力",
     "save": "保存",

--- a/src/lib/types/nostr.ts
+++ b/src/lib/types/nostr.ts
@@ -74,6 +74,7 @@ export interface AuthServiceDependencies {
     window?: Window;
     navigator?: Navigator;
     serviceWorkerEnabled?: boolean;
+    localNsecAuthEnabled?: boolean;
     console?: Console;
     setNsecAuth?: (pubkey: string, npub: string, nprofile: string) => void;
     setNip07Auth?: (pubkey: string, npub: string, nprofile: string) => void;

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ configureAppRuntimeEnvironment({
   serviceWorkerEnabled: true,
   externalInputEnabled: true,
   historyEnabled: true,
+  localNsecAuthEnabled: true,
 })
 startServiceWorkerRegistration()
 

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -218,7 +218,7 @@ test("applies Accent/Base themes while preserving default and meaning colors", a
     });
 
     const defaultLight = await readTheme();
-    expect(defaultLight.shellPixel).toEqual([227, 227, 227, 255]);
+    expect(defaultLight.shellPixel).toEqual([240, 240, 240, 255]);
     expect(defaultLight.primaryBackground).not.toBe("rgba(0, 0, 0, 0)");
 
     await page.locator("ehagaki-composer").evaluate(async (element) => {
@@ -677,6 +677,130 @@ test("applies Button styles inside a Portal dialog in the Shadow DOM", async ({ 
         ).backgroundColor;
     });
     expect(darkDialogBackground).not.toBe(lightResult.dialogBackground);
+});
+
+test("offers NIP-07 and NIP-46 without rendering local nsec login UI", async ({ page }) => {
+    await page.goto(hostOrigin);
+    await page.evaluate(async (pubkeyHex) => {
+        window.nostr = {
+            getPublicKey: async () => pubkeyHex,
+            signEvent: async (event: any) => ({ ...event, id: "66".repeat(32), sig: "77".repeat(64) }),
+        };
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+        };
+        composer.style.width = "360px";
+        composer.style.height = "600px";
+        document.body.append(composer);
+        await composer.whenReady();
+    }, testPubkeyHex);
+
+    await page.waitForFunction(() =>
+        !!document.querySelector("ehagaki-composer")?.shadowRoot?.querySelector("button.login-btn"),
+    );
+    await page.evaluate(() => {
+        document.querySelector("ehagaki-composer")!.shadowRoot!
+            .querySelector<HTMLButtonElement>("button.login-btn")!.click();
+    });
+    await page.waitForFunction(() =>
+        !!document.querySelector("ehagaki-composer")?.shadowRoot
+            ?.querySelector('[part~="overlay-root"] .login-dialog'),
+    );
+    const result = await page.evaluate(() => {
+        const composer = document.querySelector("ehagaki-composer")!;
+        const shadow = composer.shadowRoot!;
+        const overlay = shadow.querySelector<HTMLElement>('[part~="overlay-root"]')!;
+        const dialog = overlay.querySelector<HTMLElement>(".login-dialog")!;
+        const componentRect = composer.getBoundingClientRect();
+        const dialogRect = dialog.getBoundingClientRect();
+        return {
+            secretInputCount: dialog.querySelectorAll('#secretKey, input[placeholder="nsec1..."]').length,
+            secretSectionCount: dialog.querySelectorAll(".secret-key-section").length,
+            nip07Visible: !!dialog.querySelector(".nip07-login-button"),
+            nip07Enabled: !dialog.querySelector<HTMLButtonElement>(".nip07-login-button")?.disabled,
+            nip46Visible: !!dialog.querySelector(".nostrconnect-open-btn"),
+            hasAddedWarning: /Web Component.*秘密鍵|秘密鍵.*入力しない/.test(dialog.textContent ?? ""),
+            fitsComponent:
+                dialogRect.left >= componentRect.left - 1
+                && dialogRect.right <= componentRect.right + 1
+                && dialogRect.top >= componentRect.top - 1
+                && dialogRect.bottom <= componentRect.bottom + 1,
+        };
+    });
+
+    expect(result).toEqual({
+        secretInputCount: 0,
+        secretSectionCount: 0,
+        nip07Visible: true,
+        nip07Enabled: true,
+        nip46Visible: true,
+        hasAddedWarning: false,
+        fitsComponent: true,
+    });
+});
+
+test("cleans only legacy Web Component nsec state and restores the remaining NIP-07 account", async ({ page }) => {
+    await page.goto(hostOrigin);
+    const nsecPubkey = "aa".repeat(32);
+    const nip46Pubkey = "bb".repeat(32);
+    await page.evaluate(async ({ componentStoragePrefix, nsecPubkey, nip07Pubkey, nip46Pubkey }) => {
+        window.nostr = {
+            getPublicKey: async () => nip07Pubkey,
+            signEvent: async (event: any) => ({ ...event, id: "88".repeat(32), sig: "99".repeat(64) }),
+        };
+        localStorage.setItem(
+            `${componentStoragePrefix}nostr-accounts`,
+            JSON.stringify([
+                { pubkeyHex: nsecPubkey, type: "nsec", addedAt: 1 },
+                { pubkeyHex: nip07Pubkey, type: "nip07", addedAt: 2 },
+                { pubkeyHex: nip46Pubkey, type: "nip46", addedAt: 3 },
+            ]),
+        );
+        localStorage.setItem(`${componentStoragePrefix}nostr-active-account`, nsecPubkey);
+        localStorage.setItem(`${componentStoragePrefix}nostr-secret-key`, "legacy-component-credential");
+        localStorage.setItem(`${componentStoragePrefix}nostr-secret-key-${nsecPubkey}`, "managed-component-credential");
+        localStorage.setItem(`${componentStoragePrefix}nostr-nip46-session-${nip46Pubkey}`, "nip46-session-sentinel");
+        localStorage.setItem(`${componentStoragePrefix}component-sentinel`, "keep");
+
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+        };
+        document.body.append(composer);
+        await composer.whenReady();
+    }, {
+        componentStoragePrefix,
+        nsecPubkey,
+        nip07Pubkey: testPubkeyHex,
+        nip46Pubkey,
+    });
+
+    await page.waitForFunction(() =>
+        !!document.querySelector("ehagaki-composer")?.shadowRoot?.querySelector(".profile-display"),
+    );
+    const result = await page.evaluate(({ componentStoragePrefix, nsecPubkey, nip46Pubkey, sentinels }) => ({
+        accounts: JSON.parse(localStorage.getItem(`${componentStoragePrefix}nostr-accounts`) ?? "[]"),
+        activeAccount: localStorage.getItem(`${componentStoragePrefix}nostr-active-account`),
+        legacyCredential: localStorage.getItem(`${componentStoragePrefix}nostr-secret-key`),
+        managedCredential: localStorage.getItem(`${componentStoragePrefix}nostr-secret-key-${nsecPubkey}`),
+        nip46Session: localStorage.getItem(`${componentStoragePrefix}nostr-nip46-session-${nip46Pubkey}`),
+        componentSentinel: localStorage.getItem(`${componentStoragePrefix}component-sentinel`),
+        rawHostValues: Object.fromEntries(
+            Object.keys(sentinels).map((key) => [key, localStorage.getItem(key)]),
+        ),
+    }), { componentStoragePrefix, nsecPubkey, nip46Pubkey, sentinels });
+
+    expect(result.accounts).toEqual([
+        { pubkeyHex: testPubkeyHex, type: "nip07", addedAt: 2 },
+        { pubkeyHex: nip46Pubkey, type: "nip46", addedAt: 3 },
+    ]);
+    expect(result.activeAccount).toBe(testPubkeyHex);
+    expect(result.legacyCredential).toBeNull();
+    expect(result.managedCredential).toBeNull();
+    expect(result.nip46Session).toBe("nip46-session-sentinel");
+    expect(result.componentSentinel).toBe("keep");
+    expect(result.rawHostValues).toEqual(sentinels);
 });
 
 test("keeps authenticated profile and post history dialogs inside the component", async ({ page }) => {

--- a/src/test/unit/authService.authenticate.test.ts
+++ b/src/test/unit/authService.authenticate.test.ts
@@ -36,6 +36,21 @@ describe('AuthService.authenticateWithNsec', () => {
         expect(mockDependencies.setNsecAuth).toHaveBeenCalledWith('test-pubkey', 'npub123', 'nprofile123');
     });
 
+    it('ローカルnsec認証が無効なruntimeでは検証・保存前に拒否する', async () => {
+        const service = new AuthService({
+            ...mockDependencies,
+            localNsecAuthEnabled: false,
+        });
+
+        await expect(service.authenticateWithNsec('nsec1disabled')).resolves.toEqual({
+            success: false,
+            error: 'local-nsec-auth-disabled',
+        });
+        expect(mockKeyManager.isValidNsec).not.toHaveBeenCalled();
+        expect(mockKeyManager.saveToStorage).not.toHaveBeenCalled();
+        expect(mockDependencies.setNsecAuth).not.toHaveBeenCalled();
+    });
+
     it('無効な秘密鍵で認証に失敗する', async () => {
         mockKeyManager.isValidNsec.mockReturnValue(false);
 

--- a/src/test/unit/authService.initialize.test.ts
+++ b/src/test/unit/authService.initialize.test.ts
@@ -9,6 +9,10 @@ import { AccountManager } from '../../lib/accountManager';
 import { getNsecStorageKey } from '../../lib/authStorageKeys';
 import { STORAGE_KEYS } from '../../lib/constants';
 import {
+    createWebComponentStorage,
+    EHAGAKI_WEB_COMPONENT_STORAGE_PREFIX,
+} from '../../lib/appStorage';
+import {
     createMockAccountManager,
     createMockDependencies,
     createMockNip07Dependencies,
@@ -263,6 +267,76 @@ describe('AuthService.initializeAuth', () => {
 
         expect(result.hasAuth).toBe(true);
         expect(result.pubkeyHex).toBe('legacy-pubkey');
+    });
+
+    it('ローカルnsec認証が無効なruntimeではaccount managerなしでもlegacy nsec restoreを開始しない', async () => {
+        mockKeyManager.loadFromStorage.mockReturnValue('legacy-nsec');
+        const service = new AuthService({
+            ...mockDependencies,
+            localNsecAuthEnabled: false,
+        });
+
+        await expect(service.initializeAuth()).resolves.toEqual({ hasAuth: false });
+        expect(mockKeyManager.loadFromStorage).not.toHaveBeenCalled();
+        expect(mockDependencies.setNsecAuth).not.toHaveBeenCalled();
+    });
+
+    it('Web Component storage内のnsecだけをcleanupし、NIP-07復元とNIP-46・hostデータを維持する', async () => {
+        const hostStorage = new MockStorage();
+        const componentStorage = createWebComponentStorage(hostStorage);
+        const nsecPubkey = '12'.repeat(32);
+        const nip07Pubkey = '34'.repeat(32);
+        const nip46Pubkey = '56'.repeat(32);
+        const hostSentinels = {
+            'host-sentinel': 'unchanged',
+            [STORAGE_KEYS.NOSTR_ACCOUNTS]: 'host-accounts',
+            [STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY]: 'host-credential-sentinel',
+        };
+        for (const [key, value] of Object.entries(hostSentinels)) {
+            hostStorage.setItem(key, value);
+        }
+        componentStorage.setItem(STORAGE_KEYS.NOSTR_ACCOUNTS, JSON.stringify([
+            { pubkeyHex: nsecPubkey, type: 'nsec', addedAt: 1 },
+            { pubkeyHex: nip07Pubkey, type: 'nip07', addedAt: 2 },
+            { pubkeyHex: nip46Pubkey, type: 'nip46', addedAt: 3 },
+        ]));
+        componentStorage.setItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT, nsecPubkey);
+        componentStorage.setItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY, 'legacy-component-credential');
+        componentStorage.setItem(getNsecStorageKey(nsecPubkey), 'managed-component-credential');
+        componentStorage.setItem(
+            `${STORAGE_KEYS.NOSTR_NIP46_SESSION_PREFIX}${nip46Pubkey}`,
+            'nip46-session-sentinel',
+        );
+        componentStorage.setItem('component-sentinel', 'keep');
+
+        const service = new AuthService({
+            ...createMockNip07Dependencies(nip07Pubkey),
+            localStorage: componentStorage,
+            localNsecAuthEnabled: false,
+        });
+        const accountManager = new AccountManager({ localStorage: componentStorage });
+        service.setAccountManager(accountManager);
+
+        await expect(service.initializeAuth()).resolves.toEqual({
+            hasAuth: true,
+            pubkeyHex: nip07Pubkey,
+        });
+        expect(accountManager.getAccounts()).toEqual([
+            { pubkeyHex: nip07Pubkey, type: 'nip07', addedAt: 2 },
+            { pubkeyHex: nip46Pubkey, type: 'nip46', addedAt: 3 },
+        ]);
+        expect(accountManager.getActiveAccountPubkey()).toBe(nip07Pubkey);
+        expect(componentStorage.getItem(STORAGE_KEYS.NOSTR_SECRET_KEY_LEGACY)).toBeNull();
+        expect(componentStorage.getItem(getNsecStorageKey(nsecPubkey))).toBeNull();
+        expect(componentStorage.getItem(
+            `${STORAGE_KEYS.NOSTR_NIP46_SESSION_PREFIX}${nip46Pubkey}`,
+        )).toBe('nip46-session-sentinel');
+        expect(componentStorage.getItem('component-sentinel')).toBe('keep');
+        for (const [key, value] of Object.entries(hostSentinels)) {
+            expect(hostStorage.getItem(key)).toBe(value);
+        }
+        expect(Array.from({ length: hostStorage.length }, (_, index) => hostStorage.key(index)))
+            .toContain(`${EHAGAKI_WEB_COMPONENT_STORAGE_PREFIX}component-sentinel`);
     });
 
     it('アカウントなし→レガシーNIP-07検出', async () => {

--- a/src/test/unit/authService.restore.test.ts
+++ b/src/test/unit/authService.restore.test.ts
@@ -79,6 +79,21 @@ describe('AuthService.restoreAccount', () => {
         );
     });
 
+    it('ローカルnsec認証が無効なruntimeではmanaged nsec restoreを開始しない', async () => {
+        const service = createManagedService(
+            { ...mockDependencies, localNsecAuthEnabled: false },
+            NSEC_PUBKEY,
+            'nsec',
+        );
+
+        await expect(service.restoreAccount(NSEC_PUBKEY, 'nsec')).resolves.toEqual({
+            hasAuth: false,
+            reason: 'local-nsec-auth-disabled',
+        });
+        expect(mockKeyManager.readStoredKey).not.toHaveBeenCalled();
+        expect(mockDependencies.setNsecAuth).not.toHaveBeenCalled();
+    });
+
     it('nsec: mismatchではsecret stateとauth stateを変更しない', async () => {
         mockKeyManager.readStoredKey.mockReturnValue({ status: 'found', secretKey: 'stored-nsec' });
         mockKeyManager.isValidNsec.mockReturnValue(true);

--- a/src/test/unit/loginDialog.test.ts
+++ b/src/test/unit/loginDialog.test.ts
@@ -6,6 +6,7 @@ import { locale, waitLocale } from 'svelte-i18n';
 const mockTranslate = vi.hoisted(() => (key: string) => {
     const translations: Record<string, string> = {
         'clearInput': '入力内容を消去',
+        'loginDialog.login_methods_hint': 'ログイン方法を選択',
         'loginDialog.input_secret': '秘密鍵',
         'loginDialog.hint_input_secret': 'nsec1から始まる秘密鍵を入力',
         'loginDialog.add_account_title': 'アカウントを追加',
@@ -124,6 +125,7 @@ describe('LoginDialog', () => {
         nip46NostrConnectErrorMessage: '',
         initialNostrConnectRelayCandidates: [...DEFAULT_NIP46_CONNECTION_RELAY_CANDIDATES],
         isAddAccountMode: false,
+        localNsecAuthEnabled: true,
     };
 
     beforeEach(async () => {
@@ -170,6 +172,21 @@ describe('LoginDialog', () => {
         });
 
         expect(screen.getAllByText('or').length).toBeGreaterThan(0);
+    });
+
+    it('ローカルnsec認証が無効な場合はnsec UIを生成せずNIP-07とNIP-46を維持する', () => {
+        render(LoginDialog, {
+            props: {
+                ...defaultProps,
+                localNsecAuthEnabled: false,
+            },
+        });
+
+        expect(screen.queryByPlaceholderText('nsec1...')).toBeNull();
+        expect(screen.queryByText('秘密鍵')).toBeNull();
+        expect(screen.getByText('ブラウザ拡張機能')).toBeTruthy();
+        expect(screen.getByText('リモートサイナー')).toBeTruthy();
+        expect(screen.queryByText(/Web Component.*秘密鍵/)).toBeNull();
     });
 
     it('Enter で送信した場合は保存処理を1回だけ実行する', async () => {

--- a/src/web-component/element.ts
+++ b/src/web-component/element.ts
@@ -267,6 +267,7 @@ export class EHagakiComposerElement extends HTMLElement {
                 serviceWorkerEnabled: false,
                 externalInputEnabled: false,
                 historyEnabled: false,
+                localNsecAuthEnabled: false,
             });
 
             const { default: App } = await import("../App.svelte");


### PR DESCRIPTION
## Summary

- Disable local nsec authentication only in the Direct Web Component runtime through an explicit runtime capability.
- Remove the nsec input from Direct Web Component login dialogs and block new saves, managed-account restores, legacy restores, and account switching into nsec accounts.
- On Direct Web Component startup, clean only the component-scoped `ehagaki.web-component.v1:` storage: remove nsec account records and credentials, repair the active account, and preserve NIP-07/NIP-46 accounts, NIP-46 sessions, profiles, relays, component settings, and raw host-page storage.
- Keep local nsec authentication unchanged for the PWA and iframe builds.
- Update Web Component documentation, the parent-client sample, runtime maps, and regression coverage.

## Verification

- `npm run check` — passed with 0 errors and 0 warnings.
- `npm test` — 333 files and 3,842 tests passed.
- `npm run build` — passed, including the PWA/service-worker build and Direct Web Component build.
- Targeted auth/login unit tests — 144 tests passed; final cleanup-focused rerun — 48 tests passed.
- Full Web Component Playwright suite on desktop Chromium, mobile Chromium, and mobile WebKit — 46 passed, 2 touch-only hover skips.
- Final targeted Direct Web Component Playwright cases on all three projects — 6 passed.
- `git diff --check` — passed.

Browser verification confirmed that the Direct Web Component renders no nsec DOM, retains NIP-07 and NIP-46 choices, fits the tested host widths, removes only component-scoped nsec data, and leaves host-page sentinel values and non-nsec data intact.

The existing Web Component theme assertion was updated from the older light-surface value to the current 94% token after the full suite exposed that stale expectation; no runtime theme behavior was changed here.

## Not run

- No physical Android or iPhone verification was performed. The mobile Chromium and mobile WebKit results are Playwright device emulation and do not prove real OS/browser/PWA behavior.
- Desktop Firefox was not run; the requested desktop Chromium, mobile Chromium, and mobile WebKit projects were covered.