### PR TITLE
feat: strengthen base color tint

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -41,54 +41,54 @@
   /* ライトモード・ダークモード用のneutral surface生成 */
   --surface-bg: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 94%)) 14%, hsl(0, 0%, 94%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 12%)) 24%, hsl(0, 0%, 12%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 12%)) 20%, hsl(0, 0%, 12%))
   );
   --surface-input: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 100%)) 10%, hsl(0, 0%, 100%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 19%)) 18%, hsl(0, 0%, 19%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 19%)) 15%, hsl(0, 0%, 19%))
   );
   --surface-footer: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 82%)) 18%, hsl(0, 0%, 82%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 10%)) 28%, hsl(0, 0%, 10%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 10%)) 24%, hsl(0, 0%, 10%))
   );
   --surface-buttonbar: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 91%)) 16%, hsl(0, 0%, 91%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 28%)) 24%, hsl(0, 0%, 28%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 28%)) 20%, hsl(0, 0%, 28%))
   );
 
   --surface-button: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 92%)) 14%, hsl(0, 0%, 92%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 25%)) 22%, hsl(0, 0%, 25%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 25%)) 18%, hsl(0, 0%, 25%))
   );
   --surface-button-border: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 75%)) 20%, hsl(0, 0%, 75%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 28%, hsl(0, 0%, 30%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 24%, hsl(0, 0%, 30%))
   );
   --surface-button-preview-action: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 74%)) 18%, hsl(0, 0%, 74%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 36%)) 28%, hsl(0, 0%, 36%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 36%)) 24%, hsl(0, 0%, 36%))
   );
 
   --surface-border: light-dark(
     color-mix(in srgb, var(--base-color, var(--light-gray)) 20%, var(--light-gray)),
-    color-mix(in srgb, var(--base-color, dimgray) 28%, dimgray)
+    color-mix(in srgb, var(--base-color, dimgray) 24%, dimgray)
   );
   --surface-border-hr: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 84%)) 16%, hsl(0, 0%, 84%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 24%, hsl(0, 0%, 30%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 20%, hsl(0, 0%, 30%))
   );
   --surface-border-hr-light: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 92%)) 12%, hsl(0, 0%, 92%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 20%)) 18%, hsl(0, 0%, 20%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 20%)) 15%, hsl(0, 0%, 20%))
   );
 
   --surface-dialog: light-dark(
     color-mix(in srgb, var(--base-color, white) 10%, white),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 18%, hsl(0, 0%, 14%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 15%, hsl(0, 0%, 14%))
   );
   --surface-window: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 95%)) 10%, hsl(0, 0%, 95%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 18%, hsl(0, 0%, 14%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 15%, hsl(0, 0%, 14%))
   );
 
   --bg: var(--surface-bg);

