### PR TITLE
feat: recolor mascot only for custom accent

### DIFF
--- a/src/components/HeaderComponent.svelte
+++ b/src/components/HeaderComponent.svelte
@@ -8,7 +8,7 @@
     import { resolveCompactMessageText } from "../lib/utils/headerComponentUtils";
     import { preventKeyboardFocusChange } from "../lib/utils/keyboardFocusUtils";
     import { getAppRuntimeEnvironment } from "../lib/appRuntimeEnvironment";
-    import { resolveAppAssetUrl } from "../lib/appAssetUrl";
+    import { themeColorStore } from "../stores/themeColorStore.svelte";
 
     const OFFICIAL_EHAGAKI_URL = "https://lokuyow.github.io/ehagaki/";
 
@@ -41,12 +41,23 @@
     const siteIconHref = isWebComponent || isIframe
         ? OFFICIAL_EHAGAKI_URL
         : runtimeEnvironment.appHomeHref;
-    const ehagakiIconUrl = resolveAppAssetUrl("ehagaki_icon.svg");
 
     let postStatus = $derived(editorState.postStatus);
     let isUploading = $derived(editorState.isUploading);
     let canPost = $derived(editorState.canPost);
     let canResetCurrentPostContent = $derived(canResetPostContent ?? canPost);
+    let hasCustomAccent = $derived(
+        themeColorStore.isAvailable && themeColorStore.accentColor !== null,
+    );
+    let mascotOuterFill = $derived(
+        hasCustomAccent ? "var(--mascot-accent-color)" : "#3FB57E",
+    );
+    let mascotInnerFill = $derived(
+        hasCustomAccent ? "var(--mascot-inner-color)" : "#EDFCF5",
+    );
+    let mascotFaceFill = $derived(
+        hasCustomAccent ? "var(--mascot-face-color)" : "#4D524F",
+    );
     let compactSuccessText = $derived(
         $_("balloonMessage.success.compact_post_success") || "投稿完了",
     );
@@ -68,11 +79,46 @@
                 target={isWebComponent ? "_blank" : undefined}
                 rel={isWebComponent ? "noopener noreferrer" : undefined}
             >
-                <img
-                    src={ehagakiIconUrl}
-                    alt="ehagaki icon"
+                <svg
                     class="site-icon"
