### PR TITLE
fix: split site icon link by runtime

### DIFF
--- a/src/components/HeaderComponent.svelte
+++ b/src/components/HeaderComponent.svelte
@@ -10,6 +10,8 @@
     import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
     import { resolveAppAssetUrl } from "../lib/appAssetUrl";
 
+    const OFFICIAL_EHAGAKI_URL = "https://lokuyow.github.io/ehagaki/";
+
     interface Props {
         onResetPostContent: () => void;
         onShowDraftList: () => void;
@@ -31,8 +33,14 @@
         showMascot = true,
         showFlavorText = true,
     }: Props = $props();
-    const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
-    const isContainerLayout = getAppRuntimeEnvironment().layoutMode === "container";
+    const runtimeEnvironment = getAppRuntimeEnvironment();
+    const overlayTarget = runtimeEnvironment.overlayTarget;
+    const isContainerLayout = runtimeEnvironment.layoutMode === "container";
+    const isWebComponent = runtimeEnvironment.runtimeKind === "web-component";
+    const isIframe = runtimeEnvironment.runtimeKind === "iframe";
+    const siteIconHref = isWebComponent || isIframe
+        ? OFFICIAL_EHAGAKI_URL
+        : runtimeEnvironment.appHomeHref;
     const ehagakiIconUrl = resolveAppAssetUrl("ehagaki_icon.svg");
 
     let postStatus = $derived(editorState.postStatus);
