### PR TITLE
Refresh eHagaki agent skills

### DIFF
--- a/.agents/skills/ehagaki-browser-debug/SKILL.md
+++ b/.agents/skills/ehagaki-browser-debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ehagaki-browser-debug
-description: "eHagakiのブラウザ固有または実ブラウザ統合の不具合を、再現・計測・根因特定・最小修正・レビューするときに使用する。対象はモバイルIME、viewport、focus、Dialog/Popover、Tiptap/ProseMirror、touch・clipboard、iframe、IndexedDB/PWA/service worker、media描画、Playwright調査。ブラウザ固有性のない通常のUI、CSS、文言変更には使用しない。"
+description: "eHagakiのブラウザ固有または実ブラウザ統合の不具合を、再現・計測・根因特定・最小修正・レビューするときに使用する。対象はモバイルIME、viewport、focus、Dialog/Popover、Tiptap/ProseMirror、touch・clipboard、iframe、Direct Web Component、IndexedDB/PWA/service worker、media描画、Playwright調査。ブラウザ固有性のない通常のUI、CSS、文言変更には使用しない。"
 ---
 
 # eHagaki Browser Debug
@@ -15,12 +15,21 @@ eHagakiの現在のcheckoutを根拠に、ブラウザ制約とアプリケー�
 4. `playwright.config.ts`、対象projectの実際の`browserName`、device descriptor、viewport、baseURL、webServer、testMatch、fixture/harnessを確認する。project名だけからbrowser engineを推測しない。
 5. ファイル名、関数名、browser support、library APIを記憶から決めず、現在のコード、ローカル型、既存利用箇所で確認する。
 
+## 実行環境と埋め込み境界
+
+- standalone/PWA、iframe、Direct Web Componentを別の実行環境として扱う。document、Window、origin、service worker、history、外部入力の差を最初に固定する。
+- iframeは別documentと`postMessage`/origin境界を持つ。Direct Web Componentはhost pageと同じWindow realmで動くため、host document、host element、Shadow DOM内部を分けて観測する。
+- viewport基準のレイアウトとcontainer基準のレイアウトを混同しない。host elementの幅だけでhost documentのviewport挙動を推測せず、両方のDOMRectとcomputed styleを比較する。
+- Shadow DOMはCSSの境界であって、positioningがhost-relativeになる証拠ではない。Shadow DOM内のmount target、overlay、Dialog/Popover、fixed/absolute要素を実際のgeometryで確認する。
+- browser realm、geometry、lifecycle、WebSocket interceptionなどの観測はこのSkillで扱う。NIP、event、tag、signer、relayのprotocol semanticsは[ehagaki-nostr](../ehagaki-nostr/SKILL.md)へ分離し、同じ説明を重複させない。
+- standaloneの360 CSS px minimumと、iframe/Web Componentで360px未満も対応対象とするembed方針を区別する。public sampleの代表幅確認を、360px未満の既存E2E確認とは扱わない。
+
 ## 再現条件を固定する
 
 次を区別して記録する。
 
 - OS、ブラウザ名とバージョン
-- 通常タブまたはPWA、iframe内または単独起動
+- standalone/PWA、iframe、Direct Web Componentのどれで実行したか
 - portraitまたはlandscape、layout/visual viewportサイズ
 - タッチまたはマウス、ソフトキーボードまたは物理キーボード
 - 対象inputまたはeditor、再現操作

--- a/.agents/skills/ehagaki-browser-debug/references/browser-debug-map.md
+++ b/.agents/skills/ehagaki-browser-debug/references/browser-debug-map.md
@@ -1,6 +1,6 @@
 # eHagaki browser debug map
 
-この索引は2026-07-26時点のローカルcheckoutを調査した結果である。実装が移動または変更されている場合は現在のコードを優先する。
+この索引は現在のcheckoutを調査するための入口を整理したものである。記載と現在のコードが異なる場合は、現在のコードを優先する。
 
 ## 目次
 
