### PR TITLE
test: prove Direct Web Component relay WebSocket interception

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@testing-library/svelte": "^5.3.1",
         "@types/node": "^24.2.0",
         "@types/qrcode": "^1.5.6",
+        "@types/ws": "^8.18.1",
         "@vitejs/plugin-basic-ssl": "^2.1.0",
         "fake-indexeddb": "^6.2.5",
         "gh-pages": "^6.3.0",
@@ -55,7 +56,8 @@
         "vite": "^7.0.6",
         "vite-plugin-pwa": "^1.3.0",
         "vite-plugin-static-copy": "^3.1.3",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.6",
+        "ws": "^8.18.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -127,6 +129,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1736,6 +1739,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1759,6 +1763,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2216,6 +2221,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
       "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
@@ -3086,6 +3092,7 @@
       "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "deepmerge": "^4.3.1",
@@ -3124,7 +3131,6 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
       "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -3231,6 +3237,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.4.tgz",
       "integrity": "sha512-vGIGm/HpqLg8EAAQXQ+koV+/S828OEpzocfWcPOwo1u2QUVf9dQG47Yy6JJ8zFFaJwfv4dBcOXli+7BrJwsxDQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3466,6 +3473,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.4.tgz",
       "integrity": "sha512-Xe8UFvvHmyp/c/TJsFwlwU9CWACYbBirNsluJ3U1+H8BTu1wqdrT/AXR5uIXeyCl5kiWKgX5q71eHWbYFOrqrg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3571,6 +3579,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.4.tgz",
       "integrity": "sha512-fOe8VptJvLPs32bNdUYo8SRyljwqKNQVXWW056VoXIc5en/59OdJlJQVeHI0jRRciH3MtrqODi/gfJR0VHNZ8A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3585,6 +3594,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.4.tgz",
       "integrity": "sha512-hj8Qka6WcHRllHUdeSjDnq2XaisUo4KsoGJc1WcFpoa1Yd+OeD861zUMnV7DFVGdZRy45Obht0CUYJpXQ4yA4w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-commands": "^1.6.2",
@@ -3916,6 +3926,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3939,6 +3950,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4283,6 +4295,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7340,6 +7353,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7861,6 +7875,7 @@
       "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7966,6 +7981,7 @@
       "resolved": "https://registry.npmjs.org/rx-nostr/-/rx-nostr-3.7.4.tgz",
       "integrity": "sha512-YgvOitpHmo5qrLOX2kYswre6A24nGBhjFAkodI8zAuBebyKsYtvOqhTOmgwuh1VOJWQZt2hJimeiiT1IjqgU7w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "^25.6.0",
         "nostr-typedef": "^0.13.0",
@@ -8600,6 +8616,7 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
       "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -9081,6 +9098,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9236,6 +9254,7 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -9454,6 +9473,7 @@
       "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.6",
         "@vitest/mocker": "4.1.6",

--- a/package.json
+++ b/package.json
@@ -39,10 +39,12 @@
     "svelte": "^5.55.7",
     "svelte-check": "^4.4.8",
     "typescript": "~5.8.3",
+    "@types/ws": "^8.18.1",
     "vite": "^7.0.6",
     "vite-plugin-pwa": "^1.3.0",
     "vite-plugin-static-copy": "^3.1.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.6",
