### PR TITLE
Fix E2E regressions and stale build outputs

### DIFF
--- a/scripts/ensureWebComponentE2EOutput.mjs
+++ b/scripts/ensureWebComponentE2EOutput.mjs
@@ -1,0 +1,186 @@
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { access, mkdir, open, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const cacheDirectory = join(repositoryRoot, "playwright", ".cache");
+const markerPath = join(cacheDirectory, "web-component-e2e-output.json");
+const lockPath = join(cacheDirectory, "web-component-e2e-output.lock");
+const requiredOutputPaths = [
+    "dist/web-component/ehagaki-composer.js",
+    "dist/web-component-parent-client-example.html",
+    "dist/web-component-parent-client-example.js",
+    "dist-web-component/ehagaki-composer.js",
+];
+const sourceDirectories = ["public", "scripts", "legacy-bridge"];
+const sourceFiles = [
+    "index.html",
+    "package.json",
+    "package-lock.json",
+    "tsconfig.json",
+    "vite.config.ts",
+    "vite.web-component.config.ts",
+];
+
+/** @param {number} milliseconds */
+function delay(milliseconds) {
+    /** @type {Promise<void>} */
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+/** @param {string} directory @returns {Promise<string[]>} */
+async function listFiles(directory) {
+    const entries = await readdir(directory, { withFileTypes: true });
+    const nestedFiles = await Promise.all(entries.map(async (entry) => {
+        const path = join(directory, entry.name);
+        return entry.isDirectory() ? listFiles(path) : [path];
+    }));
+    return nestedFiles.flat();
+}
+
+/** @returns {Promise<string[]>} */
+async function getBuildInputPaths() {
+    const files = [...sourceFiles.map((path) => join(repositoryRoot, path))];
+    const sourceRoot = join(repositoryRoot, "src");
+    const sourceEntries = await readdir(sourceRoot, { withFileTypes: true });
+
+    for (const entry of sourceEntries) {
+        if (entry.name === "test") continue;
+        const path = join(sourceRoot, entry.name);
+        files.push(...(entry.isDirectory() ? await listFiles(path) : [path]));
+    }
+
+    for (const directory of sourceDirectories) {
+        files.push(...await listFiles(join(repositoryRoot, directory)));
+    }
+
+    return files.sort((left, right) => left.localeCompare(right));
+}
+
+/** @returns {Promise<string>} */
+async function createBuildInputFingerprint() {
+    const digest = createHash("sha256");
+    const files = await getBuildInputPaths();
+
+    for (const file of files) {
+        digest.update(relative(repositoryRoot, file));
+        digest.update("\0");
+        digest.update(await readFile(file));
+        digest.update("\0");
+    }
+
+    return digest.digest("hex");
+}
+
+/** @param {string} fingerprint @returns {Promise<boolean>} */
+async function outputIsCurrent(fingerprint) {
+    try {
+        const marker = JSON.parse(await readFile(markerPath, "utf8"));
+        if (marker.fingerprint !== fingerprint) return false;
+        await Promise.all(requiredOutputPaths.map((path) =>
+            access(join(repositoryRoot, path)),
+        ));
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** @param {unknown} error */
+function getErrorCode(error) {
+    return typeof error === "object" && error !== null && "code" in error
+        && typeof error.code === "string"
+        ? error.code
+        : undefined;
+}
+
+/** @param {string} fingerprint @returns {Promise<import("node:fs/promises").FileHandle | null>} */
+async function acquireBuildLock(fingerprint) {
+    const deadline = Date.now() + 10 * 60_000;
+    while (Date.now() < deadline) {
+        try {
+            const lock = await open(lockPath, "wx");
+            await lock.writeFile(`${JSON.stringify({ pid: process.pid })}\n`, "utf8");
+            return lock;
+        } catch (error) {
+            if (getErrorCode(error) !== "EEXIST") throw error;
+            if (await outputIsCurrent(fingerprint)) return null;
+
+            const lockInfo = await stat(lockPath).catch(() => null);
+            const lockOwner = await readFile(lockPath, "utf8")
+                .then((source) => JSON.parse(source).pid)
+                .catch(() => null);
+            const ownerIsRunning = typeof lockOwner === "number" && (() => {
+                try {
+                    process.kill(lockOwner, 0);
+                    return true;
+                } catch (processError) {
+                    return getErrorCode(processError) !== "ESRCH";
+                }
+            })();
+            if (lockInfo && !ownerIsRunning && Date.now() - lockInfo.mtimeMs > 1_000) {
+                await rm(lockPath, { force: true });
+                continue;
+            }
+            await delay(100);
+        }
+    }
+
+    throw new Error("Timed out waiting for the Web Component E2E build preparation.");
+}
+
+async function runProductionBuild() {
+    const isWindows = process.platform === "win32";
+    const command = isWindows ? (process.env.ComSpec ?? "cmd.exe") : "npm";
+    const args = isWindows
+        ? ["/d", "/s", "/c", "npm run build"]
+        : ["run", "build"];
+    /** @type {Promise<void>} */
+    const buildCompleted = new Promise((resolve, reject) => {
+        const child = spawn(command, args, {
+            cwd: repositoryRoot,
+            stdio: "inherit",
+            windowsHide: true,
+        });
+        child.once("error", reject);
+        child.once("exit", (code, signal) => {
+            if (code === 0) {
+                resolve();
+                return;
+            }
+            reject(new Error(`npm run build failed (${signal ?? code ?? "unknown"}).`));
+        });
+    });
+    await buildCompleted;
+}
+
+/**
+ * Rebuild the production files only when the source inputs differ from the
+ * output previously prepared for a Web Component E2E run.
+ */
+export async function ensureWebComponentE2EOutput() {
+    const fingerprint = await createBuildInputFingerprint();
+    if (await outputIsCurrent(fingerprint)) return;
+
+    await mkdir(cacheDirectory, { recursive: true });
+    const lock = await acquireBuildLock(fingerprint);
+    if (!lock) return;
+
+    try {
+        if (await outputIsCurrent(fingerprint)) return;
+
+        await runProductionBuild();
+        const temporaryMarkerPath = `${markerPath}.${process.pid}.tmp`;
+        await writeFile(
+            temporaryMarkerPath,
+            `${JSON.stringify({ fingerprint })}\n`,
+            "utf8",
+        );
+        await rename(temporaryMarkerPath, markerPath);
+    } finally {
+        await lock.close();
+        await rm(lockPath, { force: true });
+    }
+}

--- a/src/components/ComposerTargetDialog.svelte
+++ b/src/components/ComposerTargetDialog.svelte
@@ -124,6 +124,7 @@
     let fullscreenMediaItems = $state<FullscreenMediaItem[]>([]);
     let fullscreenIndex = $state(-1);
     let showImageFullscreen = $state(false);
+    let fullscreenFocusOrigin = $state<HTMLElement | null>(null);
     const postActionUi =
         usePostHistoryPostActionUiController<PostHistoryRecord>();
     let rawJsonDialogOpen = $state(false);
@@ -342,6 +343,7 @@
         fullscreenMediaItems = [];
         fullscreenIndex = -1;
         showImageFullscreen = false;
+        fullscreenFocusOrigin = null;
     }
 
     function resolveStatusText(): string {
@@ -621,9 +623,11 @@
     function handleImageOpen(params: {
         index: number;
         mediaList: FullscreenMediaItem[];
+        focusOrigin: HTMLElement | null;
     }): void {
         fullscreenMediaItems = params.mediaList;
         fullscreenIndex = params.index;
+        fullscreenFocusOrigin = params.focusOrigin;
         showImageFullscreen = true;
     }
 
@@ -631,6 +635,7 @@
         showImageFullscreen = false;
         fullscreenMediaItems = [];
         fullscreenIndex = -1;
+        fullscreenFocusOrigin = null;
     }
 
     function handleFullscreenNavigate(index: number): void {
@@ -1081,6 +1086,7 @@
     mediaList={fullscreenMediaItems}
     currentIndex={fullscreenIndex}
     onNavigate={handleFullscreenNavigate}
+    openingFocusOrigin={fullscreenFocusOrigin}
 />
 
 <FloatingMessage

--- a/src/components/ImageFullscreen.svelte
+++ b/src/components/ImageFullscreen.svelte
@@ -9,6 +9,7 @@
         pauseFullscreenVideoContent,
     } from "../lib/utils/fullscreenViewerUtils";
     import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
+    import { getActiveElement } from "../lib/utils/appDomUtils";
 
     interface Props {
         src?: string;
@@ -249,20 +250,30 @@
 
     $effect(() => {
         if (
+            !show ||
+            normalizedIndex < 0 ||
+            resolvedMediaList.length === 0 ||
+            focusOrigin
+        ) {
+            return;
+        }
+
+        focusOrigin = openingFocusOrigin ?? getActiveElement();
+        focusOriginDialog = focusOrigin?.closest<HTMLElement>(
+            '[role="dialog"]',
+        ) ?? null;
+    });
+
+    $effect(() => {
+        if (
             show &&
             normalizedIndex >= 0 &&
             resolvedMediaList.length > 0 &&
-            !historyPushed
-            && appRuntimeEnvironment.historyEnabled
+            !historyPushed &&
+            appRuntimeEnvironment.historyEnabled
         ) {
             history.pushState({ imageFullscreen: true }, "");
             historyPushed = true;
-            const activeElement = document.activeElement;
-            focusOrigin = openingFocusOrigin ??
-                (activeElement instanceof HTMLElement ? activeElement : null);
-            focusOriginDialog = focusOrigin?.closest<HTMLElement>(
-                '[role="dialog"]',
-            ) ?? null;
         }
     });
 

--- a/src/components/ImageFullscreen.svelte
+++ b/src/components/ImageFullscreen.svelte
@@ -18,6 +18,7 @@
         mediaList?: FullscreenMediaItem[];
         currentIndex?: number;
         onNavigate?: (index: number) => void;
+        openingFocusOrigin?: HTMLElement | null;
     }
 
     type CloseMode = "popstate" | "internal" | null;
@@ -33,6 +34,7 @@
         mediaList = [],
         currentIndex = -1,
         onNavigate = undefined,
+        openingFocusOrigin = null,
     }: Props = $props();
 
     let activePhotoSwipe: any = null;
@@ -213,7 +215,7 @@
             padding: VIEWER_PADDING,
             escKey: true,
             arrowKeys: true,
-            returnFocus: true,
+            returnFocus: false,
         });
 
         bindCustomContentEvents(instance);
