### PR TITLE
Add eHagaki NIP-46 client metadata

### DIFF
--- a/src/lib/nip46Service.ts
+++ b/src/lib/nip46Service.ts
@@ -54,6 +54,11 @@ const NIP46_FINAL_LOCAL_RELAY_UNREACHABLE_MESSAGE =
     'Could not connect to the local relay specified by the remote signer';
 const NIP46_FINAL_RELAY_VERIFICATION_FAILED_MESSAGE =
     'Communication could not be verified on the relay selected by the remote signer';
+const NIP46_CLIENT_METADATA = {
+    name: EHAGAKI_APP_NAME,
+    url: 'https://lokuyow.github.io/ehagaki/',
+    image: 'https://lokuyow.github.io/ehagaki/ehagaki_icon_x192.png',
+} as const;
 
 type Nip46LogFailureReason =
     | 'unexpected'
@@ -1576,6 +1581,12 @@ export class Nip46Service {
                 ? [originalSecret]
                 : [originalSecret, normalizedSecret];
             const connectParamCandidates = secretCandidates.flatMap((secret) => [
+                [
+                    bunkerPointer.pubkey,
+                    secret,
+                    NIP46_REQUESTED_PERMS,
+                    JSON.stringify(NIP46_CLIENT_METADATA),
+                ],
                 [bunkerPointer.pubkey, secret, NIP46_REQUESTED_PERMS],
                 [bunkerPointer.pubkey, secret],
             ]);
@@ -1685,7 +1696,7 @@ export class Nip46Service {
             relays: sanitizedRelays,
             secret: sharedSecret,
             perms: [...NIP46_REQUESTED_PERMISSIONS],
-            name: EHAGAKI_APP_NAME,
+            ...NIP46_CLIENT_METADATA,
         });
 
         let handshakeClosed = false;
@@ -2018,7 +2029,7 @@ export class Nip46Service {
                     relays: connectedRelays,
                     secret: sharedSecret,
                     perms: [...NIP46_REQUESTED_PERMISSIONS],
-                    name: EHAGAKI_APP_NAME,
+                    ...NIP46_CLIENT_METADATA,
                 });
 
                 if (settled) {
@@ -2323,6 +2334,12 @@ export class Nip46Service {
             });
 
             const reconnectConnectParamCandidates = [
+                [
+                    bunkerPointer.pubkey,
+                    '',
+                    NIP46_REQUESTED_PERMS,
+                    JSON.stringify(NIP46_CLIENT_METADATA),
+                ],
                 [bunkerPointer.pubkey, '', NIP46_REQUESTED_PERMS],
                 [bunkerPointer.pubkey, ''],
             ];

--- a/src/test/unit/nip46Service.test.ts
+++ b/src/test/unit/nip46Service.test.ts
@@ -19,6 +19,11 @@ import { expectConsoleCallsNotToContain } from '../logAssertions';
 const TEST_USER_PUBKEY = 'b'.repeat(64);
 const TEST_RECONNECT_PUBKEY = 'c'.repeat(64);
 const TEST_NEW_USER_PUBKEY = 'e'.repeat(64);
