### PR TITLE
Add eHagaki embed runtime skill

### DIFF
--- a/.agents/skills/ehagaki-embed-runtime/SKILL.md
+++ b/.agents/skills/ehagaki-embed-runtime/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: ehagaki-embed-runtime
+description: "eHagaki の standalone・iframe・Web Component 間の runtime 境界と埋め込み契約を扱う。Custom Element API/lifecycle、Parent Client/postMessage/origin、auth・settings・composer context・storage delegation、asset/base path、Shadow DOM、embed sample/E2E を調査・設計・実装・レビューするときに使用する。通常の standalone UI 変更、純粋な NIP 変更、ブラウザ固有の IME/geometry 調査には使用しない。"
+---
+
+# eHagaki Embed Runtime
+
+eHagaki の standalone、iframe、Direct Web Component の公開契約と runtime ownership を、現在の checkout を根拠に扱う。入口、公開 API、message producer/consumer、sample、テストの索引は [embed runtime map](references/embed-runtime-map.md) を読む。map と checkout が異なる場合は、現在のコードを優先する。
+
+## 対象を切り分ける
+
+変更前に対象 runtime を確定する。`AppRuntimeEnvironment.runtimeKind`、各 iframe service の実際の iframe 判定、Web Component entrypoint を source of truth とし、DOM 形状や layout から推測しない。複数 runtime に影響する変更では、共通の App 側責務と runtime 固有の adapter/entrypoint を分けて caller・callee・テストまで追う。
+
+- standalone / iframe の document entry は `src/main.ts`、Direct Web Component は `src/web-component/entry.ts` と `element.ts` から始める。
+- iframe の Parent Client、settings、composer context、storage、IndexedDB delegation はそれぞれ独立した service を持つ。いずれも同じ `postMessage` を使うからといって、勝手に一つの transport や state に統合しない。
+- Web Component は host page と同じ Window realm で動き、`postMessage` の代わりに public method と composed DOM event を使う。Shadow DOM 内の app-owned DOM と host document の責務を混同しない。
+
+## public contract を先に確認する
+
+内部実装より先に、現在提供している contract の producer と consumer を確認する。
+
+- iframe は `embedProtocol.ts` の namespace/version/envelope、message type、`requestId` 要否、payload validation を起点に、service・controller・`public/embed-parent-client-example.*`・関連 test を揃えて確認する。
+- 親との通信では `parentOrigin`、`event.origin`、`event.source`、envelope/schema、capability、request ID、timeout、pending request cleanup を確認する。embed の利便性を理由に既存 validation を省略しない。
+- Web Component は tag、attribute/property、`whenReady()`、public method、event、ready/error、single-instance と reconnect 契約を `src/web-component/types.ts`、`element.ts`、`docs/WEB_COMPONENT.md`、sample/E2E で突き合わせる。実装にない attribute、event、`::part()` surface、複数 instance 対応を新しい仕様として足さない。
+- URL query、external input、settings bootstrap、runtime message は別の入力経路である。parser、bootstrap、controller、runtime service、sample の一部だけを変えない。
+
+## ownership と lifecycle を守る
+
+値または副作用ごとに app-owned、host-owned、delegated、shared contract のいずれかを実装から特定する。parent client に委譲する state に、根拠なく local fallback・二重 source of truth・standalone global state を追加しない。
+
+- Web Component では connect / ready / disconnect / remove / recreate、Svelte mount/unmount、listener/observer、queued operation、pending ready promise、single-instance slot を追う。iframe service では listener registration、request timeout、pending request、disconnect cleanup の owner を追う。
+- 初期化中または parent auth 中に保留する composer context は、既存 controller の queue/flush 境界を保つ。任意の timer や global workaround を追加しない。
+- runtime 固有の機能制御（service worker、external input、history、local nsec auth、storage namespace、layout/overlay/theme target）は `AppRuntimeEnvironment` と各 entrypoint で確認し、別 runtime へ漏らさない。
+
+## asset と style の境界を守る
+
+asset URL は active runtime の `assetBase` と `resolveAppAssetUrl()` を起点に追う。Vite の document base path と Web Component bundle の `asset-base` は同じ値であるとは限らない。host origin の root-relative asset、host global CSS、または偶然の document layout に依存する変更をしない。
+
+Web Component の open Shadow DOM、CSS transform、`:host`、component container、overlay target、実在する `--ehagaki-*` custom properties を確認する。公開 `::part()` API は現在確認できないため、必要性が明示されない限り導入しない。container/viewport、focus、portal geometry、browser engine 差を実ブラウザで再現・計測する必要がある場合は [ehagaki-browser-debug](../ehagaki-browser-debug/SKILL.md) を併用する。
+
+## Nostr とブラウザ固有調査の境界
+
+親 signer への delegation、request/response transport、runtime ownership はこの skill が扱う。event kind、tag、relay、署名内容、NIP-07/NIP-46 の protocol semantics は [ehagaki-nostr](../ehagaki-nostr/SKILL.md) を主として併用する。
+
+iOS Safari 固有の focus、IME、VisualViewport、touch/scroll、browser engine の layout/geometry は `ehagaki-browser-debug` を併用する。本 skill はそれらの現象に関係する embed contract と owner を扱うが、browser 固有の再現・計測手順を重複して定義しない。
+
+## 最小の owner を変更し、検証する
+
+runtime 判定、transport、auth delegation、settings/storage、Custom Element、asset resolution、build/sample のうち問題がある最小 owner を変更する。iframe 固有の問題を `App.svelte` の global workaround にせず、共通責務の問題を runtime ごとの duplicate implementation で隠さない。互換性や versioning policy は、現在の code、docs、sample、test、明示された要件から判断し、記憶だけで決めない。
+
+- runtime boundary の変更は、map に挙がる直接の unit/integration test と、必要なら real iframe / Web Component を使う Playwright を選ぶ。asset base、bundle entry、Web Component dev/production sample、service worker、generated output に触れる場合は `npm run build` を実行する。
+- Svelte/Vite/Playwright 等の現在の API が判断に影響するときは、`package.json`、local type、project usage、必要なら Context7 の順に確認する。eHagaki 固有 contract は repository code を source of truth とする。
+- secret、nsec、private key、authentication payload、token、署名 payload を log、fixture、trace、screenshot、report に残さない。
+
+主要な runtime responsibility、public contract、entrypoint、ownership/security boundary、関連 test が変わる変更では、この skill と同じ変更で [embed runtime map](references/embed-runtime-map.md) も更新する。単なる内部リファクタリングだけで map 更新を要求しない。