@@ -256,8 +258,8 @@
             history.pushState({ imageFullscreen: true }, "");
             historyPushed = true;
             const activeElement = document.activeElement;
-            focusOrigin =
-                activeElement instanceof HTMLElement ? activeElement : null;
+            focusOrigin = openingFocusOrigin ??
+                (activeElement instanceof HTMLElement ? activeElement : null);
             focusOriginDialog = focusOrigin?.closest<HTMLElement>(
                 '[role="dialog"]',
             ) ?? null;

--- a/src/components/PostContentPreview.svelte
+++ b/src/components/PostContentPreview.svelte
@@ -37,6 +37,7 @@
         onImageOpen?: (params: {
             index: number;
             mediaList: FullscreenMediaItem[];
+            focusOrigin: HTMLElement | null;
         }) => void;
         betweenContentAndMedia?: Snippet;
     }

--- a/src/components/PostHistoryMediaList.svelte
+++ b/src/components/PostHistoryMediaList.svelte
@@ -26,6 +26,7 @@
         onImageOpen?: (params: {
             index: number;
             mediaList: FullscreenMediaItem[];
+            focusOrigin: HTMLElement | null;
         }) => void;
         mediaLayout?: PostHistoryMediaLayout;
     }
@@ -370,7 +371,10 @@
         void mediaCache.fetchAndCacheMedia(item.url);
     }
 
