### PR TITLE
Update Web Component icon asset E2E for inline mascot SVG

### DIFF
--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -709,24 +709,35 @@ test("loads app-owned icons from the component asset base instead of the host", 
         document.body.append(composer);
         await composer.whenReady();
         const shadow = composer.shadowRoot!;
-        const logo = shadow.querySelector<HTMLImageElement>("img.site-icon")!;
-        const siteIconLink = shadow.querySelector<HTMLAnchorElement>("a.site-icon-link")!;
-        await new Promise<void>((resolve, reject) => {
-            if (logo.complete && logo.naturalWidth > 0) {
+        await new Promise<void>((resolve) => {
+            const selectors = [
+                "svg.site-icon",
+                "a.site-icon-link",
+                ".trash-icon",
+                ".login-icon",
+                ".settings-icon",
+            ];
+            const observer = new MutationObserver(() => {
+                if (selectors.every((selector) => shadow.querySelector(selector))) {
+                    observer.disconnect();
+                    resolve();
+                }
+            });
+            observer.observe(shadow, { childList: true, subtree: true });
+            if (selectors.every((selector) => shadow.querySelector(selector))) {
+                observer.disconnect();
                 resolve();
-                return;
             }
-            logo.addEventListener("load", () => resolve(), { once: true });
-            logo.addEventListener("error", () => reject(new Error("logo failed to load")), { once: true });
         });
+        const mascot = shadow.querySelector<SVGElement>("svg.site-icon");
+        const siteIconLink = shadow.querySelector<HTMLAnchorElement>("a.site-icon-link")!;
         const masks = [
             shadow.querySelector<HTMLElement>(".trash-icon")!,
             shadow.querySelector<HTMLElement>(".login-icon")!,
             shadow.querySelector<HTMLElement>(".settings-icon")!,
         ].map((icon) => getComputedStyle(icon).maskImage);
         return {
-            logoSrc: logo.src,
-            naturalWidth: logo.naturalWidth,
+            hasInlineMascot: mascot !== null,
             masks,
             siteIconHrefAttribute: siteIconLink.getAttribute("href"),
             siteIconHref: siteIconLink.href,
@@ -735,21 +746,22 @@ test("loads app-owned icons from the component asset base instead of the host", 
         };
     });
 
-    expect(result.logoSrc.startsWith(componentOrigin)).toBe(true);
+    expect(result.hasInlineMascot).toBe(true);
     expect(result.siteIconHrefAttribute).toBe("https://lokuyow.github.io/ehagaki/");
     expect(result.siteIconHref).toBe("https://lokuyow.github.io/ehagaki/");
     expect(result.siteIconTarget).toBe("_blank");
     expect(result.siteIconRel).toBe("noopener noreferrer");
     expect(result.siteIconHref).not.toContain(hostOrigin);
-    expect(result.naturalWidth).toBeGreaterThan(0);
     for (const mask of result.masks) {
         expect(mask).not.toBe("none");
         expect(mask).toContain(componentOrigin);
     }
     expect([...hostRequests].some((path) =>
-        path === "/ehagaki_icon.svg" || path.startsWith("/icons/"))).toBe(false);
-    expect(componentRequests).toContain("/ehagaki_icon.svg");
-    expect([...componentRequests].some((path) => path.startsWith("/icons/"))).toBe(true);
+        path.startsWith("/icons/"))).toBe(false);
+    await expect.poll(
+        () => [...componentRequests].some((path) => path.startsWith("/icons/")),
+        { message: "component server should receive a request for an app-owned mask icon" },
+    ).toBe(true);
 });
 
 test("rejects a second connected component and releases the slot after disconnect", async ({ page }) => {


### PR DESCRIPTION
## Summary

PR #160でマスコットが外部`<img>`からinline SVGへ変更された後も、Web Component E2Eが旧画像前提を残していたため、現行実装へ追従しました。

## Changes

- `img.site-icon`、`complete`、`naturalWidth`、`logo.src`、画像の`load`/`error`待機、`/ehagaki_icon.svg`のcomponent request検証を削除
- Shadow DOM内の`svg.site-icon`存在検証を追加
- site icon linkの属性・解決後URL・host origin非依存検証を維持
- `.trash-icon`、`.login-icon`、`.settings-icon`のcomputed `maskImage`とcomponent origin検証を維持
- footer iconのDOM追加をMutationObserverで待ち、`/icons/`のcomponent server実リクエスト確認を`expect.poll()`で安定化
- host originからの`/icons/`取得なしの検証を維持

## Verification

- desktop Chromium: 対象テスト 3/3 passed
- mobile Chromium: 対象テスト 3/3 passed
- mobile WebKit: 対象テスト 1/1 passed
- desktop Firefox: 対象テスト 1/1 passed
- `npm run check`: passed (0 errors, 0 warnings)
- `npm test`: passed (335 files passed, 1 skipped; 3890 tests passed, 1 skipped)
- `git diff --check`: passed

production codeの変更ではないため、production buildは単独では実行していません。なおPlaywright対象実行時のE2E出力生成でbuildは実行されています。実Android/iOS端末での検証はこの環境では未実行です。