--- a/.agents/skills/ehagaki-embed-runtime/references/embed-runtime-map.md
+++ b/.agents/skills/ehagaki-embed-runtime/references/embed-runtime-map.md
@@ -1,0 +1,95 @@
+# eHagaki embed runtime map
+
+この map は調査時点の checkout を索引化したものです。実装、公開 sample、または test が変わった場合は現在の code を優先し、主要 contract が変わる変更ではこの map も更新します。
+
+## Runtime environment と document entry
+
+- **責務:** `src/main.ts` は document entry で `configureAppRuntimeEnvironment()` を行ってから `App.svelte` を dynamic import/mount する。`runtimeKind` は `window.top === window` なら `standalone`、それ以外は `iframe`。viewport layout、document/body targets、`import.meta.env.BASE_URL` からの `appHomeHref` / `assetBase`、service worker、external input、history、local nsec auth を有効にする。
+- **flow:** `main.ts` → `applyEmbedSettingsBootstrap()` / `applyUploadDestinationBootstrap()` → `App.svelte` → `runAppInitializationBootstrap()`。iframe は別 entrypoint ではなく、この document entry と URL を使う。
+- **ownership:** document と service worker は app-owned。iframe host は `parentOrigin` と Parent Client message の consumer であり、child document を直接操作する contract ではない。
+- **注意点:** `AppRuntimeEnvironment` は process/module-level configuration。Web Component は `App.svelte` を import する前にこれを明示的に置き換えるため、entrypoint の import順が contract になる。
+- **関連 test:** `src/test/unit/appAssetUrl.test.ts`、`src/test/unit/appRuntimeBindings.test.ts`、`src/test/unit/headerComponent.test.ts`、`src/test/unit/uiStore.test.ts`。
+
+## iframe detection と Parent Client protocol
+
+- **主な実装:** `src/lib/embedProtocol.ts` は `ehagaki.embed` / version `1` の envelope、message type、`embedMessageRequiresRequestId()`、`getParentOriginFromSearch()` を定義する。`src/lib/embedMessageTrustGate.ts` は受信 envelope、`event.source === window.parent`、指定された parent origin の照合を行う。
+- **public input:** iframe URL の `parentOrigin`。message envelope は `{ namespace, version, type, requestId?, payload? }`。`auth.*`、`rpc.*`、`settings.*`、`storage.*`、`idb.*`、`composer.*` の request/response 系で non-empty `requestId` が必要。
+- **flow:** parent sample → iframe window の `postMessage(..., childOrigin)`、または child service → `window.parent.postMessage(..., parentOrigin)`。`IframeMessageService` は `ready`、post result、settings/composer acknowledgement を child から送信する adapter。
+- **trust/lifecycle:** `src/lib/iframeMessageService.ts` の `isInIframe()` は cross-origin top access 失敗時も iframe とみなす。`parentOrigin` がない、許可されない、または iframe 外なら送信しない。受信側の各 service は trust gate、payload shape、request ID、timeout/pending map を個別に保持する。
+- **関連資料/検証:** `docs/IFRAME_EMBEDDING.md`、`public/embed-parent-client-example.html` / `.js`、`src/test/unit/iframeMessageService.test.ts`、`src/test/unit/embedMessageTrustGate.test.ts`、`src/test/e2e/iframeMessageGate.spec.ts`、`src/test/e2e/embedParentClientExample.spec.ts`。
+
+## Parent Client auth delegation
+
+- **主な実装:** `src/lib/parentClientAuthService.ts` の `ParentClientAuthService` と `ParentClientSignerAdapter`、`src/lib/parentClientAuthCoordinator.ts`、`src/lib/appParentClientSyncController.ts`。`App.svelte` は runtime binding で remote login/logout を controller へ渡す。
+- **contract:** child は `ready` を通知し、`auth.request` に対する `auth.result` / `auth.error`、署名等の `rpc.request` に対する `rpc.result` / `rpc.error` を request ID で対応付ける。現在の capability allowlist は `signEvent`、`nip44.encrypt`、`nip44.decrypt` で、既定 request は `signEvent`。
+- **ownership/trust:** signer と認証 UI/state は parent-owned、child は validated capability と session を使う。service は parent origin、source、envelope、request kind、pubkey/capability/payload shape を照合し、timeout と pending request を cleanup する。秘密鍵や signing payload を host/child 間 contract に追加しない。
+- **関連 test:** `src/test/unit/parentClientAuthService.test.ts`、`src/test/unit/parentClientAuthCoordinator.test.ts`、`src/test/unit/appParentClientSyncController.test.ts`、`src/test/integration/app-parent-client.integration.test.ts`。NIP や署名の内容を変える作業は `ehagaki-nostr` も読む。
+
+## Settings と composer context delegation
+
+- **settings:** `src/lib/embedSettingsService.ts` は trusted parent の `settings.set` を validation して listener へ届ける。`App.svelte` → `createAppEmbedController()` → `settingsStore.applyParentSettings()` が app state と persistence を適用し、`settings.applied` / `settings.error` を同じ request ID で通知する。first-paint URL handling は `src/lib/bootstrap/embedSettingsBootstrap.ts` と `index.html`、runtime update は message service であり、混同しない。
+- **composer:** `src/lib/embedComposerContextService.ts` は `composer.setContext` を受信し、`src/lib/embedComposerContextValidation.ts`、`embedComposerContextPatch.ts`、`embedComposerContextApply.ts` が payload を全体検証してから patch/apply する。`AppEmbedController` は bootstrap / parent auth 中の action を保留し、flush 後に `composer.contextApplied` / `composer.contextError` を返す。local user change は `embedComposerContextNotification.ts` 経由で `composer.contextUpdated` を通知する。
+- **public input:** composer context は `reply`、`quotes`、`content`、`channel` を持つ patch payload。URL startup input は `src/lib/urlQueryHandler.ts` と `src/lib/bootstrap/externalInputBootstrap.ts`、runtime change は `composer.setContext`。`undefined` と明示的な `null` / empty array の意味は `docs/IFRAME_EMBEDDING.md` と validation/apply test で確認する。
+- **関連 test:** `src/test/unit/embedSettingsService.test.ts`、`embedSettingsBootstrap.test.ts`、`embedComposerContextService.test.ts`、`embedComposerContextApply.test.ts`、`embedComposerContextPatch.test.ts`、`embedComposerContextNotification.test.ts`、`externalInputBootstrap.test.ts`、`urlQueryHandler.test.ts`、`appEmbedController.test.ts`、`appRuntimeBindings.test.ts`、`embedParentClientExample.spec.ts`。
+
+## localStorage と IndexedDB delegation
+
+- **storage:** `src/lib/embedStorageService.ts` は iframe 内でのみ `storage.get` / `storage.set` / `storage.remove` を parent に request する。`src/lib/embedStorageKeys.ts` の allowlist 以外は delegation しない。`AppEmbedController.initializeEmbedStorageSync()` は snapshot を local storage に反映し、stored settings を再適用してから allowed keys を mirror する。
+- **IndexedDB:** `src/lib/embedIndexedDbService.ts` は `idb.getSnapshot` / `idb.setSnapshot` と `idb.result` / `idb.error` を扱う。現在の `EmbedIndexedDbStoreName` は `uploadDestinations` のみ。`src/lib/bootstrap/uploadDestinationBootstrap.ts` と upload destination repository の caller も確認する。
+- **ownership/trust:** child local persistence は app-owned。parent persistence は optional delegated mirror で、host の storage 全体、account、credential、draft、profile/relay cache を渡す contract ではない。双方とも trusted parent、validated payload、request ID、timeout、pending request cleanup を守る。
+- **関連資料/検証:** `docs/IFRAME_EMBEDDING.md`、`public/embed-parent-client-example.js`、`src/test/unit/embedStorageService.test.ts`、`src/test/unit/embedIndexedDbService.test.ts`。
+
+## URL query と external input
+
+- **主な実装:** `src/lib/urlQueryHandler.ts` が query を parse/clean up し、`src/lib/bootstrap/externalInputBootstrap.ts` が shared content、composer context、URL input を bootstrap へ適用する。`src/lib/bootstrap/appInitializationBootstrap.ts` は `externalInputEnabled` が true のときだけこれを呼ぶ。
+- **runtime差:** standalone/iframe document entry では external input が有効。Web Component は `externalInputEnabled: false` のため URL / share-target input を consumer にしない。Web Component host は `setContext()` / `setSettings()` を使用する。
+- **関連 test:** `src/test/unit/urlQueryHandler.test.ts`、`src/test/unit/externalInputBootstrap.test.ts`、iframe parent sample E2E。
+
+## Web Component entrypoint と public API
+
+- **entry/build input:** `src/web-component/entry.ts` は `EHAGAKI_COMPOSER_TAG_NAME` (`ehagaki-composer`) を既に登録されていなければ `EHagakiComposerElement` として登録する。型と API version は `src/web-component/types.ts`。
+- **public surface:** `src/web-component/element.ts` の observed attribute は `asset-base`、対応 property は `assetBase`。公開 method は `whenReady(): Promise<void>`、`setContext(context)`、`setSettings(settings)`。`setContext` / `setSettings` は connect 前や ready 前の呼び出しを operation queue に入れる。
+- **events:** `ehagaki-ready`（`apiVersion`）、`ehagaki-initialization-error`（`initialization_failed` / `multiple_instances_unsupported` / `disconnected`）、`ehagaki-post-success`、`ehagaki-post-error`、`ehagaki-composer-context-updated`。`src/web-component/notificationPort.ts` が App notification を composed/bubbling CustomEvent に adapter する。
+- **app seam:** `App.svelte` が export する `setEmbedContext()` / `setEmbedSettings()` を element が in-process に使用する。Web Component は Parent Client `postMessage` を使わない。
+- **関連資料/検証:** `docs/WEB_COMPONENT.md`、`public/web-component-parent-client-example.html` / `.js`、`src/test/unit/webComponentNotificationPort.test.ts`、`src/test/integration/webComponentSubst.integration.test.ts`、`src/test/e2e/webComponentEmbed.spec.ts`、`webComponentParentClientExample.spec.ts`。
+
+## Web Component lifecycle と instance ownership
+
+- **責務:** `EHagakiComposerElement.connectedCallback()` は one connected instance を許可し、2 個目は `multiple_instances_unsupported` で ready promise を reject する。`disconnectedCallback()` は connection generation を進め、MutationObserver を disconnect、Svelte app を unmount、active slot を release する。
+- **ready/error:** mount 後の App `onInitialized` が ready promise を resolve して `ehagaki-ready` を dispatch する。mount failure、ready 前 disconnect、同時 primary instance は initialization error を dispatch し promise を reject する。remove 後に replacement を connect するのは既存 contract。
+- **host/component boundary:** host は element の creation/removal、size、attribute/property/method/event consumer。component は shadow root、mount target、overlay root、stateful App instance、operation queue、asset observer を所有する。hidden/redisplay と remove/recreate は同じものではない。
+- **関連 E2E:** `webComponentEmbed.spec.ts` は second instance rejection、disconnect/recreate、hidden redisplay、ready 前 `setContext`、host/storage/service-worker isolation を確認する。`webComponentParentClientExample.spec.ts` は sample の auto/manual mount と lifecycle control を確認する。
+
+## Web Component storage、auth、navigation の差
+
+- **storage:** `src/lib/appStorage.ts` の `createWebComponentStorage()` は host `localStorage` を versioned `ehagaki.web-component.v1:` namespace に限定する。raw host storage を App に渡さない。
+- **auth/navigation/runtime switches:** element は runtime を `web-component`、container layout、ShadowRoot/host targets、`serviceWorkerEnabled: false`、`externalInputEnabled: false`、`historyEnabled: false`、`localNsecAuthEnabled: false` に設定する。NIP-07/NIP-46 の contract 自体は Nostr/auth implementation を確認する。
+- **確認対象:** component-only change では、host storage namespace、service worker registration、history behavior、local nsec UI/legacy cleanup を Web Component E2E の該当 case と照合する。
+
+## asset base、Shadow DOM、style surface
+
+- **asset flow:** document app は `import.meta.env.BASE_URL` から `assetBase` を設定する。`src/lib/appAssetUrl.ts` の `resolveAppAssetUrl()` と asset-consuming caller は active runtime base を使う。Web Component は `asset-base` または entry module URL に相対な base を `new URL(..., import.meta.url)` で解決する。
+- **icons/build transform:** `src/web-component/element.ts` は app CSS を open ShadowRoot に inline し、document-root selector を `:host` / shell 用に transform する。`src/web-component/iconAssets.ts` は build-only icon CSS variable を component `assetBase` の `icons/*.svg` URL に置換する。FFmpeg worker/core/WASM も active asset base の caller を確認する。
+- **style API:** host に提供されている theme surface は `getWebComponentThemeCss()` の `--ehagaki-accent-color`、`--ehagaki-base-color`、`--ehagaki-background`、`--ehagaki-text`、`--ehagaki-border`、`--ehagaki-link`、`--ehagaki-input-background`、`--ehagaki-footer-background`、`--ehagaki-dialog-background`、`--ehagaki-font-family`。Shadow root は open。公開 `::part()` API は checkout で確認できない。
+- **layout:** component shell は `container-type: inline-size`。container behavior、overlay containment、host width/height、computed styles は `webComponentEmbed.spec.ts` の DOM/geometry assertions を基準に確認する。browser-specific geometry は `ehagaki-browser-debug` の領域。
+- **関連 test:** `src/test/unit/appAssetUrl.test.ts`、`webComponentIconAssets.test.ts`、`src/test/e2e/webComponentEmbed.spec.ts`。
+
+## Web Component build、delivery、sample
+
+- **scripts:** `package.json` の `build:web-component` は `scripts/runWebComponentBuild.mjs`、`dev:web-component` は `scripts/devWebComponentSample.mjs` を入口にする。build execution/working directory は `scripts/webComponentBuildRunner.mjs` と `scripts/webComponentBuildWorkingDirectory.mjs`、dev host/proxy config は `scripts/webComponentDevServerConfig.mjs`、output validation は `scripts/verifyWebComponentBuild.mjs`、site assembly は `scripts/assembleWebComponentSite.mjs` を確認する。
+- **contract-relevant output:** `dist-web-component/ehagaki-composer.js`、その asset directory、host page からの module import、`asset-base`、production/dev sample の URL はまとめて扱う。Windows working-directory handling は build plumbing であり、runtime contract に影響する output/path のときだけ追う。
+- **sample:** `public/web-component-parent-client-example.html` / `.js` は host API、asset-base、mount/destroy/recreate、auto/manual module loading の consumer。iframe の parent sample はこれと別に `public/embed-parent-client-example.html` / `.js`。
+- **関連 test/config:** `src/test/unit/webComponentDevServerConfig.test.ts`、`webComponentBuildWorkingDirectory.test.ts`、`src/test/e2e/webComponentDevServer.spec.ts`、`playwright.web-component-dev.config.ts`。通常 E2E project は `playwright.config.ts` の desktop Chromium/mobile Chromium/mobile WebKit/desktop Firefox の実際の `testMatch` / `testIgnore` を確認する。
+
+## 検証選択
+
+- message schema、origin/source、request ID、timeout、validation、controller state は unit/integration test を先に選ぶ。
+- public iframe contract、real iframe message gate、Web Component registration/public API/Shadow DOM/lifecycle/asset origin は Playwright を使う。project 名だけから browser engine や実端末対応を推測しない。
+- `src/test/e2e/webComponentEmbed.spec.ts` は production-style bundle、cross-origin asset base、storage/SW isolation、style/theme, lifecycle、pre-ready API、FFmpeg asset load を横断的に扱う。`src/test/e2e/webComponentParentClientExample.spec.ts` は host sample と responsive/lifecycle contract を扱う。
+- Vite entry、Web Component output、asset path、worker/WASM、sample delivery、PWA/service worker に触れた変更は `npm run build` を実行する。document-only map/skill update には application test、Playwright、build は不要。
+
+## 現 checkout で確認できなかった public surface
+
+- Web Component の公開 `::part()` style API。
+- Web Component の複数同時接続インスタンスを許可する contract（現実装は one active connected instance）。
+- Web Component と parent iframe client 間の `postMessage` contract（Direct Web Component は DOM method/event adapter）。


### PR DESCRIPTION
## Summary
- add the eHagaki embed runtime skill
- add a current-checkout map for standalone, iframe, and Web Component contracts

## Verification
- inspected mapped paths and public symbols
- confirmed the reference is trackable and checked the staged diff
- application tests were not run because this changes documentation only