--- a/src/app.css
+++ b/src/app.css
@@ -41,54 +41,54 @@
   /* ライトモード・ダークモード用のneutral surface生成 */
   --surface-bg: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 94%)) 14%, hsl(0, 0%, 94%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 12%)) 20%, hsl(0, 0%, 12%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 12%)) 16%, hsl(0, 0%, 12%))
   );
   --surface-input: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 100%)) 10%, hsl(0, 0%, 100%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 19%)) 15%, hsl(0, 0%, 19%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 19%)) 12%, hsl(0, 0%, 19%))
   );
   --surface-footer: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 82%)) 18%, hsl(0, 0%, 82%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 10%)) 24%, hsl(0, 0%, 10%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 10%)) 20%, hsl(0, 0%, 10%))
   );
   --surface-buttonbar: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 91%)) 16%, hsl(0, 0%, 91%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 28%)) 20%, hsl(0, 0%, 28%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 28%)) 16%, hsl(0, 0%, 28%))
   );
 
   --surface-button: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 92%)) 14%, hsl(0, 0%, 92%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 25%)) 18%, hsl(0, 0%, 25%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 25%)) 14%, hsl(0, 0%, 25%))
   );
   --surface-button-border: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 75%)) 20%, hsl(0, 0%, 75%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 24%, hsl(0, 0%, 30%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 20%, hsl(0, 0%, 30%))
   );
   --surface-button-preview-action: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 74%)) 18%, hsl(0, 0%, 74%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 36%)) 24%, hsl(0, 0%, 36%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 36%)) 20%, hsl(0, 0%, 36%))
   );
 
   --surface-border: light-dark(
     color-mix(in srgb, var(--base-color, var(--light-gray)) 20%, var(--light-gray)),
-    color-mix(in srgb, var(--base-color, dimgray) 24%, dimgray)
+    color-mix(in srgb, var(--base-color, dimgray) 20%, dimgray)
   );
   --surface-border-hr: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 84%)) 16%, hsl(0, 0%, 84%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 20%, hsl(0, 0%, 30%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 16%, hsl(0, 0%, 30%))
   );
   --surface-border-hr-light: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 92%)) 12%, hsl(0, 0%, 92%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 20%)) 15%, hsl(0, 0%, 20%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 20%)) 12%, hsl(0, 0%, 20%))
   );
 
   --surface-dialog: light-dark(
     color-mix(in srgb, var(--base-color, white) 10%, white),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 15%, hsl(0, 0%, 14%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 12%, hsl(0, 0%, 14%))
   );
   --surface-window: light-dark(
     color-mix(in srgb, var(--base-color, hsl(0, 0%, 95%)) 10%, hsl(0, 0%, 95%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 15%, hsl(0, 0%, 14%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 12%, hsl(0, 0%, 14%))
   );
 
   --bg: var(--surface-bg);

--- a/src/app.css
+++ b/src/app.css
@@ -40,55 +40,55 @@
 
   /* ライトモード・ダークモード用のneutral surface生成 */
   --surface-bg: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 94%)) 8%, hsl(0, 0%, 94%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 12%)) 8%, hsl(0, 0%, 12%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 94%)) 14%, hsl(0, 0%, 94%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 12%)) 24%, hsl(0, 0%, 12%))
   );
   --surface-input: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 100%)) 5%, hsl(0, 0%, 100%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 19%)) 5%, hsl(0, 0%, 19%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 100%)) 10%, hsl(0, 0%, 100%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 19%)) 18%, hsl(0, 0%, 19%))
   );
   --surface-footer: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 82%)) 12%, hsl(0, 0%, 82%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 10%)) 12%, hsl(0, 0%, 10%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 82%)) 18%, hsl(0, 0%, 82%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 10%)) 28%, hsl(0, 0%, 10%))
   );
   --surface-buttonbar: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 91%)) 10%, hsl(0, 0%, 91%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 28%)) 10%, hsl(0, 0%, 28%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 91%)) 16%, hsl(0, 0%, 91%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 28%)) 24%, hsl(0, 0%, 28%))
   );
 
   --surface-button: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 92%)) 8%, hsl(0, 0%, 92%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 25%)) 8%, hsl(0, 0%, 25%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 92%)) 14%, hsl(0, 0%, 92%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 25%)) 22%, hsl(0, 0%, 25%))
   );
   --surface-button-border: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 75%)) 14%, hsl(0, 0%, 75%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 14%, hsl(0, 0%, 30%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 75%)) 20%, hsl(0, 0%, 75%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 28%, hsl(0, 0%, 30%))
   );
   --surface-button-preview-action: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 74%)) 12%, hsl(0, 0%, 74%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 36%)) 12%, hsl(0, 0%, 36%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 74%)) 18%, hsl(0, 0%, 74%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 36%)) 28%, hsl(0, 0%, 36%))
   );
 
   --surface-border: light-dark(
-    color-mix(in srgb, var(--base-color, var(--light-gray)) 14%, var(--light-gray)),
-    color-mix(in srgb, var(--base-color, dimgray) 14%, dimgray)
+    color-mix(in srgb, var(--base-color, var(--light-gray)) 20%, var(--light-gray)),
+    color-mix(in srgb, var(--base-color, dimgray) 28%, dimgray)
   );
   --surface-border-hr: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 84%)) 10%, hsl(0, 0%, 84%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 10%, hsl(0, 0%, 30%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 84%)) 16%, hsl(0, 0%, 84%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 24%, hsl(0, 0%, 30%))
   );
   --surface-border-hr-light: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 92%)) 7%, hsl(0, 0%, 92%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 20%)) 7%, hsl(0, 0%, 20%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 92%)) 12%, hsl(0, 0%, 92%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 20%)) 18%, hsl(0, 0%, 20%))
   );
 
   --surface-dialog: light-dark(
-    color-mix(in srgb, var(--base-color, white) 5%, white),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 5%, hsl(0, 0%, 14%))
+    color-mix(in srgb, var(--base-color, white) 10%, white),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 18%, hsl(0, 0%, 14%))
   );
   --surface-window: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 95%)) 5%, hsl(0, 0%, 95%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 5%, hsl(0, 0%, 14%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 95%)) 10%, hsl(0, 0%, 95%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 18%, hsl(0, 0%, 14%))
   );
 
   --bg: var(--surface-bg);

