### PR TITLE
test: isolate Playwright E2E ports per run

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,15 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
-import { fileURLToPath, URL as NodeURL } from 'node:url';
 import {
     buildPlaywrightEndpoints,
     buildPlaywrightViteCommand,
     resolvePlaywrightPort,
 } from './scripts/playwrightWorktreePort';
 
-const worktreeRoot = import.meta.url.startsWith('file://')
-    ? fileURLToPath(new NodeURL('.', import.meta.url))
-    : process.cwd();
-const resolvedPort = resolvePlaywrightPort({ rootPath: worktreeRoot });
+const resolvedPort = resolvePlaywrightPort({});
 const endpoints = buildPlaywrightEndpoints(resolvedPort);
 
 export default defineConfig({

--- a/scripts/playwrightWorktreePort.ts
+++ b/scripts/playwrightWorktreePort.ts
@@ -1,15 +1,16 @@
-import path from 'node:path';
+import { randomInt } from 'node:crypto';
 
 export const PLAYWRIGHT_HOST = '127.0.0.1';
 export const PLAYWRIGHT_APP_BASE_PATH = '/ehagaki/';
 export const PLAYWRIGHT_READY_PATH =
     '/ehagaki/post-history-dialog-playwright.html';
 export const PLAYWRIGHT_PORT_ENV = 'EHAGAKI_E2E_PORT';
+const PLAYWRIGHT_AUTO_PORT_ENV = 'EHAGAKI_E2E_AUTO_PORT';
 export const MIN_PLAYWRIGHT_PORT = 1_024;
 export const MAX_PLAYWRIGHT_PORT = 65_535;
 
-const AUTO_PORT_MIN = 45_000;
-const AUTO_PORT_SPAN = 10_000;
+export const AUTO_PORT_MIN = 45_000;
+export const AUTO_PORT_MAX_EXCLUSIVE = 55_000;
 
 export function parsePlaywrightPort(value: string): number {
     const trimmed = value.trim();
@@ -34,58 +35,45 @@ export function parsePlaywrightPort(value: string): number {
     return port;
 }
 
-export function normalizeWorktreeRoot(
-    rootPath: string,
-    platform: NodeJS.Platform = process.platform,
-): string {
-    if (!rootPath.trim()) {
-        throw new Error('Playwright worktree root path must not be empty.');
+export function generatePlaywrightPort(
+    portSource: () => number = () =>
+        randomInt(AUTO_PORT_MIN, AUTO_PORT_MAX_EXCLUSIVE),
+): number {
+    const port = portSource();
+    if (
+        !Number.isSafeInteger(port) ||
+        port < AUTO_PORT_MIN ||
+        port >= AUTO_PORT_MAX_EXCLUSIVE
+    ) {
+        throw new Error(
+            `Generated Playwright port must be an integer from ${AUTO_PORT_MIN} to ${AUTO_PORT_MAX_EXCLUSIVE - 1}.`,
+        );
     }
 
-    const pathApi = platform === 'win32' ? path.win32 : path.posix;
-    const normalized = pathApi.normalize(pathApi.resolve(rootPath));
-    const root = pathApi.parse(normalized).root;
-    const withoutTrailingSeparator =
-        normalized.length > root.length
-            ? normalized.replace(/[\\/]+$/, '')
-            : normalized;
-
-    return platform === 'win32'
-        ? withoutTrailingSeparator.toLowerCase()
-        : withoutTrailingSeparator;
-}
-
-export function hashWorktreeRoot(normalizedRoot: string): number {
-    let hash = 2_166_136_261;
-
-    for (let index = 0; index < normalizedRoot.length; index += 1) {
-        hash ^= normalizedRoot.charCodeAt(index);
-        hash = Math.imul(hash, 16_777_619);
-    }
-
-    return hash >>> 0;
-}
-
-export function derivePlaywrightPort(normalizedRoot: string): number {
-    return AUTO_PORT_MIN + (hashWorktreeRoot(normalizedRoot) % AUTO_PORT_SPAN);
+    return port;
 }
 
 export interface ResolvePlaywrightPortOptions {
-    rootPath: string;
     envPort?: string;
-    platform?: NodeJS.Platform;
+    portSource?: () => number;
 }
 
 export function resolvePlaywrightPort({
-    rootPath,
     envPort = process.env[PLAYWRIGHT_PORT_ENV],
-    platform = process.platform,
+    portSource,
 }: ResolvePlaywrightPortOptions): number {
     if (envPort !== undefined) {
         return parsePlaywrightPort(envPort);
     }
 
-    return derivePlaywrightPort(normalizeWorktreeRoot(rootPath, platform));
+    const existingAutoPort = process.env[PLAYWRIGHT_AUTO_PORT_ENV];
+    if (existingAutoPort !== undefined) {
+        return parsePlaywrightPort(existingAutoPort);
+    }
+
+    const generatedPort = generatePlaywrightPort(portSource);
+    process.env[PLAYWRIGHT_AUTO_PORT_ENV] = String(generatedPort);
+    return generatedPort;
 }
 
 export interface PlaywrightEndpoints {

--- a/src/test/unit/playwrightWorktreePort.test.ts
+++ b/src/test/unit/playwrightWorktreePort.test.ts
@@ -1,21 +1,30 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+    AUTO_PORT_MAX_EXCLUSIVE,
+    AUTO_PORT_MIN,
     buildPlaywrightEndpoints,
     buildPlaywrightViteCommand,
-    derivePlaywrightPort,
-    normalizeWorktreeRoot,
+    generatePlaywrightPort,
     parsePlaywrightPort,
     resolvePlaywrightPort,
 } from '../../../scripts/playwrightWorktreePort';
 
-describe('playwright worktree port resolver', () => {
+describe('playwright port resolver', () => {
+    const originalAutoPort = process.env.EHAGAKI_E2E_AUTO_PORT;
+
+    afterEach(() => {
+        if (originalAutoPort === undefined) {
+            delete process.env.EHAGAKI_E2E_AUTO_PORT;
+        } else {
+            process.env.EHAGAKI_E2E_AUTO_PORT = originalAutoPort;
+        }
+    });
+
     it('uses a valid explicit port and trims surrounding whitespace', () => {
         expect(parsePlaywrightPort('4173')).toBe(4173);
         expect(
             resolvePlaywrightPort({
-                rootPath: 'C:/worktrees/ehagaki',
                 envPort: '  51234  ',
-                platform: 'win32',
             }),
         ).toBe(51234);
     });
@@ -34,49 +43,39 @@ describe('playwright worktree port resolver', () => {
         expect(parsePlaywrightPort('65535')).toBe(65535);
     });
 
-    it('normalizes Windows separators, case, dot segments, and trailing separators', () => {
-        const slashPath = normalizeWorktreeRoot(
-            'C:/Users/Example/ehagaki/./test/../',
-            'win32',
-        );
-        const backslashPath = normalizeWorktreeRoot(
-            'c:\\users\\example\\ehagaki\\',
-            'win32',
-        );
-
-        expect(slashPath).toBe('c:\\users\\example\\ehagaki');
-        expect(backslashPath).toBe(slashPath);
+    it('generates a port in the automatic range', () => {
+        expect(generatePlaywrightPort(() => AUTO_PORT_MIN)).toBe(AUTO_PORT_MIN);
+        expect(
+            generatePlaywrightPort(() => AUTO_PORT_MAX_EXCLUSIVE - 1),
+        ).toBe(AUTO_PORT_MAX_EXCLUSIVE - 1);
     });
 
-    it('derives a stable port for the same root and distinct ports for representative roots', () => {
-        const firstRoot = normalizeWorktreeRoot(
-            'C:/Users/Example/.codex/worktrees/first/ehagaki',
-            'win32',
-        );
-        const secondRoot = normalizeWorktreeRoot(
-            'C:/Users/Example/.codex/worktrees/second/ehagaki',
-            'win32',
-        );
+    it('reuses one generated port when the config is evaluated again', () => {
+        delete process.env.EHAGAKI_E2E_AUTO_PORT;
+        const portSource = vi.fn(() => 45_123);
 
-        const firstPort = derivePlaywrightPort(firstRoot);
-        expect(resolvePlaywrightPort({
-            rootPath: 'c:\\users\\example\\.codex\\worktrees\\first\\ehagaki\\',
-            platform: 'win32',
-        })).toBe(firstPort);
-        expect(firstPort).not.toBe(derivePlaywrightPort(secondRoot));
-        expect(firstPort).toBeGreaterThanOrEqual(1024);
-        expect(firstPort).toBeLessThanOrEqual(65535);
+        expect(resolvePlaywrightPort({ portSource })).toBe(45_123);
+        expect(resolvePlaywrightPort({ portSource })).toBe(45_123);
+        expect(portSource).toHaveBeenCalledTimes(1);
     });
 
-    it('is independent of time, process id, and randomness', () => {
-        const root = normalizeWorktreeRoot('C:/worktrees/ehagaki', 'win32');
+    it.each([44_999, 55_000, 45_123.5, Number.NaN])(
+        'rejects an invalid generated port %j',
+        (value) => {
+            expect(() => generatePlaywrightPort(() => value)).toThrow(
+                /Generated Playwright port/,
+            );
+        },
+    );
 
-        expect([
-            derivePlaywrightPort(root),
-            derivePlaywrightPort(root),
-            derivePlaywrightPort(root),
-        ]).toEqual([expect.any(Number), expect.any(Number), expect.any(Number)]);
-        expect(derivePlaywrightPort(root)).toBe(derivePlaywrightPort(root));
+    it('does not allow the automatic source to override an explicit port', () => {
+        const portSource = () => {
+            throw new Error('port source should not be called');
+        };
+
+        expect(
+            resolvePlaywrightPort({ envPort: '51234', portSource }),
+        ).toBe(51234);
     });
 });
 
@@ -95,6 +94,8 @@ describe('Playwright config connection values', () => {
         expect(baseUrl.hostname).toBe('127.0.0.1');
         expect(readyUrl.hostname).toBe('127.0.0.1');
         expect(baseUrl.port).toBe(readyUrl.port);
+        expect(Number(baseUrl.port)).toBeGreaterThanOrEqual(AUTO_PORT_MIN);
+        expect(Number(baseUrl.port)).toBeLessThan(AUTO_PORT_MAX_EXCLUSIVE);
         expect(baseUrl.pathname).toBe('/ehagaki/');
         expect(readyUrl.pathname).toBe(
             '/ehagaki/post-history-dialog-playwright.html',

--- a/src/test/unit/playwrightWorktreePort.test.ts
+++ b/src/test/unit/playwrightWorktreePort.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
     AUTO_PORT_MAX_EXCLUSIVE,
     AUTO_PORT_MIN,
@@ -10,9 +10,20 @@ import {
 } from '../../../scripts/playwrightWorktreePort';
 
 describe('playwright port resolver', () => {
+    const originalPortOverride = process.env.EHAGAKI_E2E_PORT;
     const originalAutoPort = process.env.EHAGAKI_E2E_AUTO_PORT;
 
+    beforeEach(() => {
+        delete process.env.EHAGAKI_E2E_PORT;
+        delete process.env.EHAGAKI_E2E_AUTO_PORT;
+    });
+
     afterEach(() => {
+        if (originalPortOverride === undefined) {
+            delete process.env.EHAGAKI_E2E_PORT;
+        } else {
+            process.env.EHAGAKI_E2E_PORT = originalPortOverride;
+        }
         if (originalAutoPort === undefined) {
             delete process.env.EHAGAKI_E2E_AUTO_PORT;
         } else {
@@ -81,41 +92,62 @@ describe('playwright port resolver', () => {
 
 describe('Playwright config connection values', () => {
     it('uses one host and port for the app, server command, and ready URL', async () => {
-        const { default: config } = await import('../../../playwright.config');
-        const baseURL = config.use?.baseURL;
-        const webServer = config.webServer as {
-            command: string;
-            reuseExistingServer?: boolean;
-            url: string;
-        };
-        const baseUrl = new URL(baseURL as string);
-        const readyUrl = new URL(webServer.url);
+        const originalPortOverride = process.env.EHAGAKI_E2E_PORT;
+        const originalAutoPort = process.env.EHAGAKI_E2E_AUTO_PORT;
 
-        expect(baseUrl.hostname).toBe('127.0.0.1');
-        expect(readyUrl.hostname).toBe('127.0.0.1');
-        expect(baseUrl.port).toBe(readyUrl.port);
-        expect(Number(baseUrl.port)).toBeGreaterThanOrEqual(AUTO_PORT_MIN);
-        expect(Number(baseUrl.port)).toBeLessThan(AUTO_PORT_MAX_EXCLUSIVE);
-        expect(baseUrl.pathname).toBe('/ehagaki/');
-        expect(readyUrl.pathname).toBe(
-            '/ehagaki/post-history-dialog-playwright.html',
-        );
-        expect(webServer.command).toContain(`--host 127.0.0.1`);
-        expect(webServer.command).toContain(`--port ${baseUrl.port}`);
-        expect(webServer.command).toContain('--strictPort');
-        expect(webServer.reuseExistingServer).toBe(false);
-        expect(config.projects?.map((project) => project.name)).toEqual([
-            'desktop-chromium',
-            'mobile-chromium',
-            'mobile-webkit',
-            'desktop-firefox',
-        ]);
-        expect(config.projects?.[2]?.testMatch).toEqual([
-            '**/composerTargetDialog.spec.ts',
-            '**/webComponentEmbed.spec.ts',
-            '**/webComponentParentClientExample.spec.ts',
-            '**/postEditorSending.spec.ts',
-        ]);
+        try {
+            delete process.env.EHAGAKI_E2E_PORT;
+            delete process.env.EHAGAKI_E2E_AUTO_PORT;
+            vi.resetModules();
+
+            const { default: config } = await import('../../../playwright.config');
+            const baseURL = config.use?.baseURL;
+            const webServer = config.webServer as {
+                command: string;
+                reuseExistingServer?: boolean;
+                url: string;
+            };
+            const baseUrl = new URL(baseURL as string);
+            const readyUrl = new URL(webServer.url);
+
+            expect(baseUrl.hostname).toBe('127.0.0.1');
+            expect(readyUrl.hostname).toBe('127.0.0.1');
+            expect(baseUrl.port).toBe(readyUrl.port);
+            expect(Number(baseUrl.port)).toBeGreaterThanOrEqual(AUTO_PORT_MIN);
+            expect(Number(baseUrl.port)).toBeLessThan(AUTO_PORT_MAX_EXCLUSIVE);
+            expect(baseUrl.pathname).toBe('/ehagaki/');
+            expect(readyUrl.pathname).toBe(
+                '/ehagaki/post-history-dialog-playwright.html',
+            );
+            expect(webServer.command).toContain(`--host 127.0.0.1`);
+            expect(webServer.command).toContain(`--port ${baseUrl.port}`);
+            expect(webServer.command).toContain('--strictPort');
+            expect(webServer.reuseExistingServer).toBe(false);
+            expect(config.projects?.map((project) => project.name)).toEqual([
+                'desktop-chromium',
+                'mobile-chromium',
+                'mobile-webkit',
+                'desktop-firefox',
+            ]);
+            expect(config.projects?.[2]?.testMatch).toEqual([
+                '**/composerTargetDialog.spec.ts',
+                '**/webComponentEmbed.spec.ts',
+                '**/webComponentParentClientExample.spec.ts',
+                '**/postEditorSending.spec.ts',
+            ]);
+        } finally {
+            if (originalPortOverride === undefined) {
+                delete process.env.EHAGAKI_E2E_PORT;
+            } else {
+                process.env.EHAGAKI_E2E_PORT = originalPortOverride;
+            }
+            if (originalAutoPort === undefined) {
+                delete process.env.EHAGAKI_E2E_AUTO_PORT;
+            } else {
+                process.env.EHAGAKI_E2E_AUTO_PORT = originalAutoPort;
+            }
+            vi.resetModules();
+        }
     });
 
     it('builds all connection values from a supplied port', () => {


### PR DESCRIPTION
## Summary
- replace deterministic worktree-derived Playwright ports with per-process random ports
- preserve `EHAGAKI_E2E_PORT`, `reuseExistingServer: false`, and `--strictPort`
- share the generated port across repeated config evaluation in one Playwright process

## Verification
- `npx vitest run src/test/unit/playwrightWorktreePort.test.ts`
- `npm run check`
- `npm test` (335 files, 3,883 passed, 1 skipped)
- Playwright desktop smoke with an automatic port: passed
- explicit override smoke: passed
- busy explicit port: fail-fast preserved

`npm run build` was not run because application/build/PWA sources were not changed.