### PR TITLE
Show active account avatar in editor placeholder

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1921,6 +1921,7 @@
                     bind:this={postComponentRef}
                     {rxNostr}
                     hasStoredKey={isAuthenticated}
+                    {isSwitchingAccount}
                     availableComposerHeight={postAvailableComposerHeight}
                     minEditorHeight={postEditorMinHeight}
                     onPostSuccess={handlePostSuccess}

--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -119,13 +119,13 @@
   let profileData = $derived(profileDataStore.value);
   let profileLoaded = $derived(profileLoadedStore.value);
   let isLoadingProfile = $derived(isLoadingProfileStore.value);
+  let editorIsEmpty = $state(true);
   let showAccountPlaceholder = $derived(
     hasStoredKey &&
       !isSwitchingAccount &&
       profileLoaded &&
       !isLoadingProfile &&
-      !editorState.content.trim() &&
-      !editorState.hasImage,
+      editorIsEmpty,
   );
   let postContainerEl: HTMLDivElement | null = null;
   let editorContainerEl: HTMLElement | null = null;
@@ -359,9 +359,21 @@
     editor = editorResources.editor;
 
     // エディターの購読
+    let subscribedEditor: TipTapEditor | null = null;
+    const handleEditorTransaction = ({ editor: editorInstance }: { editor: TipTapEditor }) => {
+      editorIsEmpty = editorInstance.isEmpty;
+    };
+
     editorSubscriptionUnsubscribe = editor.subscribe(
       (editorInstance: TipTapEditor | null) => {
+        if (subscribedEditor) {
+          subscribedEditor.off("transaction", handleEditorTransaction);
+        }
+
+        subscribedEditor = editorInstance;
         currentEditor = editorInstance;
+        editorIsEmpty = editorInstance?.isEmpty ?? true;
+        editorInstance?.on("transaction", handleEditorTransaction);
         // ストアにも設定
         currentEditorStore.set(editorInstance);
       },
@@ -388,6 +400,9 @@
         handleImageFullscreenRequest,
       );
       if (editorResources) {
+        if (subscribedEditor) {
+          subscribedEditor.off("transaction", handleEditorTransaction);
+        }
         cleanupEditor({
           unsubscribe: editorResources.unsubscribe,
           componentUnsubscribe: editorSubscriptionUnsubscribe ?? (() => {}),
@@ -901,8 +916,8 @@
     top: 11px;
     left: 10px;
     z-index: 3;
-    width: 22px;
-    height: 22px;
+    width: 28px;
+    height: 28px;
     opacity: 0.5;
     pointer-events: none;
   }
@@ -929,7 +944,7 @@
 
   .editor-container.account-avatar-placeholder
     :global(p.is-editor-empty:first-child::before) {
-    padding-left: 30px;
+    padding-left: 36px;
   }
 
   .editor-container.sending {

--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -70,18 +70,25 @@
   import { insertCustomEmojiWithoutUnwantedKeyboard } from "../lib/editor/customEmojiInsertion";
   import { focusEditorWithoutKeyboardForCurrentTap } from "../lib/utils/keyboardFocusUtils";
   import { isEditorElement } from "../lib/utils/appDomUtils";
+  import {
+    profileDataStore,
+    isLoadingProfileStore,
+    profileLoadedStore,
+  } from "../stores/profileStore.svelte";
   import { POST_EDITOR_MIN_HEIGHT } from "../lib/postLayoutUtils";
   import {
     measureElementOuterHeight,
     resolvePostEditorTargetHeight,
   } from "../lib/utils/composerLayoutUtils";
   import ImageFullscreen from "./ImageFullscreen.svelte";
+  import ProfileAvatar from "./ProfileAvatar.svelte";
   import type { InitializeEditorResult, MenuItem } from "../lib/types";
   import type { AppPostNotificationPort } from "../lib/appNotificationPort";
 
   interface Props {
     rxNostr?: RxNostr;
     hasStoredKey: boolean;
+    isSwitchingAccount?: boolean;
     onPostSuccess?: (result?: PostResult) => void;
     availableComposerHeight?: number;
     minEditorHeight?: number;
@@ -92,6 +99,7 @@
   let {
     rxNostr,
     hasStoredKey,
+    isSwitchingAccount = false,
     onPostSuccess,
     availableComposerHeight = POST_EDITOR_MIN_HEIGHT,
     minEditorHeight = POST_EDITOR_MIN_HEIGHT,
@@ -108,6 +116,17 @@
   let mediaFreePlacement = $derived(mediaFreePlacementStore.value);
   let postStatus = $derived(editorState.postStatus);
   let uploadErrorMessage = $derived(editorState.uploadErrorMessage);
+  let profileData = $derived(profileDataStore.value);
+  let profileLoaded = $derived(profileLoadedStore.value);
+  let isLoadingProfile = $derived(isLoadingProfileStore.value);
+  let showAccountPlaceholder = $derived(
+    hasStoredKey &&
+      !isSwitchingAccount &&
+      profileLoaded &&
+      !isLoadingProfile &&
+      !editorState.content.trim() &&
+      !editorState.hasImage,
+  );
   let postContainerEl: HTMLDivElement | null = null;
   let editorContainerEl: HTMLElement | null = null;
   let editorResources: InitializeEditorResult | null = null;
@@ -741,6 +760,7 @@
     class:drag-over={dragOver}
     class:gallery-mode={!mediaFreePlacement}
     class:sending={postStatus.sending}
+    class:account-avatar-placeholder={showAccountPlaceholder}
     onclick={handleEditorContainerClick}
     onkeydown={handleEditorContainerKeydown}
     use:fileDropActionWithDragState={{
@@ -755,6 +775,16 @@
     tabindex="-1"
     bind:this={editorContainerEl}
   >
+    {#if showAccountPlaceholder}
+      <div class="editor-account-placeholder" aria-hidden="true">
+        <ProfileAvatar
+          src={profileData?.picture || ""}
+          alt=""
+          fallbackAriaLabel=""
+          rootClassName="editor-account-placeholder-avatar"
+        />
+      </div>
+    {/if}
     {#if editor && currentEditor}
       <!-- svelte-tiptap の Editor 型差異を回避するためここでは any キャスト -->
       <EditorContent editor={currentEditor as any} class="editor-content" />
@@ -862,6 +892,28 @@
     background: var(--bg-input);
     -webkit-tap-highlight-color: transparent;
     overflow: hidden;
+  }
+
+  :global(.editor-account-placeholder) {
+    position: absolute;
+    top: 11px;
+    left: 10px;
+    z-index: 3;
+    width: 22px;
+    height: 22px;
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
+  :global(.editor-account-placeholder-avatar) {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .editor-container.account-avatar-placeholder
+    :global(p.is-editor-empty:first-child::before) {
+    padding-left: 30px;
   }
 
   .editor-container.sending {

--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -782,6 +782,8 @@
           alt=""
           fallbackAriaLabel=""
           rootClassName="editor-account-placeholder-avatar"
+          imageClassName="editor-account-placeholder-image"
+          fallbackClassName="editor-account-placeholder-fallback"
         />
       </div>
     {/if}
@@ -909,6 +911,20 @@
     display: block;
     width: 100%;
     height: 100%;
+    overflow: hidden;
+    border-radius: 50%;
+  }
+
+  :global(.editor-account-placeholder-image),
+  :global(.editor-account-placeholder-fallback) {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+  }
+
+  :global(.editor-account-placeholder-image) {
+    object-fit: cover;
   }
 
   .editor-container.account-avatar-placeholder

--- a/src/test/e2e/PostEditorSendingHarness.svelte
+++ b/src/test/e2e/PostEditorSendingHarness.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-    import { onDestroy } from 'svelte';
+    import { onDestroy, onMount } from 'svelte';
     import PostComponent from '../../components/PostComponent.svelte';
     import { editorState, resetPostStatus, updatePostStatus } from '../../stores/editorStore.svelte';
+    import { isLoadingProfileStore, profileDataStore, profileLoadedStore } from '../../stores/profileStore.svelte';
 
     let sending = $derived(editorState.postStatus.sending);
 
@@ -9,8 +10,29 @@
         updatePostStatus({ ...editorState.postStatus, sending: !editorState.postStatus.sending });
     }
 
+    onMount(() => {
+        const hasProfileAvatar = window.location.search.includes('withProfileAvatar');
+        const hasFallbackAvatar = window.location.search.includes('withFallbackAvatar');
+        if (!hasProfileAvatar && !hasFallbackAvatar) return;
+
+        profileDataStore.set({
+            name: 'Geometry Test Profile',
+            displayName: 'Geometry Test Profile',
+            picture: hasProfileAvatar
+                ? new URL(`${import.meta.env.BASE_URL}ehagaki_icon_x512.png`, window.location.origin).href
+                : '',
+            npub: '',
+            nprofile: '',
+        });
+        isLoadingProfileStore.set(false);
+        profileLoadedStore.set(true);
+    });
+
     onDestroy(() => {
         resetPostStatus();
+        profileDataStore.set({ name: '', displayName: '', picture: '', npub: '', nprofile: '' });
+        isLoadingProfileStore.set(false);
+        profileLoadedStore.set(false);
     });
 </script>
 

--- a/src/test/e2e/postEditorSending.spec.ts
+++ b/src/test/e2e/postEditorSending.spec.ts
@@ -75,6 +75,8 @@ test.describe('post editor sending state', () => {
             };
         });
 
+        expect(geometry.wrapper.width).toBeCloseTo(28, 0);
+        expect(geometry.wrapper.height).toBeCloseTo(28, 0);
         expect(geometry.root.width).toBeLessThanOrEqual(geometry.wrapper.width + 0.5);
         expect(geometry.root.height).toBeLessThanOrEqual(geometry.wrapper.height + 0.5);
         expect(geometry.image.width).toBeLessThanOrEqual(geometry.wrapper.width + 0.5);
@@ -92,12 +94,22 @@ test.describe('post editor sending state', () => {
         await expect.poll(() => page.locator('.tiptap-editor').evaluate((element) => document.activeElement === element)).toBe(true);
 
         await editor.pressSequentially('geometry');
-        await expect(wrapper).toHaveCount(0);
+        await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+        const afterInput = await page.evaluate(() => ({
+            placeholderVisible: document.querySelector('.tiptap-editor p')?.classList.contains('is-editor-empty') ?? false,
+            avatarVisible: Boolean(document.querySelector('.editor-account-placeholder')),
+        }));
+        expect(afterInput).toEqual({ placeholderVisible: false, avatarVisible: false });
 
         for (let index = 0; index < 'geometry'.length; index += 1) {
             await page.keyboard.press('Backspace');
         }
-        await expect(wrapper).toBeVisible();
+        await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+        const afterDelete = await page.evaluate(() => ({
+            placeholderVisible: document.querySelector('.tiptap-editor p')?.classList.contains('is-editor-empty') ?? false,
+            avatarVisible: Boolean(document.querySelector('.editor-account-placeholder')),
+        }));
+        expect(afterDelete).toEqual({ placeholderVisible: true, avatarVisible: true });
 
         await page.goto('post-editor-sending-playwright.html?withFallbackAvatar=1');
         const fallbackWrapper = page.locator('.editor-account-placeholder');
@@ -105,6 +117,8 @@ test.describe('post editor sending state', () => {
         const fallbackGeometry = await fallbackWrapper.locator('.editor-account-placeholder-fallback').boundingBox();
         const wrapperGeometry = await fallbackWrapper.boundingBox();
         if (!fallbackGeometry || !wrapperGeometry) throw new Error('Fallback geometry was not found.');
+        expect(wrapperGeometry.width).toBeCloseTo(28, 0);
+        expect(wrapperGeometry.height).toBeCloseTo(28, 0);
         expect(fallbackGeometry.width).toBeLessThanOrEqual(wrapperGeometry.width + 0.5);
         expect(fallbackGeometry.height).toBeLessThanOrEqual(wrapperGeometry.height + 0.5);
     });

--- a/src/test/e2e/postEditorSending.spec.ts
+++ b/src/test/e2e/postEditorSending.spec.ts
@@ -37,4 +37,75 @@ test.describe('post editor sending state', () => {
             await expect(editor).toContainText('編集再開');
         }
     });
+
+    test('contains a large active-account avatar inside the empty-editor placeholder', async ({ page }) => {
+        await page.goto('post-editor-sending-playwright.html?withProfileAvatar=1');
+
+        const editorContainer = page.getByRole('textbox', { name: '投稿エディター' });
+        const editor = editorContainer.locator('.tiptap-editor');
+        const wrapper = page.locator('.editor-account-placeholder');
+        const image = wrapper.locator('img');
+
+        await expect(image).toHaveJSProperty('naturalWidth', 512);
+        await expect(image).toHaveJSProperty('naturalHeight', 512);
+
+        const geometry = await page.evaluate(() => {
+            const wrapper = document.querySelector('.editor-account-placeholder');
+            const root = wrapper?.querySelector('.editor-account-placeholder-avatar');
+            const image = wrapper?.querySelector('img');
+            const paragraph = document.querySelector('.tiptap-editor p');
+            if (!wrapper || !root || !image || !paragraph) {
+                throw new Error('Editor placeholder geometry nodes were not found.');
+            }
+
+            const wrapperRect = wrapper.getBoundingClientRect();
+            const rootRect = root.getBoundingClientRect();
+            const imageRect = image.getBoundingClientRect();
+            const paragraphRect = paragraph.getBoundingClientRect();
+            const paddingLeft = Number.parseFloat(getComputedStyle(paragraph, '::before').paddingLeft) || 0;
+
+            return {
+                wrapper: { x: wrapperRect.x, y: wrapperRect.y, width: wrapperRect.width, height: wrapperRect.height },
+                root: { x: rootRect.x, y: rootRect.y, width: rootRect.width, height: rootRect.height },
+                image: { x: imageRect.x, y: imageRect.y, width: imageRect.width, height: imageRect.height },
+                paragraph: { x: paragraphRect.x, y: paragraphRect.y, width: paragraphRect.width, height: paragraphRect.height },
+                placeholderTextStart: paragraphRect.x + paddingLeft,
+                documentWidth: document.documentElement.scrollWidth,
+                viewportWidth: document.documentElement.clientWidth,
+            };
+        });
+
+        expect(geometry.root.width).toBeLessThanOrEqual(geometry.wrapper.width + 0.5);
+        expect(geometry.root.height).toBeLessThanOrEqual(geometry.wrapper.height + 0.5);
+        expect(geometry.image.width).toBeLessThanOrEqual(geometry.wrapper.width + 0.5);
+        expect(geometry.image.height).toBeLessThanOrEqual(geometry.wrapper.height + 0.5);
+        expect(geometry.image.x).toBeGreaterThanOrEqual(geometry.wrapper.x - 0.5);
+        expect(geometry.image.y).toBeGreaterThanOrEqual(geometry.wrapper.y - 0.5);
+        expect(geometry.image.x + geometry.image.width).toBeLessThanOrEqual(geometry.wrapper.x + geometry.wrapper.width + 0.5);
+        expect(geometry.image.y + geometry.image.height).toBeLessThanOrEqual(geometry.wrapper.y + geometry.wrapper.height + 0.5);
+        expect(geometry.image.x + geometry.image.width).toBeLessThanOrEqual(geometry.placeholderTextStart + 0.5);
+        expect(geometry.documentWidth).toBeLessThanOrEqual(geometry.viewportWidth);
+
+        const clickPoint = await wrapper.boundingBox();
+        if (!clickPoint) throw new Error('Editor placeholder wrapper has no box.');
+        await page.mouse.click(clickPoint.x + clickPoint.width / 2, clickPoint.y + clickPoint.height / 2);
+        await expect.poll(() => page.locator('.tiptap-editor').evaluate((element) => document.activeElement === element)).toBe(true);
+
+        await editor.pressSequentially('geometry');
+        await expect(wrapper).toHaveCount(0);
+
+        for (let index = 0; index < 'geometry'.length; index += 1) {
+            await page.keyboard.press('Backspace');
+        }
+        await expect(wrapper).toBeVisible();
+
+        await page.goto('post-editor-sending-playwright.html?withFallbackAvatar=1');
+        const fallbackWrapper = page.locator('.editor-account-placeholder');
+        await expect(fallbackWrapper.locator('.editor-account-placeholder-fallback')).toBeVisible();
+        const fallbackGeometry = await fallbackWrapper.locator('.editor-account-placeholder-fallback').boundingBox();
+        const wrapperGeometry = await fallbackWrapper.boundingBox();
+        if (!fallbackGeometry || !wrapperGeometry) throw new Error('Fallback geometry was not found.');
+        expect(fallbackGeometry.width).toBeLessThanOrEqual(wrapperGeometry.width + 0.5);
+        expect(fallbackGeometry.height).toBeLessThanOrEqual(wrapperGeometry.height + 0.5);
+    });
 });

--- a/src/test/unit/accessibilityComponent.test.ts
+++ b/src/test/unit/accessibilityComponent.test.ts
@@ -68,8 +68,8 @@ import SvelteImageNode from '../../components/SvelteImageNode.svelte';
 import SvelteVideoNode from '../../components/SvelteVideoNode.svelte';
 import ProfileComponent from '../../components/ProfileComponent.svelte';
 import { authState } from '../../stores/authStore.svelte';
-import { currentEditorStore, editorState, resetPostStatus, updatePostStatus } from '../../stores/editorStore.svelte';
-import { profileDataStore } from '../../stores/profileStore.svelte';
+import { currentEditorStore, editorState, resetEditorState, resetPostStatus, updatePostStatus } from '../../stores/editorStore.svelte';
+import { isLoadingProfileStore, profileDataStore, profileLoadedStore } from '../../stores/profileStore.svelte';
 import { handleImageInteraction, requestNodeSelection } from '../../lib/utils/mediaNodeUtils';
 
 function createImageNode(attrs: Record<string, unknown> = {}) {
@@ -124,6 +124,9 @@ describe('accessibility component tests', () => {
             npub: 'npub1testprofile',
             nprofile: 'nprofile1testprofile',
         };
+        (profileLoadedStore as any).value = false;
+        (isLoadingProfileStore as any).value = false;
+        resetEditorState();
     });
 
     it('PostComponent exposes localized editor aria-label in Japanese and English', async () => {
@@ -138,6 +141,94 @@ describe('accessibility component tests', () => {
         await waitLocale();
 
         expect(screen.getByRole('textbox', { name: 'Post editor' })).toBeTruthy();
+    });
+
+    it('shows the active account avatar only while the editor is empty', async () => {
+        (profileDataStore as any).value = {
+            name: 'current-name',
+            displayName: 'Current display',
+            picture: 'https://example.com/current.png',
+            npub: 'npub1testprofile',
+            nprofile: 'nprofile1testprofile',
+        };
+        (profileLoadedStore as any).value = true;
+
+        const { container } = render(PostComponent, { hasStoredKey: true });
+        const editor = await waitFor(() => {
+            const instance = currentEditorStore.value;
+            if (!instance) throw new Error('Editor was not initialized');
+            return instance;
+        });
+        const avatarPlaceholder = container.querySelector('.editor-account-placeholder');
+
+        expect(avatarPlaceholder).toBeTruthy();
+        expect(avatarPlaceholder?.querySelector('img')?.getAttribute('src')).toBe(
+            'https://example.com/current.png',
+        );
+        expect(container.querySelector('.tiptap-editor p')?.getAttribute('data-placeholder')).toBe(
+            'いまどうしてる？',
+        );
+
+        editor.commands.insertContent('本文');
+        await waitFor(() => {
+            expect(container.querySelector('.editor-account-placeholder')).toBeNull();
+        });
+        expect(JSON.stringify(editor.getJSON())).not.toContain('current.png');
+
+        editor.commands.clearContent();
+        await waitFor(() => {
+            expect(container.querySelector('.editor-account-placeholder')).toBeTruthy();
+        });
+    });
+
+    it('does not show the avatar when unauthenticated or while switching accounts', async () => {
+        (profileDataStore as any).value = {
+            name: 'current-name',
+            displayName: 'Current display',
+            picture: 'https://example.com/current.png',
+            npub: 'npub1testprofile',
+            nprofile: 'nprofile1testprofile',
+        };
+        (profileLoadedStore as any).value = true;
+
+        const { container, rerender } = render(PostComponent, { hasStoredKey: false });
+        await waitFor(() => expect(currentEditorStore.value).toBeTruthy());
+        expect(container.querySelector('.editor-account-placeholder')).toBeNull();
+
+        await rerender({ hasStoredKey: true, isSwitchingAccount: true });
+        expect(container.querySelector('.editor-account-placeholder')).toBeNull();
+    });
+
+    it('uses the latest profile store value after the active account changes', async () => {
+        (profileDataStore as any).value = {
+            name: 'first-name',
+            displayName: 'First display',
+            picture: 'https://example.com/first.png',
+            npub: 'npub1first',
+            nprofile: 'nprofile1first',
+        };
+        (profileLoadedStore as any).value = true;
+
+        const { container, unmount } = render(PostComponent, { hasStoredKey: true });
+        await waitFor(() => expect(container.querySelector('.editor-account-placeholder')).toBeTruthy());
+        expect(container.querySelector('.editor-account-placeholder img')?.getAttribute('src')).toBe(
+            'https://example.com/first.png',
+        );
+
+        (profileDataStore as any).value = {
+            name: 'second-name',
+            displayName: 'Second display',
+            picture: 'https://example.com/second.png',
+            npub: 'npub1second',
+            nprofile: 'nprofile1second',
+        };
+        unmount();
+        cleanup();
+        const { container: nextContainer } = render(PostComponent, { hasStoredKey: true });
+
+        expect(nextContainer.querySelector('.editor-account-placeholder img')?.getAttribute('src')).toBe(
+            'https://example.com/second.png',
+        );
     });
 
     it('makes the editor read-only only while a post is sending', async () => {


### PR DESCRIPTION
## Summary
- Show the active account's existing `ProfileAvatar` in the empty post editor placeholder.
- Keep the avatar outside the Tiptap/ProseMirror document and hide it during input, when unauthenticated, and while switching accounts.
- Reuse the existing profile store/loading/fallback path.
- Constrain the placeholder avatar root, image, and fallback to the circular wrapper so large source images cannot overflow.
- Use the editor's immediate Tiptap `isEmpty` state for avatar visibility, independently of the debounced content tracking state.
- Display the placeholder avatar at 28px with matching text spacing.

## Verification
- `npm test` — 335 files passed, 3886 tests passed, 1 skipped
- `npm run check` — passed
- `npm run build` — passed
- `npx playwright test src/test/e2e/postEditorSending.spec.ts --project=desktop-chromium --project=mobile-chromium --project=mobile-webkit` — 6 passed
- `npx playwright test src/test/e2e/webComponentEmbed.spec.ts --project=desktop-chromium --project=mobile-webkit` — 37 passed, 1 skipped
- Manual Playwright visual/geometry verification — desktop Chromium screenshot plus Desktop Chromium, Mobile Chromium, and Mobile WebKit geometry checks for 28px containment, immediate input/delete synchronization, focus, fallback, and horizontal overflow