### PR TITLE
Disable post editor while sending

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
                 '**/composerTargetDialog.spec.ts',
                 '**/webComponentEmbed.spec.ts',
                 '**/webComponentParentClientExample.spec.ts',
+                '**/postEditorSending.spec.ts',
             ],
             use: {
                 ...devices['iPhone 13'],

--- a/post-editor-sending-playwright.html
+++ b/post-editor-sending-playwright.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Post editor sending harness</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/test/e2e/postEditorSendingHarnessEntry.ts"></script>
+  </body>
+</html>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1037,6 +1037,12 @@
     }
   });
 
+  $effect(() => {
+    if (editorState.postStatus.sending && customEmojiPickerOpen) {
+      customEmojiPickerOpen = false;
+    }
+  });
+
   async function initializeNostr(pubkeyHex?: string): Promise<void> {
     await runInitializeNostrSession({
       pubkeyHex,
@@ -1819,6 +1825,11 @@
   }
 
   function handleCustomEmojiSelect(emoji: CustomEmojiSelection): void {
+    if (editorState.postStatus.sending) {
+      customEmojiPickerOpen = false;
+      return;
+    }
+
     postComponentRef?.insertCustomEmoji?.({
       identityKey: emoji.identityKey,
       shortcode: emoji.shortcode,

--- a/src/components/KeyboardButtonBar.svelte
+++ b/src/components/KeyboardButtonBar.svelte
@@ -252,7 +252,7 @@
                 contentLayout="icon"
                 className="custom-emoji-button"
                 selected={customEmojiPickerOpen}
-                disabled={!hasStoredKey}
+                disabled={!hasStoredKey || postStatus.sending}
                 onClick={() => {
                     setCustomEmojiPickerOpen(!customEmojiPickerOpen);
                 }}

--- a/src/components/MediaActionButtons.svelte
+++ b/src/components/MediaActionButtons.svelte
@@ -8,6 +8,7 @@
         deleteAriaLabel: string;
         copyAriaLabel: string;
         copySuccessMessage: string;
+        deleteDisabled?: boolean;
         /**
          * レイアウト種別: 各コンテナに応じたボタン配置・サイズを制御する
          * - editor-image: 画像エディタノード (40x40px, copy=bottom-right, delete=top-right)
@@ -23,6 +24,7 @@
         deleteAriaLabel,
         copyAriaLabel,
         copySuccessMessage,
+        deleteDisabled = false,
         layout = "editor-image",
     }: Props = $props();
 
@@ -33,6 +35,7 @@
 
     function handleDelete(event: MouseEvent) {
         event.stopPropagation();
+        if (deleteDisabled) return;
         onDelete();
     }
 </script>
@@ -52,6 +55,7 @@
     shape="circle"
     className="media-delete-btn media-delete-btn--{layout}"
     ariaLabel={deleteAriaLabel}
+    disabled={deleteDisabled}
     onClick={handleDelete}
 >
     <div class="close-icon svg-icon"></div>

--- a/src/components/MediaGallery.svelte
+++ b/src/components/MediaGallery.svelte
@@ -9,6 +9,7 @@
     } from "../lib/constants";
     import { consumeMediaGalleryWheelScroll } from "../lib/utils/mediaGalleryWheelUtils";
     import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
+    import { editorState } from "../stores/editorStore.svelte";
 
     // PC ドラッグ＆ドロップ状態
     let dragFromIndex = $state(-1);
@@ -27,6 +28,7 @@
     let autoScrollFrame: number | null = null;
 
     let items = $derived(mediaGalleryStore.items);
+    let isSending = $derived(editorState.postStatus.sending);
 
     // 現在有効な挿入位置（移動なしの場合は -1）
     let effectiveInsertIndex = $derived.by(() => {
@@ -40,6 +42,10 @@
 
     // --- PC DnD ハンドラ ---
     function handleDragStart(index: number, event: DragEvent) {
+        if (isSending) {
+            event.preventDefault();
+            return;
+        }
         dragFromIndex = index;
         event.dataTransfer?.setData("text/plain", String(index));
         if (event.dataTransfer) {
@@ -49,6 +55,7 @@
 
     function handleDragOver(index: number, event: DragEvent) {
         event.preventDefault();
+        if (isSending) return;
         // アイテムの左半分ならそのインデックス、右半分なら次の位置
         const wrappers = galleryEl?.querySelectorAll(".gallery-item-wrapper");
         const wrapperEl = wrappers?.[index] as HTMLElement | undefined;
@@ -77,6 +84,11 @@
     function handleGalleryDragOver(event: DragEvent) {
         if (dragFromIndex === -1) return;
         event.preventDefault();
+        if (isSending) {
+            stopGalleryAutoScroll();
+            pcInsertIndex = -1;
+            return;
+        }
 
         // アイテム外の空白エリアにカーソルがある場合、端の挿入位置を検出
         const wrappers = galleryEl?.querySelectorAll(".gallery-item-wrapper");
@@ -110,6 +122,11 @@
     function handleGalleryDrop(event: DragEvent) {
         event.preventDefault();
         stopGalleryAutoScroll();
+        if (isSending) {
+            dragFromIndex = -1;
+            pcInsertIndex = -1;
+            return;
+        }
         const insertIdx = pcInsertIndex;
         if (
             dragFromIndex !== -1 &&
@@ -127,6 +144,7 @@
     }
 
     function handleDelete(id: string) {
+        if (isSending) return;
         mediaGalleryStore.removeItem(id);
     }
 
@@ -188,6 +206,7 @@
 
     // --- タッチ DnD ハンドラ ---
     function handleTouchDragStart(index: number, x: number, y: number) {
+        if (isSending) return;
         touchDragIndex = index;
 
         // ドラッグプレビューの作成
@@ -234,6 +253,11 @@
     function handleGlobalTouchMove(event: TouchEvent) {
         if (touchDragIndex === -1 || event.touches.length !== 1) return;
         event.preventDefault();
+        if (isSending) {
+            stopGalleryAutoScroll();
+            touchInsertIndex = -1;
+            return;
+        }
 
         const touch = event.touches[0];
 
@@ -298,6 +322,13 @@
         document.removeEventListener("touchend", handleGlobalTouchEnd);
         stopGalleryAutoScroll();
 
+        if (isSending) {
+            removeTouchPreview();
+            touchDragIndex = -1;
+            touchInsertIndex = -1;
+            return;
+        }
+
         const insertIdx = touchInsertIndex;
         if (
             touchDragIndex !== -1 &&
@@ -356,6 +387,7 @@
 {#if items.length > 0}
     <div
         class="media-gallery"
+        class:sending={isSending}
         bind:this={galleryEl}
         ondragover={handleGalleryDragOver}
         ondrop={handleGalleryDrop}
@@ -378,6 +410,7 @@
                     onDragEnd={handleDragEnd}
                     onDrop={handleDrop}
                     onTouchDragStart={handleTouchDragStart}
+                    disabled={isSending}
                 />
             </div>
         {/each}
@@ -395,6 +428,19 @@
         scrollbar-width: thin;
         gap: 4px;
         background-color: var(--window);
+    }
+
+    .media-gallery.sending {
+        background-color: color-mix(
+            in srgb,
+            var(--window) 82%,
+            var(--surface-button) 18%
+        );
+        cursor: not-allowed;
+    }
+
+    .media-gallery.sending :global(.gallery-item) {
+        cursor: not-allowed;
     }
 
     .gallery-item-wrapper {

--- a/src/components/MediaGalleryItem.svelte
+++ b/src/components/MediaGalleryItem.svelte
@@ -16,6 +16,7 @@
         onDragEnd: () => void;
         onDrop: (toIndex: number) => void;
         onTouchDragStart?: (index: number, x: number, y: number) => void;
+        disabled?: boolean;
     }
 
     let {
@@ -27,6 +28,7 @@
         onDragEnd,
         onDrop,
         onTouchDragStart,
+        disabled = false,
     }: Props = $props();
 
     let cardEl: HTMLDivElement | undefined = $state();
@@ -37,6 +39,7 @@
     // タッチ長押しドラッグ（親コンポーネントに委譲）
     useLongPress(() => cardEl, {
         onLongPress: (x, y) => {
+            if (disabled) return;
             onTouchDragStart?.(index, x, y);
         },
     });
@@ -83,6 +86,10 @@
 
     // PC ドラッグ＆ドロップ
     function handleDragStartEvent(event: DragEvent) {
+        if (disabled) {
+            event.preventDefault();
+            return;
+        }
         // オーバーレイからのドラッグ時はカード全体をゴースト画像に使用
         if (cardEl && event.dataTransfer) {
             const rect = cardEl.getBoundingClientRect();
@@ -106,11 +113,13 @@
 
     function handleDragOverEvent(event: DragEvent) {
         event.preventDefault();
+        if (disabled) return;
         onDragOver(index, event);
     }
 
     function handleDropEvent(event: DragEvent) {
         event.preventDefault();
+        if (disabled) return;
         onDrop(index);
     }
 
@@ -129,7 +138,8 @@
     bind:this={cardEl}
     class="gallery-item"
     class:is-placeholder={item.isPlaceholder}
-    draggable={item.type !== "video" || item.isPlaceholder}
+    class:is-disabled={disabled}
+    draggable={!disabled && (item.type !== "video" || item.isPlaceholder)}
     ondragstart={handleDragStartEvent}
     ondragover={handleDragOverEvent}
     ondrop={handleDropEvent}
@@ -195,7 +205,7 @@
                 <!-- svelte-ignore a11y_no_static_element_interactions -->
                 <div
                     class="video-drag-overlay"
-                    draggable="true"
+                    draggable={!disabled}
                     ondragstart={handleDragStartEvent}
                     onclick={handleOverlayClick}
                     aria-hidden="true"
@@ -213,6 +223,7 @@
             copyAriaLabel={$_("imageContextMenu.copyUrl")}
             copySuccessMessage={$_("imageContextMenu.copySuccess")}
             layout="gallery"
+            deleteDisabled={disabled}
         />
     {/if}
 </div>
@@ -246,6 +257,16 @@
     .gallery-item:active,
     .video-drag-overlay:active {
         cursor: grabbing;
+    }
+
+    .gallery-item.is-disabled,
+    .gallery-item.is-disabled .gallery-item-media,
+    .gallery-item.is-disabled .video-drag-overlay {
+        cursor: not-allowed;
+    }
+
+    .gallery-item.is-disabled {
+        opacity: 0.82;
     }
 
     .gallery-item {

--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -125,6 +125,16 @@
     updatePlaceholderText(editorPlaceholderText);
   });
 
+  $effect(() => {
+    const editorInstance = currentEditor;
+    const editable = !postStatus.sending;
+
+    if (editorInstance && editorInstance.isEditable !== editable) {
+      // Tiptap v3 supports suppressing the update event for this option-only change.
+      editorInstance.setEditable(editable, false);
+    }
+  });
+
   function syncEditorTargetHeight() {
     const minHeight = minEditorHeight;
 
@@ -152,6 +162,11 @@
   }
 
   function handleEditorContainerClick(event: MouseEvent) {
+    if (postStatus.sending) {
+      event.preventDefault();
+      return;
+    }
+
     if (!(event.target instanceof HTMLElement) || !currentEditor) {
       return;
     }
@@ -164,6 +179,11 @@
   }
 
   function handleEditorContainerKeydown(event: KeyboardEvent) {
+    if (postStatus.sending) {
+      event.preventDefault();
+      return;
+    }
+
     if (
       !currentEditor ||
       event.currentTarget !== event.target ||
@@ -465,7 +485,7 @@
   }
 
   export function insertCustomEmoji(emoji: CustomEmojiAttrs): void {
-    if (!currentEditor) return;
+    if (!currentEditor || postStatus.sending) return;
     insertCustomEmojiWithoutUnwantedKeyboard(currentEditor, emoji);
   }
 
@@ -717,6 +737,7 @@
     class="editor-container"
     class:drag-over={dragOver}
     class:gallery-mode={!mediaFreePlacement}
+    class:sending={postStatus.sending}
     onclick={handleEditorContainerClick}
     onkeydown={handleEditorContainerKeydown}
     use:fileDropActionWithDragState={{
@@ -726,6 +747,7 @@
     use:touchAction
     use:keydownAction
     aria-label={$_("postComponent.editor_label")}
+    aria-disabled={postStatus.sending ? "true" : undefined}
     role="textbox"
     tabindex="-1"
     bind:this={editorContainerEl}
@@ -837,6 +859,22 @@
     background: var(--bg-input);
     -webkit-tap-highlight-color: transparent;
     overflow: hidden;
+  }
+
+  .editor-container.sending {
+    background: color-mix(in srgb, var(--bg-input) 82%, var(--surface-button) 18%);
+    cursor: not-allowed;
+  }
+
+  .editor-container.sending :global(.tiptap-editor) {
+    cursor: not-allowed;
+    opacity: 0.82;
+  }
+
+  .editor-container.sending :global(.editor-image-button),
+  .editor-container.sending :global(.custom-emoji-drag-target),
+  .editor-container.sending :global(.media-delete-btn) {
+    pointer-events: none;
   }
 
   .editor-container.drag-over {

--- a/src/lib/editor/clipboardExtension.ts
+++ b/src/lib/editor/clipboardExtension.ts
@@ -118,6 +118,11 @@ export const ClipboardExtension = Extension.create({
                      * 6. Sliceを作成してエディタに挿入
                      */
                     handlePaste(view, event, slice) {
+                        if (view.editable === false) {
+                            event.preventDefault();
+                            return true;
+                        }
+
                         const { state, dispatch } = view;
                         const { clipboardData } = event;
 

--- a/src/lib/editor/customEmojiDragDrop.ts
+++ b/src/lib/editor/customEmojiDragDrop.ts
@@ -120,6 +120,11 @@ export const CustomEmojiDragDropExtension = Extension.create({
                 },
                 props: {
                     handleDrop: (view, event) => {
+                        if (view.editable === false) {
+                            event.preventDefault();
+                            return true;
+                        }
+
                         const nodeData = parseCustomEmojiDragData(event);
                         if (!nodeData) return false;
 
@@ -147,6 +152,11 @@ export const CustomEmojiDragDropExtension = Extension.create({
                     },
                     handleDOMEvents: {
                         dragstart: (view, event) => {
+                            if (view.editable === false) {
+                                event.preventDefault();
+                                return true;
+                            }
+
                             const dragEvent = event as DragEvent;
                             const nodeData = getCustomEmojiDragData(view, dragEvent);
                             if (!nodeData) return false;
@@ -170,7 +180,12 @@ export const CustomEmojiDragDropExtension = Extension.create({
                             );
                             return false;
                         },
-                        dragover: (_view, event) => {
+                        dragover: (view, event) => {
+                            if (view.editable === false) {
+                                event.preventDefault();
+                                return true;
+                            }
+
                             const dragEvent = event as DragEvent;
                             if (!dragEvent.dataTransfer?.types?.includes(INTERNAL_NODE_MIME)) {
                                 return false;
@@ -181,6 +196,8 @@ export const CustomEmojiDragDropExtension = Extension.create({
                             return false;
                         },
                         dragend: (view) => {
+                            if (view.editable === false) return false;
+
                             setDraggingFalse(view);
                             return false;
                         },
@@ -233,6 +250,11 @@ export const CustomEmojiDragDropExtension = Extension.create({
                     };
 
                     const handleTouchDrop = (event: CustomEvent) => {
+                        if (editorView.editable === false) {
+                            stopAutoScroll();
+                            return;
+                        }
+
                         stopAutoScroll();
                         const { nodeData, dropPosition, dropX, dropY } = event.detail;
                         editorView.dispatch(
@@ -267,6 +289,8 @@ export const CustomEmojiDragDropExtension = Extension.create({
                     };
 
                     const handleTouchDragStart = (event: CustomEvent) => {
+                        if (editorView.editable === false) return;
+
                         const { nodePos } = event.detail;
                         editorView.dispatch(
                             editorView.state.tr.setMeta(CUSTOM_EMOJI_DRAG_META, {
@@ -277,6 +301,11 @@ export const CustomEmojiDragDropExtension = Extension.create({
                     };
 
                     const handleTouchMove = (event: CustomEvent) => {
+                        if (editorView.editable === false) {
+                            stopAutoScroll();
+                            return;
+                        }
+
                         const { touchY } = event.detail;
                         if (typeof touchY !== 'number') return;
 
@@ -294,6 +323,8 @@ export const CustomEmojiDragDropExtension = Extension.create({
                     };
 
                     const handleNativeDragStart = (event: CustomEvent) => {
+                        if (editorView.editable === false) return;
+
                         const { nodePos } = event.detail;
                         editorView.dispatch(
                             editorView.state.tr.setMeta(CUSTOM_EMOJI_DRAG_META, {
@@ -304,6 +335,8 @@ export const CustomEmojiDragDropExtension = Extension.create({
                     };
 
                     const handleNativeDragEnd = () => {
+                        if (editorView.editable === false) return;
+
                         setDraggingFalse(editorView);
                     };
 

--- a/src/lib/editor/editorDomActions.svelte.ts
+++ b/src/lib/editor/editorDomActions.svelte.ts
@@ -34,10 +34,25 @@ function hasExternalFiles(dt: DataTransfer | null | undefined): boolean {
     }
 }
 
+function isPostSending(node: HTMLElement): boolean {
+    const rawPostStatus = (node as any).__postStatus;
+    const postStatus = typeof rawPostStatus === "function"
+        ? rawPostStatus()
+        : rawPostStatus as { sending: boolean } | undefined;
+    return postStatus?.sending === true;
+}
+
 // fileDropAction
 export function fileDropAction(node: HTMLElement) {
     let dragOver = $state(false);
     function handleDragOver(event: DragEvent) {
+        if (isPostSending(node)) {
+            event.preventDefault();
+            dragOver = false;
+            node.classList.remove("drag-over");
+            return;
+        }
+
         const dt = event.dataTransfer;
         const internal = isInternalTiptapDrag(dt);
         const externalFiles = hasExternalFiles(dt);
@@ -69,6 +84,11 @@ export function fileDropAction(node: HTMLElement) {
         // 常に drag-over をリセット
         dragOver = false;
         node.classList.remove("drag-over");
+
+        if (isPostSending(node)) {
+            event.preventDefault();
+            return;
+        }
 
         const dt = event.dataTransfer;
         // 内部ドラッグ（エディタ内ノード）なら何もしない — ProseMirror が処理する
@@ -106,6 +126,12 @@ export function fileDropActionWithDragState(
 ) {
     const action = fileDropAction(node);
     function handleDragOver(event: DragEvent) {
+        if (isPostSending(node)) {
+            event.preventDefault();
+            params.dragOver(false);
+            return;
+        }
+
         const dt = event.dataTransfer;
         const internal = isInternalTiptapDrag(dt);
         const externalFiles = hasExternalFiles(dt);
@@ -122,6 +148,9 @@ export function fileDropActionWithDragState(
     }
     function handleDrop(event: DragEvent) {
         params.dragOver(false);
+        if (isPostSending(node)) {
+            event.preventDefault();
+        }
     }
     node.addEventListener("dragover", handleDragOver);
     node.addEventListener("dragleave", handleDragLeave);
@@ -140,6 +169,11 @@ export function fileDropActionWithDragState(
 // 画像ファイルのペーストのみを処理（テキストペーストはClipboardExtensionで処理）
 export function pasteAction(node: HTMLElement) {
     function handlePaste(event: ClipboardEvent) {
+        if (isPostSending(node)) {
+            event.preventDefault();
+            return;
+        }
+
         if (!event.clipboardData) return;
         const files: File[] = [];
         for (const item of event.clipboardData.items) {

--- a/src/lib/editor/imageDragDrop.ts
+++ b/src/lib/editor/imageDragDrop.ts
@@ -38,6 +38,11 @@ export const ImageDragDropExtension = Extension.create({
                 },
                 props: {
                     handleDrop: (view, event, _slice, moved) => {
+                        if (view.editable === false) {
+                            event.preventDefault();
+                            return true;
+                        }
+
                         const dragData = event.dataTransfer?.getData('application/x-tiptap-node');
                         if (!moved && dragData) {
                             try {
@@ -68,21 +73,36 @@ export const ImageDragDropExtension = Extension.create({
                         return false;
                     },
                     handleDOMEvents: {
-                        dragstart: (_view, event) => {
+                        dragstart: (view, event) => {
+                            if (view.editable === false) {
+                                event.preventDefault();
+                                return true;
+                            }
+
                             if (isTouchDevice()) {
                                 event.preventDefault();
                                 return true;
                             }
                             return false;
                         },
-                        dragover: (_view, event) => {
+                        dragover: (view, event) => {
+                            if (view.editable === false) {
+                                event.preventDefault();
+                                return true;
+                            }
+
                             if (isTouchDevice()) {
                                 event.preventDefault();
                                 return true;
                             }
                             return false;
                         },
-                        drop: (_view, event) => {
+                        drop: (view, event) => {
+                            if (view.editable === false) {
+                                event.preventDefault();
+                                return true;
+                            }
+
                             if (isTouchDevice()) {
                                 event.preventDefault();
                                 return true;
@@ -152,6 +172,11 @@ export const ImageDragDropExtension = Extension.create({
                     };
 
                     const handleTouchDrop = (event: CustomEvent) => {
+                        if (editorView.editable === false) {
+                            stopAutoScroll();
+                            return;
+                        }
+
                         const { nodeData, dropPosition, dropX, dropY } = event.detail;
                         stopAutoScroll();
 
@@ -181,6 +206,8 @@ export const ImageDragDropExtension = Extension.create({
                     };
 
                     const handleTouchDragStart = (event: CustomEvent) => {
+                        if (editorView.editable === false) return;
+
                         const { nodePos } = event.detail;
                         editorView.dispatch(
                             editorView.state.tr.setMeta('imageDrag', {
@@ -191,6 +218,11 @@ export const ImageDragDropExtension = Extension.create({
                     };
 
                     const handleTouchMove = (event: CustomEvent) => {
+                        if (editorView.editable === false) {
+                            stopAutoScroll();
+                            return;
+                        }
+
                         const { touchY } = event.detail;
                         if (typeof touchY !== 'number') return;
 

--- a/src/lib/editor/mediaPaste.ts
+++ b/src/lib/editor/mediaPaste.ts
@@ -122,6 +122,11 @@ export const MediaPasteExtension = Extension.create({
                 key: new PluginKey('image-paste'),
                 props: {
                     handlePaste: (view, event) => {
+                        if (view.editable === false) {
+                            event.preventDefault();
+                            return true;
+                        }
+
                         const text = event.clipboardData?.getData('text/plain') || '';
                         const mediaUrls = extractMediaUrls(text);
 
@@ -186,6 +191,10 @@ export const MediaPasteExtension = Extension.create({
 
                     // スマートフォン対応: inputイベントも処理
                     handleTextInput: (view, from, to, text) => {
+                        if (view.editable === false) {
+                            return true;
+                        }
+
                         // 改行を含む長いテキストが入力された場合のみ処理
                         if (text.includes('\n') || text.length > 20) {
                             const mediaUrls = extractMediaUrls(text);

--- a/src/test/e2e/PostEditorSendingHarness.svelte
+++ b/src/test/e2e/PostEditorSendingHarness.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+    import { onDestroy } from 'svelte';
+    import PostComponent from '../../components/PostComponent.svelte';
+    import { editorState, resetPostStatus, updatePostStatus } from '../../stores/editorStore.svelte';
+
+    let sending = $derived(editorState.postStatus.sending);
+
+    function toggleSending(): void {
+        updatePostStatus({ ...editorState.postStatus, sending: !editorState.postStatus.sending });
+    }
+
+    onDestroy(() => {
+        resetPostStatus();
+    });
+</script>
+
+<main>
+    <button type="button" data-testid="toggle-sending" onclick={toggleSending}>
+        Toggle sending
+    </button>
+    <output data-testid="sending-state">{sending ? 'sending' : 'idle'}</output>
+    <PostComponent hasStoredKey={true} />
+</main>

--- a/src/test/e2e/postEditorSending.spec.ts
+++ b/src/test/e2e/postEditorSending.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('post editor sending state', () => {
+    test('keeps the content readable and blocks editing in light and dark themes', async ({ page }) => {
+        for (const colorScheme of ['light', 'dark'] as const) {
+            await page.emulateMedia({ colorScheme });
+            await page.goto('post-editor-sending-playwright.html');
+
+            const editorContainer = page.getByRole('textbox', { name: '投稿エディター' });
+            const editor = editorContainer.locator('.tiptap-editor');
+            await expect(editor).toHaveAttribute('contenteditable', 'true');
+
+            await editor.click();
+            await page.keyboard.type('送信中も確認する本文');
+            await expect(editor).toContainText('送信中も確認する本文');
+
+            await page.getByTestId('toggle-sending').click();
+            await expect(page.getByTestId('sending-state')).toHaveText('sending');
+            await expect(editorContainer).toHaveClass(/sending/);
+            await expect(editorContainer).toHaveAttribute('aria-disabled', 'true');
+            await expect(editor).toHaveAttribute('contenteditable', 'false');
+            await expect(editor).toContainText('送信中も確認する本文');
+            await expect.poll(() => editor.evaluate((element) => getComputedStyle(element).opacity)).toBe('0.82');
+
+            await editor.click();
+            await page.keyboard.type('変更不可');
+            await expect(editor).toHaveText('送信中も確認する本文');
+
+            await page.getByTestId('toggle-sending').click();
+            await expect(page.getByTestId('sending-state')).toHaveText('idle');
+            await expect(editor).toHaveAttribute('contenteditable', 'true');
+            await expect(editorContainer).not.toHaveClass(/sending/);
+            await expect(editorContainer).not.toHaveAttribute('aria-disabled');
+
+            await editor.click();
+            await page.keyboard.type('編集再開');
+            await expect(editor).toContainText('編集再開');
+        }
+    });
+});

--- a/src/test/e2e/postEditorSendingHarnessEntry.ts
+++ b/src/test/e2e/postEditorSendingHarnessEntry.ts
@@ -1,0 +1,12 @@
+import '../../app.css';
+import '../../i18n';
+import { mount } from 'svelte';
+import PostEditorSendingHarness from './PostEditorSendingHarness.svelte';
+
+const target = document.getElementById('app');
+
+if (!target) {
+    throw new Error('Harness mount target was not found.');
+}
+
+mount(PostEditorSendingHarness, { target });

--- a/src/test/unit/accessibilityComponent.test.ts
+++ b/src/test/unit/accessibilityComponent.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import '../../i18n';
 import { locale, waitLocale } from 'svelte-i18n';
@@ -68,6 +68,7 @@ import SvelteImageNode from '../../components/SvelteImageNode.svelte';
 import SvelteVideoNode from '../../components/SvelteVideoNode.svelte';
 import ProfileComponent from '../../components/ProfileComponent.svelte';
 import { authState } from '../../stores/authStore.svelte';
+import { currentEditorStore, editorState, resetPostStatus, updatePostStatus } from '../../stores/editorStore.svelte';
 import { profileDataStore } from '../../stores/profileStore.svelte';
 import { handleImageInteraction, requestNodeSelection } from '../../lib/utils/mediaNodeUtils';
 
@@ -137,6 +138,65 @@ describe('accessibility component tests', () => {
         await waitLocale();
 
         expect(screen.getByRole('textbox', { name: 'Post editor' })).toBeTruthy();
+    });
+
+    it('makes the editor read-only only while a post is sending', async () => {
+        resetPostStatus();
+        const { component, unmount } = render(PostComponent, {
+            hasStoredKey: true,
+        });
+        const editorContainer = screen.getByRole('textbox', { name: '投稿エディター' });
+        const tiptapEditor = await waitFor(() => {
+            const element = editorContainer.querySelector<HTMLElement>('.tiptap-editor');
+            if (!element || !currentEditorStore.value) {
+                throw new Error('Editor was not initialized');
+            }
+            return element;
+        });
+        const editor = currentEditorStore.value!;
+        editor.commands.setContent('<p>送信中も確認できる本文</p>', { emitUpdate: false });
+        const updateListener = vi.fn();
+        editor.on('update', updateListener);
+
+        expect(editor.isEditable).toBe(true);
+        expect(tiptapEditor.getAttribute('contenteditable')).toBe('true');
+        expect(editorContainer.classList.contains('sending')).toBe(false);
+
+        updatePostStatus({ ...editorState.postStatus, sending: true });
+        await tick();
+
+        expect(editor.isEditable).toBe(false);
+        expect(tiptapEditor.getAttribute('contenteditable')).toBe('false');
+        expect(editorContainer.classList.contains('sending')).toBe(true);
+        expect(editorContainer.getAttribute('aria-disabled')).toBe('true');
+        expect(editorContainer.textContent).toContain('送信中も確認できる本文');
+        expect(updateListener).not.toHaveBeenCalled();
+
+        const contentBeforeInput = editor.getJSON();
+        await fireEvent.input(tiptapEditor, {
+            inputType: 'insertText',
+            data: '変更不可',
+        });
+        expect(editor.getJSON()).toEqual(contentBeforeInput);
+
+        (component as any).insertCustomEmoji({
+            identityKey: 'test\u0000https://example.com/test.webp',
+            shortcode: 'test',
+            src: 'https://example.com/test.webp',
+            setAddress: null,
+        });
+        expect(editor.getJSON()).toEqual(contentBeforeInput);
+
+        updatePostStatus({ ...editorState.postStatus, sending: false });
+        await tick();
+
+        expect(editor.isEditable).toBe(true);
+        expect(tiptapEditor.getAttribute('contenteditable')).toBe('true');
+        expect(editorContainer.classList.contains('sending')).toBe(false);
+        expect(editorContainer.getAttribute('aria-disabled')).toBeNull();
+
+        unmount();
+        resetPostStatus();
     });
 
     it('SvelteImageNode uses the provided alt and localized fallbacks', async () => {

--- a/src/test/unit/editorDomActions.test.ts
+++ b/src/test/unit/editorDomActions.test.ts
@@ -97,7 +97,7 @@ function createDragEvent(type: string, dataTransfer?: DragEventDataTransferLike)
 }
 
 function createClipboardEvent(type: string, clipboardData: ClipboardDataLike): ClipboardEvent {
-    const event = new ClipboardEvent(type, { bubbles: true });
+    const event = new ClipboardEvent(type, { bubbles: true, cancelable: true });
     Object.defineProperty(event, "clipboardData", {
         value: clipboardData,
     });
@@ -157,6 +157,20 @@ describe("fileDropAction", () => {
         node.dispatchEvent(event);
         expect(node.__uploadFiles).not.toHaveBeenCalled();
     });
+
+    it("rejects file drops while a post is sending", () => {
+        node.__postStatus = { sending: true };
+        const file = new File(["foo"], "foo.png", { type: "image/png" });
+        const event = createDragEvent("drop", {
+            files: [file],
+            types: ["Files"],
+        });
+
+        node.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(node.__uploadFiles).not.toHaveBeenCalled();
+    });
 });
 
 describe("pasteAction", () => {
@@ -199,6 +213,23 @@ describe("pasteAction", () => {
         };
         const event = createClipboardEvent("paste", clipboardData);
         node.dispatchEvent(event);
+        expect(node.__uploadFiles).not.toHaveBeenCalled();
+    });
+
+    it("rejects image paste while a post is sending", () => {
+        node.__postStatus = { sending: true };
+        const file = new File(["foo"], "foo.png", { type: "image/png" });
+        const event = createClipboardEvent("paste", {
+            items: [{
+                kind: "file",
+                type: "image/png",
+                getAsFile: () => file,
+            }],
+        });
+
+        node.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
         expect(node.__uploadFiles).not.toHaveBeenCalled();
     });
 });

--- a/src/test/unit/keyboardButtonBar.test.ts
+++ b/src/test/unit/keyboardButtonBar.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
+import { clearAuthState, updateAuthState } from '../../stores/authStore.svelte';
+import { editorState, resetPostStatus } from '../../stores/editorStore.svelte';
 
 const mockTranslate = vi.hoisted(() => (key: string) => {
     const translations: Record<string, string> = {
@@ -28,6 +30,8 @@ describe('KeyboardButtonBar', () => {
     afterEach(() => {
         vi.useRealTimers();
         document.documentElement.style.removeProperty('--keyboard-height');
+        clearAuthState();
+        resetPostStatus();
     });
 
     it('button 押下前の pointerdown で focus 移動を抑止する', () => {
@@ -116,5 +120,15 @@ describe('KeyboardButtonBar', () => {
         expect(editor.getAttribute('inputmode')).toBe('text');
         expect(editor.getAttribute('virtualkeyboardpolicy')).toBe('auto');
         expect(document.activeElement).toBe(editor);
+    });
+
+    it('送信中はカスタム絵文字Pickerを開くボタンを無効化する', () => {
+        updateAuthState({ type: 'nip46', isValid: true });
+        editorState.postStatus.sending = true;
+
+        render(KeyboardButtonBarWithProvider);
+
+        const button = screen.getByRole('button', { name: 'カスタム絵文字' });
+        expect(button.hasAttribute('disabled')).toBe(true);
     });
 });

--- a/src/test/unit/mediaGallery.test.ts
+++ b/src/test/unit/mediaGallery.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, cleanup, render } from "@testing-library/svelte";
+import { readable } from "svelte/store";
+import { tick } from "svelte";
+import type { MediaGalleryItem } from "../../lib/types";
+import MediaGallery from "../../components/MediaGallery.svelte";
+import {
+    editorState,
+    resetPostStatus,
+    updatePostStatus,
+} from "../../stores/editorStore.svelte";
+import { mediaGalleryStore } from "../../stores/mediaGalleryStore.svelte";
+
+const mockTranslate = vi.hoisted(() => (key: string) => {
+    const translations: Record<string, string> = {
+        "mediaGallery.aria_label": "メディアギャラリー",
+        "imageContextMenu.delete": "削除",
+        "imageContextMenu.copyUrl": "URLをコピー",
+        "imageContextMenu.copySuccess": "コピーしました",
+    };
+
+    return translations[key] || key;
+});
+
+vi.mock("svelte-i18n", () => ({
+    _: readable(mockTranslate),
+}));
+
+function createItem(id: string): MediaGalleryItem {
+    return {
+        id,
+        type: "image",
+        src: `https://example.com/${id}.png`,
+        isPlaceholder: false,
+        alt: id,
+    };
+}
+
+function createDragEvent(type: string, clientX = 10): DragEvent {
+    const event = new Event(type, {
+        bubbles: true,
+        cancelable: true,
+    }) as DragEvent;
+    Object.defineProperty(event, "clientX", { value: clientX });
+    Object.defineProperty(event, "dataTransfer", {
+        value: {
+            effectAllowed: "none",
+            setData: vi.fn(),
+            setDragImage: vi.fn(),
+        },
+    });
+    return event;
+}
+
+function createTouchEvent(type: string, clientX = 10): TouchEvent {
+    const event = new Event(type, {
+        bubbles: true,
+        cancelable: true,
+    }) as TouchEvent;
+    Object.defineProperty(event, "touches", {
+        value:
+            type === "touchend"
+                ? []
+                : [{ clientX, clientY: 10 }],
+    });
+    return event;
+}
+
+describe("MediaGallery sending state", () => {
+    beforeEach(() => {
+        mediaGalleryStore.clearAll();
+        resetPostStatus();
+        mediaGalleryStore.addItem(createItem("image-1"));
+        mediaGalleryStore.addItem(createItem("image-2"));
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.useRealTimers();
+        mediaGalleryStore.clearAll();
+        resetPostStatus();
+    });
+
+    it("blocks deletion and PC reorder while sending, then restores both operations", async () => {
+        const { container } = render(MediaGallery);
+        const gallery = container.querySelector<HTMLElement>(".media-gallery")!;
+        const firstItem = gallery.querySelector<HTMLElement>(".gallery-item")!;
+        const secondItem = gallery.querySelectorAll<HTMLElement>(".gallery-item")[1];
+
+        // A drag that started before sending must not be committed after sending starts.
+        firstItem.dispatchEvent(createDragEvent("dragstart"));
+        updatePostStatus({ ...editorState.postStatus, sending: true });
+        await tick();
+
+        expect(gallery.classList.contains("sending")).toBe(true);
+        expect(
+            (gallery.querySelector(".media-delete-btn") as HTMLButtonElement)
+                .disabled,
+        ).toBe(true);
+
+        const blockedStart = createDragEvent("dragstart");
+        expect(firstItem.dispatchEvent(blockedStart)).toBe(false);
+
+        secondItem.dispatchEvent(createDragEvent("dragover"));
+        gallery.dispatchEvent(createDragEvent("drop"));
+        await tick();
+        expect(mediaGalleryStore.items.map((item) => item.id)).toEqual([
+            "image-1",
+            "image-2",
+        ]);
+
+        await fireEvent.click(gallery.querySelector(".media-delete-btn")!);
+        expect(mediaGalleryStore.items.map((item) => item.id)).toEqual([
+            "image-1",
+            "image-2",
+        ]);
+
+        updatePostStatus({ ...editorState.postStatus, sending: false });
+        await tick();
+
+        expect(gallery.classList.contains("sending")).toBe(false);
+        expect(
+            (gallery.querySelector(".media-delete-btn") as HTMLButtonElement)
+                .disabled,
+        ).toBe(false);
+
+        const refreshedItems = gallery.querySelectorAll<HTMLElement>(".gallery-item");
+        refreshedItems[0].dispatchEvent(createDragEvent("dragstart"));
+        refreshedItems[1].dispatchEvent(createDragEvent("dragover"));
+        gallery.dispatchEvent(createDragEvent("drop"));
+        await tick();
+
+        expect(mediaGalleryStore.items.map((item) => item.id)).toEqual([
+            "image-2",
+            "image-1",
+        ]);
+
+        await fireEvent.click(gallery.querySelector(".media-delete-btn")!);
+        expect(mediaGalleryStore.items.map((item) => item.id)).toEqual([
+            "image-1",
+        ]);
+    });
+
+    it("does not commit a touch reorder while sending and restores it afterward", async () => {
+        vi.useFakeTimers();
+        const { container } = render(MediaGallery);
+        const gallery = container.querySelector<HTMLElement>(".media-gallery")!;
+        const firstItem = gallery.querySelector<HTMLElement>(".gallery-item")!;
+        const secondWrapper = gallery.querySelectorAll<HTMLElement>(
+            ".gallery-item-wrapper",
+        )[1];
+        const originalElementFromPoint = document.elementFromPoint;
+        Object.defineProperty(document, "elementFromPoint", {
+            configurable: true,
+            value: vi.fn(() => secondWrapper),
+        });
+
+        try {
+            firstItem.dispatchEvent(createTouchEvent("touchstart"));
+            vi.advanceTimersByTime(400);
+
+            document.dispatchEvent(createTouchEvent("touchmove"));
+            updatePostStatus({ ...editorState.postStatus, sending: true });
+            await tick();
+            document.dispatchEvent(createTouchEvent("touchend"));
+            await tick();
+
+            expect(mediaGalleryStore.items.map((item) => item.id)).toEqual([
+                "image-1",
+                "image-2",
+            ]);
+
+            updatePostStatus({ ...editorState.postStatus, sending: false });
+            await tick();
+
+            firstItem.dispatchEvent(createTouchEvent("touchstart"));
+            vi.advanceTimersByTime(400);
+            document.dispatchEvent(createTouchEvent("touchmove"));
+            document.dispatchEvent(createTouchEvent("touchend"));
+            await tick();
+
+            expect(mediaGalleryStore.items.map((item) => item.id)).toEqual([
+                "image-2",
+                "image-1",
+            ]);
+        } finally {
+            Object.defineProperty(document, "elementFromPoint", {
+                configurable: true,
+                value: originalElementFromPoint,
+            });
+        }
+    });
+});

--- a/src/test/unit/playwrightWorktreePort.test.ts
+++ b/src/test/unit/playwrightWorktreePort.test.ts
@@ -113,6 +113,7 @@ describe('Playwright config connection values', () => {
             '**/composerTargetDialog.spec.ts',
             '**/webComponentEmbed.spec.ts',
             '**/webComponentParentClientExample.spec.ts',
+            '**/postEditorSending.spec.ts',
         ]);
     });
 


### PR DESCRIPTION
## Summary

- Switch the existing Tiptap editor to read-only while `editorState.postStatus.sending` is true.
- Add a muted, clearly disabled editor presentation and block custom DOM editing paths during submission.
- Add unit/component coverage and deterministic Playwright coverage for desktop Chromium, mobile Chromium, and mobile WebKit in light and dark themes.

## Root cause

The editor itself had no synchronization from the existing sending status to Tiptap's editable option, and several upload/drag/picker paths were implemented outside Tiptap's normal editable handling.

## Validation

- `npm run check`
- `npm test`
- `npm run build`
- `git diff --check`
- `npx playwright test src/test/e2e/postEditorSending.spec.ts --project=desktop-chromium --project=mobile-chromium --project=mobile-webkit`