-                />
+                    class:custom-accent={hasCustomAccent}
+                    viewBox="0 0 700 700"
+                    aria-hidden="true"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <path
+                        d="M85 0C93.2843 0 99.7748 6.86473 102.22 14.7798C108.523 35.179 127.531 50 150 50C172.469 50 191.477 35.179 197.78 14.7798C200.225 6.86473 206.716 0 215 0H285C293.284 0 299.775 6.86473 302.22 14.7798C308.523 35.179 327.531 50 350 50C372.469 50 391.477 35.179 397.78 14.7798C400.225 6.86473 406.716 0 415 0H485C493.284 0 499.775 6.86473 502.22 14.7798C508.523 35.179 527.531 50 550 50C572.469 50 591.477 35.179 597.78 14.7798C600.225 6.86473 606.716 0 615 0H685C693.284 0 700 6.71573 700 15V79C700 87.2843 693.135 93.7748 685.22 96.2204C664.821 102.523 650 121.531 650 144C650 166.469 664.821 185.477 685.22 191.78C693.135 194.225 700 200.716 700 209V279C700 287.284 693.135 293.775 685.22 296.22C664.821 302.523 650 321.531 650 344C650 366.469 664.821 385.477 685.22 391.78C693.135 394.225 700 400.716 700 409V479C700 487.284 693.135 493.775 685.22 496.22C664.821 502.523 650 521.531 650 544C650 566.469 664.821 585.477 685.22 591.78C693.135 594.225 700 600.716 700 609V685C700 693.284 693.284 700 685 700H615C606.716 700 600.225 693.135 597.78 685.22C591.477 664.821 572.469 650 550 650C527.531 650 508.523 664.821 502.22 685.22C499.775 693.135 493.284 700 485 700H415C406.716 700 400.225 693.135 397.78 685.22C391.477 664.821 372.469 650 350 650C327.531 650 308.523 664.821 302.22 685.22C299.775 693.135 293.284 700 285 700H215C206.716 700 200.225 693.135 197.78 685.22C191.477 664.821 172.469 650 150 650C127.531 650 108.523 664.821 102.22 685.22C99.7748 693.135 93.2843 700 85 700H15C6.71573 700 0 693.284 0 685V609C0 600.716 6.86473 594.225 14.7798 591.78C35.179 585.477 50 566.469 50 544C50 521.531 35.179 502.523 14.7798 496.22C6.86473 493.775 0 487.284 0 479V409C0 400.716 6.86473 394.225 14.7798 391.78C35.179 385.477 50 366.469 50 344C50 321.531 35.179 302.523 14.7798 296.22C6.86473 293.775 0 287.284 0 279V209C0 200.716 6.86473 194.225 14.7798 191.78C35.179 185.477 50 166.469 50 144C50 121.531 35.179 102.523 14.7798 96.2204C6.86473 93.7748 0 87.2843 0 79V15C0 6.71573 6.71573 0 15 0H85Z"
+                        fill={mascotOuterFill}
+                        data-mascot-part="outer"
+                    />
+                    <rect
+                        x="90"
+                        y="90"
+                        width="520"
+                        height="520"
+                        rx="15"
+                        fill={mascotInnerFill}
+                        data-mascot-part="inner"
+                    />
+                    <path
+                        d="M402.84 444.677C407.332 435.388 401.155 424.496 390.842 424.148C371.637 423.5 352.138 424.309 332.96 426.552C323.152 427.699 317.817 438.316 322.303 447.113V447.113C325.214 452.821 331.494 455.935 337.849 455.108C354.489 452.943 371.523 452.284 388.167 453.162C394.319 453.486 400.159 450.224 402.84 444.677V444.677Z"
+                        fill={mascotFaceFill}
+                        data-mascot-part="face"
+                    />
+                    <rect
+                        width="46.7771"
+                        height="133.689"
+                        rx="23.3885"
+                        transform="matrix(0.99863 -0.052336 0.048357 0.99883 155.532 284.427)"
+                        fill={mascotFaceFill}
+                        data-mascot-part="face"
+                    />
+                    <path
+                        d="M499.352 306.026C499.43 293.111 509.963 282.607 522.878 282.564V282.564C535.793 282.521 546.199 292.955 546.12 305.87L545.591 392.817C545.512 405.731 534.979 416.235 522.064 416.279V416.279C509.149 416.322 498.744 405.887 498.822 392.973L499.352 306.026Z"
+                        fill={mascotFaceFill}
+                        data-mascot-part="face"
+                    />
+                </svg>
             </a>
         {/if}
         {#if showFlavorText && balloonMessage}
@@ -227,9 +273,26 @@
     }
 
     .site-icon {
+        --mascot-accent-color: var(--accent-color);
+        --mascot-inner-color: color-mix(
+            in srgb,
+            var(--accent-color) 15%,
+            white 85%
+        );
+        --mascot-face-color: color-mix(
+            in srgb,
+            var(--accent-color) 40%,
+            black 60%
+        );
         width: 52px;
         height: 52px;
         margin-top: auto;
+    }
+
+    .site-icon:not(.custom-accent) {
+        --mascot-accent-color: #3FB57E;
+        --mascot-inner-color: #EDFCF5;
+        --mascot-face-color: #4D524F;
     }
 
     .compact-message {

--- a/src/test/unit/headerComponent.test.ts
+++ b/src/test/unit/headerComponent.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
@@ -21,12 +21,93 @@ vi.mock('svelte-i18n', () => ({
 
 import HeaderComponent from '../../components/HeaderComponent.svelte';
 import { configureAppRuntimeEnvironment } from '../../lib/appRuntimeEnvironment';
+import { themeColorStore } from '../../stores/themeColorStore.svelte';
+import { MockStorage } from '../helpers';
 
 describe('HeaderComponent', () => {
+    beforeEach(() => {
+        configureAppRuntimeEnvironment({
+            storage: new MockStorage(),
+            window,
+            document,
+            domRoot: document,
+            styleTarget: document.documentElement,
+            layoutTarget: document.body,
+            overlayTarget: document.body,
+            themeTarget: document.documentElement,
+            layoutMode: 'viewport',
+            runtimeKind: 'standalone',
+        });
+        themeColorStore.reload();
+    });
+
     afterEach(() => {
+        themeColorStore.reset();
         configureAppRuntimeEnvironment({
             runtimeKind: 'standalone',
             appHomeHref: './',
+        });
+    });
+
+    it('標準アクセントではきってんの3部分を従来の色で表示する', () => {
+        const { container } = render(HeaderComponent, {
+            props: {
+                onResetPostContent: vi.fn(),
+                onShowDraftList: vi.fn(),
+                showFlavorText: false,
+            },
+        });
+
+        const mascot = container.querySelector<SVGElement>('.site-icon')!;
+        const fills = Array.from(
+            mascot.querySelectorAll<SVGElement>('[data-mascot-part]'),
+        ).map((part) => [part.dataset.mascotPart, part.getAttribute('fill')]);
+
+        expect(mascot.classList.contains('custom-accent')).toBe(false);
+        expect(fills).toEqual([
+            ['outer', '#3FB57E'],
+            ['inner', '#EDFCF5'],
+            ['face', '#4D524F'],
+            ['face', '#4D524F'],
+            ['face', '#4D524F'],
+        ]);
+    });
+
+    it('カスタムアクセントでは3部分を役割別の色変数で即時に切り替える', async () => {
+        themeColorStore.setAccentColor('#c04444');
+        const { container } = render(HeaderComponent, {
+            props: {
+                onResetPostContent: vi.fn(),
+                onShowDraftList: vi.fn(),
+                showFlavorText: false,
+            },
+        });
+
+        const mascot = container.querySelector<SVGElement>('.site-icon')!;
+        const getFills = () => Array.from(
+            mascot.querySelectorAll<SVGElement>('[data-mascot-part]'),
+        ).map((part) => part.getAttribute('fill'));
+
+        expect(mascot.classList.contains('custom-accent')).toBe(true);
+        expect(getFills()).toEqual([
+            'var(--mascot-accent-color)',
+            'var(--mascot-inner-color)',
+            'var(--mascot-face-color)',
+            'var(--mascot-face-color)',
+            'var(--mascot-face-color)',
+        ]);
+        expect(new Set(getFills()).size).toBe(3);
+
+        themeColorStore.reset();
+        await waitFor(() => {
+            expect(mascot.classList.contains('custom-accent')).toBe(false);
+            expect(getFills()).toEqual([
+                '#3FB57E',
+                '#EDFCF5',
+                '#4D524F',
+                '#4D524F',
+                '#4D524F',
+            ]);
         });
     });
 


### PR DESCRIPTION
## Summary
- Inline the header mascot SVG so its outer, inner, and face colors can be controlled independently.
- Keep the existing mascot colors when no standalone custom accent is saved.
- Apply accent-based light/dark `color-mix()` colors only for a custom accent and restore defaults on reset.

## Verification
- `npm run test -- src/test/unit/headerComponent.test.ts src/test/unit/themeColorStore.test.ts`
- `npm run check`
- `npm test`
- `npm run build`
- `git diff --check`
- Chromium browser check: default, custom accent, reset, and dark mode.