@@ -54,9 +62,11 @@
     <div class="header-left">
         {#if showMascot}
             <a
-                href="https://lokuyow.github.io/ehagaki/"
+                href={siteIconHref}
                 class="site-icon-link"
                 aria-label="ehagaki"
+                target={isWebComponent ? "_blank" : undefined}
+                rel={isWebComponent ? "noopener noreferrer" : undefined}
             >
                 <img
                     src={ehagakiIconUrl}

--- a/src/lib/appRuntimeEnvironment.ts
+++ b/src/lib/appRuntimeEnvironment.ts
@@ -4,6 +4,7 @@ import {
 } from "./appStorage";
 
 export type AppLayoutMode = "viewport" | "container";
+export type AppRuntimeKind = "standalone" | "iframe" | "web-component";
 
 export interface AppRuntimeEnvironment {
     storage: Storage;
@@ -15,6 +16,8 @@ export interface AppRuntimeEnvironment {
     overlayTarget: HTMLElement;
     themeTarget: HTMLElement;
     layoutMode: AppLayoutMode;
+    runtimeKind: AppRuntimeKind;
+    appHomeHref: string;
     assetBase: URL | undefined;
     serviceWorkerEnabled: boolean;
     externalInputEnabled: boolean;
@@ -48,6 +51,8 @@ function createDefaultEnvironment(): AppRuntimeEnvironment {
         overlayTarget: body,
         themeTarget: documentElement,
         layoutMode: "viewport",
+        runtimeKind: "standalone",
+        appHomeHref: "./",
         assetBase: windowObj?.location?.href
             ? new URL(".", windowObj.location.href)
             : undefined,

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,8 @@ configureAppRuntimeEnvironment({
   overlayTarget: document.body,
   themeTarget: document.documentElement,
   layoutMode: 'viewport',
+  runtimeKind: window.top === window ? 'standalone' : 'iframe',
+  appHomeHref: import.meta.env.BASE_URL,
   assetBase: new URL(import.meta.env.BASE_URL, window.location.href),
   serviceWorkerEnabled: true,
   externalInputEnabled: true,

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -710,6 +710,7 @@ test("loads app-owned icons from the component asset base instead of the host", 
         await composer.whenReady();
         const shadow = composer.shadowRoot!;
         const logo = shadow.querySelector<HTMLImageElement>("img.site-icon")!;
+        const siteIconLink = shadow.querySelector<HTMLAnchorElement>("a.site-icon-link")!;
         await new Promise<void>((resolve, reject) => {
             if (logo.complete && logo.naturalWidth > 0) {
                 resolve();
@@ -723,10 +724,23 @@ test("loads app-owned icons from the component asset base instead of the host", 
             shadow.querySelector<HTMLElement>(".login-icon")!,
             shadow.querySelector<HTMLElement>(".settings-icon")!,
         ].map((icon) => getComputedStyle(icon).maskImage);
-        return { logoSrc: logo.src, naturalWidth: logo.naturalWidth, masks };
+        return {
+            logoSrc: logo.src,
+            naturalWidth: logo.naturalWidth,
+            masks,
+            siteIconHrefAttribute: siteIconLink.getAttribute("href"),
+            siteIconHref: siteIconLink.href,
+            siteIconTarget: siteIconLink.getAttribute("target"),
+            siteIconRel: siteIconLink.getAttribute("rel"),
+        };
     });
 
     expect(result.logoSrc.startsWith(componentOrigin)).toBe(true);
+    expect(result.siteIconHrefAttribute).toBe("https://lokuyow.github.io/ehagaki/");
+    expect(result.siteIconHref).toBe("https://lokuyow.github.io/ehagaki/");
+    expect(result.siteIconTarget).toBe("_blank");
+    expect(result.siteIconRel).toBe("noopener noreferrer");
+    expect(result.siteIconHref).not.toContain(hostOrigin);
     expect(result.naturalWidth).toBeGreaterThan(0);
     for (const mask of result.masks) {
         expect(mask).not.toBe("none");

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -438,6 +438,19 @@ test("keeps the normal app desktop header layout viewport-based", async ({ page 
     await expect(page.locator(".header-container")).not.toHaveClass(/container-layout/);
 });
 
+test("uses the normal app delivery base for the site icon home link", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForFunction(() => !!document.querySelector("a.site-icon-link"));
+
+    const link = page.locator("a.site-icon-link");
+    const href = await link.getAttribute("href");
+    expect(href).not.toBe("https://lokuyow.github.io/ehagaki/");
+    expect(href).toMatch(/^\//);
+    expect(new URL(href!, await page.url()).origin).toBe(new URL(await page.url()).origin);
+    await expect(link).not.toHaveAttribute("target");
+    await expect(link).not.toHaveAttribute("rel");
+});
+
 test("boots from production site output and exercises the public sample API", async ({ page }) => {
     await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html`);
 

--- a/src/test/unit/headerComponent.test.ts
+++ b/src/test/unit/headerComponent.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
@@ -20,8 +20,67 @@ vi.mock('svelte-i18n', () => ({
 }));
 
 import HeaderComponent from '../../components/HeaderComponent.svelte';
+import { configureAppRuntimeEnvironment } from '../../lib/appRuntimeEnvironment';
 
 describe('HeaderComponent', () => {
+    afterEach(() => {
+        configureAppRuntimeEnvironment({
+            runtimeKind: 'standalone',
+            appHomeHref: './',
+        });
+    });
+
+    it('通常版では runtime の配信元ホームへ同じタブで戻る', () => {
+        configureAppRuntimeEnvironment({
+            runtimeKind: 'standalone',
+            appHomeHref: '/custom-app/',
+        });
+
+        const { container } = render(HeaderComponent, {
+            props: {
+                onResetPostContent: vi.fn(),
+                onShowDraftList: vi.fn(),
+                showFlavorText: false,
+            },
+        });
+
+        const link = container.querySelector<HTMLAnchorElement>('.site-icon-link')!;
+        expect(link.getAttribute('href')).toBe('/custom-app/');
+        expect(link.getAttribute('target')).toBeNull();
+        expect(link.getAttribute('rel')).toBeNull();
+        expect(link.getAttribute('href')).not.toBe('https://lokuyow.github.io/ehagaki/');
+    });
+
+    it('Web Component では公式サイトを新しいタブで開く', () => {
+        configureAppRuntimeEnvironment({ runtimeKind: 'web-component' });
+
+        const { container } = render(HeaderComponent, {
+            props: {
+                onResetPostContent: vi.fn(),
+                onShowDraftList: vi.fn(),
+                showFlavorText: false,
+            },
+        });
+
+        const link = container.querySelector<HTMLAnchorElement>('.site-icon-link')!;
+        expect(link.getAttribute('href')).toBe('https://lokuyow.github.io/ehagaki/');
+        expect(link.getAttribute('target')).toBe('_blank');
+        expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+    });
+
+    it('showMascot=false ではサイトアイコンリンクを表示しない', () => {
+        const { container } = render(HeaderComponent, {
+            props: {
+                onResetPostContent: vi.fn(),
+                onShowDraftList: vi.fn(),
+                showMascot: false,
+                showFlavorText: false,
+            },
+        });
+
+        expect(container.querySelector('.site-icon-link')).toBeNull();
+    });
+
     it('ヘッダーに下書き保存ボタンがなく、宛先指定ボタンが最右に表示される', async () => {
         const onChooseTarget = vi.fn();
         const onShowDraftList = vi.fn();

--- a/src/web-component/element.ts
+++ b/src/web-component/element.ts
@@ -258,6 +258,7 @@ export class EHagakiComposerElement extends HTMLElement {
                 overlayTarget,
                 themeTarget: this,
                 layoutMode: "container",
+                runtimeKind: "web-component",
                 assetBase,
                 serviceWorkerEnabled: false,
                 externalInputEnabled: false,


### PR DESCRIPTION
## 変更概要

左上のサイトアイコンリンクを実行環境ごとに分離しました。

- 通常版: Vite の `BASE_URL` を使う同一オリジンの配信元ホームへ同じタブで遷移
- Web Component: `https://lokuyow.github.io/ehagaki/` を `_blank`、`noopener noreferrer` で開く
- iframe: 既存の公式サイト・同一タブ挙動を維持

## 実装

`AppRuntimeEnvironment` に `runtimeKind` と `appHomeHref` を追加し、レイアウト状態とは独立して Header のリンクを選択します。`showMascot`、アイコン画像、Header レイアウト、Web Component の `asset-base` 解決は維持しています。

## 検証

- `npm run test -- src/test/unit/headerComponent.test.ts`: 6 passed
- `npm run check`: 0 errors / 0 warnings
- Web Component E2E desktop Chromium: 1 passed
- 通常版 E2E desktop Chromium: 1 passed
- `npm test`: 335 files passed, 3,879 tests passed, 1 skipped
- `npm run build`: 成功
- `git diff --check`: 成功

build に既存の Svelte rest props と blurhash dynamic/static import の警告がありますが、今回の変更起因ではありません。