### PR TITLE
fix: preserve parent sample URL query parameters

### DIFF
--- a/public/embed-parent-client-example.js
+++ b/public/embed-parent-client-example.js
@@ -126,6 +126,7 @@ const urlContextOverrides = {
     replyQuote: false,
     channel: false,
     content: false,
+    settings: false,
 };
 let timelineSubscription = null;
 let composerRequestSequence = 0;
@@ -767,13 +768,6 @@ function updateTimelineSelection() {
 }
 
 function applyComposerContextUpdate(payload) {
-    if (Object.hasOwn(payload, "reply") || Object.hasOwn(payload, "quotes")) {
-        urlContextOverrides.replyQuote = true;
-    }
-    if (Object.hasOwn(payload, "channel")) {
-        urlContextOverrides.channel = true;
-    }
-
     selectedReplyReference = typeof payload.reply === "string"
         ? createReferenceFromQueryValue(payload.reply)
         : null;
@@ -1252,7 +1246,6 @@ function normalizeInitialReplyNotification(value) {
 function syncInitialSettingsControlsFromAppUrl() {
     try {
         const url = new URL(appUrlInput.value || getDefaultAppUrl(), window.location.href);
-        initialLocaleSelect.value = normalizeInitialLocale(url.searchParams.get("embedLocale"));
         const hasDefaultSettings = [
             "defaultLocale",
             "defaultTheme",
@@ -1261,22 +1254,25 @@ function syncInitialSettingsControlsFromAppUrl() {
             "defaultReplyNotification",
         ].some((key) => url.searchParams.has(key));
         initialQueryModeSelect.value = hasDefaultSettings ? "default" : "embed";
-        if (hasDefaultSettings) {
-            initialLocaleSelect.value = normalizeInitialLocale(url.searchParams.get("defaultLocale"));
-        }
-        const initialTheme = url.searchParams.get(hasDefaultSettings ? "defaultTheme" : "embedTheme");
-        if (initialTheme !== null) {
-            initialThemeSelect.value = normalizeInitialTheme(initialTheme);
-        }
+        const queryPrefix = hasDefaultSettings ? "default" : "embed";
+        initialLocaleSelect.value = normalizeInitialLocale(url.searchParams.get(`${queryPrefix}Locale`));
+        initialThemeSelect.value = normalizeInitialTheme(url.searchParams.get(`${queryPrefix}Theme`));
         initialHideMascotInput.checked = url.searchParams.get(
-            hasDefaultSettings ? "defaultShowMascot" : "embedShowMascot",
+            `${queryPrefix}ShowMascot`,
         ) === "false";
         initialReplyNotificationSelect.value = normalizeInitialReplyNotification(
-            url.searchParams.get(hasDefaultSettings ? "defaultReplyNotification" : "embedReplyNotification"),
+            url.searchParams.get(`${queryPrefix}ReplyNotification`),
         );
     } catch {
         // app-url の入力途中など一時的な不正値では既存 UI を維持する
     }
+}
+
+function resetUrlContextOverrides() {
+    urlContextOverrides.replyQuote = false;
+    urlContextOverrides.channel = false;
+    urlContextOverrides.content = false;
+    urlContextOverrides.settings = false;
 }
 
 function getTargetOrigin() {
@@ -1307,58 +1303,64 @@ function buildEmbedUrl() {
         url.searchParams.delete("channelAbout");
         url.searchParams.delete("channelPicture");
     }
-    url.searchParams.delete("embedLocale");
-    url.searchParams.delete("embedTheme");
-    url.searchParams.delete("embedShowMascot");
-    url.searchParams.delete("embedShowFlavorText");
-    url.searchParams.delete("embedReplyNotification");
-    url.searchParams.delete("defaultLocale");
-    url.searchParams.delete("defaultTheme");
-    url.searchParams.delete("defaultShowMascot");
-    url.searchParams.delete("defaultShowFlavorText");
-    url.searchParams.delete("defaultReplyNotification");
+    if (urlContextOverrides.settings) {
+        [
+            "embedLocale",
+            "embedTheme",
+            "embedShowMascot",
+            "embedReplyNotification",
+            "defaultLocale",
+            "defaultTheme",
+            "defaultShowMascot",
+            "defaultReplyNotification",
+        ].forEach((key) => url.searchParams.delete(key));
 
-    const queryPrefix = initialQueryModeSelect.value === "default" ? "default" : "embed";
-    const storedLocale = normalizeInitialLocale(getParentStoredEmbedValue("locale"));
-    const storedTheme = normalizeInitialTheme(getParentStoredEmbedValue("themeMode"));
-    const initialLocale =
-        normalizeInitialLocale(initialLocaleSelect.value)
-        || (queryPrefix === "default" ? storedLocale : "");
-    const initialTheme =
-        resolveInitialTheme(initialThemeSelect.value)
-        || (queryPrefix === "default" ? storedTheme : "");
+        const queryPrefix = initialQueryModeSelect.value === "default" ? "default" : "embed";
+        const storedLocale = normalizeInitialLocale(getParentStoredEmbedValue("locale"));
+        const storedTheme = normalizeInitialTheme(getParentStoredEmbedValue("themeMode"));
+        const initialLocale =
+            normalizeInitialLocale(initialLocaleSelect.value)
+            || (queryPrefix === "default" ? storedLocale : "");
+        const initialTheme =
+            resolveInitialTheme(initialThemeSelect.value)
+            || (queryPrefix === "default" ? storedTheme : "");
 
-    if (initialLocale) {
-        url.searchParams.set(`${queryPrefix}Locale`, initialLocale);
+        if (initialLocale) {
+            url.searchParams.set(`${queryPrefix}Locale`, initialLocale);
+        }
+
+        if (initialTheme) {
+            url.searchParams.set(`${queryPrefix}Theme`, initialTheme);
+        }
+
+        if (initialHideMascotInput.checked) {
+            url.searchParams.set(`${queryPrefix}ShowMascot`, "false");
+        }
+
+        const replyNotification = normalizeInitialReplyNotification(initialReplyNotificationSelect.value);
+        if (replyNotification) {
+            url.searchParams.set(`${queryPrefix}ReplyNotification`, replyNotification);
+        }
     }
 
-    if (initialTheme) {
-        url.searchParams.set(`${queryPrefix}Theme`, initialTheme);
+    if (urlContextOverrides.content) {
+        const content = getComposerContentValue();
+        if (content !== null) {
+            url.searchParams.set("content", content);
+        }
     }
 
-    if (initialHideMascotInput.checked) {
-        url.searchParams.set(`${queryPrefix}ShowMascot`, "false");
+    if (urlContextOverrides.replyQuote) {
+        if (selectedReplyReference) {
+            url.searchParams.set("reply", selectedReplyReference.queryValue);
+        }
+
+        selectedQuoteReferences.forEach((reference) => {
+            url.searchParams.append("quote", reference.queryValue);
+        });
     }
 
-    const replyNotification = normalizeInitialReplyNotification(initialReplyNotificationSelect.value);
-    if (replyNotification) {
-        url.searchParams.set(`${queryPrefix}ReplyNotification`, replyNotification);
-    }
-
-    const content = getComposerContentValue();
-    if (content !== null) {
-        url.searchParams.set("content", content);
-    }
-
-    if (selectedReplyReference) {
-        url.searchParams.set("reply", selectedReplyReference.queryValue);
-    }
-
-    selectedQuoteReferences.forEach((reference) => {
-        url.searchParams.append("quote", reference.queryValue);
-    });
-
-    if (selectedChannelContext) {
+    if (urlContextOverrides.channel && selectedChannelContext) {
         url.searchParams.set("channel", selectedChannelContext.reference);
         if (Array.isArray(selectedChannelContext.relays) && selectedChannelContext.relays.length > 0) {
             url.searchParams.set("channelRelays", selectedChannelContext.relays.join(","));
@@ -2338,17 +2340,24 @@ syncChannelInputsFromSelection();
 updateDisplayedEmbedUrl();
 reloadIframeButton.addEventListener("click", loadIframe);
 appUrlInput.addEventListener("input", () => {
+    resetUrlContextOverrides();
     syncInitialSettingsControlsFromAppUrl();
     updateDisplayedEmbedUrl();
 });
 appUrlInput.addEventListener("change", () => {
+    resetUrlContextOverrides();
     syncInitialSettingsControlsFromAppUrl();
     updateDisplayedEmbedUrl();
 });
-initialLocaleSelect.addEventListener("change", updateDisplayedEmbedUrl);
-initialQueryModeSelect.addEventListener("change", updateDisplayedEmbedUrl);
-initialThemeSelect.addEventListener("change", updateDisplayedEmbedUrl);
-initialHideMascotInput.addEventListener("change", updateDisplayedEmbedUrl);
+function updateDisplayedEmbedUrlForSettingsChange() {
+    urlContextOverrides.settings = true;
+    updateDisplayedEmbedUrl();
+}
+initialLocaleSelect.addEventListener("change", updateDisplayedEmbedUrlForSettingsChange);
+initialQueryModeSelect.addEventListener("change", updateDisplayedEmbedUrlForSettingsChange);
+initialThemeSelect.addEventListener("change", updateDisplayedEmbedUrlForSettingsChange);
+initialReplyNotificationSelect.addEventListener("change", updateDisplayedEmbedUrlForSettingsChange);
+initialHideMascotInput.addEventListener("change", updateDisplayedEmbedUrlForSettingsChange);
 syncRuntimeSettingsButton.addEventListener("click", () => {
     syncRuntimeSettings("手動 settings 同期");
 });

--- a/public/embed-parent-client-example.js
+++ b/public/embed-parent-client-example.js
@@ -122,6 +122,11 @@ let timelineEvents = [];
 let selectedReplyReference = null;
 let selectedQuoteReferences = [];
 let selectedChannelContext = null;
+const urlContextOverrides = {
+    replyQuote: false,
+    channel: false,
+    content: false,
+};
 let timelineSubscription = null;
 let composerRequestSequence = 0;
 let settingsRequestSequence = 0;
@@ -762,6 +767,13 @@ function updateTimelineSelection() {
 }
 
 function applyComposerContextUpdate(payload) {
+    if (Object.hasOwn(payload, "reply") || Object.hasOwn(payload, "quotes")) {
+        urlContextOverrides.replyQuote = true;
+    }
+    if (Object.hasOwn(payload, "channel")) {
+        urlContextOverrides.channel = true;
+    }
+
     selectedReplyReference = typeof payload.reply === "string"
         ? createReferenceFromQueryValue(payload.reply)
         : null;
@@ -999,6 +1011,7 @@ async function selectReplyEvent(event) {
 
     if (isReplySelected(reference.eventId)) {
         selectedReplyReference = null;
+        urlContextOverrides.replyQuote = true;
         renderTimeline();
         reloadIframeForReplyQuote("reply テスト設定を解除しました", {
             quoteCount: selectedQuoteReferences.length,
@@ -1007,6 +1020,7 @@ async function selectReplyEvent(event) {
     }
 
     selectedReplyReference = reference;
+    urlContextOverrides.replyQuote = true;
     selectedQuoteReferences = selectedQuoteReferences.filter(
         (quoteReference) => quoteReference.eventId !== reference.eventId,
     );
@@ -1022,6 +1036,7 @@ async function toggleQuoteEvent(event) {
     const reference = createTimelineReference(event);
 
     if (isQuoteSelected(reference.eventId)) {
+        urlContextOverrides.replyQuote = true;
         selectedQuoteReferences = selectedQuoteReferences.filter(
             (quoteReference) => quoteReference.eventId !== reference.eventId,
         );
@@ -1037,6 +1052,7 @@ async function toggleQuoteEvent(event) {
         selectedReplyReference = null;
     }
 
+    urlContextOverrides.replyQuote = true;
     selectedQuoteReferences = [...selectedQuoteReferences, reference];
     renderTimeline();
     reloadIframeForReplyQuote("quote テスト設定を更新しました", {
@@ -1052,6 +1068,7 @@ function clearReplyQuoteSelection() {
 
     selectedReplyReference = null;
     selectedQuoteReferences = [];
+    urlContextOverrides.replyQuote = true;
     renderTimeline();
     sendRuntimeComposerMessage("composer.setContext", buildComposerContextPayload({ includeReplyQuote: true }), {
         actionLabel: "reply / quote コンテキスト解除",
@@ -1070,6 +1087,7 @@ function syncChannelContext() {
         return;
     }
 
+    urlContextOverrides.channel = true;
     syncChannelInputsFromSelection();
     updateTimelineSelection();
     sendRuntimeComposerMessage("composer.setContext", buildComposerContextPayload({ includeChannel: true }), {
@@ -1090,6 +1108,7 @@ function clearChannelContext() {
     }
 
     selectedChannelContext = null;
+    urlContextOverrides.channel = true;
     syncChannelInputsFromSelection();
     updateTimelineSelection();
     sendRuntimeComposerMessage("composer.setContext", buildComposerContextPayload({ includeChannel: true }), {
@@ -1108,6 +1127,7 @@ function syncComposerContent() {
         return;
     }
 
+    urlContextOverrides.content = true;
     sendRuntimeComposerMessage("composer.setContext", buildComposerContextPayload({ includeContent: true }), {
         actionLabel: "本文同期",
         infoMessage: "本文同期を送信しました",
@@ -1123,6 +1143,7 @@ function syncComposerContent() {
 
 function clearComposerContent() {
     composerContentInput.value = "";
+    urlContextOverrides.content = true;
     sendRuntimeComposerMessage("composer.setContext", buildComposerContextPayload({ clearContent: true }), {
         actionLabel: "本文クリア",
         infoMessage: "本文クリアを送信しました",
@@ -1269,14 +1290,23 @@ function getConfiguredAppOrigin() {
 function buildEmbedUrl() {
     const url = new URL(appUrlInput.value, window.location.href);
     url.searchParams.set("parentOrigin", window.location.origin);
-    url.searchParams.delete("content");
-    url.searchParams.delete("reply");
-    url.searchParams.delete("quote");
-    url.searchParams.delete("channel");
-    url.searchParams.delete("channelRelays");
-    url.searchParams.delete("channelName");
-    url.searchParams.delete("channelAbout");
-    url.searchParams.delete("channelPicture");
+
+    if (urlContextOverrides.content) {
+        url.searchParams.delete("content");
+    }
+
+    if (urlContextOverrides.replyQuote) {
+        url.searchParams.delete("reply");
+        url.searchParams.delete("quote");
+    }
+
+    if (urlContextOverrides.channel) {
+        url.searchParams.delete("channel");
+        url.searchParams.delete("channelRelays");
+        url.searchParams.delete("channelName");
+        url.searchParams.delete("channelAbout");
+        url.searchParams.delete("channelPicture");
+    }
     url.searchParams.delete("embedLocale");
     url.searchParams.delete("embedTheme");
     url.searchParams.delete("embedShowMascot");
@@ -2323,7 +2353,10 @@ syncRuntimeSettingsButton.addEventListener("click", () => {
     syncRuntimeSettings("手動 settings 同期");
 });
 resetInitialSettingsButton.addEventListener("click", resetInitialSettingsState);
-composerContentInput.addEventListener("input", updateDisplayedEmbedUrl);
+composerContentInput.addEventListener("input", () => {
+    urlContextOverrides.content = true;
+    updateDisplayedEmbedUrl();
+});
 syncChannelContextButton.addEventListener("click", syncChannelContext);
 clearChannelContextButton.addEventListener("click", clearChannelContext);
 loginNip07Button.addEventListener("click", () => {

--- a/src/test/e2e/embedParentClientExample.spec.ts
+++ b/src/test/e2e/embedParentClientExample.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+test("preserves input URL queries when reloading the parent client iframe", async ({ page }) => {
+    await page.goto("/ehagaki/embed-parent-client-example.html");
+
+    const appUrl = new URL("/ehagaki/", page.url());
+    appUrl.search = new URLSearchParams([
+        ["quote", "A"],
+        ["quote", "B"],
+        ["content", "input content"],
+        ["reply", "reply-value"],
+        ["channel", "channel-value"],
+        ["futureEmbedQuery", "preserve-me"],
+        ["parentOrigin", "https://attacker.example"],
+    ]).toString();
+
+    await page.getByLabel("eHagaki URL").fill(appUrl.toString());
+    await page.getByRole("button", { name: "iframe を再読み込み" }).click();
+
+    const iframeUrl = new URL(await page.locator("#ehagaki-iframe").getAttribute("src") ?? "");
+    expect(iframeUrl.origin).toBe(appUrl.origin);
+    expect(iframeUrl.searchParams.getAll("quote")).toEqual(["A", "B"]);
+    expect(iframeUrl.searchParams.get("content")).toBe("input content");
+    expect(iframeUrl.searchParams.get("reply")).toBe("reply-value");
+    expect(iframeUrl.searchParams.get("channel")).toBe("channel-value");
+    expect(iframeUrl.searchParams.get("futureEmbedQuery")).toBe("preserve-me");
+    expect(iframeUrl.searchParams.get("parentOrigin")).toBe(new URL(page.url()).origin);
+});

--- a/src/test/e2e/embedParentClientExample.spec.ts
+++ b/src/test/e2e/embedParentClientExample.spec.ts
@@ -1,15 +1,43 @@
 import { test, expect } from "@playwright/test";
+import { nip19 } from "nostr-tools";
 
-test("preserves input URL queries when reloading the parent client iframe", async ({ page }) => {
-    await page.goto("/ehagaki/embed-parent-client-example.html");
+test("uses an edited URL as the source of truth after an iframe context update", async ({ page }) => {
+    const previousQuote = nip19.noteEncode("1".repeat(64));
+    const quotes = [
+        nip19.noteEncode("a".repeat(64)),
+        nip19.noteEncode("b".repeat(64)),
+    ];
+
+    await page.goto("/ehagaki/public/embed-parent-client-example.html");
+    const initialFrame = page.frameLocator("#ehagaki-iframe");
+    await expect(initialFrame.locator(".tiptap-editor")).toBeVisible();
+
+    const childFrame = page.frames().find((frame) => frame !== page.mainFrame());
+    if (!childFrame) {
+        throw new Error("initial iframe did not start");
+    }
+    await childFrame.evaluate((quote) => {
+        window.parent.postMessage({
+            namespace: "ehagaki.embed",
+            version: 1,
+            type: "composer.contextUpdated",
+            payload: {
+                timestamp: Date.now(),
+                reply: null,
+                quotes: [quote],
+            },
+        }, window.location.origin);
+    }, previousQuote);
+    await expect(page.locator("#timeline-selection")).toContainText("quote: 1 件");
 
     const appUrl = new URL("/ehagaki/", page.url());
     appUrl.search = new URLSearchParams([
-        ["quote", "A"],
-        ["quote", "B"],
+        ["quote", quotes[0]],
+        ["quote", quotes[1]],
         ["content", "input content"],
-        ["reply", "reply-value"],
-        ["channel", "channel-value"],
+        ["embedLocale", "en"],
+        ["defaultTheme", "dark"],
+        ["embedShowFlavorText", "false"],
         ["futureEmbedQuery", "preserve-me"],
         ["parentOrigin", "https://attacker.example"],
     ]).toString();
@@ -19,10 +47,37 @@ test("preserves input URL queries when reloading the parent client iframe", asyn
 
     const iframeUrl = new URL(await page.locator("#ehagaki-iframe").getAttribute("src") ?? "");
     expect(iframeUrl.origin).toBe(appUrl.origin);
-    expect(iframeUrl.searchParams.getAll("quote")).toEqual(["A", "B"]);
+    expect(iframeUrl.searchParams.getAll("quote")).toEqual(quotes);
     expect(iframeUrl.searchParams.get("content")).toBe("input content");
-    expect(iframeUrl.searchParams.get("reply")).toBe("reply-value");
-    expect(iframeUrl.searchParams.get("channel")).toBe("channel-value");
+    expect(iframeUrl.searchParams.get("embedLocale")).toBe("en");
+    expect(iframeUrl.searchParams.get("defaultTheme")).toBe("dark");
+    expect(iframeUrl.searchParams.get("embedShowFlavorText")).toBe("false");
     expect(iframeUrl.searchParams.get("futureEmbedQuery")).toBe("preserve-me");
     expect(iframeUrl.searchParams.get("parentOrigin")).toBe(new URL(page.url()).origin);
+
+    const reloadedFrame = page.frameLocator("#ehagaki-iframe");
+    await expect(reloadedFrame.locator(".reply-quote-preview")).toHaveCount(2);
+});
+
+test("only replaces initial settings queries after the settings UI changes", async ({ page }) => {
+    await page.goto("/ehagaki/embed-parent-client-example.html");
+
+    const appUrl = new URL("/ehagaki/", page.url());
+    appUrl.search = new URLSearchParams([
+        ["embedLocale", "en"],
+        ["defaultTheme", "dark"],
+        ["embedShowFlavorText", "false"],
+    ]).toString();
+    await page.getByLabel("eHagaki URL").fill(appUrl.toString());
+
+    let iframeUrl = new URL(await page.locator("#iframe-src").textContent() ?? "");
+    expect(iframeUrl.searchParams.get("embedLocale")).toBe("en");
+    expect(iframeUrl.searchParams.get("defaultTheme")).toBe("dark");
+    expect(iframeUrl.searchParams.get("embedShowFlavorText")).toBe("false");
+
+    await page.getByLabel("locale").selectOption("ja");
+    iframeUrl = new URL(await page.locator("#iframe-src").textContent() ?? "");
+    expect(iframeUrl.searchParams.get("defaultLocale")).toBe("ja");
+    expect(iframeUrl.searchParams.has("embedLocale")).toBe(false);
+    expect(iframeUrl.searchParams.get("embedShowFlavorText")).toBe("false");
 });


### PR DESCRIPTION
## 問題
Parent Client Sample は iframe 側の composer.contextUpdated を親UI操作として扱っていました。その後に eHagaki URL を編集しても古い reply / quote 選択が新しい入力URLを上書きし、引用指定が失われる場合がありました。初回設定クエリも毎回削除・再構築されていました。

## 変更概要
- eHagaki URL の input / change 時に、reply / quote、channel、content、設定のサンプルUI override を解除
- composer.contextUpdated は親UI表示の同期だけにし、URL override を立てない
- 各サンプルUIを明示操作した場合だけ、その管理対象のURLクエリを置換
- 初回設定クエリも、設定UIを操作するまで入力URLの値を保持
- sample UIにない embedShowFlavorText / defaultShowFlavorText は設定変更後も保持
- parentOrigin は実際の親 window.location.origin で常に上書き

## URLクエリ保持の挙動
有効な複数 note1 引用を含むURLを、初期iframeが contextUpdated を送った後に入力して再読み込みしても、iframe src に複数 quote が残り、子eHagaki内の引用プレビューが2件表示されます。未知クエリと入力済み設定クエリも保持します。

## 検証
- npx playwright test src/test/e2e/embedParentClientExample.spec.ts src/test/e2e/iframeMessageGate.spec.ts: 10 passed (desktop Chromium / mobile Chromium)
- npm run check: passed, 0 errors / 0 warnings
- npm test: 3879 passed, 1 skipped
- npm run build: passed
- node --check public/embed-parent-client-example.js: passed
- git diff --check: passed

## 未実行
実端末（Android / iPhone）およびWebKitでの確認は未実施です。今回のURL・iframe起動経路はdesktop/mobile Chromium Playwrightで確認しています。