-    function handleImageOpen(item: DisplayMediaItem): void {
+    function handleImageOpen(
+        item: DisplayMediaItem,
+        focusOrigin: HTMLElement | null,
+    ): void {
         if (!item.cached) {
             return;
         }
@@ -385,6 +389,7 @@
         onImageOpen?.({
             index,
             mediaList: resolvedMediaLayout.fullscreenMediaItems,
+            focusOrigin,
         });
     }
 
@@ -601,8 +606,13 @@
                                                 item,
                                             )}
                                             title={getLinkLabel(item)}
-                                            onclick={() =>
-                                                handleImageOpen(item)}
+                                            onclick={(event) =>
+                                                handleImageOpen(
+                                                    item,
+                                                    event.currentTarget instanceof HTMLElement
+                                                        ? event.currentTarget
+                                                        : null,
+                                                )}
                                         >
                                             {#if isSingleImage}
                                                 <div

--- a/src/test/e2e/postEditorSending.spec.ts
+++ b/src/test/e2e/postEditorSending.spec.ts
@@ -20,7 +20,7 @@ test.describe('post editor sending state', () => {
             await expect(editorContainer).toHaveAttribute('aria-disabled', 'true');
             await expect(editor).toHaveAttribute('contenteditable', 'false');
             await expect(editor).toContainText('送信中も確認する本文');
-            await expect.poll(() => editor.evaluate((element) => getComputedStyle(element).opacity)).toBe('0.82');
+            await expect.poll(() => editor.evaluate((element) => getComputedStyle(element).opacity)).toBe('0.72');
 
             await editor.click();
             await page.keyboard.type('変更不可');

--- a/src/test/e2e/webComponentDevServer.spec.ts
+++ b/src/test/e2e/webComponentDevServer.spec.ts
@@ -109,7 +109,7 @@ test("serves the Web Component sample through the local dev proxy", async ({ pag
         await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
         await expect(page.locator("#module-url")).toHaveValue(`${origin}/ehagaki/web-component/ehagaki-composer.js`);
         await expect(page.locator("#asset-base")).toHaveValue(`${origin}/ehagaki/web-component/`);
-        await expect(page.locator("#ready-status")).toHaveText("whenReady(): resolved");
+        await expect(page.locator("#ready-status")).toContainText("whenReady(): resolved");
         await page.waitForFunction(() => document.querySelector("ehagaki-composer")?.shadowRoot?.querySelector(".footer-bar"));
 
         const iconStatus = await page.evaluate(async () => (

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -3,6 +3,7 @@ import { createServer, type Server } from "node:http";
 import { readFile, readdir } from "node:fs/promises";
 import { extname, join, normalize } from "node:path";
 import { nip19 } from "nostr-tools";
+import { ensureWebComponentE2EOutput } from "../../../scripts/ensureWebComponentE2EOutput.mjs";
 
 declare global {
     interface Window {
@@ -55,6 +56,8 @@ function contentTypeFor(filePath: string): string {
 }
 
 test.beforeAll(async () => {
+    test.setTimeout(180_000);
+    await ensureWebComponentE2EOutput();
     componentServer = createServer(async (request, response) => {
         const pathname = new URL(request.url ?? "/", componentOrigin).pathname;
         componentRequests.add(pathname);
@@ -114,7 +117,10 @@ test.beforeEach(() => {
 });
 
 test.afterAll(async () => {
-    await Promise.all([close(componentServer), close(hostServer)]);
+    await Promise.all([
+        componentServer && close(componentServer),
+        hostServer && close(hostServer),
+    ]);
 });
 
 test("mounts across origins without touching host storage or registering an eHagaki Service Worker", async ({ page }) => {

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -898,6 +898,75 @@ test("keeps authenticated profile and post history dialogs inside the component"
     expect(result.history.listScrollHeight).toBeLessThanOrEqual(result.history.listClientHeight + 1);
 });
 
+test("restores Web Component image focus without using browser history", async ({ page }) => {
+    const imageBody = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+        "base64",
+    );
+    await page.route("**/web-component-focus-image.jpg", (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: "image/png",
+            body: imageBody,
+        }),
+    );
+    await page.goto(hostOrigin);
+
+    await page.evaluate(async () => {
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+        };
+        composer.style.width = "360px";
+        composer.style.height = "520px";
+        document.body.append(composer);
+        await composer.whenReady();
+        const shadow = composer.shadowRoot!;
+        // The public embed API has no media-insertion method; exercise the
+        // component's real image-fullscreen ingress from a Shadow DOM image button.
+        const imageButton = document.createElement("button");
+        imageButton.type = "button";
+        imageButton.className = "web-component-focus-image";
+        imageButton.setAttribute("aria-label", "Focus image");
+        const image = document.createElement("img");
+        image.src = `${location.origin}/web-component-focus-image.jpg`;
+        image.alt = "Focus image";
+        imageButton.append(image);
+        imageButton.addEventListener("click", () => {
+            window.dispatchEvent(new CustomEvent("image-fullscreen-request", {
+                detail: { src: image.src, alt: image.alt },
+            }));
+        });
+        shadow.append(imageButton);
+    });
+
+    const composer = page.locator("ehagaki-composer");
+    const image = composer.locator(".web-component-focus-image");
+    await expect(composer.locator(".tiptap-editor")).toBeVisible();
+    const beforeOpen = await page.evaluate(() => ({
+        length: history.length,
+        state: history.state,
+    }));
+    await image.focus();
+    await expect(image).toBeFocused();
+    await image.press("Enter");
+    await expect(composer.locator(".ehagaki-pswp")).toBeVisible();
+    const duringViewer = await page.evaluate(() => ({
+        length: history.length,
+        state: history.state,
+    }));
+    expect(duringViewer).toEqual(beforeOpen);
+
+    await page.keyboard.press("Escape");
+    await expect(composer.locator(".ehagaki-pswp")).toBeHidden();
+    await expect(image).toBeFocused();
+    const afterClose = await page.evaluate(() => ({
+        length: history.length,
+        state: history.state,
+    }));
+    expect(afterClose).toEqual(beforeOpen);
+});
+
 test("keeps a large Web Component post history list scrolling above its footer", async ({ page }) => {
     await page.goto(hostOrigin);
     const result = await page.evaluate(async ({ componentStoragePrefix, testPubkeyHex }) => {

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -3,6 +3,7 @@ import { createServer, type Server } from "node:http";
 import { extname, join, normalize } from "node:path";
 import { access, readFile } from "node:fs/promises";
 import { nip19 } from "nostr-tools";
+import { ensureWebComponentE2EOutput } from "../../../scripts/ensureWebComponentE2EOutput.mjs";
 
 let server: Server;
 let origin = "";
@@ -41,6 +42,8 @@ function close(value: Server): Promise<void> {
 }
 
 test.beforeAll(async () => {
+    test.setTimeout(180_000);
+    await ensureWebComponentE2EOutput();
     await access(join(process.cwd(), "dist", "web-component", "ehagaki-composer.js"));
     server = createServer(async (request, response) => {
         const pathname = new URL(request.url ?? "/", origin).pathname;
@@ -86,7 +89,9 @@ test.beforeAll(async () => {
 test.beforeEach(() => requests.clear());
 
 test.afterAll(async () => {
-    await close(server);
+    if (server) {
+        await close(server);
+    }
 });
 
 test("keeps the playground hierarchy and card stacks balanced across desktop and mobile", async ({ page }) => {

--- a/src/test/unit/postHistoryMediaList.test.ts
+++ b/src/test/unit/postHistoryMediaList.test.ts
@@ -967,6 +967,7 @@ describe('PostHistoryMediaList', () => {
 
         expect(onImageOpen).toHaveBeenCalledWith({
             index: 0,
+            focusOrigin: expect.any(HTMLButtonElement),
             mediaList: [
                 {
                     id: 'https://example.com/image.jpg',


### PR DESCRIPTION
## Cause
- E2E expectations lagged behind the sending editor opacity and ready-status copy.
- PhotoSwipe focus restoration captured the origin after reactive updates, allowing focus to drift to a sibling image.
- Production-output Web Component specs could silently read stale ignored build directories.

## Changes
- Update the focused assertions without changing the product UI values.
- Capture the image button synchronously and let the application restore it after PhotoSwipe closes.
- Add source-fingerprinted, lock-protected Web Component E2E preparation for the two specs that directly serve production outputs. It builds only when required outputs are missing or fingerprinted source inputs changed, so normal Vite E2E remain build-free and projects reuse the prepared output.

## Validation
- npm run check
- npm test (335 files, 3861 tests)
- npm run build
- npm run test:e2e (198 tests; no failure artifacts)
- git diff --check
- Targeted desktop/mobile/WebKit sending and focus E2E, production sample and embed E2E.

No physical device verification was run; mobile coverage uses Playwright emulation.