### PR TITLE
Fix editor height after gallery clear

### DIFF
--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -233,6 +233,9 @@
     mediaFreePlacement;
     uploadErrorMessage;
     currentEditor;
+    if (!mediaFreePlacement) {
+      mediaGalleryStore.items.length;
+    }
 
     if (typeof window === "undefined") {
       editorTargetHeight = POST_EDITOR_MIN_HEIGHT;

--- a/src/test/e2e/postGalleryLayout.spec.ts
+++ b/src/test/e2e/postGalleryLayout.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test, type Page } from '@playwright/test';
+
+type LayoutSnapshot = {
+    editor: { top: number; bottom: number; height: number };
+    gallery: { top: number; bottom: number; height: number } | null;
+    post: { top: number; bottom: number; height: number };
+    toolbar: { top: number; bottom: number; height: number };
+    editorToToolbar: number;
+    postToToolbar: number;
+    editorText: string;
+};
+
+async function readLayout(page: Page): Promise<LayoutSnapshot> {
+    return page.evaluate(() => {
+        const readBox = (selector: string) => {
+            const element = document.querySelector<HTMLElement>(selector);
+            if (!element) return null;
+            const rect = element.getBoundingClientRect();
+            return { top: rect.top, bottom: rect.bottom, height: rect.height };
+        };
+
+        const editor = readBox('.editor-container');
+        const post = readBox('.post-container');
+        const toolbar = readBox('.footer-button-bar');
+        const gallery = readBox('.media-gallery');
+        const editorElement = document.querySelector('.tiptap-editor');
+
+        if (!editor || !post || !toolbar || !(editorElement instanceof HTMLElement)) {
+            throw new Error('Composer layout elements are not ready');
+        }
+
+        return {
+            editor,
+            gallery,
+            post,
+            toolbar,
+            editorToToolbar: toolbar.top - editor.bottom,
+            postToToolbar: toolbar.top - post.bottom,
+            editorText: editorElement.textContent ?? '',
+        };
+    });
+}
+
+async function waitForAnimationFrame(page: Page): Promise<void> {
+    await page.evaluate(
+        () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+    );
+}
+
+async function waitForFrames(page: Page, count: number): Promise<void> {
+    for (let index = 0; index < count; index += 1) {
+        await waitForAnimationFrame(page);
+    }
+}
+
+test.describe('post gallery layout', () => {
+    test('restores editor height immediately after gallery clear in the normal app', async ({ page }) => {
+        await page.setViewportSize({ width: 900, height: 1600 });
+        await page.goto('/ehagaki/');
+
+        const editor = page.getByRole('textbox', { name: '投稿エディター' });
+        const editorContent = editor.locator('.tiptap-editor');
+        await expect(editorContent).toBeVisible();
+
+        const welcomeDialog = page.locator('.welcome-dialog');
+        if (await welcomeDialog.isVisible().catch(() => false)) {
+            await welcomeDialog.getByRole('button', { name: 'はじめる' }).click();
+        }
+
+        await editor.click();
+        await page.keyboard.type('gallery layout regression');
+        const initialLayout = await readLayout(page);
+        expect(initialLayout.gallery).toBeNull();
+        expect(initialLayout.editor.height).toBeGreaterThan(0);
+        expect(initialLayout.editorToToolbar).toBeCloseTo(0, 0);
+        expect(initialLayout.postToToolbar).toBeCloseTo(0, 0);
+
+        await page.evaluate(async () => {
+            const loadModule = (path: string) => import(/* @vite-ignore */ path);
+            const [settingsModule, galleryModule] = await Promise.all([
+                loadModule('/ehagaki/src/stores/settingsStore.svelte.ts'),
+                loadModule('/ehagaki/src/stores/mediaGalleryStore.svelte.ts'),
+            ]);
+
+            settingsModule.settingsStore.mediaFreePlacement = false;
+            galleryModule.mediaGalleryStore.addItem({
+                id: 'post-gallery-layout-regression',
+                type: 'image',
+                src: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==',
+                isPlaceholder: false,
+                mimeType: 'image/gif',
+            });
+        });
+
+        await expect.poll(async () => (await readLayout(page)).gallery?.height ?? 0).toBeGreaterThan(0);
+        await waitForFrames(page, 4);
+        await editor.click();
+
+        const galleryLayout = await readLayout(page);
+        expect(galleryLayout.gallery).not.toBeNull();
+        expect(galleryLayout.editor.height).toBeLessThan(initialLayout.editor.height);
+        expect(
+            Math.abs(
+                initialLayout.editor.height
+                - galleryLayout.editor.height
+                - galleryLayout.gallery!.height,
+            ),
+        ).toBeLessThanOrEqual(2);
+        expect(galleryLayout.postToToolbar).toBeCloseTo(0, 0);
+
+        await page.evaluate(async () => {
+            const loadModule = (path: string) => import(/* @vite-ignore */ path);
+            const [galleryModule, editorModule, statusModule] = await Promise.all([
+                loadModule('/ehagaki/src/stores/mediaGalleryStore.svelte.ts'),
+                loadModule('/ehagaki/src/stores/editorStore.svelte.ts'),
+                loadModule('/ehagaki/src/lib/postComponentUtils.ts'),
+            ]);
+
+            const handlers = statusModule.createPostStatusHandlers({
+                updatePostStatus: editorModule.updatePostStatus,
+                clearContentAfterSuccess: () => {
+                    const currentEditor = editorModule.currentEditorStore.value;
+                    if (!currentEditor) throw new Error('Editor is not ready');
+                    currentEditor.chain().clearContent().run();
+                    galleryModule.mediaGalleryStore.clearAll();
+                },
+            });
+
+            handlers.markSending();
+            handlers.markSuccess();
+        });
+
+        await expect.poll(async () => (await readLayout(page)).gallery === null).toBe(true);
+        await waitForAnimationFrame(page);
+
+        const restoredLayout = await readLayout(page);
+        expect(restoredLayout.gallery).toBeNull();
+        expect(restoredLayout.editor.height).toBeCloseTo(initialLayout.editor.height, 0);
+        expect(restoredLayout.editorToToolbar).toBeCloseTo(0, 0);
+        expect(restoredLayout.postToToolbar).toBeCloseTo(0, 0);
+        expect(restoredLayout.editorText).toBe('');
+        await expect(editorContent).toHaveText('');
+
+        await editor.click();
+        await page.keyboard.type('next post input');
+        await expect(editorContent).toContainText('next post input');
+    });
+});


### PR DESCRIPTION
## Summary
- Re-run the existing PostComponent height synchronization when gallery item count changes in gallery mode.
- Restore the editor height in the existing requestAnimationFrame measurement path after MediaGallery is cleared.
- Add a normal-App Playwright regression test covering gallery add, success-equivalent clear, next-frame geometry recovery, and subsequent input.

## Root cause
MediaGallery mounts and unmounts from `mediaGalleryStore.items`, but the existing height synchronization effect did not directly depend on the gallery item count. After gallery removal, the stale editor target height could leave one gallery-row-sized outer gap until a later ResizeObserver/requestAnimationFrame cycle.

## Validation
- `npx playwright test src/test/e2e/postGalleryLayout.spec.ts --project=desktop-chromium`
- `npm run check`
- `npm test`
- `npm run build`
- `git diff --check`

The Playwright regression fails without the dependency change with the editor remaining 180px too short, and passes with it.