+    "ws": "^8.18.3"
   },
   "dependencies": {
     "@ffmpeg/core": "^0.12.6",

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -3,11 +3,18 @@ import { createServer, type Server } from "node:http";
 import { readFile, readdir } from "node:fs/promises";
 import { extname, join, normalize } from "node:path";
 import { nip19 } from "nostr-tools";
+import { WebSocketServer, type WebSocket } from "ws";
 import { ensureWebComponentE2EOutput } from "../../../scripts/ensureWebComponentE2EOutput.mjs";
 
 declare global {
     interface Window {
         __componentOrigin: string;
+        __webComponentRelayInterception?: {
+            installedBeforeImport: boolean;
+            importStartedAfterInstall: boolean;
+            originalUrls: string[];
+            mappedUrls: string[];
+        };
     }
 }
 
@@ -16,6 +23,9 @@ let hostServer: Server;
 let componentOrigin = "";
 let hostOrigin = "";
 let ffmpegCompressionModulePath = "";
+let relayServer: WebSocketServer;
+let relayOrigin = "";
+let relayConnectionCount = 0;
 const componentRequests = new Set<string>();
 const hostRequests = new Set<string>();
 const componentStoragePrefix = "ehagaki.web-component.v1:";
@@ -46,6 +56,31 @@ function close(server: Server): Promise<void> {
     return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
 }
 
+function listenWebSocketServer(server: WebSocketServer): Promise<number> {
+    return new Promise((resolve, reject) => {
+        const onError = (error: Error) => {
+            server.off("listening", onListening);
+            reject(error);
+        };
+        const onListening = () => {
+            server.off("error", onError);
+            const address = server.address();
+            resolve(typeof address === "object" && address ? address.port : 0);
+        };
+        server.once("error", onError);
+        server.once("listening", onListening);
+    });
+}
+
+function closeWebSocketServer(server: WebSocketServer): Promise<void> {
+    for (const client of server.clients) {
+        client.terminate();
+    }
+    return new Promise((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+    });
+}
+
 function contentTypeFor(filePath: string): string {
     switch (extname(filePath)) {
         case ".js": return "text/javascript";
@@ -58,6 +93,22 @@ function contentTypeFor(filePath: string): string {
 test.beforeAll(async () => {
     test.setTimeout(180_000);
     await ensureWebComponentE2EOutput();
+    relayServer = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    relayServer.on("connection", (socket: WebSocket) => {
+        relayConnectionCount += 1;
+        socket.on("message", (rawMessage) => {
+            try {
+                const message = JSON.parse(rawMessage.toString()) as unknown[];
+                if (message[0] === "REQ" && typeof message[1] === "string") {
+                    socket.send(JSON.stringify(["EOSE", message[1]]));
+                }
+            } catch {
+                // The relay only needs to accept the browser connection for this proof.
+            }
+        });
+    });
+    const relayPort = await listenWebSocketServer(relayServer);
+    relayOrigin = `ws://127.0.0.1:${relayPort}`;
     componentServer = createServer(async (request, response) => {
         const pathname = new URL(request.url ?? "/", componentOrigin).pathname;
         componentRequests.add(pathname);
@@ -114,13 +165,113 @@ test.beforeAll(async () => {
 test.beforeEach(() => {
     componentRequests.clear();
     hostRequests.clear();
+    relayConnectionCount = 0;
 });
 
 test.afterAll(async () => {
     await Promise.all([
         componentServer && close(componentServer),
         hostServer && close(hostServer),
+        relayServer && closeWebSocketServer(relayServer),
     ]);
+});
+
+test("routes the real authenticated relay connection through the host WebSocket interceptor", async ({ page }) => {
+    const originalRelayUrl = "wss://issue-89-test-relay.example";
+
+    await page.goto(hostOrigin);
+    await page.evaluate(async ({ componentOrigin, componentStoragePrefix, originalRelayUrl, relayOrigin, pubkeyHex }) => {
+        const interceptionState = {
+            installedBeforeImport: false,
+            importStartedAfterInstall: false,
+            originalUrls: [] as string[],
+            mappedUrls: [] as string[],
+        };
+        const nativeWebSocket = window.WebSocket;
+        window.WebSocket = new Proxy(nativeWebSocket, {
+            construct(target, args, newTarget) {
+                const [url, protocols] = args as [string | URL, string | string[] | undefined];
+                const originalUrl = String(url);
+                if (/^wss?:\/\//.test(originalUrl)) {
+                    interceptionState.originalUrls.push(originalUrl);
+                    interceptionState.mappedUrls.push(relayOrigin);
+                    return Reflect.construct(
+                        target,
+                        [relayOrigin, protocols].filter((value) => value !== undefined),
+                        newTarget,
+                    );
+                }
+                return Reflect.construct(target, args, newTarget);
+            },
+        });
+        interceptionState.installedBeforeImport = window.WebSocket !== nativeWebSocket;
+        window.__webComponentRelayInterception = interceptionState;
+        window.nostr = {
+            getPublicKey: async () => pubkeyHex,
+            signEvent: async (event: any) => ({ ...event, id: "66".repeat(32), sig: "77".repeat(64) }),
+        };
+
+        localStorage.setItem(
+            `${componentStoragePrefix}nostr-accounts`,
+            JSON.stringify([{ pubkeyHex, type: "nip07", addedAt: 1 }]),
+        );
+        localStorage.setItem(`${componentStoragePrefix}nostr-active-account`, pubkeyHex);
+        localStorage.setItem(
+            `${componentStoragePrefix}nostr-relays-${pubkeyHex}`,
+            JSON.stringify({ [originalRelayUrl]: { read: true, write: true } }),
+        );
+
+        interceptionState.importStartedAfterInstall = interceptionState.installedBeforeImport;
+        await import(`${componentOrigin}/ehagaki-composer.js`);
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+        };
+        composer.style.width = "360px";
+        composer.style.height = "600px";
+        document.body.append(composer);
+        await composer.whenReady();
+    }, {
+        componentOrigin,
+        componentStoragePrefix,
+        originalRelayUrl,
+        relayOrigin,
+        pubkeyHex: testPubkeyHex,
+    });
+
+    await expect.poll(() => page.evaluate(() => {
+        const state = window.__webComponentRelayInterception;
+        return state?.originalUrls ?? [];
+    })).toContain(originalRelayUrl);
+    await expect.poll(() => relayConnectionCount).toBeGreaterThan(0);
+
+    const result = await page.evaluate(({ originalRelayUrl, relayOrigin }) => {
+        const state = window.__webComponentRelayInterception!;
+        const composer = document.querySelector("ehagaki-composer")!;
+        return {
+            installedBeforeImport: state.installedBeforeImport,
+            importStartedAfterInstall: state.importStartedAfterInstall,
+            interceptionCount: state.originalUrls.length,
+            capturedRelayUrls: state.originalUrls,
+            originalRelayCaptured: state.originalUrls.includes(originalRelayUrl),
+            mappedRelayUrls: state.mappedUrls,
+            expectedMappingCaptured: state.originalUrls.includes(originalRelayUrl)
+                && state.mappedUrls[state.originalUrls.indexOf(originalRelayUrl)] === relayOrigin,
+            sameWindowRealm: window.top === window
+                && composer.ownerDocument.defaultView === window,
+            iframeCount: document.querySelectorAll("iframe").length,
+        };
+    }, { originalRelayUrl, relayOrigin });
+
+    expect(result.installedBeforeImport).toBe(true);
+    expect(result.importStartedAfterInstall).toBe(true);
+    expect(result.interceptionCount).toBeGreaterThan(0);
+    expect(result.originalRelayCaptured).toBe(true);
+    expect(result.expectedMappingCaptured).toBe(true);
+    expect(result.capturedRelayUrls.every((url) => /^wss?:\/\//.test(url))).toBe(true);
+    expect(result.mappedRelayUrls.every((url) => url === relayOrigin)).toBe(true);
+    expect(relayConnectionCount).toBeGreaterThan(0);
+    expect(result.sameWindowRealm).toBe(true);
+    expect(result.iframeCount).toBe(0);
 });
 
 test("mounts across origins without touching host storage or registering an eHagaki Service Worker", async ({ page }) => {


### PR DESCRIPTION
## Summary

Closes #89

This PR adds the browser-level proof for the remaining Issue #89 requirement: a Direct Web Component's real Nostr relay connection passes through a host-installed `window.WebSocket` interceptor that was installed before the Web Component module import.

## E2E construction

- The Playwright host page installs a `window.WebSocket` Proxy before importing `ehagaki-composer.js`.
- The test provides a test-only host `window.nostr` NIP-07 signer and restores a persisted NIP-07 account through the normal eHagaki authentication path.
- The test supplies one explicit relay URL, `wss://issue-89-test-relay.example`, through the Web Component's namespaced relay storage.
- eHagaki proceeds through its normal authenticated bootstrap, `initializeNostrSession()`, `RelayManager`/profile initialization, rx-nostr, and the browser WebSocket constructor.
- The interceptor records the original Nostr relay URLs and maps every `ws:`/`wss:` connection to a process-local `ws://127.0.0.1:<port>` endpoint.
- A local WebSocket server accepts the browser connection and returns deterministic EOSE responses, so the test does not depend on public relay availability.

## Assertions

The test asserts that:

- the interceptor was installed before the Web Component import;
- at least one real relay URL reached the host interceptor;
- the explicit relay URL was captured and mapped to the local relay;
- all captured URLs are Nostr `ws:`/`wss:` URLs;
- the local WebSocket server accepted a browser connection;
- the Web Component remains in the host Window realm and is not iframe-based.

No production relay implementation, Web Component public API, NIP-07 behavior, relay selection, iframe behavior, or PWA behavior was changed.

## Verification

- Targeted E2E: desktop Chromium, mobile Chromium, mobile WebKit, desktop Firefox
- Existing Direct Web Component E2E: desktop Chromium, 18 passed
- `npm run check`
- `npm test`: 335 files, 3,877 passed, 1 skipped
- `npm run build`
- `npm run build:web-component`
- `git diff --check`