### PR TITLE
Recover stale Web Component subst mappings safely

### DIFF
--- a/scripts/devWebComponentSample.mjs
+++ b/scripts/devWebComponentSample.mjs
@@ -126,11 +126,25 @@ function startWebComponentServer() {
 }
 
 function watchChild(label, child) {
+    let handled = false;
+    const handleFailure = (detail) => {
+        if (handled || shuttingDown) return;
+        handled = true;
+        console.error(`${label} stopped unexpectedly (${detail}).`);
+        requestShutdown(1);
+    };
+    child.once("error", (error) => {
+        handleFailure(error instanceof Error ? error.message : String(error));
+    });
     child.once("exit", (code, signal) => {
-        if (!shuttingDown) {
-            console.error(`${label} stopped unexpectedly (${signal ?? code ?? "unknown"}).`);
-            void shutdown(code ?? 1);
-        }
+        handleFailure(signal ?? code ?? "unknown");
+    });
+}
+
+function requestShutdown(exitCode) {
+    void shutdown(exitCode).catch((error) => {
+        console.error(error instanceof Error ? error.message : error);
+        process.exitCode = 1;
     });
 }
 
@@ -167,12 +181,18 @@ function terminateChild(child) {
 async function shutdown(exitCode) {
     if (shuttingDown) return;
     shuttingDown = true;
-    await Promise.all([
+    const terminationResults = await Promise.allSettled([
         terminateChild(initialBuild),
         terminateChild(watcher),
         terminateChild(viteServer),
         closeServer(webComponentServer),
     ]);
+    for (const result of terminationResults) {
+        if (result.status === "rejected") {
+            console.error(result.reason instanceof Error ? result.reason.message : result.reason);
+            exitCode = 1;
+        }
+    }
     try {
         await webComponentBuildWorkingDirectory?.cleanup();
     } catch (error) {
@@ -221,9 +241,12 @@ async function main() {
     }
 }
 
-for (const signal of ["SIGINT", "SIGTERM"]) {
+const shutdownSignals = ["SIGINT", "SIGTERM", "SIGHUP"];
+if (process.platform === "win32") shutdownSignals.push("SIGBREAK");
+
+for (const signal of shutdownSignals) {
     process.once(signal, () => {
-        void shutdown(0);
+        requestShutdown(0);
     });
 }
 

--- a/scripts/runWebComponentBuild.mjs
+++ b/scripts/runWebComponentBuild.mjs
@@ -15,10 +15,15 @@ function waitForExit(child) {
 async function shutdown(exitCode) {
     if (shuttingDown) return;
     shuttingDown = true;
-    if (activeChild?.exitCode === null) {
-        const exited = waitForExit(activeChild);
-        activeChild.kill("SIGTERM");
-        await exited;
+    try {
+        if (activeChild?.exitCode === null) {
+            const exited = waitForExit(activeChild);
+            activeChild.kill("SIGTERM");
+            await exited;
+        }
+    } catch (error) {
+        console.error(error instanceof Error ? error.message : error);
+        exitCode = 1;
     }
     try {
         await workingDirectoryHandle?.cleanup();
@@ -29,9 +34,15 @@ async function shutdown(exitCode) {
     process.exitCode = exitCode;
 }
 
-for (const signal of ["SIGINT", "SIGTERM"]) {
+const shutdownSignals = ["SIGINT", "SIGTERM", "SIGHUP"];
+if (process.platform === "win32") shutdownSignals.push("SIGBREAK");
+
+for (const signal of shutdownSignals) {
     process.once(signal, () => {
-        void shutdown(0);
+        void shutdown(0).catch((error) => {
+            console.error(error instanceof Error ? error.message : error);
+            process.exitCode = 1;
+        });
     });
 }
 

--- a/scripts/webComponentBuildWorkingDirectory.mjs
+++ b/scripts/webComponentBuildWorkingDirectory.mjs
@@ -1,46 +1,129 @@
+import { createHash, randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
+import { mkdir, open, readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join, win32 } from "node:path";
 
 const candidateDriveLetters = "ZYXWVUTSRQPONMLKJIHGFED";
+const stateFormatVersion = 1;
+const stateDirectoryName = "ehagaki-web-component-build";
+/** @type {Promise<string|null>|undefined} */
+let substOutputEncodingPromise;
 
 /** @param {string} repositoryRoot @param {NodeJS.Platform} [platform] */
 export function needsWindowsAsciiWorkingDirectory(repositoryRoot, platform = process.platform) {
     return platform === "win32" && /[^\x00-\x7F]/.test(repositoryRoot);
 }
 
+/** @param {string} repositoryRoot */
+export function normalizeWindowsRepositoryRoot(repositoryRoot) {
+    const normalized = win32.normalize(repositoryRoot).replaceAll("/", "\\");
+    if (/^[a-z]:\\$/i.test(normalized)) return normalized.toLowerCase();
+    return normalized.replace(/[\\]+$/, "").toLowerCase();
+}
+
+/** @param {string} normalizedRepositoryRoot @param {string} [stateDirectory] */
+export function getWebComponentBuildStatePaths(normalizedRepositoryRoot, stateDirectory = tmpdir()) {
+    const rootHash = createHash("sha256").update(normalizedRepositoryRoot).digest("hex");
+    const directory = join(stateDirectory, stateDirectoryName, rootHash);
+    return {
+        directory,
+        leasePath: join(directory, "lease.json"),
+        mappingStatePath: join(directory, "mapping-state.json"),
+    };
+}
+
 /** @param {(path: string) => boolean} [pathExists] */
 export function findAvailableSubstDriveLetter(pathExists = existsSync) {
     for (const driveLetter of candidateDriveLetters) {
-        if (!pathExists(`${driveLetter}:\\`)) {
-            return driveLetter;
-        }
+        if (!pathExists(`${driveLetter}:\\`)) return driveLetter;
     }
     throw new Error("Could not find an unused Windows drive letter for the temporary Web Component build path.");
 }
 
-/** @param {string[]} args @returns {Promise<void>} */
+/** @returns {Promise<string|null>} */
+function getWindowsAnsiEncoding() {
+    if (substOutputEncodingPromise) return substOutputEncodingPromise;
+    substOutputEncodingPromise = new Promise((resolve, reject) => {
+        const child = spawn("reg.exe", [
+            "query",
+            "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage",
+            "/v",
+            "ACP",
+        ], { stdio: ["ignore", "pipe", "ignore"], windowsHide: true });
+        /** @type {Buffer[]} */
+        const chunks = [];
+        child.stdout.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        child.once("error", reject);
+        child.once("exit", (code) => {
+            if (code !== 0) {
+                resolve(null);
+                return;
+            }
+            const codePage = Buffer.concat(chunks).toString("ascii").match(/ACP\s+REG_SZ\s+(\d+)/i)?.[1];
+            /** @type {Record<string, string>} */
+            const encodings = {
+                "65001": "utf-8",
+                "932": "shift_jis",
+                "936": "gbk",
+                "949": "euc-kr",
+                "950": "big5",
+                "1250": "windows-1250",
+                "1251": "windows-1251",
+                "1252": "windows-1252",
+                "1253": "windows-1253",
+                "1254": "windows-1254",
+                "1255": "windows-1255",
+                "1256": "windows-1256",
+                "1257": "windows-1257",
+                "1258": "windows-1258",
+            };
+            resolve(codePage ? encodings[codePage] ?? null : null);
+        });
+    });
+    return substOutputEncodingPromise;
+}
+
+/** @param {Buffer} output @returns {Promise<string>} */
+async function decodeSubstOutput(output) {
+    const encoding = process.platform === "win32" ? await getWindowsAnsiEncoding() : "utf-8";
+    if (!encoding) throw new Error("Could not determine the Windows ANSI code page for subst output.");
+    return new TextDecoder(encoding).decode(output);
+}
+
+/** @param {string[]} args @returns {Promise<string>} */
 function runSubst(args) {
     return new Promise((resolve, reject) => {
-        const child = spawn("subst", args, {
+        const command = args.length === 0 ? "cmd.exe" : "subst";
+        const commandArgs = args.length === 0 ? ["/d", "/s", "/c", "chcp 65001>nul & subst"] : args;
+        const child = spawn(command, commandArgs, {
             stdio: ["ignore", "pipe", "pipe"],
             windowsHide: true,
         });
-        let output = "";
-        child.stdout.on("data", (chunk) => {
-            output += String(chunk);
-        });
-        child.stderr.on("data", (chunk) => {
-            output += String(chunk);
-        });
+        /** @type {Buffer[]} */
+        const chunks = [];
+        child.stdout.on("data", (chunk) => { chunks.push(Buffer.from(chunk)); });
+        child.stderr.on("data", (chunk) => { chunks.push(Buffer.from(chunk)); });
         child.once("error", reject);
         child.once("exit", (code) => {
             if (code === 0) {
-                resolve();
+                void decodeSubstOutput(Buffer.concat(chunks)).then(resolve, reject);
                 return;
             }
+            const output = Buffer.concat(chunks).toString("utf8");
             reject(new Error(`subst ${args.join(" ")} failed (${code ?? "unknown"})${output ? `: ${output.trim()}` : ""}`));
         });
     });
+}
+
+/** @param {string} drive @param {() => Promise<string>} [listSubst] */
+export async function readSubstMapping(drive, listSubst = () => runSubst([])) {
+    const output = await listSubst();
+    const driveLetter = drive.slice(0, 1).toUpperCase();
+    const mappingPattern = new RegExp(`^${driveLetter}:\\\\:\\s*=>\\s*(.+)$`, "im");
+    const match = output.match(mappingPattern);
+    return match ? match[1].trim() : null;
 }
 
 /**
@@ -48,9 +131,239 @@ function runSubst(args) {
  * @property {string} physicalRepositoryRoot
  * @property {NodeJS.Platform} [platform]
  * @property {(path: string) => boolean} [pathExists]
- * @property {(args: string[]) => Promise<void>} [executeSubst]
+ * @property {(args: string[]) => Promise<string|void>} [executeSubst]
+ * @property {(drive: string) => Promise<string|null>} [readSubstMapping]
+ * @property {(pid: number) => "alive"|"dead"|"unknown"} [getProcessStatus]
+ * @property {string} [stateDirectory]
+ * @property {number} [ownerPid]
+ * @property {() => string} [createLeaseId]
+ * @property {(path: string, value: unknown) => Promise<void>} [writeState]
  * @property {(message: string) => void} [log]
  */
+
+/** @param {unknown} value @returns {value is Record<string, unknown>} */
+function isRecord(value) {
+    return typeof value === "object" && value !== null;
+}
+
+/** @param {unknown} value @returns {value is { code?: string }} */
+function isFileNotFoundError(value) {
+    return isRecord(value) && value.code === "ENOENT";
+}
+
+/** @param {number} pid */
+function getProcessStatus(pid) {
+    try {
+        process.kill(pid, 0);
+        return "alive";
+    } catch (error) {
+        if (isRecord(error) && error.code === "ESRCH") return "dead";
+        return "unknown";
+    }
+}
+
+/** @param {string} path */
+async function readJson(path) {
+    return JSON.parse(await readFile(path, "utf8"));
+}
+
+/** @param {string} path @param {unknown} value */
+async function writeJsonAtomically(path, value) {
+    await mkdir(dirname(path), { recursive: true });
+    const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+        await writeFile(temporaryPath, `${JSON.stringify(value)}\n`, { flag: "wx" });
+        await rename(temporaryPath, path);
+    } finally {
+        await rm(temporaryPath, { force: true });
+    }
+}
+
+/** @param {string} path */
+async function removeFile(path) {
+    await unlink(path).catch((error) => {
+        if (!isFileNotFoundError(error)) throw error;
+    });
+}
+
+/** @param {unknown} value @param {string} normalizedRoot @param {string} kind */
+function validateState(value, normalizedRoot, kind) {
+    if (!isRecord(value)) {
+        throw new Error(`Invalid Web Component ${kind} format.`);
+    }
+    const ownerPid = value.ownerPid;
+    const leaseId = value.leaseId;
+    if (value.formatVersion !== stateFormatVersion
+        || (normalizedRoot && value.normalizedPhysicalRepositoryRoot !== normalizedRoot)
+        || typeof ownerPid !== "number"
+        || !Number.isSafeInteger(ownerPid)
+        || ownerPid <= 0
+        || typeof leaseId !== "string"
+        || leaseId.length === 0) {
+        throw new Error(`Invalid Web Component ${kind} format.`);
+    }
+    if (kind === "mapping state"
+        && (typeof value.drive !== "string"
+            || !/^[A-Z]:$/i.test(value.drive)
+            || (value.phase !== "prepared" && value.phase !== "mapped"))) {
+        throw new Error("Invalid Web Component mapping state format.");
+    }
+    return /** @type {Record<string, unknown>} */ (value);
+}
+
+/** @param {string} prefix @param {Record<string, unknown>} details */
+function diagnosticError(prefix, details) {
+    return new Error(`${prefix} ${Object.entries(details).map(([key, value]) => `${key}=${String(value)}`).join(" ")}`);
+}
+
+/** @param {string} mappingTarget @param {string} normalizedRoot */
+function isMatchingMapping(mappingTarget, normalizedRoot) {
+    return normalizeWindowsRepositoryRoot(mappingTarget) === normalizedRoot;
+}
+
+/**
+ * @param {{ leasePath: string; mappingStatePath: string }} paths
+ * @param {Record<string, unknown>} lease
+ * @param {string} normalizedRoot
+ * @param {(drive: string) => Promise<string|null>} readMapping
+ * @param {(args: string[]) => Promise<string|void>} executeSubst
+ */
+async function recoverStaleLease(paths, lease, normalizedRoot, readMapping, executeSubst) {
+    validateState(lease, normalizedRoot, "lease");
+    let mappingState;
+    try {
+        mappingState = validateState(await readJson(paths.mappingStatePath), normalizedRoot, "mapping state");
+    } catch (error) {
+        if (isFileNotFoundError(error)) {
+            await removeFile(paths.leasePath);
+            return;
+        }
+        throw diagnosticError("Cannot recover invalid Web Component lease.", {
+            leasePath: paths.leasePath,
+            mappingStatePath: paths.mappingStatePath,
+            physicalRoot: normalizedRoot,
+            recordedPhysicalRoot: lease.normalizedPhysicalRepositoryRoot,
+            recordedPid: lease.ownerPid,
+            mappingStatePresent: true,
+            reason: error instanceof Error ? error.message : String(error),
+        });
+    }
+
+    if (mappingState.leaseId !== lease.leaseId || mappingState.ownerPid !== lease.ownerPid) {
+        throw diagnosticError("Cannot recover mismatched Web Component lease state.", {
+            leasePath: paths.leasePath,
+            mappingStatePath: paths.mappingStatePath,
+            physicalRoot: normalizedRoot,
+            recordedPid: lease.ownerPid,
+            recordedDrive: mappingState.drive,
+            mappingStatePresent: true,
+            reason: "lease and mapping state identity differs",
+        });
+    }
+
+    const drive = String(mappingState.drive).toUpperCase();
+    const mappingTarget = await readMapping(drive);
+    if (mappingTarget === null) {
+        await removeFile(paths.mappingStatePath);
+        await removeFile(paths.leasePath);
+        return;
+    }
+    if (!isMatchingMapping(mappingTarget, normalizedRoot)) {
+        await removeFile(paths.mappingStatePath);
+        await removeFile(paths.leasePath);
+        return;
+    }
+
+    await executeSubst([drive, "/D"]);
+    if (await readMapping(drive) !== null) {
+        throw diagnosticError("Web Component stale mapping cleanup did not remove the mapping.", {
+            leasePath: paths.leasePath,
+            mappingStatePath: paths.mappingStatePath,
+            physicalRoot: normalizedRoot,
+            recordedPid: lease.ownerPid,
+            recordedDrive: drive,
+            mappingTarget,
+            mappingStatePresent: true,
+            reason: "subst mapping remains after /D",
+        });
+    }
+    await removeFile(paths.mappingStatePath);
+    await removeFile(paths.leasePath);
+}
+
+/**
+ * @param {{ leasePath: string; mappingStatePath: string; directory: string }} paths
+ * @param {string} normalizedRoot
+ * @param {number} ownerPid
+ * @param {string} leaseId
+ * @param {(pid: number) => "alive"|"dead"|"unknown"} getStatus
+ * @param {(drive: string) => Promise<string|null>} readMapping
+ * @param {(args: string[]) => Promise<string|void>} executeSubst
+ */
+async function acquireLease(paths, normalizedRoot, ownerPid, leaseId, getStatus, readMapping, executeSubst) {
+    await mkdir(paths.directory, { recursive: true });
+    const lease = {
+        formatVersion: stateFormatVersion,
+        normalizedPhysicalRepositoryRoot: normalizedRoot,
+        ownerPid,
+        leaseId,
+    };
+
+    for (;;) {
+        try {
+            const handle = await open(paths.leasePath, "wx");
+            try {
+                await handle.writeFile(`${JSON.stringify(lease)}\n`);
+            } finally {
+                await handle.close();
+            }
+            return lease;
+        } catch (error) {
+            if (!isRecord(error) || error.code !== "EEXIST") throw error;
+        }
+
+        let existingLease;
+        try {
+            existingLease = validateState(await readJson(paths.leasePath), normalizedRoot, "lease");
+        } catch (error) {
+            if (isFileNotFoundError(error)) continue;
+            throw diagnosticError("Cannot inspect existing Web Component lease.", {
+                leasePath: paths.leasePath,
+                physicalRoot: normalizedRoot,
+                mappingStatePresent: existsSync(paths.mappingStatePath),
+                reason: error instanceof Error ? error.message : String(error),
+            });
+        }
+
+        const status = getStatus(/** @type {number} */ (existingLease.ownerPid));
+        if (status !== "dead") {
+            throw diagnosticError("A Web Component build is already active for this repository.", {
+                leasePath: paths.leasePath,
+                physicalRoot: normalizedRoot,
+                recordedPid: existingLease.ownerPid,
+                mappingStatePresent: existsSync(paths.mappingStatePath),
+                reason: status === "unknown" ? "owner liveness could not be confirmed" : "owner is alive",
+            });
+        }
+        await recoverStaleLease(paths, existingLease, normalizedRoot, readMapping, executeSubst);
+    }
+}
+
+/** @param {{ mappingStatePath: string; leasePath: string }} paths @param {string} normalizedRoot @param {string} leaseId @param {number} ownerPid */
+async function removeOwnedState(paths, normalizedRoot, leaseId, ownerPid) {
+    let lease;
+    try {
+        lease = validateState(await readJson(paths.leasePath), normalizedRoot, "lease");
+    } catch (error) {
+        if (isFileNotFoundError(error)) return;
+        throw error;
+    }
+    if (lease.leaseId !== leaseId || lease.ownerPid !== ownerPid) {
+        throw new Error("Web Component lease ownership changed before cleanup.");
+    }
+    await removeFile(paths.mappingStatePath);
+    await removeFile(paths.leasePath);
+}
 
 /** @param {WebComponentBuildWorkingDirectoryOptions} options */
 export async function createWebComponentBuildWorkingDirectory({
@@ -58,6 +371,12 @@ export async function createWebComponentBuildWorkingDirectory({
     platform = process.platform,
     pathExists = existsSync,
     executeSubst = runSubst,
+    readSubstMapping: readMapping = (drive) => readSubstMapping(drive),
+    getProcessStatus: getStatus = getProcessStatus,
+    stateDirectory = tmpdir(),
+    ownerPid = process.pid,
+    createLeaseId = randomUUID,
+    writeState = writeJsonAtomically,
     log = console.log,
 }) {
     if (!needsWindowsAsciiWorkingDirectory(physicalRepositoryRoot, platform)) {
@@ -68,16 +387,97 @@ export async function createWebComponentBuildWorkingDirectory({
         };
     }
 
-    const driveLetter = findAvailableSubstDriveLetter(pathExists);
-    const drive = `${driveLetter}:`;
+    const normalizedRoot = normalizeWindowsRepositoryRoot(physicalRepositoryRoot);
+    const paths = getWebComponentBuildStatePaths(normalizedRoot, stateDirectory);
+    const leaseId = createLeaseId();
+    const lease = await acquireLease(paths, normalizedRoot, ownerPid, leaseId, getStatus, readMapping, executeSubst);
+    let drive;
+    let cleanedUp = false;
+
     try {
-        await executeSubst([drive, physicalRepositoryRoot]);
+        for (;;) {
+            const driveLetter = findAvailableSubstDriveLetter(pathExists);
+            drive = `${driveLetter}:`;
+            await writeState(paths.mappingStatePath, {
+                formatVersion: stateFormatVersion,
+                normalizedPhysicalRepositoryRoot: normalizedRoot,
+                ownerPid,
+                leaseId,
+                drive,
+                phase: "prepared",
+            });
+
+            try {
+                await executeSubst([drive, physicalRepositoryRoot]);
+            } catch (error) {
+                const mappingTarget = await readMapping(drive);
+                if (mappingTarget !== null && isMatchingMapping(mappingTarget, normalizedRoot)) {
+                    await executeSubst([drive, "/D"]);
+                    if (await readMapping(drive) !== null) {
+                        throw new Error("Temporary Web Component subst mapping remained after collision cleanup.");
+                    }
+                } else if (mappingTarget !== null) {
+                    await removeFile(paths.mappingStatePath);
+                    continue;
+                } else {
+                    await removeFile(paths.mappingStatePath);
+                    throw error;
+                }
+                await removeFile(paths.mappingStatePath);
+                continue;
+            }
+
+            const mappingTarget = await readMapping(drive);
+            if (mappingTarget === null) {
+                await removeFile(paths.mappingStatePath);
+                throw new Error(`subst succeeded but ${drive} was not visible as a mapping.`);
+            }
+            if (!isMatchingMapping(mappingTarget, normalizedRoot)) {
+                await removeFile(paths.mappingStatePath);
+                throw diagnosticError("Temporary Web Component drive became a foreign mapping.", {
+                    leasePath: paths.leasePath,
+                    mappingStatePath: paths.mappingStatePath,
+                    physicalRoot: normalizedRoot,
+                    recordedPid: ownerPid,
+                    recordedDrive: drive,
+                    mappingTarget,
+                    reason: "mapping target does not match current repository",
+                });
+            }
+
+            try {
+                await writeState(paths.mappingStatePath, {
+                    formatVersion: stateFormatVersion,
+                    normalizedPhysicalRepositoryRoot: normalizedRoot,
+                    ownerPid,
+                    leaseId,
+                    drive,
+                    phase: "mapped",
+                });
+            } catch (error) {
+                await executeSubst([drive, "/D"]);
+                if (await readMapping(drive) === null) {
+                    await removeOwnedState(paths, normalizedRoot, leaseId, ownerPid);
+                }
+                throw error;
+            }
+            break;
+        }
     } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error);
-        throw new Error(`Could not create a temporary Windows path for the Web Component build: ${detail}`);
+        try {
+            const mappingTarget = drive ? await readMapping(drive) : null;
+            if (mappingTarget === null || !isMatchingMapping(mappingTarget, normalizedRoot)) {
+                await removeOwnedState(paths, normalizedRoot, leaseId, ownerPid);
+            }
+        } catch (cleanupError) {
+            throw new Error(
+                `Could not create a temporary Windows path for the Web Component build: ${error instanceof Error ? error.message : String(error)}; `
+                + `setup cleanup also failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+            );
+        }
+        throw new Error(`Could not create a temporary Windows path for the Web Component build: ${error instanceof Error ? error.message : String(error)}`);
     }
 
-    let cleanedUp = false;
     log(`Web Component build uses temporary Windows path ${drive}\\`);
     return {
         workingDirectory: `${drive}\\`,
@@ -85,7 +485,42 @@ export async function createWebComponentBuildWorkingDirectory({
         cleanup: async () => {
             if (cleanedUp) return;
             cleanedUp = true;
+            let currentLease;
+            try {
+                currentLease = validateState(await readJson(paths.leasePath), normalizedRoot, "lease");
+            } catch (error) {
+                if (isFileNotFoundError(error)) return;
+                cleanedUp = false;
+                throw error;
+            }
+            if (currentLease.leaseId !== lease.leaseId || currentLease.ownerPid !== ownerPid) {
+                cleanedUp = false;
+                throw new Error("Web Component lease ownership changed before cleanup.");
+            }
+
+            const mappingTarget = await readMapping(drive);
+            if (mappingTarget === null) {
+                await removeOwnedState(paths, normalizedRoot, leaseId, ownerPid);
+                return;
+            }
+            if (!isMatchingMapping(mappingTarget, normalizedRoot)) {
+                await removeOwnedState(paths, normalizedRoot, leaseId, ownerPid);
+                throw diagnosticError("Refusing to remove a foreign Web Component mapping.", {
+                    leasePath: paths.leasePath,
+                    mappingStatePath: paths.mappingStatePath,
+                    physicalRoot: normalizedRoot,
+                    recordedPid: ownerPid,
+                    recordedDrive: drive,
+                    mappingTarget,
+                    reason: "mapping target changed before cleanup",
+                });
+            }
             await executeSubst([drive, "/D"]);
+            if (await readMapping(drive) !== null) {
+                cleanedUp = false;
+                throw new Error(`Temporary Web Component subst mapping ${drive} remained after cleanup.`);
+            }
+            await removeOwnedState(paths, normalizedRoot, leaseId, ownerPid);
         },
     };
 }

--- a/scripts/webComponentBuildWorkingDirectory.mjs
+++ b/scripts/webComponentBuildWorkingDirectory.mjs
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, open, readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
+import { mkdir, open, readFile, realpath, rename, rm, unlink, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { dirname, join, win32 } from "node:path";
@@ -8,8 +8,6 @@ import { dirname, join, win32 } from "node:path";
 const candidateDriveLetters = "ZYXWVUTSRQPONMLKJIHGFED";
 const stateFormatVersion = 1;
 const stateDirectoryName = "ehagaki-web-component-build";
-/** @type {Promise<string|null>|undefined} */
-let substOutputEncodingPromise;
 
 /** @param {string} repositoryRoot @param {NodeJS.Platform} [platform] */
 export function needsWindowsAsciiWorkingDirectory(repositoryRoot, platform = process.platform) {
@@ -42,62 +40,14 @@ export function findAvailableSubstDriveLetter(pathExists = existsSync) {
     throw new Error("Could not find an unused Windows drive letter for the temporary Web Component build path.");
 }
 
-/** @returns {Promise<string|null>} */
-function getWindowsAnsiEncoding() {
-    if (substOutputEncodingPromise) return substOutputEncodingPromise;
-    substOutputEncodingPromise = new Promise((resolve, reject) => {
-        const child = spawn("reg.exe", [
-            "query",
-            "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage",
-            "/v",
-            "ACP",
-        ], { stdio: ["ignore", "pipe", "ignore"], windowsHide: true });
-        /** @type {Buffer[]} */
-        const chunks = [];
-        child.stdout.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
-        child.once("error", reject);
-        child.once("exit", (code) => {
-            if (code !== 0) {
-                resolve(null);
-                return;
-            }
-            const codePage = Buffer.concat(chunks).toString("ascii").match(/ACP\s+REG_SZ\s+(\d+)/i)?.[1];
-            /** @type {Record<string, string>} */
-            const encodings = {
-                "65001": "utf-8",
-                "932": "shift_jis",
-                "936": "gbk",
-                "949": "euc-kr",
-                "950": "big5",
-                "1250": "windows-1250",
-                "1251": "windows-1251",
-                "1252": "windows-1252",
-                "1253": "windows-1253",
-                "1254": "windows-1254",
-                "1255": "windows-1255",
-                "1256": "windows-1256",
-                "1257": "windows-1257",
-                "1258": "windows-1258",
-            };
-            resolve(codePage ? encodings[codePage] ?? null : null);
-        });
-    });
-    return substOutputEncodingPromise;
-}
-
-/** @param {Buffer} output @returns {Promise<string>} */
-async function decodeSubstOutput(output) {
-    const encoding = process.platform === "win32" ? await getWindowsAnsiEncoding() : "utf-8";
-    if (!encoding) throw new Error("Could not determine the Windows ANSI code page for subst output.");
-    return new TextDecoder(encoding).decode(output);
-}
-
-/** @param {string[]} args @returns {Promise<string>} */
-function runSubst(args) {
+/**
+ * @param {string[]} args
+ * @param {typeof spawn} [spawnProcess]
+ * @returns {Promise<Buffer|void>}
+ */
+export function runSubst(args, spawnProcess = spawn) {
     return new Promise((resolve, reject) => {
-        const command = args.length === 0 ? "cmd.exe" : "subst";
-        const commandArgs = args.length === 0 ? ["/d", "/s", "/c", "chcp 65001>nul & subst"] : args;
-        const child = spawn(command, commandArgs, {
+        const child = spawnProcess("subst", args, {
             stdio: ["ignore", "pipe", "pipe"],
             windowsHide: true,
         });
@@ -108,22 +58,38 @@ function runSubst(args) {
         child.once("error", reject);
         child.once("exit", (code) => {
             if (code === 0) {
-                void decodeSubstOutput(Buffer.concat(chunks)).then(resolve, reject);
+                resolve(args.length === 0 ? Buffer.concat(chunks) : undefined);
                 return;
             }
-            const output = Buffer.concat(chunks).toString("utf8");
-            reject(new Error(`subst ${args.join(" ")} failed (${code ?? "unknown"})${output ? `: ${output.trim()}` : ""}`));
+            reject(new Error(`subst ${args.join(" ")} failed (${code ?? "unknown"}).`));
         });
     });
 }
 
-/** @param {string} drive @param {() => Promise<string>} [listSubst] */
-export async function readSubstMapping(drive, listSubst = () => runSubst([])) {
-    const output = await listSubst();
-    const driveLetter = drive.slice(0, 1).toUpperCase();
-    const mappingPattern = new RegExp(`^${driveLetter}:\\\\:\\s*=>\\s*(.+)$`, "im");
-    const match = output.match(mappingPattern);
-    return match ? match[1].trim() : null;
+/** @param {Buffer|string} output */
+export function parseSubstDriveLetters(output) {
+    const listing = Buffer.isBuffer(output) ? output.toString("latin1") : output;
+    return [...listing.matchAll(/^([A-Z]):\\:\s*=>/gim)].map((match) => `${match[1].toUpperCase()}:`);
+}
+
+/**
+ * @param {string} drive
+ * @param {() => Promise<Buffer|string>} [listSubst]
+ * @param {(path: string) => Promise<string>} [resolveMappingTarget]
+ */
+export async function readSubstMapping(
+    drive,
+    listSubst = async () => {
+        const output = await runSubst([]);
+        if (!Buffer.isBuffer(output)) throw new Error("subst listing did not return output.");
+        return output;
+    },
+    resolveMappingTarget = realpath,
+) {
+    const listedDrives = parseSubstDriveLetters(await listSubst());
+    const normalizedDrive = `${drive.slice(0, 1).toUpperCase()}:`;
+    if (!listedDrives.includes(normalizedDrive)) return null;
+    return resolveMappingTarget(`${normalizedDrive}\\`);
 }
 
 /**
@@ -131,7 +97,7 @@ export async function readSubstMapping(drive, listSubst = () => runSubst([])) {
  * @property {string} physicalRepositoryRoot
  * @property {NodeJS.Platform} [platform]
  * @property {(path: string) => boolean} [pathExists]
- * @property {(args: string[]) => Promise<string|void>} [executeSubst]
+ * @property {(args: string[]) => Promise<void>} [executeSubst]
  * @property {(drive: string) => Promise<string|null>} [readSubstMapping]
  * @property {(pid: number) => "alive"|"dead"|"unknown"} [getProcessStatus]
  * @property {string} [stateDirectory]
@@ -226,7 +192,7 @@ function isMatchingMapping(mappingTarget, normalizedRoot) {
  * @param {Record<string, unknown>} lease
  * @param {string} normalizedRoot
  * @param {(drive: string) => Promise<string|null>} readMapping
- * @param {(args: string[]) => Promise<string|void>} executeSubst
+ * @param {(args: string[]) => Promise<void>} executeSubst
  */
 async function recoverStaleLease(paths, lease, normalizedRoot, readMapping, executeSubst) {
     validateState(lease, normalizedRoot, "lease");
@@ -298,7 +264,7 @@ async function recoverStaleLease(paths, lease, normalizedRoot, readMapping, exec
  * @param {string} leaseId
  * @param {(pid: number) => "alive"|"dead"|"unknown"} getStatus
  * @param {(drive: string) => Promise<string|null>} readMapping
- * @param {(args: string[]) => Promise<string|void>} executeSubst
+ * @param {(args: string[]) => Promise<void>} executeSubst
  */
 async function acquireLease(paths, normalizedRoot, ownerPid, leaseId, getStatus, readMapping, executeSubst) {
     await mkdir(paths.directory, { recursive: true });
@@ -370,7 +336,7 @@ export async function createWebComponentBuildWorkingDirectory({
     physicalRepositoryRoot,
     platform = process.platform,
     pathExists = existsSync,
-    executeSubst = runSubst,
+    executeSubst = async (args) => { await runSubst(args); },
     readSubstMapping: readMapping = (drive) => readSubstMapping(drive),
     getProcessStatus: getStatus = getProcessStatus,
     stateDirectory = tmpdir(),

--- a/src/test/integration/webComponentSubst.integration.test.ts
+++ b/src/test/integration/webComponentSubst.integration.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    createWebComponentBuildWorkingDirectory,
+    getWebComponentBuildStatePaths,
+    normalizeWindowsRepositoryRoot,
+} from "../../../scripts/webComponentBuildWorkingDirectory.mjs";
+
+const enabled = process.platform === "win32" && process.env.EHAGAKI_RUN_SUBST_INTEGRATION === "1";
+
+function runSubst(args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const command = args.length === 0 ? "cmd.exe" : "subst";
+        const commandArgs = args.length === 0 ? ["/d", "/s", "/c", "chcp 65001>nul & subst"] : args;
+        const child = spawn(command, commandArgs, {
+            stdio: ["ignore", "pipe", "pipe"],
+            windowsHide: true,
+        });
+        const chunks: Buffer[] = [];
+        child.stdout.on("data", (chunk) => { chunks.push(Buffer.from(chunk)); });
+        child.stderr.on("data", (chunk) => { chunks.push(Buffer.from(chunk)); });
+        child.once("error", reject);
+        child.once("exit", (code) => {
+            if (code === 0) {
+                resolve(new TextDecoder("shift_jis").decode(Buffer.concat(chunks)));
+                return;
+            }
+            reject(new Error(`subst ${args.join(" ")} failed (${code ?? "unknown"}): ${Buffer.concat(chunks).toString("utf8").trim()}`));
+        });
+    });
+}
+
+function parseMappings(output: string): Map<string, string> {
+    const mappings = new Map<string, string>();
+    for (const line of output.split(/\r?\n/)) {
+        const match = line.match(/^([A-Z]):\\:\s*=>\s*(.+)$/i);
+        if (match) mappings.set(`${match[1].toUpperCase()}:`, match[2].trim());
+    }
+    return mappings;
+}
+
+const testGroup = enabled ? describe : describe.skip;
+
+testGroup("Web Component subst integration", () => {
+    it("recovers a stale mapping after an abrupt-termination fixture", async () => {
+        const stateDirectory = await mkdtemp(join(tmpdir(), "ehagaki-subst-integration-"));
+        const physicalRoot = await mkdtemp(join(tmpdir(), "ehagaki-subst-日本-"));
+        const initialMappings = parseMappings(await runSubst([]));
+        const normalizedRoot = normalizeWindowsRepositoryRoot(physicalRoot);
+        const paths = getWebComponentBuildStatePaths(normalizedRoot, stateDirectory);
+        const drivesCreatedByTest = new Set<string>();
+        let firstHandle: Awaited<ReturnType<typeof createWebComponentBuildWorkingDirectory>> | undefined;
+        let secondHandle: Awaited<ReturnType<typeof createWebComponentBuildWorkingDirectory>> | undefined;
+
+        try {
+            firstHandle = await createWebComponentBuildWorkingDirectory({
+                physicalRepositoryRoot: physicalRoot,
+                stateDirectory,
+            });
+            const firstDrive = firstHandle.workingDirectory.slice(0, 2).toUpperCase();
+            drivesCreatedByTest.add(firstDrive);
+
+            const lease = JSON.parse(await readFile(paths.leasePath, "utf8"));
+            const state = JSON.parse(await readFile(paths.mappingStatePath, "utf8"));
+            await writeFile(paths.leasePath, JSON.stringify({ ...lease, ownerPid: 999999 }));
+            await writeFile(paths.mappingStatePath, JSON.stringify({ ...state, ownerPid: 999999 }));
+
+            secondHandle = await createWebComponentBuildWorkingDirectory({
+                physicalRepositoryRoot: physicalRoot,
+                stateDirectory,
+                getProcessStatus: () => "dead",
+            });
+            drivesCreatedByTest.add(secondHandle.workingDirectory.slice(0, 2).toUpperCase());
+            const recoveredMappings = parseMappings(await runSubst([]));
+            expect(recoveredMappings.get(firstDrive)).toBe(physicalRoot);
+            expect([...recoveredMappings.entries()].filter(([drive]) => !initialMappings.has(drive))).toHaveLength(1);
+        } finally {
+            for (const drive of drivesCreatedByTest) {
+                const currentMappings = parseMappings(await runSubst([]));
+                if (currentMappings.get(drive) === physicalRoot) {
+                    await runSubst([drive, "/D"]);
+                }
+            }
+            if (secondHandle) await secondHandle.cleanup().catch(() => {});
+            if (firstHandle) await firstHandle.cleanup().catch(() => {});
+            try {
+                const finalMappings = parseMappings(await runSubst([]));
+                expect([...finalMappings.entries()]).toEqual([...initialMappings.entries()]);
+            } finally {
+                await rm(stateDirectory, { recursive: true, force: true });
+                await rm(physicalRoot, { recursive: true, force: true });
+            }
+        }
+    });
+});

--- a/src/test/integration/webComponentSubst.integration.test.ts
+++ b/src/test/integration/webComponentSubst.integration.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { spawn } from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,39 +6,21 @@ import {
     createWebComponentBuildWorkingDirectory,
     getWebComponentBuildStatePaths,
     normalizeWindowsRepositoryRoot,
+    parseSubstDriveLetters,
+    readSubstMapping,
+    runSubst,
 } from "../../../scripts/webComponentBuildWorkingDirectory.mjs";
 
 const enabled = process.platform === "win32" && process.env.EHAGAKI_RUN_SUBST_INTEGRATION === "1";
 
-function runSubst(args: string[]): Promise<string> {
-    return new Promise((resolve, reject) => {
-        const command = args.length === 0 ? "cmd.exe" : "subst";
-        const commandArgs = args.length === 0 ? ["/d", "/s", "/c", "chcp 65001>nul & subst"] : args;
-        const child = spawn(command, commandArgs, {
-            stdio: ["ignore", "pipe", "pipe"],
-            windowsHide: true,
-        });
-        const chunks: Buffer[] = [];
-        child.stdout.on("data", (chunk) => { chunks.push(Buffer.from(chunk)); });
-        child.stderr.on("data", (chunk) => { chunks.push(Buffer.from(chunk)); });
-        child.once("error", reject);
-        child.once("exit", (code) => {
-            if (code === 0) {
-                resolve(new TextDecoder("shift_jis").decode(Buffer.concat(chunks)));
-                return;
-            }
-            reject(new Error(`subst ${args.join(" ")} failed (${code ?? "unknown"}): ${Buffer.concat(chunks).toString("utf8").trim()}`));
-        });
-    });
-}
-
-function parseMappings(output: string): Map<string, string> {
-    const mappings = new Map<string, string>();
-    for (const line of output.split(/\r?\n/)) {
-        const match = line.match(/^([A-Z]):\\:\s*=>\s*(.+)$/i);
-        if (match) mappings.set(`${match[1].toUpperCase()}:`, match[2].trim());
-    }
-    return mappings;
+async function listMappings(): Promise<Map<string, string>> {
+    const listing = await runSubst([]);
+    if (!Buffer.isBuffer(listing)) throw new Error("subst listing did not return output.");
+    return new Map(await Promise.all(parseSubstDriveLetters(listing).map(async (drive) => {
+        const target = await readSubstMapping(drive, async () => listing);
+        if (target === null) throw new Error(`subst mapping ${drive} disappeared while reading it.`);
+        return [drive, target] as const;
+    })));
 }
 
 const testGroup = enabled ? describe : describe.skip;
@@ -48,7 +29,7 @@ testGroup("Web Component subst integration", () => {
     it("recovers a stale mapping after an abrupt-termination fixture", async () => {
         const stateDirectory = await mkdtemp(join(tmpdir(), "ehagaki-subst-integration-"));
         const physicalRoot = await mkdtemp(join(tmpdir(), "ehagaki-subst-日本-"));
-        const initialMappings = parseMappings(await runSubst([]));
+        const initialMappings = await listMappings();
         const normalizedRoot = normalizeWindowsRepositoryRoot(physicalRoot);
         const paths = getWebComponentBuildStatePaths(normalizedRoot, stateDirectory);
         const drivesCreatedByTest = new Set<string>();
@@ -74,12 +55,12 @@ testGroup("Web Component subst integration", () => {
                 getProcessStatus: () => "dead",
             });
             drivesCreatedByTest.add(secondHandle.workingDirectory.slice(0, 2).toUpperCase());
-            const recoveredMappings = parseMappings(await runSubst([]));
+            const recoveredMappings = await listMappings();
             expect(recoveredMappings.get(firstDrive)).toBe(physicalRoot);
             expect([...recoveredMappings.entries()].filter(([drive]) => !initialMappings.has(drive))).toHaveLength(1);
         } finally {
             for (const drive of drivesCreatedByTest) {
-                const currentMappings = parseMappings(await runSubst([]));
+                const currentMappings = await listMappings();
                 if (currentMappings.get(drive) === physicalRoot) {
                     await runSubst([drive, "/D"]);
                 }
@@ -87,7 +68,7 @@ testGroup("Web Component subst integration", () => {
             if (secondHandle) await secondHandle.cleanup().catch(() => {});
             if (firstHandle) await firstHandle.cleanup().catch(() => {});
             try {
-                const finalMappings = parseMappings(await runSubst([]));
+                const finalMappings = await listMappings();
                 expect([...finalMappings.entries()]).toEqual([...initialMappings.entries()]);
             } finally {
                 await rm(stateDirectory, { recursive: true, force: true });

--- a/src/test/unit/webComponentBuildWorkingDirectory.test.ts
+++ b/src/test/unit/webComponentBuildWorkingDirectory.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
 import {
     createWebComponentBuildWorkingDirectory,
     findAvailableSubstDriveLetter,
     getWebComponentBuildStatePaths,
     needsWindowsAsciiWorkingDirectory,
     normalizeWindowsRepositoryRoot,
+    parseSubstDriveLetters,
     readSubstMapping,
+    runSubst,
 } from "../../../scripts/webComponentBuildWorkingDirectory.mjs";
 import {
     createPhysicalViteDevServerCommand,
@@ -98,6 +102,21 @@ async function createWorkingDirectory(harness: Awaited<ReturnType<typeof createH
         createLeaseId: () => "current-lease",
         log: vi.fn(),
         ...options,
+    });
+}
+
+function createSuccessfulSubstSpawn(output = Buffer.from([0x80])) {
+    return vi.fn(() => {
+        const child = Object.assign(new EventEmitter(), {
+            stdout: new PassThrough(),
+            stderr: new PassThrough(),
+        });
+        queueMicrotask(() => {
+            child.stdout.end(output);
+            child.stderr.end();
+            child.emit("exit", 0);
+        });
+        return child;
     });
 }
 
@@ -270,6 +289,49 @@ describe("Web Component build working directory", () => {
         }
     });
 
+    it("keeps ownership state when mapping confirmation cannot read the subst listing", async () => {
+        const harness = await createHarness();
+        try {
+            const readMapping = vi.fn(async () => { throw new Error("subst listing unavailable"); });
+            await expect(createWorkingDirectory(harness, { readSubstMapping: readMapping })).rejects.toThrow(
+                /subst listing unavailable/,
+            );
+            const paths = getWebComponentBuildStatePaths(normalizedRoot, harness.stateDirectory);
+            expect(harness.substCalls).toEqual([["Z:", physicalRoot]]);
+            expect(harness.mappings.get("Z:")).toBe(physicalRoot);
+            await expect(readFile(paths.leasePath, "utf8")).resolves.toContain("current-lease");
+            await expect(readFile(paths.mappingStatePath, "utf8")).resolves.toContain("prepared");
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    it("does not delete a foreign mapping when listing it fails during stale recovery", async () => {
+        const harness = await createHarness({ Z: "D:\\foreign" });
+        try {
+            const paths = await writeLeaseAndState(harness.stateDirectory, { drive: "Z:", phase: "mapped" });
+            const readMapping = vi.fn(async () => { throw new Error("subst listing unavailable"); });
+            await expect(createWorkingDirectory(harness, { readSubstMapping: readMapping })).rejects.toThrow(
+                /subst listing unavailable/,
+            );
+            expect(harness.substCalls).toEqual([]);
+            expect(harness.mappings.get("Z:")).toBe("D:\\foreign");
+            await expect(readFile(paths.leasePath, "utf8")).resolves.toContain("stale-lease");
+            await expect(readFile(paths.mappingStatePath, "utf8")).resolves.toContain("stale-lease");
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    it("does not decode successful subst mutations", async () => {
+        const spawnProcess = createSuccessfulSubstSpawn();
+        const fakeSpawn = spawnProcess as unknown as typeof import("node:child_process").spawn;
+        await expect(runSubst(["Z:", physicalRoot], fakeSpawn)).resolves.toBeUndefined();
+        await expect(runSubst(["Z:", "/D"], fakeSpawn)).resolves.toBeUndefined();
+        expect(spawnProcess).toHaveBeenNthCalledWith(1, "subst", ["Z:", physicalRoot], expect.anything());
+        expect(spawnProcess).toHaveBeenNthCalledWith(2, "subst", ["Z:", "/D"], expect.anything());
+    });
+
     it("keeps the Web Component build command on the selected safe path", () => {
         expect(createWebComponentBuildCommand("Y:\\", { watch: true })).toEqual({
             command: process.execPath,
@@ -300,10 +362,26 @@ describe("Web Component build working directory", () => {
         });
     });
 
+    it("can expose only the Vite app server while preserving the loopback proxy target", () => {
+        const command = createPhysicalViteDevServerCommand(physicalRoot, {
+            host: "0.0.0.0",
+            appPort: 5173,
+            webComponentPort: 5174,
+        });
+
+        expect(command.args).toContain("0.0.0.0");
+        expect(command.environment).toMatchObject({
+            EHAGAKI_WEB_COMPONENT_DEV_PROXY: "true",
+            EHAGAKI_WEB_COMPONENT_DEV_PORT: "5174",
+        });
+    });
+
     it("parses a subst listing for one drive", async () => {
-        await expect(readSubstMapping("Y:", async () => "Y:\\: => D:\\ドキュメント\\GitHub\\ehagaki\r\n")).resolves.toBe(
+        const rawListing = Buffer.concat([Buffer.from("Y:\\: => "), Buffer.from([0x80]), Buffer.from("\r\n")]);
+        expect(parseSubstDriveLetters(rawListing)).toEqual(["Y:"]);
+        await expect(readSubstMapping("Y:", async () => rawListing, async () => physicalRoot)).resolves.toBe(
             "D:\\ドキュメント\\GitHub\\ehagaki",
         );
-        await expect(readSubstMapping("Z:", async () => "Y:\\: => D:\\other\r\n")).resolves.toBeNull();
+        await expect(readSubstMapping("Z:", async () => rawListing, async () => physicalRoot)).resolves.toBeNull();
     });
 });

--- a/src/test/unit/webComponentBuildWorkingDirectory.test.ts
+++ b/src/test/unit/webComponentBuildWorkingDirectory.test.ts
@@ -1,45 +1,273 @@
 import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
     createWebComponentBuildWorkingDirectory,
     findAvailableSubstDriveLetter,
+    getWebComponentBuildStatePaths,
     needsWindowsAsciiWorkingDirectory,
+    normalizeWindowsRepositoryRoot,
+    readSubstMapping,
 } from "../../../scripts/webComponentBuildWorkingDirectory.mjs";
 import {
     createPhysicalViteDevServerCommand,
     createWebComponentBuildCommand,
 } from "../../../scripts/webComponentBuildRunner.mjs";
 
+const physicalRoot = "D:\\ドキュメント\\GitHub\\ehagaki";
+const normalizedRoot = normalizeWindowsRepositoryRoot(physicalRoot);
+
+async function createHarness(initialMappings: Record<string, string> = {}) {
+    const stateDirectory = await mkdtemp(join(tmpdir(), "ehagaki-web-component-test-"));
+    const mappings = new Map(Object.entries(initialMappings).map(([drive, target]) => [
+        `${drive.slice(0, 1).toUpperCase()}:`,
+        target,
+    ]));
+    const substCalls: string[][] = [];
+    const executeSubst = vi.fn(async (args: string[]) => {
+        substCalls.push(args);
+        const drive = args[0];
+        if (args[1] === "/D") {
+            if (!mappings.has(drive)) throw new Error(`mapping ${drive} is absent`);
+            mappings.delete(drive);
+            return;
+        }
+        if (mappings.has(drive)) throw new Error(`mapping ${drive} is occupied`);
+        mappings.set(drive, args[1]);
+    });
+    const readMapping = vi.fn(async (drive: string) => mappings.get(drive) ?? null);
+    const pathExists = (path: string) => mappings.has(`${path.slice(0, 1).toUpperCase()}:`);
+    const dispose = async () => rm(stateDirectory, { recursive: true, force: true });
+    return { stateDirectory, mappings, substCalls, executeSubst, readMapping, pathExists, dispose };
+}
+
+async function writeLeaseAndState(
+    stateDirectory: string,
+    {
+        leaseId = "stale-lease",
+        ownerPid = 999999,
+        drive = "Z:",
+        phase = "prepared",
+        includeState = true,
+        lease = {},
+        state = {},
+    }: {
+        leaseId?: string;
+        ownerPid?: number;
+        drive?: string;
+        phase?: "prepared" | "mapped";
+        includeState?: boolean;
+        lease?: Record<string, unknown>;
+        state?: Record<string, unknown>;
+    } = {},
+) {
+    const paths = getWebComponentBuildStatePaths(normalizedRoot, stateDirectory);
+    await mkdir(paths.directory, { recursive: true });
+    await writeFile(paths.leasePath, JSON.stringify({
+        formatVersion: 1,
+        normalizedPhysicalRepositoryRoot: normalizedRoot,
+        ownerPid,
+        leaseId,
+        ...lease,
+    }));
+    if (includeState) {
+        await writeFile(paths.mappingStatePath, JSON.stringify({
+            formatVersion: 1,
+            normalizedPhysicalRepositoryRoot: normalizedRoot,
+            ownerPid,
+            leaseId,
+            drive,
+            phase,
+            ...state,
+        }));
+    }
+    return paths;
+}
+
+async function createWorkingDirectory(harness: Awaited<ReturnType<typeof createHarness>>, options: Record<string, unknown> = {}) {
+    return createWebComponentBuildWorkingDirectory({
+        physicalRepositoryRoot: physicalRoot,
+        platform: "win32",
+        stateDirectory: harness.stateDirectory,
+        pathExists: harness.pathExists,
+        executeSubst: harness.executeSubst,
+        readSubstMapping: harness.readMapping,
+        getProcessStatus: () => "dead",
+        ownerPid: 1234,
+        createLeaseId: () => "current-lease",
+        log: vi.fn(),
+        ...options,
+    });
+}
+
 describe("Web Component build working directory", () => {
-    it("uses the physical repository path unless Windows has a non-ASCII path", () => {
+    it("uses the physical repository path unless Windows has a non-ASCII path", async () => {
         expect(needsWindowsAsciiWorkingDirectory("C:\\work\\ehagaki", "win32")).toBe(false);
         expect(needsWindowsAsciiWorkingDirectory("D:\\ドキュメント\\ehagaki", "linux")).toBe(false);
-        expect(needsWindowsAsciiWorkingDirectory("D:\\ドキュメント\\ehagaki", "win32")).toBe(true);
+        expect(needsWindowsAsciiWorkingDirectory(physicalRoot, "win32")).toBe(true);
+
+        const harness = await createHarness();
+        try {
+            const result = await createWebComponentBuildWorkingDirectory({
+                physicalRepositoryRoot: physicalRoot,
+                platform: "linux",
+                stateDirectory: harness.stateDirectory,
+                executeSubst: harness.executeSubst,
+                readSubstMapping: harness.readMapping,
+            });
+            expect(result.workingDirectory).toBe(physicalRoot);
+            expect(result.usesTemporaryWindowsPath).toBe(false);
+            expect(harness.executeSubst).not.toHaveBeenCalled();
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    it("normalizes equivalent Windows roots to one state identity", () => {
+        expect(normalizeWindowsRepositoryRoot("D:/ドキュメント/GitHub/ehagaki\\")).toBe(normalizedRoot);
+        expect(getWebComponentBuildStatePaths(normalizedRoot).leasePath).toContain("ehagaki-web-component-build");
     });
 
     it("selects an unused drive letter without replacing an existing mapping", () => {
         expect(findAvailableSubstDriveLetter((path) => path === "Z:\\" || path === "Y:\\")).toBe("X");
     });
 
-    it("creates and removes only its temporary mapping for a Windows non-ASCII path", async () => {
-        const executeSubst = vi.fn().mockResolvedValue(undefined);
-        const log = vi.fn();
-        const workingDirectory = await createWebComponentBuildWorkingDirectory({
-            physicalRepositoryRoot: "D:\\ドキュメント\\GitHub\\ehagaki",
-            platform: "win32",
-            pathExists: (path) => path === "Z:\\",
-            executeSubst,
-            log,
-        });
+    it("creates, maps, and removes only its temporary mapping", async () => {
+        const harness = await createHarness({ Z: "D:\\other" });
+        try {
+            const workingDirectory = await createWorkingDirectory(harness);
+            expect(workingDirectory.workingDirectory).toBe("Y:\\");
 
-        expect(workingDirectory.workingDirectory).toBe("Y:\\");
-        expect(workingDirectory.usesTemporaryWindowsPath).toBe(true);
-        expect(executeSubst).toHaveBeenCalledWith(["Y:", "D:\\ドキュメント\\GitHub\\ehagaki"]);
-        expect(log).toHaveBeenCalledWith("Web Component build uses temporary Windows path Y:\\");
+            await workingDirectory.cleanup();
+            await workingDirectory.cleanup();
+            expect(harness.substCalls).toEqual([["Y:", physicalRoot], ["Y:", "/D"]]);
+            expect(harness.mappings.get("Z:")).toBe("D:\\other");
+            expect(harness.mappings.has("Y:")).toBe(false);
+        } finally {
+            await harness.dispose();
+        }
+    });
 
-        await workingDirectory.cleanup();
-        await workingDirectory.cleanup();
-        expect(executeSubst).toHaveBeenLastCalledWith(["Y:", "/D"]);
-        expect(executeSubst).toHaveBeenCalledTimes(2);
+    it("recovers a lease-only stale state without querying or deleting subst mappings", async () => {
+        const harness = await createHarness({ Z: "D:\\foreign" });
+        try {
+            await writeLeaseAndState(harness.stateDirectory, { includeState: false });
+            const workingDirectory = await createWorkingDirectory(harness);
+            expect(harness.substCalls[0]).toEqual(["Y:", physicalRoot]);
+            expect(harness.readMapping).toHaveBeenCalledTimes(1);
+            expect(harness.substCalls.some(([drive, command]) => command === "/D" && drive === "Z:")).toBe(false);
+            expect(harness.mappings.get("Z:")).toBe("D:\\foreign");
+            await workingDirectory.cleanup();
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    it.each(["prepared", "mapped"] as const)("recovers %s state when its mapping is absent without /D", async (phase) => {
+        const harness = await createHarness();
+        try {
+            await writeLeaseAndState(harness.stateDirectory, { drive: "Z:", phase });
+            const workingDirectory = await createWorkingDirectory(harness);
+            expect(harness.substCalls).toContainEqual(["Z:", physicalRoot]);
+            expect(harness.substCalls).not.toContainEqual(["Z:", "/D"]);
+            await workingDirectory.cleanup();
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    it.each(["prepared", "mapped"] as const)("recovers matching %s mapping", async (phase) => {
+        const harness = await createHarness({ Z: physicalRoot });
+        try {
+            await writeLeaseAndState(harness.stateDirectory, { drive: "Z:", phase });
+            const workingDirectory = await createWorkingDirectory(harness);
+            expect(harness.substCalls[0]).toEqual(["Z:", "/D"]);
+            await workingDirectory.cleanup();
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    it("retires stale state and lease when the recorded drive is foreign", async () => {
+        const harness = await createHarness({ Z: "D:\\foreign" });
+        try {
+            await writeLeaseAndState(harness.stateDirectory, { drive: "Z:", phase: "mapped" });
+            const workingDirectory = await createWorkingDirectory(harness);
+            expect(harness.substCalls).not.toContainEqual(["Z:", "/D"]);
+            expect(harness.mappings.get("Z:")).toBe("D:\\foreign");
+            await workingDirectory.cleanup();
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    it("fails closed for malformed lease-only state", async () => {
+        const harness = await createHarness({ Z: "D:\\foreign" });
+        try {
+            await writeLeaseAndState(harness.stateDirectory, {
+                includeState: false,
+                lease: { formatVersion: 999 },
+            });
+            await expect(createWorkingDirectory(harness)).rejects.toThrow(/leasePath=.*mappingStatePresent=false/);
+            expect(harness.substCalls).toEqual([]);
+            expect(harness.mappings.get("Z:")).toBe("D:\\foreign");
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    it.each(["alive", "unknown"] as const)("fails fast when the existing owner is %s", async (status) => {
+        const harness = await createHarness();
+        try {
+            await writeLeaseAndState(harness.stateDirectory, { includeState: false, ownerPid: 4321 });
+            await expect(createWorkingDirectory(harness, { getProcessStatus: () => status })).rejects.toThrow(
+                new RegExp(`recordedPid=4321`),
+            );
+            expect(harness.substCalls).toEqual([]);
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    it("retries a foreign drive collision only after saving the next prepared state", async () => {
+        const harness = await createHarness({ Z: "D:\\other" });
+        try {
+            let firstDriveProbe = true;
+            const workingDirectory = await createWorkingDirectory(harness, {
+                pathExists: (path: string) => {
+                    if (path === "Z:\\") {
+                        const occupied = !firstDriveProbe;
+                        firstDriveProbe = false;
+                        return occupied;
+                    }
+                    return false;
+                },
+            });
+            const paths = getWebComponentBuildStatePaths(normalizedRoot, harness.stateDirectory);
+            expect(harness.substCalls).toEqual([["Z:", physicalRoot], ["Y:", physicalRoot]]);
+            const stateAfterMapping = JSON.parse(await readFile(paths.mappingStatePath, "utf8"));
+            expect(stateAfterMapping.drive).toBe("Y:");
+            expect(stateAfterMapping.phase).toBe("mapped");
+            await workingDirectory.cleanup();
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    it("does not create a new mapping when the mapped-state update fails", async () => {
+        const harness = await createHarness();
+        try {
+            const writeState = vi.fn(async (path: string, value: { phase: string }) => {
+                if (value.phase === "mapped") throw new Error("state update failed");
+                await writeFile(path, JSON.stringify(value));
+            });
+            await expect(createWorkingDirectory(harness, { writeState })).rejects.toThrow(/state update failed/);
+            expect(harness.substCalls).toEqual([["Z:", physicalRoot], ["Z:", "/D"]]);
+            expect(harness.mappings.size).toBe(0);
+        } finally {
+            await harness.dispose();
+        }
     });
 
     it("keeps the Web Component build command on the selected safe path", () => {
@@ -57,16 +285,14 @@ describe("Web Component build working directory", () => {
     });
 
     it("keeps the normal Vite dev server on the physical repository path", () => {
-        const physicalRepositoryRoot = "D:\\ドキュメント\\GitHub\\ehagaki";
-        const command = createPhysicalViteDevServerCommand(physicalRepositoryRoot, {
+        const command = createPhysicalViteDevServerCommand(physicalRoot, {
             host: "127.0.0.1",
             appPort: 5173,
             webComponentPort: 5174,
             environment: { PATH: "test" },
         });
-
-        expect(command.cwd).toBe(physicalRepositoryRoot);
-        expect(command.args[0]).toBe("D:\\ドキュメント\\GitHub\\ehagaki\\node_modules\\vite\\bin\\vite.js");
+        expect(command.cwd).toBe(physicalRoot);
+        expect(command.args[0]).toBe(`${physicalRoot}\\node_modules\\vite\\bin\\vite.js`);
         expect(command.environment).toMatchObject({
             PATH: "test",
             EHAGAKI_WEB_COMPONENT_DEV_PROXY: "true",
@@ -74,17 +300,10 @@ describe("Web Component build working directory", () => {
         });
     });
 
-    it("can expose only the Vite app server while preserving the loopback proxy target", () => {
-        const command = createPhysicalViteDevServerCommand("D:\\ドキュメント\\GitHub\\ehagaki", {
-            host: "0.0.0.0",
-            appPort: 5173,
-            webComponentPort: 5174,
-        });
-
-        expect(command.args).toContain("0.0.0.0");
-        expect(command.environment).toMatchObject({
-            EHAGAKI_WEB_COMPONENT_DEV_PROXY: "true",
-            EHAGAKI_WEB_COMPONENT_DEV_PORT: "5174",
-        });
+    it("parses a subst listing for one drive", async () => {
+        await expect(readSubstMapping("Y:", async () => "Y:\\: => D:\\ドキュメント\\GitHub\\ehagaki\r\n")).resolves.toBe(
+            "D:\\ドキュメント\\GitHub\\ehagaki",
+        );
+        await expect(readSubstMapping("Z:", async () => "Y:\\: => D:\\other\r\n")).resolves.toBeNull();
     });
 });


### PR DESCRIPTION
## Summary
- Add root-scoped Windows temporary lease and prepared/mapped mapping state for non-ASCII Web Component builds.
- Recover only validated stale mappings owned by the recorded root; lease-only and mapping-absent states never probe or delete subst mappings, and foreign/live/unknown ownership fails closed.
- Keep retry state aligned with the actual drive and route graceful child/signal shutdown through cleanup while leaving proxy/static routing unchanged.

## Safety boundary
- Existing mappings, other roots/worktrees, physical drives, and network drives are never removed. 404/proxy behavior is out of scope.

## Verification
- Focused unit/integration tests, npm test, npm run check, npm run build:web-component, npm run build, and Web Component dev-server E2E pass.
- Opt-in Windows subst integration passed with a non-ASCII target and restored the initial mapping set.