### PR TITLE
Remove Web Component public ::part() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ eHagaki の iframe 埋め込み方法、親クライアント連携ログイン�
 
 ## Web Component埋め込み
 
-Web Component版の公開API、lifecycle、context/settings、CustomEvent、CSS Custom Properties / `::part()`、storageとtrust boundaryは [docs/WEB_COMPONENT.md](docs/WEB_COMPONENT.md) にまとめています。
+Web Component版の公開API、lifecycle、context/settings、CustomEvent、CSS Custom Properties、storageとtrust boundaryは [docs/WEB_COMPONENT.md](docs/WEB_COMPONENT.md) にまとめています。
 
 実際に `Create / Mount`、`Destroy / Unmount`、再生成、設定・context更新、2個目instanceの拒否、event log、host側styleを操作するlive sampleは [https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html](https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html) から確認できます。
 

--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -14,7 +14,7 @@ DOM へ直接組み込みたい場合に適しています。
 任意のモジュールを試す場合は URL に `?manual=1` を付けて manual mode に入り、module URL を編集してから
 `Create / Mount` を押してください。manual mode では明示的な操作までモジュールを読み込みません。サンプルでは、モジュールの読み込み、
 作成・破棄・再作成、設定、投稿コンテキスト、各種イベント、2 個目のインスタンスの拒否、
-CSS Custom Properties、`::part()` を確認できます。
+CSS Custom Properties を確認できます。
 
 ## 最小構成で埋め込む
 
@@ -154,7 +154,7 @@ GitHub Pages のようにサイトがサブパス配下にある場合は、root
 
 ## 準備完了を待つ `whenReady()`
 