@@ -12,6 +12,7 @@
 - [Tiptap、ProseMirror、selection、composition](#tiptapprosemirrorselectioncomposition)
 - [Paste、clipboard、drag-and-drop](#pasteclipboarddrag-and-drop)
 - [Iframe、postMessage、親client](#iframepostmessage親client)
+- [Direct Web Component、Shadow DOM、host geometry](#direct-web-componentshadow-domhost-geometry)
 - [URL queryと外部入力](#url-queryと外部入力)
 - [PWA、share target、service worker](#pwashare-targetservice-worker)
 - [IndexedDB、Dexie、複数context](#indexeddbdexie複数context)
@@ -116,6 +117,17 @@
 - **Playwrightまたは実端末確認が必要になる条件:** real iframe source/origin、sandbox/Permissions Policy、storage partitioning、parent navigation、focus境界はbrowser harnessが必要。
 - **注意点:** composer context、settings、storage、IndexedDBは共通の受信 trust gate で envelope・exact parent source・exact trusted origin だけを判定し、routing、requestId、payload、pending map、lifecycleは各serviceが所有する。Parent clientはこのhelper対象外であり、queryで確立したparent origin契約も維持する。`event.source`と`event.origin`の検証を弱めない。親sample、protocol、parser/bootstrap、testsを同じcontract surfaceとして確認する。
 
+## Direct Web Component、Shadow DOM、host geometry
+
+- **主な症状または責務:** host pageに直接配置した`<ehagaki-composer>`のShadow DOM、container-bound layout、host/component geometry、overlay、asset origin、mount/disconnect/reconnectを調査する。iframeの別document/postMessage経路とは分ける。
+- **主な実装ファイル:** `src/web-component/element.ts`、`src/web-component/entry.ts`、`src/web-component/types.ts`、`src/web-component/iconAssets.ts`、`src/lib/appRuntimeEnvironment.ts`、`src/lib/appAssetUrl.ts`、`src/components/DialogWrapper.svelte`、`src/stores/uiStore.svelte.ts`。
+- **主な関数、store、hook、controller:** `EHagakiComposerElement.connectedCallback()`、`disconnectedCallback()`、`whenReady()`、`mountApp()`、`configureAppRuntimeEnvironment()`、`getAppRuntimeEnvironment()`、`applyWebComponentIconAssetUrls()`。現在のruntimeは`layoutMode: "container"`、`runtimeKind: "web-component"`で、`domRoot`はopen ShadowRoot、mount/layout/style/overlay targetはcomponent shell内に設定される。
+- **Lifecycleと認証境界:** module-levelのactive instanceにより同じdocumentの接続済みinstanceを1つに制限する。connection generation、Svelte unmount、MutationObserver、pending `whenReady()` rejectionをdisconnect/reconnectごとに確認する。Web Component runtimeではService Worker、external input、history、local nsec authを無効化し、NIP-07/NIP-46などのprotocol semanticsはNostr mapを参照する。
+- **Geometryの計測:** host documentのviewport、`ehagaki-composer` host element、Shadow DOMのshell/app/overlay/dialog/footerを別々に`getBoundingClientRect()`とcomputed styleで確認する。`container-type: inline-size`、component width/height、`--app-overlay-position`、DialogWrapperのcontainer-layout absolute positioningを確認し、Shadow DOMだけでfixed要素がhost-relativeになると仮定しない。
+- **Assetの調査入口:** 接続前に設定する`asset-base`属性または`assetBase` property、component origin、`assets/`、`icons/`、FFmpeg class-worker/core/WASMのrequestとCORSを確認する。`webComponentDevServer.spec.ts`はlocal proxy/watchとasset配信、`ensureWebComponentE2EOutput.mjs`はfingerprint付きproduction output準備を担う。
+- **関連テスト:** `src/test/e2e/webComponentEmbed.spec.ts`はcross-origin host/component、host WebSocket interception、Shadow DOM、storage/SW、container geometry、portal dialog、asset、lifecycle、NIP-07/NIP-46 availabilityを確認する。`src/test/e2e/webComponentParentClientExample.spec.ts`はassembled production sample、public API、host側responsive layout、360/390px代表幅、destroy/recreateとmanual modeを確認する。`src/test/e2e/webComponentDevServer.spec.ts`、`src/test/unit/webComponentDevServerConfig.test.ts`、`src/test/unit/webComponentBuildWorkingDirectory.test.ts`、`src/test/unit/webComponentIconAssets.test.ts`も入口にする。
+- **注意点:** 現在のpublic sample E2Eは360/390pxを代表幅として確認するが、360px未満のiframe/Web Componentを既存E2Eで直接検証しているわけではない。embedの360px未満対応方針に対する追加検証ではhost widthとcomponent内部geometryを明示する。公開`::part()`契約はなく、local nsec入力・復元もWeb Componentの契約ではない。
+
 ## URL queryと外部入力
 
 - **主な症状または責務:** `content`、reply/quote/channel、embed settings、`shared=true`を起動時に読み、既存composer stateへ適用して消費済みqueryだけを削除する。
@@ -179,14 +191,15 @@
 ## Playwright config、projects、fixture、harness
 
 - **主な症状または責務:** dialog、focus、history、overflow、geometry、media表示を決定論的な実ブラウザで検証する。
-- **主な実装ファイル:** `playwright.config.ts`、`src/test/e2e/composerTargetDialog.spec.ts`、`src/test/e2e/ComposerTargetDialogHarness.svelte`、`src/test/e2e/composerTargetDialogHarnessEntry.ts`、`src/test/e2e/postHistoryDialog.spec.ts`、`src/test/e2e/PostHistoryDialogHarness.svelte`、`src/test/e2e/postHistoryDialogHarnessEntry.ts`、`composer-target-dialog-playwright.html`、`post-history-dialog-playwright.html`。
+- **主な実装ファイル:** `playwright.config.ts`、`playwright.web-component-dev.config.ts`、`scripts/playwrightWorktreePort.ts`、`scripts/ensureWebComponentE2EOutput.mjs`、`src/test/e2e/composerTargetDialog.spec.ts`、`src/test/e2e/postHistoryDialog.spec.ts`、`src/test/e2e/webComponentDevServer.spec.ts`、`src/test/e2e/webComponentEmbed.spec.ts`、`src/test/e2e/webComponentParentClientExample.spec.ts`。
 - **主な関数、store、hook、controller:** Playwright標準`test` fixtureの`page`と`isMobile`、各`gotoHarness()`、window上の`__COMPOSER_TARGET_HARNESS__`/`__POST_HISTORY_HARNESS__` ready state。独立したcustom fixture moduleは現checkoutにない。
 - **Event source:** page navigation、role/label locator操作、keyboard/tap/click、route mock、viewport resize、popup/history、DOM evaluation。
-- **StateまたはCSS変数:** config `locale=ja-JP`、trace `on-first-retry`、workers `1`、harness-injected deterministic data。`EHAGAKI_E2E_PORT`を指定した場合はそのportを使用し、未指定時はworktree rootを正規化して決定的に算出する。
+- **StateまたはCSS変数:** 通常configは`fullyParallel: false`、`workers: 2`、`locale=ja-JP`、trace `on-first-retry`。`desktop-chromium`と`mobile-chromium`は`webComponentDevServer.spec.ts`を`testIgnore`する。`mobile-webkit`の`testMatch`は`composerTargetDialog.spec.ts`、`webComponentEmbed.spec.ts`、`webComponentParentClientExample.spec.ts`、`postEditorSending.spec.ts`、`desktop-firefox`の`testMatch`は`webComponentEmbed.spec.ts`だけである。Web Component dev-server configは`webServer: undefined`、`workers: 1`、専用projectで`webComponentDevServer.spec.ts`だけを実行する。
+- **Portとserver:** `EHAGAKI_E2E_PORT`が指定された場合は検証済みの明示portを使う。未指定時はconfig load時に自動portを生成し、同一Playwright process内では内部の自動port環境値を通じて再利用する。baseURL、ready URL、Vite commandは同じresolved portを使い、Vite commandは`127.0.0.1`と`--strictPort`を指定し、`reuseExistingServer: false`で既存serverを再利用しない。worktree rootから決定的にportを算出する方式ではない。
 - **Cleanup所有者:** Playwright runnerがpage/contextを破棄し、route/popupはtestがcloseする。temporary artifactは調査完了時に削除する。
-- **関連テスト:** `src/test/e2e/composerTargetDialog.spec.ts`と`src/test/e2e/postHistoryDialog.spec.ts`。unit/component mock基盤は`src/test/setup.ts`と`src/test/mocks/`。
+- **関連テスト:** `src/test/unit/playwrightWorktreePort.test.ts`がport override、自動port共有、config project、strict port、server再利用設定を確認する。`src/test/e2e/composerTargetDialog.spec.ts`と`src/test/e2e/postHistoryDialog.spec.ts`は通常harness、Web Component系3 specはembed/sample/dev-serverの各境界を確認する。unit/component mock基盤は`src/test/setup.ts`と`src/test/mocks/`。
 - **Playwrightまたは実端末確認が必要になる条件:** config上の全projectは実browser engineでDOMを描画するが、IME/browser chrome/PWA standalone/WebViewは実端末確認を別途行う。
-- **注意点:** `desktop-chromium`は`Desktop Chrome` descriptor。`mobile-chromium`は`iPhone 13` descriptorをChromiumのdefault engineで実行する。`mobile-webkit`だけが`browserName: 'webkit'`を明示し、`composerTargetDialog.spec.ts`、`webComponentEmbed.spec.ts`、`webComponentParentClientExample.spec.ts`に限定される。`desktop-firefox`は`webComponentEmbed.spec.ts`に限定される。base URL、Vite command、post-history harness ready URLは同じresolved portを使用し、Vite commandは`--strictPort`で自動移動を禁止する。worktree rootごとにportが異なるため、通常の複数worktreeが固定`4173`を共有しない。`reuseExistingServer: false`で古いserverを再利用せず、常に現在checkoutのViteを起動する。
+- **注意点:** `desktop-chromium`は`Desktop Chrome` descriptor。`mobile-chromium`は`iPhone 13` descriptorをChromiumのdefault engineで実行する。`mobile-webkit`だけが`browserName: 'webkit'`を明示する。device descriptorはbrowser engine/viewport/touch等のemulationであり、実端末のIME、browser chrome、PWA standalone、WebViewを証明しない。
 
 ## 関連テストの選択
 

--- a/.agents/skills/ehagaki-nostr/SKILL.md
+++ b/.agents/skills/ehagaki-nostr/SKILL.md
@@ -23,8 +23,9 @@ eHagakiの既存境界と実装済みライブラリAPIを基準に、Nostr関�
 3. discovery、descriptor生成、fetch、cache、renderingを必要以上に結合しない。
 4. NIPの仕様とeHagaki固有の仕様を分けて記述する。UI表示からプロトコル仕様を推測しない。
 5. `nostr-tools`と`rx-nostr`の責務を混同しない。
-6. 一時的な互換処理やフォールバックは、仕様、対応ブラウザ、再現ログ、既存互換契約のいずれかで必要性を示せる場合だけ追加する。
-7. 曖昧さがevent semanticsや互換性を変える場合は、推測せず`needs confirmation`として扱う。
+6. iframeまたはDirect Web Componentを含む場合も、event、tag、signer、relay、subscriptionのprotocol semanticsはこのSkillで扱い、browser realm、postMessage/WebSocket interception、Shadow DOM、geometry、mount/disconnect lifecycleの観測は[ehagaki-browser-debug](../ehagaki-browser-debug/SKILL.md)へ分離する。
+7. 一時的な互換処理やフォールバックは、仕様、対応ブラウザ、再現ログ、既存互換契約のいずれかで必要性を示せる場合だけ追加する。
+8. 曖昧さがevent semanticsや互換性を変える場合は、推測せず`needs confirmation`として扱う。
 
 ## 取得と購読を検証する
 

--- a/.agents/skills/ehagaki-nostr/references/implementation-map.md
+++ b/.agents/skills/ehagaki-nostr/references/implementation-map.md
@@ -1,6 +1,6 @@
 # eHagaki Nostr implementation map
 
-この文書は2026-07-30時点のcheckoutをコードとテストから対応付けた調査用索引である。現在のコードと差がある場合は現在のコードを優先する。
+この文書は現在のcheckoutをコードとテストから対応付けた調査用索引である。記載と現在のコードが異なる場合は、現在のコードを優先する。
 
 ## 使用中のNostr関連ライブラリ
 
@@ -147,7 +147,7 @@
 - event kind: NIP-46 transport eventは`24133`。eHagakiが要求する署名範囲は`1`、`5`、`42`、`10063`、`22242`、`27235`、`24242`。
 - 主なtag: NIP-46接続で利用する`p`、Nostr Connect URIのrelay/secret/metadata、各署名対象eventのtag
 - 主な実装ファイル: `src/lib/nip46Service.ts`、`src/lib/nip46AuthFlowCoordinator.ts`、`src/lib/nip46PendingOperationUtils.ts`、`src/lib/nip46ConnectUiUtils.ts`、`src/lib/authService.ts`
-- 主な関数または責務: `Nip46Service.connect`、`startNostrConnect`、`reconnect`、`ensureConnection`、`getSignerForSession`、`disconnect`と`Nip46SignerAdapter.signEvent`が接続、同一sessionのruntime signer復旧、Signer adapterを分担する。fresh `BunkerSigner`はglobal commit前にdirect `get_public_key`でlive user identityを確認し、`reconnect`と`rebuildConnection`はcandidate-firstで進める。rebuildはsession/runtime/persistence bindingのsnapshot所有権を確認し、snapshot bindingへのsession保存成功後にcandidateをcommitする。remote signer pubkeyをuser identityへfallbackしない。`NIP46_REQUESTED_PERMISSIONS`が要求権限のsource of truthである。
+- 主な関数または責務: `Nip46Service.connect`、`startNostrConnect`、`reconnect`、`ensureConnection`、`getSignerForSession`、`disconnect`と`Nip46SignerAdapter.signEvent`が接続、同一sessionのruntime signer復旧、Signer adapterを分担する。`NIP46_CLIENT_METADATA`はname `eHagaki`、GitHub Pages URL、webp icon URLをconnect requestとNostr Connect URIへ渡し、`NIP46_REQUESTED_PERMISSIONS`/`NIP46_REQUESTED_PERMS`が要求権限のsource of truthである。fresh `BunkerSigner`はglobal commit前にdirect `get_public_key`でlive user identityを確認し、`reconnect`と`rebuildConnection`はcandidate-firstで進める。rebuildはsession/runtime/persistence bindingのsnapshot所有権を確認し、snapshot bindingへのsession保存成功後にcandidateをcommitする。remote signer pubkeyをuser identityへfallbackしない。
 - 関連テスト: `src/test/unit/nip46Service.test.ts`、`src/test/unit/nip46AuthFlowCoordinator.test.ts`、`src/test/unit/nip46PendingOperationUtils.test.ts`、`src/test/unit/nip46ConnectUiUtils.test.ts`、`src/test/unit/loginDialog.test.ts`
 - 注意点: 接続確認と`get_public_key`検証を混同しない。payload、secret、署名要求本文をログやfixtureへ残さない。`Nip46WebSocket`にはrelay互換目的の`limit:0`補正があるため、根拠なく一般化しない。
 


### PR DESCRIPTION
## Summary
- Refresh Browser Debug and Nostr repository skills against the current Playwright, Direct Web Component, Shadow DOM, and Nostr implementation boundaries.
- Remove stale checkout-date and worktree-derived Playwright port guidance.
- Keep production code, tests, package configuration, and normal documentation unchanged.

## Validation
- Manual frontmatter, referenced-path, source/config symbol, dependency-version, and full-file reread checks passed.
- git diff --check passed.
- quick_validate.py was available but could not run because the execution environment lacks the Python yaml module.
- npm test, npm run check, npm run build, and Playwright were not run because this is a documentation/instruction-only change.