### PR TITLE
revert: restore Damus relay

### DIFF
--- a/src/components/SettingsDialog.svelte
+++ b/src/components/SettingsDialog.svelte
@@ -369,7 +369,7 @@
                         class="zap-btn"
                         data-npub="npub1a3pvwe2p3v7mnjz6hle63r628wl9w567aw7u23fzqs062v5vqcqqu3sgh3"
                         data-note-id="naddr1qqxnzde4xsunzwpnxymrgwpsqgswcsk8v4qck0deepdtluag3a9rh0jh2d0wh0w9g53qg8a9x2xqvqqrqsqqql8kt67m30"
-                        data-relays="wss://nos.lol,wss://nostr.bitcoiner.social,wss://relay.nostr.wirednet.jp,wss://yabu.me"
+                        data-relays="wss://relay.damus.io,wss://nos.lol,wss://nostr.bitcoiner.social,wss://relay.nostr.wirednet.jp,wss://yabu.me"
                     >
                         Support
                     </button>
@@ -379,7 +379,7 @@
                         data-title="Thanks for the Support!"
                         data-nzv-id="naddr1qqxnzde4xsunzwpnxymrgwpsqgswcsk8v4qck0deepdtluag3a9rh0jh2d0wh0w9g53qg8a9x2xqvqqrqsqqql8kt67m30"
                         data-zap-color-mode="true"
-                        data-relay-urls="wss://nos.lol,wss://nostr.bitcoiner.social,wss://relay.nostr.wirednet.jp,wss://yabu.me"
+                        data-relay-urls="wss://relay.damus.io,wss://nos.lol,wss://nostr.bitcoiner.social,wss://relay.nostr.wirednet.jp,wss://yabu.me"
                     >
                         View
                     </button>

--- a/src/lib/relayLists.ts
+++ b/src/lib/relayLists.ts
@@ -7,6 +7,7 @@ export const BOOTSTRAP_RELAYS = [
 
 export const FALLBACK_RELAYS = [
     "wss://nos.lol/",
+    "wss://relay.damus.io/",
     "wss://relay.nostr.wirednet.jp/",
     "wss://yabu.me/",
     "wss://x.kojira.io/",
@@ -15,7 +16,6 @@ export const FALLBACK_RELAYS = [
 // サービス終了を確認した relay。追加時は正規化済みのルート URL をここで管理する。
 export const DECOMMISSIONED_RELAYS = [
     "wss://relay.nostr.band/",
-    "wss://relay.damus.io/",
     "wss://nrelay.c-stellar.net/",
     "wss://nrelay-jp.c-stellar.net/",
 ] as const;


### PR DESCRIPTION
## 概要

- `cf5e77c29023a15d4180958a72d384921f6f8bb2` をrevert
- `wss://relay.damus.io/` を `FALLBACK_RELAYS` に復元
- Damusを `DECOMMISSIONED_RELAYS` から除外
- SettingsDialogのSupport/View用 `data-relays` / `data-relay-urls` の先頭にDamusを復元
- 他のdecommissioned relayと、接続前に除外する処理は維持

## 検証

- 関連unit tests: 9 files / 238 tests passed
- `npm run check`: passed (0 errors, 0 warnings)
- `npm test`: 335 files passed, 1 skipped / 3876 tests passed, 1 skipped
- `npm run build`: passed
- `git diff --check`: passed
- 今回の変更を直接検証する既存E2Eは確認できなかったため未実行