-`whenReady(): Promise<void>` は、アプリのマウントと公開 part の準備が完了した後に解決します。
+`whenReady(): Promise<void>` は、アプリのマウントと初期化が完了した後に解決します。
 `ehagaki-ready` も同じ準備完了時に発火します。
 
 ```js
@@ -403,7 +403,7 @@ composer.addEventListener('ehagaki-post-error', (event) => {
 
 ### `ehagaki-ready`
 
-mount と公開 part の準備が完了したときに発火します。detail は `{ apiVersion: 1 }` です。
+アプリの mount と初期化が完了したときに発火します。detail は `{ apiVersion: 1 }` です。
 
 ```js
 composer.addEventListener('ehagaki-ready', (event) => {
@@ -557,25 +557,6 @@ ehagaki-composer {
 Accent / Baseをどちらも指定しない場合は、現在のeHagakiの既定色が使われます。`themeMode` の
 `system` / `light` / `dark` とhostへ適用される `color-scheme` に応じてsurfaceが切り替わります。
 
-## `::part()` によるスタイル調整
-
-公開されている part は `shell`、`header`、`composer`、`footer`、`overlay-root` です。
-ホスト側のスタイルシートから、次のように指定できます。
-
-```css
-ehagaki-composer::part(header) {
-  border-bottom: 1px solid #b8c7be;
-}
-
-ehagaki-composer::part(composer) {
-  min-height: 240px;
-}
-```
-
-ShadowRoot は open ですが、公開 API として案内していない内部 DOM を
-`shadowRoot.querySelector()` などで操作することは推奨しません。レイアウトや表示の調整には、
-CSS Custom Properties と公開された `::part()` を使用してください。
-
 ## ログイン・認証
 
 Web Component 専用の signer callback/provider API はありません。
@@ -612,7 +593,7 @@ console.log('NIP-07 available:', nip07Available);
 | 項目 | iframe | Web Component |
 | --- | --- | --- |
 | DOM 統合 | 別 document。`postMessage` で連携 | 同じ document の要素として配置 |
-| スタイル | iframe 内 document の CSS 境界 | ShadowRoot。CSS Custom Properties / `::part()` を公開 |
+| スタイル | iframe 内 document の CSS 境界 | ShadowRoot。CSS Custom Properties を公開 |
 | Window realm | ホストとは分離 | ホストと共有 |
 | NIP-07 | iframe の認証経路または parent-client 連携 | ホストの `window.nostr` を直接利用 |
 | ローカル nsec | 利用可能 | 利用不可 |
@@ -701,7 +682,7 @@ CSP の `worker-src` では配信元オリジンと `blob:` の両方を許可�
 - `ehagaki-ready`、`ehagaki-post-success`、`ehagaki-post-error`、
   `ehagaki-composer-context-updated`、`ehagaki-initialization-error`
 - 2 個目のインスタンスの `multiple_instances_unsupported` 拒否
-- CSS Custom Properties と `::part()`
+- CSS Custom Properties
 
 サンプルのイベントログは、秘密情報、署名要求 payload、生の Error を表示せず、安全な要約
 だけを記録します。外部モジュールはホストページと同じ JavaScript 権限で実行されるため、

--- a/public/web-component-parent-client-example.html
+++ b/public/web-component-parent-client-example.html
@@ -333,7 +333,7 @@
                                 <tr><th>分離方法 / API</th><td>originを分け、postMessage protocolとhandshakeで通信</td><td>同じWindow realmでmethod/property/CustomEventを使い、elementを作成・削除・再作成</td></tr>
                                 <tr><th>認証</th><td>parent-client auth/RPCやローカルnsecを利用可能</td><td>parent-client auth/RPCとローカルnsecは使用しない。NIP-07はhostのwindow.nostrを直接利用し、NIP-46はeHagaki UIを利用</td></tr>
                                 <tr><th>データの保存</th><td>storage/IndexedDBを親ページに委ねられる</td><td>localStorageは <code>ehagaki.web-component.v1:</code> namespace、IndexedDBはhost originの <code>eHagakiDB</code></td></tr>
-                                <tr><th>更新 / 見た目</th><td>iframeのreloadまたはpostMessage</td><td>setSettings()/setContext()、CSS Custom Properties / <code>::part()</code></td></tr>
+                                <tr><th>更新 / 見た目</th><td>iframeのreloadまたはpostMessage</td><td>setSettings()/setContext()、CSS Custom Properties</td></tr>
                                 <tr><th>安全な範囲</th><td>iframeとは別のoriginとして分離可能</td><td>trusted hostのみ正式サポート。hostは同じrealmのコードやstorageを確認可能</td></tr>
                             </tbody>
                         </table>
@@ -410,7 +410,7 @@
                             <div class="field"><label for="style-dialog">ダイアログの背景色（dialog background）</label><input id="style-dialog"></div>
                             <div class="field"><label for="style-font">フォント（font family）</label><input id="style-font"></div>
                         </div>
-                        <p class="small">Accent / Baseはsurface生成に使われます。公開partの利用方法は <a href="https://github.com/Lokuyow/ehagaki/blob/main/docs/WEB_COMPONENT.md" target="_blank" rel="noreferrer noopener">Web Componentのガイド</a> を参照してください。</p>
+                        <p class="small">Accent / Baseはsurface生成に使われます。利用可能なCSS Custom Propertiesは <a href="https://github.com/Lokuyow/ehagaki/blob/main/docs/WEB_COMPONENT.md" target="_blank" rel="noreferrer noopener">Web Componentのガイド</a> を参照してください。</p>
                     </div>
                 </details>
             </div>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -218,6 +218,7 @@
   interface Props {
     /** The iframe transport remains the default for the PWA and iframe entry. */
     notificationPort?: AppPostNotificationPort & AppEmbedNotificationPort;
+    onInitialized?: () => void;
   }
 
   const iframeNotificationPort: AppPostNotificationPort & AppEmbedNotificationPort = {
@@ -234,7 +235,10 @@
     notifySettingsError: (error, requestId) =>
       iframeMessageService.notifySettingsError(error, requestId),
   };
-  let { notificationPort = iframeNotificationPort }: Props = $props();
+  let {
+    notificationPort = iframeNotificationPort,
+    onInitialized = () => undefined,
+  }: Props = $props();
 
   type PostComponent =
     typeof import("./components/PostComponent.svelte").default;
@@ -946,6 +950,13 @@
     if ($locale && localeInitialized) {
       void loadPostComponent();
     }
+  });
+
+  let initializationNotified = false;
+  $effect(() => {
+    if (!$locale || !localeInitialized || initializationNotified) return;
+    initializationNotified = true;
+    onInitialized();
   });
 
   $effect(() => {
@@ -1860,7 +1871,6 @@
         />
         <div
           class="composer-scroll-region"
-          part="composer"
           bind:this={composerScrollRegionEl}
         >
           <div

--- a/src/components/FooterComponent.svelte
+++ b/src/components/FooterComponent.svelte
@@ -81,7 +81,7 @@
     }
 </script>
 
-<div class="footer-bar" part="footer">
+<div class="footer-bar">
     {#if isSwitchingAccount}
         <Button
             variant="default"

--- a/src/components/HeaderComponent.svelte
+++ b/src/components/HeaderComponent.svelte
@@ -50,7 +50,6 @@
 <div
     class="header-container"
     class:container-layout={isContainerLayout}
-    part="header"
 >
     <div class="header-left">
         {#if showMascot}

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -97,7 +97,6 @@ test.beforeAll(async () => {
         response.writeHead(200, { "Content-Type": "text/html" });
         response.end(`<!doctype html><head><style>
           ehagaki-composer { display: block; height: 600px; }
-          ehagaki-composer::part(header) { outline: 3px solid rgb(1, 2, 3); }
         </style></head><body><script>
           window.__componentOrigin = ${JSON.stringify(componentOrigin)};
           navigator.serviceWorker.register('/host-sw.js');
@@ -154,9 +153,8 @@ test("mounts across origins without touching host storage or registering an eHag
             componentKeys,
             applied,
             shadow: !!composer.shadowRoot,
-            parts: ["shell", "header", "composer", "footer", "overlay-root"].every((part) => !!composer.shadowRoot?.querySelector(`[part~="${part}"]`)),
-            headerOutline: getComputedStyle(composer.shadowRoot!.querySelector('[part~="header"]')!).outlineColor,
-            footerBackground: getComputedStyle(composer.shadowRoot!.querySelector('[part~="footer"]')!).backgroundColor,
+            publicPartCount: composer.shadowRoot?.querySelectorAll("[part]").length ?? 0,
+            footerBackground: getComputedStyle(composer.shadowRoot!.querySelector('.footer-bar')!).backgroundColor,
             serviceWorkerControlled: !!navigator.serviceWorker.controller,
             hostFetchObserved: afterFetch.fetchCount > beforeFetch.fetchCount,
             registrationCount: registrations.length,
@@ -167,8 +165,7 @@ test("mounts across origins without touching host storage or registering an eHag
     expect(result.componentKeys).toContain("ehagaki.web-component.v1:locale");
     expect(result.applied).toContain("locale");
     expect(result.shadow).toBe(true);
-    expect(result.parts).toBe(true);
-    expect(result.headerOutline).toBe("rgb(1, 2, 3)");
+    expect(result.publicPartCount).toBe(0);
     expect(result.footerBackground).toBe("rgb(4, 5, 6)");
     expect(result.serviceWorkerControlled).toBe(true);
     expect(result.hostFetchObserved).toBe(true);
@@ -191,7 +188,7 @@ test("applies Accent/Base themes while preserving default and meaning colors", a
 
     const readTheme = () => page.locator("ehagaki-composer").evaluate((element) => {
         const shadow = element.shadowRoot!;
-        const shell = shadow.querySelector<HTMLElement>('[part~="shell"]')!;
+        const shell = shadow.querySelector<HTMLElement>('.ehagaki-web-component-shell')!;
         const appRoot = shadow.querySelector<HTMLElement>(".ehagaki-app-root")!;
         const primary = shadow.querySelector<HTMLElement>("button.primary")!;
         const colorToPixel = (color: string) => {
@@ -249,7 +246,7 @@ test("applies Accent/Base themes while preserving default and meaning colors", a
         element.style.setProperty("--ehagaki-background", "rgb(1, 2, 3)");
     });
     await expect.poll(() => page.locator("ehagaki-composer").evaluate((element) =>
-        getComputedStyle(element.shadowRoot!.querySelector<HTMLElement>('[part~="shell"]')!).backgroundColor,
+        getComputedStyle(element.shadowRoot!.querySelector<HTMLElement>('.ehagaki-web-component-shell')!).backgroundColor,
     )).toBe("rgb(1, 2, 3)");
 
     await page.locator("ehagaki-composer").evaluate((element) => {
@@ -624,22 +621,22 @@ test("applies Button styles inside a Portal dialog in the Shadow DOM", async ({ 
     });
     await page.waitForFunction(() => {
         const shadow = document.querySelector("ehagaki-composer")?.shadowRoot;
-        const overlay = shadow?.querySelector('[part~="overlay-root"]');
+        const overlay = shadow?.querySelector('.ehagaki-web-component-overlays');
         return !!overlay?.querySelector(".login-dialog");
     });
 
     await page.evaluate(() => {
         const shadow = document.querySelector("ehagaki-composer")!.shadowRoot!;
-        const overlay = shadow.querySelector<HTMLElement>('[part~="overlay-root"]')!;
+        const overlay = shadow.querySelector<HTMLElement>('.ehagaki-web-component-overlays')!;
         overlay.querySelector<HTMLDetailsElement>(".remote-signer-details")!.open = true;
     });
     await page.waitForFunction(() =>
         !!document.querySelector("ehagaki-composer")?.shadowRoot
-            ?.querySelector('[part~="overlay-root"] [data-testid="nostrconnect-regenerate"]'),
+            ?.querySelector('.ehagaki-web-component-overlays [data-testid="nostrconnect-regenerate"]'),
     );
     const lightResult = await page.evaluate(() => {
         const shadow = document.querySelector("ehagaki-composer")!.shadowRoot!;
-        const overlay = shadow.querySelector<HTMLElement>('[part~="overlay-root"]')!;
+        const overlay = shadow.querySelector<HTMLElement>('.ehagaki-web-component-overlays')!;
         const primary = overlay.querySelector<HTMLButtonElement>(
             '[data-testid="nostrconnect-regenerate"]',
         )!;
@@ -672,7 +669,7 @@ test("applies Button styles inside a Portal dialog in the Shadow DOM", async ({ 
         await composer.setSettings({ themeMode: "dark" });
         return getComputedStyle(
             composer.shadowRoot!.querySelector<HTMLElement>(
-                '[part~="overlay-root"] .login-dialog',
+                '.ehagaki-web-component-overlays .login-dialog',
             )!,
         ).backgroundColor;
     });
@@ -705,12 +702,12 @@ test("offers NIP-07 and NIP-46 without rendering local nsec login UI", async ({ 
     });
     await page.waitForFunction(() =>
         !!document.querySelector("ehagaki-composer")?.shadowRoot
-            ?.querySelector('[part~="overlay-root"] .login-dialog'),
+            ?.querySelector('.ehagaki-web-component-overlays .login-dialog'),
     );
     const result = await page.evaluate(() => {
         const composer = document.querySelector("ehagaki-composer")!;
         const shadow = composer.shadowRoot!;
-        const overlay = shadow.querySelector<HTMLElement>('[part~="overlay-root"]')!;
+        const overlay = shadow.querySelector<HTMLElement>('.ehagaki-web-component-overlays')!;
         const dialog = overlay.querySelector<HTMLElement>(".login-dialog")!;
         const componentRect = composer.getBoundingClientRect();
         const dialogRect = dialog.getBoundingClientRect();
@@ -830,7 +827,7 @@ test("keeps authenticated profile and post history dialogs inside the component"
         if (!profileButton) throw new Error("authenticated profile button did not render");
         profileButton.click();
         for (let frame = 0; frame < 8; frame += 1) await nextFrame();
-        const overlayRoot = shadow.querySelector<HTMLElement>('[part~="overlay-root"]')!;
+        const overlayRoot = shadow.querySelector<HTMLElement>('.ehagaki-web-component-overlays')!;
         const rect = (element: Element | null) => {
             if (!(element instanceof HTMLElement)) return null;
             const value = element.getBoundingClientRect();
@@ -964,7 +961,7 @@ test("keeps a large Web Component post history list scrolling above its footer",
             const list = shadow.querySelector<HTMLElement>(".post-history-container");
             if ((list?.scrollHeight ?? 0) > (list?.clientHeight ?? 0)) break;
         }
-        const overlayRoot = shadow.querySelector<HTMLElement>('[part~="overlay-root"]')!;
+        const overlayRoot = shadow.querySelector<HTMLElement>('.ehagaki-web-component-overlays')!;
         const list = overlayRoot.querySelector<HTMLElement>(".post-history-container")!;
         const footer = overlayRoot.querySelector<HTMLElement>(".dialog-footer")!;
         const dialog = overlayRoot.querySelector<HTMLElement>(".post-history-dialog")!;

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -320,8 +320,8 @@ test("uses the internal theme surface even when the host forces a white backgrou
     const result = await page.locator("ehagaki-composer").evaluate(async (element) => {
         const composer = element as HTMLElement & { setSettings(value: { themeMode: "light" | "dark" }): Promise<string[]> };
         const shadow = composer.shadowRoot!;
-        const shell = shadow.querySelector<HTMLElement>('[part~="shell"]')!;
-        const header = shadow.querySelector<HTMLElement>('[part~="header"]')!;
+        const shell = shadow.querySelector<HTMLElement>('.ehagaki-web-component-shell')!;
+        const header = shadow.querySelector<HTMLElement>('.header-container')!;
         const read = () => ({
             hostBackground: getComputedStyle(composer).backgroundColor,
             shellBackground: getComputedStyle(shell).backgroundColor,
@@ -556,7 +556,7 @@ test("boots from production site output and exercises the public sample API", as
 
     const readTheme = () => page.locator("ehagaki-composer").evaluate((element) => {
         const shadow = element.shadowRoot!;
-        const shell = shadow.querySelector<HTMLElement>('[part~="shell"]')!;
+        const shell = shadow.querySelector<HTMLElement>('.ehagaki-web-component-shell')!;
         const primary = shadow.querySelector<HTMLElement>("button.primary")!;
         return {
             accent: element.style.getPropertyValue("--ehagaki-accent-color"),
@@ -807,7 +807,7 @@ test("preserves inherited Accent/Base theme across destroy and recreate", async 
 
     const readTheme = () => page.locator("ehagaki-composer").evaluate((element) => {
         const shadow = element.shadowRoot!;
-        const shell = shadow.querySelector<HTMLElement>('[part~="shell"]')!;
+        const shell = shadow.querySelector<HTMLElement>('.ehagaki-web-component-shell')!;
         const primary = shadow.querySelector<HTMLElement>("button.primary")!;
         return {
             accent: getComputedStyle(element).getPropertyValue("--accent-color").trim(),

--- a/src/web-component/element.ts
+++ b/src/web-component/element.ts
@@ -134,7 +134,6 @@ export class EHagakiComposerElement extends HTMLElement {
     #readyState: "pending" | "resolved" | "rejected" = "pending";
     #operationQueue: Promise<void> = Promise.resolve();
     #connectionGeneration = 0;
-    #publicPartsObserver: MutationObserver | null = null;
     #assetStyleObserver: MutationObserver | null = null;
 
     get assetBase(): string | null {
@@ -175,8 +174,6 @@ export class EHagakiComposerElement extends HTMLElement {
 
     disconnectedCallback(): void {
         this.#connectionGeneration += 1;
-        this.#publicPartsObserver?.disconnect();
-        this.#publicPartsObserver = null;
         this.#assetStyleObserver?.disconnect();
         this.#assetStyleObserver = null;
         if (activeInstance === this) activeInstance = null;
@@ -233,12 +230,10 @@ export class EHagakiComposerElement extends HTMLElement {
             styles.textContent = `${transformAppCss(appCss)}\n${photoSwipeCss}\n${getWebComponentThemeCss()}`;
             const shell = document.createElement("div");
             shell.className = "ehagaki-web-component-shell";
-            shell.part.add("shell");
             const mountTarget = document.createElement("div");
             mountTarget.className = "ehagaki-web-component-app";
             const overlayTarget = document.createElement("div");
             overlayTarget.className = "ehagaki-web-component-overlays ehagaki-app-root";
-            overlayTarget.part.add("overlay-root");
             shell.append(mountTarget, overlayTarget);
             shadowRoot.append(styles, shell);
 
@@ -274,15 +269,19 @@ export class EHagakiComposerElement extends HTMLElement {
             if (!this.isConnected || generation !== this.#connectionGeneration) return;
             this.#mountedApp = mount(App, {
                 target: mountTarget,
-                props: { notificationPort: createWebComponentNotificationPort(this) },
+                props: {
+                    notificationPort: createWebComponentNotificationPort(this),
+                    onInitialized: () => {
+                        if (!this.isConnected || generation !== this.#connectionGeneration) return;
+                        this.#readyState = "resolved";
+                        this.#readyResolve?.();
+                        this.dispatchSafeEvent("ehagaki-ready", { apiVersion: EHAGAKI_COMPOSER_API_VERSION });
+                    },
+                },
             });
             applyWebComponentIconAssetUrls(shadowRoot, shell, assetBase);
             this.#app = this.#mountedApp as AppInstance;
-            await this.waitForPublicParts(shadowRoot, generation);
             if (!this.isConnected || generation !== this.#connectionGeneration) return;
-            this.#readyState = "resolved";
-            this.#readyResolve?.();
-            this.dispatchSafeEvent("ehagaki-ready", { apiVersion: EHAGAKI_COMPOSER_API_VERSION });
         } catch {
             this.fail("initialization_failed", "eHagaki Composer could not be initialized.");
         }
@@ -293,35 +292,6 @@ export class EHagakiComposerElement extends HTMLElement {
             throw createError("initialization_failed", "eHagaki Composer is not ready.");
         }
         return this.#app;
-    }
-
-    private waitForPublicParts(root: ShadowRoot, generation: number): Promise<void> {
-        const requiredParts = ["header", "composer", "footer"];
-        const hasRequiredParts = () => requiredParts.every((part) =>
-            root.querySelector(`[part~="${part}"]`),
-        );
-        if (hasRequiredParts()) {
-            return Promise.resolve();
-        }
-
-        return new Promise((resolve) => {
-            const observer = new MutationObserver(() => {
-                if (
-                    generation !== this.#connectionGeneration
-                    || !this.isConnected
-                    || !hasRequiredParts()
-                ) {
-                    return;
-                }
-                observer.disconnect();
-                if (this.#publicPartsObserver === observer) {
-                    this.#publicPartsObserver = null;
-                }
-                resolve();
-            });
-            this.#publicPartsObserver = observer;
-            observer.observe(root, { childList: true, subtree: true });
-        });
     }
 
     private enqueue<T>(operation: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
## 変更概要

Web Component の公開 `::part()` API を廃止し、公開 part を0個に戻しました。CSS Custom Properties による既存のテーマ・色カスタマイズは維持しています。

## 変更理由

Web Component は正式公開前で、内部 DOM 構造を安定した公開 API として固定する具体的な要件がないためです。将来、利用要件が明確になった part だけを追加できる状態に戻します。

## 維持したもの

- Accent / Base と light / dark の surface 生成
- background、text、border、link、input background、footer background、dialog background、font family の CSS Custom Properties
- open Shadow DOM
- `whenReady()`、`setSettings()`、`setContext()`、CustomEvent、single-instance 制約、overlay の内部配置、iframe/PWA の境界

## 主な実装変更

- `shell`、`header`、`composer`、`footer`、`overlay-root` の `part` 付与を削除
- public parts 用 MutationObserver、required parts 判定、ready 待ち処理を削除
- locale 初期化後の DOM 更新完了を Web Component 内部の ready 通知にして、`whenReady()` の契約を維持
- README、ガイド、Playground、関連 E2E の公開 part 案内・検証を CSS Custom Properties 中心へ更新

## 検証

- `npm run check`
- `npm test` — 335 files / 3,861 tests passed
- `npm run build`
- `npm run build:web-component`
- Web Component E2E — 98 passed / 2 skipped（mobile project の hover 非対象）

## 未実行の検証

- Android / iPhone の実機確認は未実行です。Playwright の desktop Chromium、mobile Chromium、mobile WebKit、desktop Firefox で検証しています。