--- a/src/app.css
+++ b/src/app.css
@@ -40,55 +40,55 @@
 
   /* ライトモード・ダークモード用のneutral surface生成 */
   --surface-bg: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 94%)) 14%, hsl(0, 0%, 94%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 12%)) 16%, hsl(0, 0%, 12%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 94%)) 18%, hsl(0, 0%, 94%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 12%)) 18%, hsl(0, 0%, 12%))
   );
   --surface-input: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 100%)) 10%, hsl(0, 0%, 100%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 19%)) 12%, hsl(0, 0%, 19%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 100%)) 14%, hsl(0, 0%, 100%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 19%)) 14%, hsl(0, 0%, 19%))
   );
   --surface-footer: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 82%)) 18%, hsl(0, 0%, 82%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 10%)) 20%, hsl(0, 0%, 10%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 82%)) 22%, hsl(0, 0%, 82%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 10%)) 22%, hsl(0, 0%, 10%))
   );
   --surface-buttonbar: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 91%)) 16%, hsl(0, 0%, 91%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 28%)) 16%, hsl(0, 0%, 28%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 91%)) 20%, hsl(0, 0%, 91%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 28%)) 20%, hsl(0, 0%, 28%))
   );
 
   --surface-button: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 92%)) 14%, hsl(0, 0%, 92%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 25%)) 14%, hsl(0, 0%, 25%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 92%)) 18%, hsl(0, 0%, 92%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 25%)) 18%, hsl(0, 0%, 25%))
   );
   --surface-button-border: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 75%)) 20%, hsl(0, 0%, 75%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 20%, hsl(0, 0%, 30%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 75%)) 24%, hsl(0, 0%, 75%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 24%, hsl(0, 0%, 30%))
   );
   --surface-button-preview-action: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 74%)) 18%, hsl(0, 0%, 74%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 36%)) 20%, hsl(0, 0%, 36%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 74%)) 22%, hsl(0, 0%, 74%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 36%)) 22%, hsl(0, 0%, 36%))
   );
 
   --surface-border: light-dark(
-    color-mix(in srgb, var(--base-color, var(--light-gray)) 20%, var(--light-gray)),
-    color-mix(in srgb, var(--base-color, dimgray) 20%, dimgray)
+    color-mix(in srgb, var(--base-color, var(--light-gray)) 24%, var(--light-gray)),
+    color-mix(in srgb, var(--base-color, dimgray) 24%, dimgray)
   );
   --surface-border-hr: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 84%)) 16%, hsl(0, 0%, 84%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 16%, hsl(0, 0%, 30%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 84%)) 20%, hsl(0, 0%, 84%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 30%)) 20%, hsl(0, 0%, 30%))
   );
   --surface-border-hr-light: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 92%)) 12%, hsl(0, 0%, 92%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 20%)) 12%, hsl(0, 0%, 20%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 92%)) 16%, hsl(0, 0%, 92%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 20%)) 16%, hsl(0, 0%, 20%))
   );
 
   --surface-dialog: light-dark(
-    color-mix(in srgb, var(--base-color, white) 10%, white),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 12%, hsl(0, 0%, 14%))
+    color-mix(in srgb, var(--base-color, white) 14%, white),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 14%, hsl(0, 0%, 14%))
   );
   --surface-window: light-dark(
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 95%)) 10%, hsl(0, 0%, 95%)),
-    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 12%, hsl(0, 0%, 14%))
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 95%)) 14%, hsl(0, 0%, 95%)),
+    color-mix(in srgb, var(--base-color, hsl(0, 0%, 14%)) 14%, hsl(0, 0%, 14%))
   );
 
   --bg: var(--surface-bg);


### PR DESCRIPTION
## Summary
- Strengthen the existing neutral-surface base-color mixing while preserving the current `light-dark()` structure.
- Keep Light lighter than Dark and retain surface hierarchy.
- Preserve all existing fallbacks, accent colors, semantic colors, storage, and embed APIs.

## Adopted mix rates
- `surface-bg`: Light 14%, Dark 24%
- `surface-input`: Light 10%, Dark 18%
- `surface-footer`: Light 18%, Dark 28%
- `surface-buttonbar`: Light 16%, Dark 24%
- `surface-button`: Light 14%, Dark 22%
- `surface-button-border`: Light 20%, Dark 28%
- `surface-button-preview-action`: Light 18%, Dark 28%
- `surface-border`: Light 20%, Dark 28%
- `surface-border-hr`: Light 16%, Dark 24%
- `surface-border-hr-light`: Light 12%, Dark 18%
- `surface-dialog` / `surface-window`: Light 10%, Dark 18%

## Verification
- `npm run check`
- `npm run test -- src/test/e2e/webComponentEmbed.spec.ts` (73 passed, 2 skipped, one Firefox asset-request assertion was flaky; exact retry passed)
- `npm test`
- `npm run build`
- `git diff --check`
- Chromium manual verification with blue and purple base colors in Light/Dark, default fallback, and reset.