+const EXPECTED_NIP46_CLIENT_METADATA = {
+    name: 'eHagaki',
+    url: 'https://lokuyow.github.io/ehagaki/',
+    image: 'https://lokuyow.github.io/ehagaki/ehagaki_icon_x192.png',
+};
 
 describe('NIP46_REQUESTED_PERMISSIONS', () => {
     it('NIP-42 AUTHイベントの署名許可を要求する', () => {
@@ -60,6 +65,8 @@ vi.mock('nostr-tools/nip46', () => ({
         relays: string[];
         secret: string;
         name?: string;
+        url?: string;
+        image?: string;
     }) => {
         const query = new URLSearchParams();
         for (const relay of params.relays) {
@@ -68,6 +75,12 @@ vi.mock('nostr-tools/nip46', () => ({
         query.set('secret', params.secret);
         if (params.name) {
             query.set('name', params.name);
+        }
+        if (params.url) {
+            query.set('url', params.url);
+        }
+        if (params.image) {
+            query.set('image', params.image);
         }
         return `nostrconnect://${params.clientPubkey}?${query.toString()}`;
     }),
@@ -245,6 +258,15 @@ describe('Nip46Service', () => {
 
     function getNostrConnectUriName(uri: string): string | null {
         return new URL(uri).searchParams.get('name');
+    }
+
+    function getNostrConnectUriMetadata(uri: string) {
+        const searchParams = new URL(uri).searchParams;
+        return {
+            name: searchParams.get('name'),
+            url: searchParams.get('url'),
+            image: searchParams.get('image'),
+        };
     }
 
     afterEach(() => {
@@ -579,7 +601,12 @@ describe('Nip46Service', () => {
             expect(service.getSigner()).not.toBeNull();
             expect(mockSigner.sendRequest).toHaveBeenCalledWith(
                 'connect',
-                [mockBp.pubkey, 'test-secret', NIP46_REQUESTED_PERMS]
+                [
+                    mockBp.pubkey,
+                    'test-secret',
+                    NIP46_REQUESTED_PERMS,
+                    JSON.stringify(EXPECTED_NIP46_CLIENT_METADATA),
+                ],
             );
         });
 
@@ -1178,11 +1205,18 @@ describe('Nip46Service', () => {
 
             expect(pending.connectionUri).toContain('nostrconnect://');
             expect(getNostrConnectUriName(pending.connectionUri)).toBe('eHagaki');
+            expect(getNostrConnectUriMetadata(pending.connectionUri)).toEqual(
+                EXPECTED_NIP46_CLIENT_METADATA,
+            );
+            expect(createNostrConnectURI).toHaveBeenCalledTimes(2);
+            for (const [params] of (createNostrConnectURI as any).mock.calls) {
+                expect(params).toEqual(expect.objectContaining(EXPECTED_NIP46_CLIENT_METADATA));
+            }
             expect(createNostrConnectURI).toHaveBeenCalledWith(
                 expect.objectContaining({
                     relays: initialRelays,
                     perms: [...NIP46_REQUESTED_PERMISSIONS],
-                    name: 'eHagaki',
+                    ...EXPECTED_NIP46_CLIENT_METADATA,
                 }),
             );
 
@@ -2375,13 +2409,46 @@ describe('Nip46Service', () => {
 
             expect(mockSigner.sendRequest).toHaveBeenCalledWith(
                 'connect',
-                [mockBp.pubkey, 'test-secret', NIP46_REQUESTED_PERMS],
+                [
+                    mockBp.pubkey,
+                    'test-secret',
+                    NIP46_REQUESTED_PERMS,
+                    JSON.stringify(EXPECTED_NIP46_CLIENT_METADATA),
+                ],
             );
             expect(createNostrConnectURI).toHaveBeenCalledWith(
                 expect.objectContaining({
                     perms: [...NIP46_REQUESTED_PERMISSIONS],
-                    name: 'eHagaki',
+                    ...EXPECTED_NIP46_CLIENT_METADATA,
                 }),
+            );
+        });
+
+        it('metadata付き bunker connect が失敗した場合は既存の metadataなし fallback を試す', async () => {
+            const sendRequest = vi.fn()
+                .mockRejectedValueOnce(new Error('unsupported client metadata'))
+                .mockResolvedValueOnce('ack')
+                .mockResolvedValueOnce(TEST_USER_PUBKEY);
+
+            const { mockBp, mockSigner } = await connectService({
+                secret: 'test-secret',
+                signerOverrides: { sendRequest },
+            });
+
+            expect(mockSigner.sendRequest).toHaveBeenNthCalledWith(
+                1,
+                'connect',
+                [
+                    mockBp.pubkey,
+                    'test-secret',
+                    NIP46_REQUESTED_PERMS,
+                    JSON.stringify(EXPECTED_NIP46_CLIENT_METADATA),
+                ],
+            );
+            expect(mockSigner.sendRequest).toHaveBeenNthCalledWith(
+                2,
+                'connect',
+                [mockBp.pubkey, 'test-secret', NIP46_REQUESTED_PERMS],
             );
         });
     });
@@ -2576,6 +2643,7 @@ describe('Nip46Service', () => {
                 sessionData.remoteSignerPubkey,
                 '',
                 NIP46_REQUESTED_PERMS,
+                JSON.stringify(EXPECTED_NIP46_CLIENT_METADATA),
             ]);
             expect(mockSigner.sendRequest).toHaveBeenCalledWith('get_public_key', []);
             expect(mockSigner.getPublicKey).not.toHaveBeenCalled();
@@ -2583,6 +2651,33 @@ describe('Nip46Service', () => {
             expect(mockSigner.sendRequest).not.toHaveBeenCalledWith('ping', []);
             service.saveSession(mockStorage, sessionData.userPubkey);
             expect(JSON.parse(mockStorage.getItem(`nostr-nip46-session-${TEST_RECONNECT_PUBKEY}`)!)).toEqual(sessionData);
+        });
+
+        it('metadata付き session reconnect が失敗した場合は既存の metadataなし fallback を試す', async () => {
+            const sendRequest = vi.fn()
+                .mockRejectedValueOnce(new Error('unsupported client metadata'))
+                .mockResolvedValueOnce('ack')
+                .mockResolvedValueOnce(TEST_RECONNECT_PUBKEY);
+
+            const { sessionData, mockSigner } = await reconnectService({
+                signerOverrides: { sendRequest },
+            });
+
+            expect(mockSigner.sendRequest).toHaveBeenNthCalledWith(
+                1,
+                'connect',
+                [
+                    sessionData.remoteSignerPubkey,
+                    '',
+                    NIP46_REQUESTED_PERMS,
+                    JSON.stringify(EXPECTED_NIP46_CLIENT_METADATA),
+                ],
+            );
+            expect(mockSigner.sendRequest).toHaveBeenNthCalledWith(
+                2,
+                'connect',
+                [sessionData.remoteSignerPubkey, '', NIP46_REQUESTED_PERMS],
+            );
         });
 
         it('relayResolution が無い既存 session でも安全に再接続できる', async () => {


### PR DESCRIPTION
## Summary

- Add eHagaki client metadata to NIP-46 Nostr Connect URIs and bunker connect requests.
- Keep metadata-free compatibility fallbacks for initial bunker connect and saved-session reconnect.
- Reuse the existing eHagaki app name and the existing 192x192 PNG icon URL.

## Client metadata

```json
{
  "name": "eHagaki",
  "url": "https://lokuyow.github.io/ehagaki/",
  "image": "https://lokuyow.github.io/ehagaki/ehagaki_icon_x192.png"
}
```

## Covered flows

- `nostrconnect://`: metadata is included in both the initial URI and the URI regenerated after relay readiness.
- `bunker://`: metadata is sent as the fourth `connect` parameter for initial connection and saved-session reconnect.
- Existing metadata-free fallback candidates remain after the metadata-first candidate.

## Validation

- `npm run test -- src/test/unit/nip46Service.test.ts` — passed (113 tests)
- `npm run check` — passed
- `npm test` — passed (333 files, 3,844 tests)
- `git diff --check` — passed

Amber device display verification was not run because no Amber device environment was available. Playwright was not run because this is a protocol URI/request generation change covered by unit tests.