### PR TITLE
Speed up Playwright E2E with safe worker parallelism

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "test": "npm run complexity:thread-graph && vitest run",
     "test:unit": "npm run complexity:thread-graph && vitest run src/test/unit",
     "test:ui": "vitest --ui",
-    "test:e2e": "playwright test",
+    "test:e2e": "npm run test:e2e:dev-server && npm run test:e2e:parallel",
+    "test:e2e:dev-server": "playwright test --config=playwright.web-component-dev.config.ts",
+    "test:e2e:parallel": "playwright test --workers=2",
     "deploy": "gh-pages -d dist"
   },
   "devDependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
         timeout: 5_000,
     },
     fullyParallel: false,
-    workers: 1,
+    workers: 2,
     use: {
         baseURL: endpoints.appBaseURL,
         locale: 'ja-JP',
@@ -34,12 +34,14 @@ export default defineConfig({
     projects: [
         {
             name: 'desktop-chromium',
+            testIgnore: '**/webComponentDevServer.spec.ts',
             use: {
                 ...devices['Desktop Chrome'],
             },
         },
         {
             name: 'mobile-chromium',
+            testIgnore: '**/webComponentDevServer.spec.ts',
             use: {
                 ...devices['iPhone 13'],
             },

--- a/playwright.web-component-dev.config.ts
+++ b/playwright.web-component-dev.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig, devices } from '@playwright/test';
+import baseConfig from './playwright.config';
+
+export default defineConfig({
+    ...baseConfig,
+    webServer: undefined,
+    fullyParallel: false,
+    workers: 1,
+    projects: [
+        {
+            name: 'web-component-dev-server',
+            testMatch: '**/webComponentDevServer.spec.ts',
+            use: {
+                ...devices['Desktop Chrome'],
+            },
+        },
+    ],
+});


### PR DESCRIPTION
## 変更概要
- Web Component dev-server E2Eを専用configへ分離し、desktop Chromiumで1回だけ実行します。
- 通常のdesktop/mobile Chromium projectから同specを除外します。
- fullyParallel=falseを維持し、通常suiteをworkers=2で実行します。
- `npm run test:e2e`はdev-server suite完了後に通常suiteを実行する段階構成です。

## 競合原因
`webComponentDevServer.spec.ts`が`dist-web-component`を削除・再生成し、`src/web-component/entry.ts`のmtimeを変更する間に、Web Component E2Eが同じ成果物を読み、workers=2/4でfilesystem競合が発生していました。

## 採用方式
通常configはdev-server specをignoreし、専用configは`webServer`を起動せずdesktop Chrome相当の1 workerで対象specだけを実行します。npm scriptの`&&`で専用実行と通常suiteを順次化します。通常の`npx playwright test`も危険なdev-server並列を起こしません。

## Browser coverage
既存のdesktop Chromium、mobile Chromium、mobile WebKit、desktop Firefoxの通常coverageは維持しています。dev-server検証のみ、viewport差に依存しないためdesktop Chromiumの1回へ整理しました。

## 実測
- 変更前 workers=1 full E2E: 約379秒、190 passed / 12 skipped。
- 変更後 `npm run test:e2e`: 約247.5秒、dev-server 1 passed、通常suite 188 passed / 12 skipped、failure 0、retry 0。
- 約131秒短縮（約34.7%）。
- 変更後の project test list: desktop Chromium 69、mobile Chromium 69、mobile WebKit 45、desktop Firefox 17、専用dev-server 1。

## 検証
- `npm run test:e2e:dev-server`: 1 passed (49.2s)
- `npm run test:e2e`: passed
- `npm run check`: 0 errors / 0 warnings
- `npm test`: 335 files / 3,861 tests passed
- `git diff --check`: passed

JSON timing取得の再実行では既存のdesktop composer focus assertionが1回 intermittent failureしましたが、変更後の完全E2E本実行はfailure/retryなしで成功し、該当spec単独の再実行も15 passedでした。

未実行: workers=4の追加ベンチマーク。既定採用条件ではなく、workers=2の安全な完全E2Eを優先しました。