### PR TITLE
Tighten editor placeholder avatar spacing

### DIFF
--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -944,7 +944,7 @@
 
   .editor-container.account-avatar-placeholder
     :global(p.is-editor-empty:first-child::before) {
-    padding-left: 36px;
+    padding-left: 34px;
   }
 
   .editor-container.sending {


### PR DESCRIPTION
Adjust the editor placeholder text spacing from 8px to 6px while keeping the 28px avatar containment and synchronized empty-state behavior intact.

Verification: post editor Playwright tests passed on desktop Chromium, mobile Chromium, and mobile WebKit.