### PR TITLE
Add host-owned Web Component composer mode

### DIFF
--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -196,6 +196,58 @@ await settingsPromise;
 await contextPromise;
 ```
 
+## Host-owned Composer mode
+
+通常の Direct Web Component は従来どおり eHagaki が署名・Relay publish を行う self-publish
+mode です。Host-owned mode は明示的 opt-in です。`configureHostOwned()` を要素生成後、**最初の
+`connectedCallback` より前に一度だけ**呼び出します。接続・切断・再接続後に mode や handler を
+交換することはできません。変更が必要な場合は新しい element instance を生成してください。
+
+```js
+const composer = document.createElement('ehagaki-composer');
+composer.configureHostOwned({
+  async submit(output, { signal }) {
+    // The host owns kind, tags that express references, pubkey, timestamp,
+    // signing and publication. `output` is not an unsigned Nostr event.
+    const result = await publishFromHost(output, { signal });
+    return { eventId: result.id };
+  },
+  // Optional. Omitting it makes this a text-only composer.
+  async uploadMedia(file, metadata, { signal }) {
+    const result = await uploadFromHost(file, metadata, { signal });
+    return { url: result.url, imeta: { alt: metadata.originalName } };
+  },
+});
+const customEmojisReady = composer.setCustomEmojis([
+  { shortcode: 'wave', url: 'https://cdn.example/emoji/wave.webp' },
+]);
+document.querySelector('#composer-mount').append(composer);
+await composer.whenReady();
+await customEmojisReady;
+```
+
+`submit` は必須です。`uploadMedia` は optional capability で、未指定時は file picker、paste、
+drag & drop、gallery への新規メディア入力を受け付けず、eHagaki の upload destination や Nostr
+認証への fallback は行いません。指定時は、eHagaki が圧縮・プレビュー・ギャラリー処理を行った
+同じ Window realm の `File` を handler へ渡します。Base64 化はしません。handler は HTTP(S) URL と
+allowlist 済みの imeta field だけを返せます。
+
+Host handler に渡る `output` は `{ content, tags, context }` です。`tags` には hashtag、content
+warning、custom emoji、imeta など composer-owned tag のみが入り、`kind`、`pubkey`、`created_at`、
+`id`、`sig`、`e`/`p`/`q`/`a`/`k`、`client` は入りません。`context` は reply/quote/channel を
+immutable snapshot として保持します。Host-owned mode では eHagaki は認証、guest Relay、target
+fetch、profile/history/custom-emoji relay load を開始しません。reply/quote は reference-only の
+non-loading state で表示され、host は snapshot を使って最終 event の構造 tag を決定します。
+
+upload 中は submit を開始できず、submit 中は media input を開始できません。この判定はボタンだけで
+なく keyboard shortcut、long press、PostComponent の公開 submit/upload path にも適用されます。
+`setContext()` は既存どおり利用できますが、Host-owned submit 中は `submission_in_progress` で
+reject されます。`ehagaki-composer-context-updated`、clear、`whenReady()`、`setSettings()` は維持されます。
+
+`setCustomEmojis(catalog)` は Host-owned instance 専用のメモリ内 catalog を置換します。全 item を
+検証してから atomic に反映し、空配列は clear です。catalog は reconnect では保持し、別 element や
+self-publish mode の account-scoped catalog へは漏れません。
+
 ## 設定を変更する `setSettings()`
 
 `setSettings(settings)` は、対応している設定だけを受け付け、適用された key の配列を
@@ -687,3 +739,7 @@ CSP の `worker-src` では配信元オリジンと `blob:` の両方を許可�
 サンプルのイベントログは、秘密情報、署名要求 payload、生の Error を表示せず、安全な要約
 だけを記録します。外部モジュールはホストページと同じ JavaScript 権限で実行されるため、
 module URL と `asset-base` には信頼できる URL だけを指定してください。
+
+Host-owned の別サンプルは [host-owned-composer-example.html](../public/host-owned-composer-example.html)
+です。text-only / media-enabled の切替、catalog、context、host submit/upload の成功・失敗を、既存の
+Parent Client sample とは独立して確認できます。

--- a/public/host-owned-composer-example.html
+++ b/public/host-owned-composer-example.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Host-owned Composer example</title>
+    <style>
+      body { font: 16px system-ui, sans-serif; margin: 2rem auto; max-width: 760px; padding: 0 1rem; }
+      #mount { height: 460px; border: 1px solid #bbb; margin: 1rem 0; }
+      ehagaki-composer { display: block; height: 100%; }
+      button { margin: .25rem; } pre { min-height: 8rem; padding: .75rem; background: #f4f4f4; overflow: auto; }
+    </style>
+  </head>
+  <body>
+    <h1>Host-owned Composer</h1>
+    <p>Recreate to switch between text-only and media-enabled capability. The host handlers below intentionally use safe, local example responses.</p>
+    <button id="text">Create text-only</button>
+    <button id="media">Create media-enabled</button>
+    <button id="context">Set reply / quote context</button>
+    <button id="fail">Make next submit fail</button>
+    <div id="mount"></div>
+    <pre id="log" aria-live="polite"></pre>
+    <script type="module" src="./web-component/ehagaki-composer.js"></script>
+    <script type="module">
+      const mount = document.querySelector('#mount');
+      const log = document.querySelector('#log');
+      let composer;
+      let failNext = false;
+      const note = 'note1zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygsglnzgl';
+      const write = (label, value) => { log.textContent += `${label} ${JSON.stringify(value)}\n`; };
+
+      async function create(mediaEnabled) {
+        composer?.remove();
+        composer = document.createElement('ehagaki-composer');
+        composer.configureHostOwned({
+          async submit(output, { signal }) {
+            write('submit output:', output);
+            if (signal.aborted || failNext) {
+              failNext = false;
+              throw new Error('example host submit failure');
+            }
+            return { eventId: 'a'.repeat(64) };
+          },
+          ...(mediaEnabled ? {
+            async uploadMedia(file, metadata, { signal }) {
+              write('upload metadata:', metadata);
+              if (signal.aborted || file.name.includes('fail')) {
+                throw new Error('example host upload failure');
+              }
+              return { url: `https://example.invalid/media/${encodeURIComponent(file.name)}` };
+            },
+          } : {}),
+        });
+        const emojisReady = composer.setCustomEmojis([
+          { shortcode: 'wave', url: 'https://example.invalid/emoji/wave.webp' },
+        ]);
+        for (const name of ['ehagaki-ready', 'ehagaki-post-success', 'ehagaki-post-error', 'ehagaki-composer-context-updated']) {
+          composer.addEventListener(name, (event) => write(name, event.detail));
+        }
+        mount.append(composer);
+        await composer.whenReady();
+        await emojisReady;
+        write('ready:', { mediaEnabled });
+      }
+
+      document.querySelector('#text').onclick = () => create(false);
+      document.querySelector('#media').onclick = () => create(true);
+      document.querySelector('#fail').onclick = () => { failNext = true; write('next submit:', 'failure'); };
+      document.querySelector('#context').onclick = async () => {
+        if (!composer) return;
+        await composer.setContext({ reply: note, quotes: [note] });
+      };
+      create(false);
+    </script>
+  </body>
+</html>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -106,6 +106,7 @@
     updateReferencedEvent,
     updateAuthorProfile,
     setReplyQuoteError,
+    settleReplyQuoteReferencesWithoutHydration,
     onReplyQuoteChanged,
     replyQuoteState,
     restoreReplyQuote,
@@ -196,6 +197,14 @@
   import { focusEditor } from "./lib/utils/appDomUtils";
   import { generateMediaItemId } from "./lib/utils/appUtils";
   import { CUSTOM_EMOJI_PICKER_CHROME_HEIGHT } from "./lib/customEmoji";
+  import {
+    createCustomEmojiItem,
+    type CustomEmojiItem,
+  } from "./lib/customEmoji";
+  import type {
+    EHagakiCustomEmojiCatalogItem,
+    EHagakiHostOwnedComposerOptions,
+  } from "./web-component/types";
 
   import type { CustomEmojiSelection } from "./lib/customEmojiUsage";
   import { usePostHistoryInboundInteractionsRealtime } from "./lib/hooks/usePostHistoryInboundInteractionsRealtime.svelte";
@@ -219,6 +228,10 @@
     /** The iframe transport remains the default for the PWA and iframe entry. */
     notificationPort?: AppPostNotificationPort & AppEmbedNotificationPort;
     onInitialized?: () => void;
+    hostOwnedConfig?: EHagakiHostOwnedComposerOptions & {
+      customEmojis: EHagakiCustomEmojiCatalogItem[];
+      signal: AbortSignal;
+    };
   }
 
   const iframeNotificationPort: AppPostNotificationPort & AppEmbedNotificationPort = {
@@ -238,7 +251,32 @@
   let {
     notificationPort = iframeNotificationPort,
     onInitialized = () => undefined,
+    hostOwnedConfig,
   }: Props = $props();
+  let isHostOwnedComposer = $derived(!!hostOwnedConfig);
+  let hostCustomEmojiItems = $state<CustomEmojiItem[]>([]);
+  let hostEmojiCatalogInitialized = false;
+
+  function replaceHostCustomEmojis(
+    catalog: readonly EHagakiCustomEmojiCatalogItem[],
+  ): void {
+    hostCustomEmojiItems = catalog.flatMap((item, sortIndex) => {
+      const normalized = createCustomEmojiItem({
+        shortcode: item.shortcode,
+        src: item.url,
+        setAddress: item.setAddress,
+        sortIndex,
+      });
+      return normalized ? [normalized] : [];
+    });
+  }
+
+  $effect(() => {
+    if (!hostEmojiCatalogInitialized && hostOwnedConfig) {
+      hostEmojiCatalogInitialized = true;
+      replaceHostCustomEmojis(hostOwnedConfig.customEmojis);
+    }
+  });
 
   type PostComponent =
     typeof import("./components/PostComponent.svelte").default;
@@ -408,7 +446,9 @@
     publicKeyState.setNsec(secretKey);
   });
 
-  let isAuthenticated = $derived(authState.value?.isAuthenticated ?? false);
+  let isAuthenticated = $derived(
+    isHostOwnedComposer || authState.value?.isAuthenticated === true,
+  );
   let isAuthInitialized = $derived(authState.value?.isInitialized ?? false);
 
   let rxNostr: NostrSessionBootstrap["rxNostr"] | undefined = $state();
@@ -1189,20 +1229,27 @@
       updateUrlQueryContentStore,
     },
     composerContextApply: {
-      applyReplyQuoteSelection: (query) =>
-        applyReplyQuoteSelection({
+      applyReplyQuoteSelection: (query) => {
+        const references = applyReplyQuoteSelection({
           replyQuoteQuery: query,
           setReplyQuote,
-        }),
+        });
+        if (isHostOwnedComposer && !rxNostr) {
+          settleReplyQuoteReferencesWithoutHydration(references);
+        }
+        return references;
+      },
       hydrateReplyQuoteReferences: (references, runtime) =>
-        hydrateReplyQuoteReferences({
-          references,
-          rxNostr: runtime.rxNostr,
-          relayConfig: runtime.relayConfig,
-          updateReferencedEvent,
-          initializeReplyNotificationRecipients,
-          setReplyQuoteError,
-        }),
+        isHostOwnedComposer && !runtime.rxNostr
+          ? Promise.resolve()
+          : hydrateReplyQuoteReferences({
+            references,
+            rxNostr: runtime.rxNostr,
+            relayConfig: runtime.relayConfig,
+            updateReferencedEvent,
+            initializeReplyNotificationRecipients,
+            setReplyQuoteError,
+          }),
       clearReplyQuote,
       applyChannelContextQuery: (query, runtime) => {
         channelContextApplyController.applyExternal({
@@ -1267,6 +1314,8 @@
         rxNostr,
         relayConfig: relayConfigStore.value,
       }),
+      isSubmissionInProgress: () =>
+        isHostOwnedComposer && editorState.postStatus.sending,
     },
     storage: {
       getEmbedStorageSnapshot: async () => {
@@ -1335,6 +1384,16 @@
     payload: EmbedSettingsSetPayload,
   ): Promise<ReadonlyArray<AppEmbedAppliedSettingKey>> {
     return appEmbedController.applySettings(payload);
+  }
+
+  /** Per-element Host-owned catalog; never writes to the account-scoped store. */
+  export async function setHostCustomEmojis(
+    catalog: EHagakiCustomEmojiCatalogItem[],
+  ): Promise<void> {
+    if (!isHostOwnedComposer) {
+      throw new DOMException("Host-owned Composer is not configured.", "InvalidStateError");
+    }
+    replaceHostCustomEmojis(catalog);
   }
 
   async function handleRemoteParentClientLogin(
@@ -1414,9 +1473,11 @@
   }
 
   $effect(() => {
-    appAuthEffectController.runAuthenticatedCustomEmojiPrefetch(
-      authState.value,
-    );
+    if (!isHostOwnedComposer) {
+      appAuthEffectController.runAuthenticatedCustomEmojiPrefetch(
+        authState.value,
+      );
+    }
   });
 
   $effect(() => {
@@ -1498,8 +1559,9 @@
         appEmbedController.notifyComposerContextUpdatedIfChanged(),
     });
 
-    // NIP-07拡張機能の遅延注入を検出（nos2x等のdocument_endで注入される拡張機能に対応）
-    if (!nip07ExtensionAvailable) {
+    // Host-owned Composer deliberately has no eHagaki authentication surface.
+    // Other runtimes retain delayed NIP-07 discovery.
+    if (!isHostOwnedComposer && !nip07ExtensionAvailable) {
       waitNostr(3000).then((nostr) => {
         if (nostr) nip07ExtensionAvailable = true;
       });
@@ -1532,36 +1594,48 @@
       allowSharedMediaRecovery: true,
     });
 
-    void runAppInitializationBootstrap({
-      reloadSettings: () => settingsStore.reload(),
-      locationSearch: window.location.search,
-      clearSharedMediaError,
-      waitForLocale: waitLocale,
-      markLocaleInitialized: () => {
+    if (isHostOwnedComposer) {
+      // Do not restore accounts, start a guest relay session, resolve upload
+      // destinations, or run URL/share input. The host supplies publication.
+      void waitLocale().finally(() => {
         localeInitialized = true;
-      },
-      initializeAuth: () => authService.initializeAuth(),
-      handleAuthenticated: handlePostAuth,
-      initializeGuestSession: () => initializeNostr(),
-      stopProfileLoading: () => isLoadingProfileStore.set(false),
-      refreshAccountList,
-      markAuthInitialized: () => authService.markAuthInitialized(),
-      getExternalInputBootstrapParams,
-      externalInputEnabled: appRuntimeEnvironment.externalInputEnabled,
-      console,
-    }).finally(() => {
-      isBootstrappingApp = false;
-      void flushPendingRemoteParentClientAndEmbedActions().finally(() => {
+        isBootstrappingApp = false;
         appEmbedController.notifyComposerContextUpdatedIfChanged();
       });
-    });
+    } else {
+      void runAppInitializationBootstrap({
+        reloadSettings: () => settingsStore.reload(),
+        locationSearch: window.location.search,
+        clearSharedMediaError,
+        waitForLocale: waitLocale,
+        markLocaleInitialized: () => {
+          localeInitialized = true;
+        },
+        initializeAuth: () => authService.initializeAuth(),
+        handleAuthenticated: handlePostAuth,
+        initializeGuestSession: () => initializeNostr(),
+        stopProfileLoading: () => isLoadingProfileStore.set(false),
+        refreshAccountList,
+        markAuthInitialized: () => authService.markAuthInitialized(),
+        getExternalInputBootstrapParams,
+        externalInputEnabled: appRuntimeEnvironment.externalInputEnabled,
+        console,
+      }).finally(() => {
+        isBootstrappingApp = false;
+        void flushPendingRemoteParentClientAndEmbedActions().finally(() => {
+          appEmbedController.notifyComposerContextUpdatedIfChanged();
+        });
+      });
+    }
 
-    const cleanupVisibilityHandler = registerNip46VisibilityHandler({
-      document: appRuntimeEnvironment.document ?? document,
-      authState,
-      nip46Service,
-      console,
-    });
+    const cleanupVisibilityHandler = isHostOwnedComposer
+      ? () => undefined
+      : registerNip46VisibilityHandler({
+        document: appRuntimeEnvironment.document ?? document,
+        authState,
+        nip46Service,
+        console,
+      });
 
     return () => {
       overlayScopeTarget.classList.remove("ehagaki-app-root");
@@ -1578,8 +1652,10 @@
       } else {
         rxNostr = undefined;
       }
-      void cancelPendingNip46Auth(undefined, { preserveError: true });
-      void nip46Service.disconnect();
+      if (!isHostOwnedComposer) {
+        void cancelPendingNip46Auth(undefined, { preserveError: true });
+        void nip46Service.disconnect();
+      }
     };
   });
 
@@ -1855,20 +1931,22 @@
   <Tooltip.Provider>
     <main class="ehagaki-app-root">
       <div class="main-content">
-        <HeaderComponent
-          onResetPostContent={handleResetPostContent}
-          onShowDraftList={draftListDialog.open}
-          onChooseTarget={composerTargetDialog.open}
-          canResetPostContent={hasDraftComposerContext || undefined}
-          balloonMessage={showHeaderBalloonMessage
-            ? balloon.finalMessage
-            : null}
-          compactMessage={showHeaderBalloonMessage
-            ? null
-            : balloon.compactMessage}
-          showMascot={settingsStore.showMascot}
-          showFlavorText={showHeaderBalloonMessage}
-        />
+        {#if !isHostOwnedComposer}
+          <HeaderComponent
+            onResetPostContent={handleResetPostContent}
+            onShowDraftList={draftListDialog.open}
+            onChooseTarget={composerTargetDialog.open}
+            canResetPostContent={hasDraftComposerContext || undefined}
+            balloonMessage={showHeaderBalloonMessage
+              ? balloon.finalMessage
+              : null}
+            compactMessage={showHeaderBalloonMessage
+              ? null
+              : balloon.compactMessage}
+            showMascot={settingsStore.showMascot}
+            showFlavorText={showHeaderBalloonMessage}
+          />
+        {/if}
         <div
           class="composer-scroll-region"
           bind:this={composerScrollRegionEl}
@@ -1927,6 +2005,10 @@
                     onPostSuccess={handlePostSuccess}
                     onCustomEmojiSelect={recordCustomEmojiUse}
                     {notificationPort}
+                    {hostOwnedConfig}
+                    hostCustomEmojiItems={isHostOwnedComposer
+                      ? hostCustomEmojiItems
+                      : undefined}
                   />
                 {/if}
                 {#if customEmojiPickerOpen && CustomEmojiPickerComponent}
@@ -1940,7 +2022,12 @@
                       open={customEmojiPickerOpen}
                       maxHeight={customEmojiPickerMaxHeight}
                       onSelect={handleCustomEmojiSelect}
-                      customEmojiUsageItems={customEmojiUsageStore.items}
+                      customEmojiUsageItems={isHostOwnedComposer
+                        ? []
+                        : customEmojiUsageStore.items}
+                      hostCustomEmojiItems={isHostOwnedComposer
+                        ? hostCustomEmojiItems
+                        : undefined}
                       onMoveCaretLeft={() =>
                         postComponentRef?.moveCaretLeft?.()}
                       onMoveCaretRight={() =>
@@ -1978,20 +2065,25 @@
         onUploadImage={() => postComponentRef?.openFileDialog()}
         onPostButtonTap={() => balloon.showTips()}
         {customEmojiPickerOpen}
+        hasPostingCapability={isHostOwnedComposer || isAuthenticated}
+        mediaEnabled={!isHostOwnedComposer || !!hostOwnedConfig?.uploadMedia}
+        customEmojiEnabled={isHostOwnedComposer || isAuthenticated}
         onCustomEmojiPickerOpenChange={(open) => (customEmojiPickerOpen = open)}
       />
-      <FooterComponent
-        {isAuthenticated}
-        {isAuthInitialized}
-        {isSwitchingAccount}
-        swNeedRefresh={appRuntimeEnvironment.serviceWorkerEnabled &&
-          ($swNeedRefresh || staleAssetReloadRequired)}
-        onShowLoginDialog={loginDialog.open}
-        onPreloadPostHistoryDialog={handlePreloadPostHistoryDialog}
-        onOpenPostHistoryDialog={postHistoryDialog.open}
-        onOpenSettingsDialog={handleOpenSettingsFromFooter}
-        onOpenLogoutDialog={logoutDialog.open}
-      />
+      {#if !isHostOwnedComposer}
+        <FooterComponent
+          {isAuthenticated}
+          {isAuthInitialized}
+          {isSwitchingAccount}
+          swNeedRefresh={appRuntimeEnvironment.serviceWorkerEnabled &&
+            ($swNeedRefresh || staleAssetReloadRequired)}
+          onShowLoginDialog={loginDialog.open}
+          onPreloadPostHistoryDialog={handlePreloadPostHistoryDialog}
+          onOpenPostHistoryDialog={postHistoryDialog.open}
+          onOpenSettingsDialog={handleOpenSettingsFromFooter}
+          onOpenLogoutDialog={logoutDialog.open}
+        />
+      {/if}
       <ConfirmDialog
         open={showStaleAssetReloadPrompt}
         onOpenChange={(open) => (showStaleAssetReloadPrompt = open)}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -446,9 +446,11 @@
     publicKeyState.setNsec(secretKey);
   });
 
+  // Host publication capability is independent from eHagaki account auth.
   let isAuthenticated = $derived(
-    isHostOwnedComposer || authState.value?.isAuthenticated === true,
+    !isHostOwnedComposer && authState.value?.isAuthenticated === true,
   );
+  let hasPostingCapability = $derived(isHostOwnedComposer || isAuthenticated);
   let isAuthInitialized = $derived(authState.value?.isInitialized ?? false);
 
   let rxNostr: NostrSessionBootstrap["rxNostr"] | undefined = $state();
@@ -1905,6 +1907,7 @@
   }
 
   function recordCustomEmojiUse(emoji: CustomEmojiSelection): void {
+    if (isHostOwnedComposer) return;
     const pubkey = authState.value?.pubkey;
     if (!pubkey) return;
 
@@ -1999,6 +2002,7 @@
                     bind:this={postComponentRef}
                     {rxNostr}
                     hasStoredKey={isAuthenticated}
+                    hasPostingCapability={hasPostingCapability}
                     {isSwitchingAccount}
                     availableComposerHeight={postAvailableComposerHeight}
                     minEditorHeight={postEditorMinHeight}
@@ -2018,7 +2022,7 @@
                   >
                     <CustomEmojiPickerComponent
                       {rxNostr}
-                      pubkey={authState.value.pubkey}
+                      pubkey={isHostOwnedComposer ? null : authState.value.pubkey}
                       open={customEmojiPickerOpen}
                       maxHeight={customEmojiPickerMaxHeight}
                       onSelect={handleCustomEmojiSelect}
@@ -2065,7 +2069,7 @@
         onUploadImage={() => postComponentRef?.openFileDialog()}
         onPostButtonTap={() => balloon.showTips()}
         {customEmojiPickerOpen}
-        hasPostingCapability={isHostOwnedComposer || isAuthenticated}
+        hasPostingCapability={hasPostingCapability}
         mediaEnabled={!isHostOwnedComposer || !!hostOwnedConfig?.uploadMedia}
         customEmojiEnabled={isHostOwnedComposer || isAuthenticated}
         onCustomEmojiPickerOpenChange={(open) => (customEmojiPickerOpen = open)}

--- a/src/components/CustomEmojiPicker.svelte
+++ b/src/components/CustomEmojiPicker.svelte
@@ -46,6 +46,8 @@
         onMoveCaretRight?: () => void;
         onDeleteBackward?: () => void;
         onInsertLineBreak?: () => void;
+        /** Per Host-owned element catalog. Undefined retains account-backed behavior. */
+        hostCustomEmojiItems?: CustomEmojiItem[];
     }
 
     let {
@@ -59,6 +61,7 @@
         onMoveCaretRight,
         onDeleteBackward,
         onInsertLineBreak,
+        hostCustomEmojiItems,
     }: Props = $props();
     let search = $state("");
     let pickerHeight = $state(CUSTOM_EMOJI_PICKER_DEFAULT_HEIGHT);
@@ -80,8 +83,8 @@
     let previousPubkey: string | null | undefined = undefined;
     const requestedImageCacheUrls = new Set<string>();
 
-    let items = $derived(customEmojiStore.items);
-    let loading = $derived(customEmojiStore.loading);
+    let items = $derived(hostCustomEmojiItems ?? customEmojiStore.items);
+    let loading = $derived(hostCustomEmojiItems === undefined && customEmojiStore.loading);
     let filteredItems = $derived.by(() => {
         const query = search.trim().toLowerCase();
         if (!query) return items;
@@ -161,6 +164,7 @@
     }
 
     function cacheLoadedEmojiImage(url: string): void {
+        if (hostCustomEmojiItems !== undefined) return;
         if (requestedImageCacheUrls.has(url)) return;
 
         requestedImageCacheUrls.add(url);
@@ -277,6 +281,13 @@
         const currentOpen = open;
         const currentRxNostr = rxNostr;
         const currentPubkey = pubkey;
+
+        if (hostCustomEmojiItems !== undefined) {
+            lastLoadRxNostr = undefined;
+            lastLoadPubkey = undefined;
+            if (currentOpen) schedulePickerLayoutUpdate();
+            return;
+        }
 
         if (!currentOpen) {
             lastLoadRxNostr = undefined;

--- a/src/components/KeyboardButtonBar.svelte
+++ b/src/components/KeyboardButtonBar.svelte
@@ -23,6 +23,9 @@
         onPostButtonTap?: () => void;
         customEmojiPickerOpen?: boolean;
         onCustomEmojiPickerOpenChange?: (open: boolean) => void;
+        hasPostingCapability?: boolean;
+        mediaEnabled?: boolean;
+        customEmojiEnabled?: boolean;
     }
     const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
 
@@ -31,6 +34,9 @@
         onPostButtonTap,
         customEmojiPickerOpen = false,
         onCustomEmojiPickerOpenChange,
+        hasPostingCapability = false,
+        mediaEnabled = true,
+        customEmojiEnabled = true,
     }: Props = $props();
 
     // 認証状態を $derived で参照（svelte/store subscribe パターンを廃止）
@@ -97,7 +103,7 @@
             !canPost ||
             postStatus.sending ||
             isUploading ||
-            !hasStoredKey ||
+            !(hasStoredKey || hasPostingCapability) ||
             !!postStatus.completed
         );
     }
@@ -225,7 +231,8 @@
                             variant="footer"
                             contentLayout="icon"
                             className="image-button"
-                            disabled={!hasStoredKey ||
+                            disabled={!mediaEnabled ||
+                                !(hasStoredKey || hasPostingCapability) ||
                                 postStatus.sending ||
                                 isUploading}
                             onClick={(e) => {
@@ -252,7 +259,7 @@
                 contentLayout="icon"
                 className="custom-emoji-button"
                 selected={customEmojiPickerOpen}
-                disabled={!hasStoredKey || postStatus.sending}
+                disabled={!customEmojiEnabled || postStatus.sending}
                 onClick={() => {
                     setCustomEmojiPickerOpen(!customEmojiPickerOpen);
                 }}
@@ -318,7 +325,7 @@
                             disabled={!canPost ||
                                 postStatus.sending ||
                                 isUploading ||
-                                !hasStoredKey ||
+                                !(hasStoredKey || hasPostingCapability) ||
                                 postStatus.completed}
                             onClick={(e) => {
                                 if (typeof tooltipOnclick === "function") {

--- a/src/components/KeyboardButtonBar.svelte
+++ b/src/components/KeyboardButtonBar.svelte
@@ -8,7 +8,6 @@
         contentWarningReasonStore,
         hashtagPinStore,
     } from "../stores/tagsStore.svelte";
-    import { authState } from "../stores/authStore.svelte";
     import { editorState, submitPost } from "../stores/editorStore.svelte";
     import {
         triggerVibration,
@@ -38,9 +37,6 @@
         mediaEnabled = true,
         customEmojiEnabled = true,
     }: Props = $props();
-
-    // 認証状態を $derived で参照（svelte/store subscribe パターンを廃止）
-    let hasStoredKey = $derived(authState.value?.isAuthenticated ?? false);
 
     // エディタ状態を取得
     let postStatus = $derived(editorState.postStatus);
@@ -103,7 +99,7 @@
             !canPost ||
             postStatus.sending ||
             isUploading ||
-            !(hasStoredKey || hasPostingCapability) ||
+            !hasPostingCapability ||
             !!postStatus.completed
         );
     }
@@ -222,38 +218,39 @@
         ontouchstartcapture={preventKeyboardFocusChange}
     >
         <div class="button-group-left">
-            <Tooltip.Root delayDuration={500}>
-                <Tooltip.Trigger>
-                    {#snippet child({ props })}
-                        {@const { onclick: tooltipOnclick, ...restProps } =
-                            props}
-                        <Button
-                            variant="footer"
-                            contentLayout="icon"
-                            className="image-button"
-                            disabled={!mediaEnabled ||
-                                !(hasStoredKey || hasPostingCapability) ||
-                                postStatus.sending ||
-                                isUploading}
-                            onClick={(e) => {
-                                onUploadImage?.();
-                                if (typeof tooltipOnclick === "function") {
-                                    tooltipOnclick(e);
-                                }
-                            }}
-                            ariaLabel={$_("postComponent.upload_image")}
-                            {...restProps}
-                        >
-                            <div class="image-icon svg-icon"></div>
-                        </Button>
-                    {/snippet}
-                </Tooltip.Trigger>
-                <Tooltip.Portal to={overlayTarget}>
-                    <Tooltip.Content sideOffset={8} class="tooltip-content">
-                        {$_("keyboardButtonBar.upload_image_tooltip")}
-                    </Tooltip.Content>
-                </Tooltip.Portal>
-            </Tooltip.Root>
+            {#if mediaEnabled}
+                <Tooltip.Root delayDuration={500}>
+                    <Tooltip.Trigger>
+                        {#snippet child({ props })}
+                            {@const { onclick: tooltipOnclick, ...restProps } =
+                                props}
+                            <Button
+                                variant="footer"
+                                contentLayout="icon"
+                                className="image-button"
+                                disabled={!hasPostingCapability ||
+                                    postStatus.sending ||
+                                    isUploading}
+                                onClick={(e) => {
+                                    onUploadImage?.();
+                                    if (typeof tooltipOnclick === "function") {
+                                        tooltipOnclick(e);
+                                    }
+                                }}
+                                ariaLabel={$_("postComponent.upload_image")}
+                                {...restProps}
+                            >
+                                <div class="image-icon svg-icon"></div>
+                            </Button>
+                        {/snippet}
+                    </Tooltip.Trigger>
+                    <Tooltip.Portal to={overlayTarget}>
+                        <Tooltip.Content sideOffset={8} class="tooltip-content">
+                            {$_("keyboardButtonBar.upload_image_tooltip")}
+                        </Tooltip.Content>
+                    </Tooltip.Portal>
+                </Tooltip.Root>
+            {/if}
             <Button
                 variant="footer"
                 contentLayout="icon"
@@ -325,7 +322,7 @@
                             disabled={!canPost ||
                                 postStatus.sending ||
                                 isUploading ||
-                                !(hasStoredKey || hasPostingCapability) ||
+                                !hasPostingCapability ||
                                 postStatus.completed}
                             onClick={(e) => {
                                 if (typeof tooltipOnclick === "function") {

--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -90,7 +90,11 @@
   import type { CustomEmojiItem } from "../lib/customEmoji";
   import { buildHostOwnedComposerOutput, getHostSubmissionEventId } from "../lib/hostOwnedComposer";
   import { createHostOwnedUploadExecutor } from "../lib/hostOwnedUpload";
-  import { uploadHelper, uploadFiles as defaultUploadFiles } from "../lib/uploadHelper";
+  import {
+    uploadHelper,
+    uploadFiles as defaultUploadFiles,
+    showUploadErrorMessage,
+  } from "../lib/uploadHelper";
   import { extractImageBlurhashMap, getMimeTypeFromUrl } from "../lib/tags/imetaTag";
   import { extractPostContentWithEmojiTags } from "../lib/utils/editorDocumentUtils";
   import {
@@ -103,6 +107,7 @@
   interface Props {
     rxNostr?: RxNostr;
     hasStoredKey: boolean;
+    hasPostingCapability?: boolean;
     isSwitchingAccount?: boolean;
     onPostSuccess?: (result?: PostResult) => void;
     availableComposerHeight?: number;
@@ -116,6 +121,7 @@
   let {
     rxNostr,
     hasStoredKey,
+    hasPostingCapability = hasStoredKey,
     isSwitchingAccount = false,
     onPostSuccess,
     availableComposerHeight = POST_EDITOR_MIN_HEIGHT,
@@ -127,6 +133,7 @@
   }: Props = $props();
   let isHostOwned = $derived(!!hostOwnedConfig);
   let mediaEnabled = $derived(!isHostOwned || !!hostOwnedConfig?.uploadMedia);
+  let hostMountActive = true;
   let editor: any = $state(null);
   let currentEditor: TipTapEditor | null = $state(null);
   let dragOver = $state(false);
@@ -278,10 +285,17 @@
     getImageXMap: () => imageXMap,
     getUploadFailedText: (key: string) => $_(key),
     updateUploadState: (isUploading: boolean, message?: string) => {
+      if (isHostOwned && !hostMountActive) return;
       updateEditorUploadState(editorState, isUploading, message);
     },
+    setUploadErrorMessage: (message: string) => {
+      if (isHostOwned && !hostMountActive) return;
+      editorState.uploadErrorMessage = message;
+    },
     uploadFiles: async (params) => {
-      if (postStatus.sending || editorState.isUploading) return null;
+      if (postStatus.sending || editorState.isUploading || (isHostOwned && !hostMountActive)) {
+        return null;
+      }
       if (!isHostOwned) {
         return await defaultUploadFiles(params);
       }
@@ -297,16 +311,31 @@
       try {
         return await uploadHelper({
           ...params,
-          showUploadError: (message) =>
-            updateEditorUploadState(editorState, true, message),
+          showUploadError: (message, duration) => showUploadErrorMessage(message, duration, {
+            updateUploadState: (nextIsUploading, nextMessage) => {
+              if (hostMountActive) {
+                updateEditorUploadState(editorState, nextIsUploading, nextMessage);
+              }
+            },
+            setUploadErrorMessage: (nextMessage) => {
+              if (hostMountActive) editorState.uploadErrorMessage = nextMessage;
+            },
+            keepUploading: true,
+          }),
+          setUploadErrorMessage: (message) => {
+            if (hostMountActive) editorState.uploadErrorMessage = message;
+          },
           devMode: false,
           prepareFiles: executor.prepareFiles,
           uploadPreparedFiles: executor.uploadPreparedFiles,
           fileUploadManager: executor.fileUploadManager,
           deferUploadStateClear: true,
+          isUploadAborted: () => (
+            !hostMountActive || !!hostOwnedConfig.signal.aborted
+          ),
         });
       } finally {
-        updateEditorUploadState(editorState, false);
+        if (hostMountActive) updateEditorUploadState(editorState, false);
       }
     },
   });
@@ -385,7 +414,8 @@
       placeholderText: editorPlaceholderText,
       editorContainerEl,
       currentEditor,
-      hasStoredKey: hasStoredKey || isHostOwned,
+      hasStoredKey,
+      hasPostingCapability,
       submitPost,
       onCustomEmojiSelect,
       getCustomEmojiItems: isHostOwned
@@ -469,6 +499,8 @@
         editorSubscriptionUnsubscribe = null;
       }
       if (isHostOwned) {
+        hostMountActive = false;
+        updateEditorUploadState(editorState, false, "");
         updatePostStatus({
           sending: false,
           success: false,
@@ -679,7 +711,7 @@
       !postStatus.sending &&
       !editorState.isUploading &&
       !postStatus.completed &&
-      (isHostOwned || !!postManager);
+      (hasPostingCapability || !!postManager);
   }
 
   function createHostOwnedImageImetaMap(editorInstance: TipTapEditor): Record<string, any> {

--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -84,6 +84,21 @@
   import ProfileAvatar from "./ProfileAvatar.svelte";
   import type { InitializeEditorResult, MenuItem } from "../lib/types";
   import type { AppPostNotificationPort } from "../lib/appNotificationPort";
+  import type {
+    EHagakiHostOwnedComposerOptions,
+  } from "../web-component/types";
+  import type { CustomEmojiItem } from "../lib/customEmoji";
+  import { buildHostOwnedComposerOutput, getHostSubmissionEventId } from "../lib/hostOwnedComposer";
+  import { createHostOwnedUploadExecutor } from "../lib/hostOwnedUpload";
+  import { uploadHelper, uploadFiles as defaultUploadFiles } from "../lib/uploadHelper";
+  import { extractImageBlurhashMap, getMimeTypeFromUrl } from "../lib/tags/imetaTag";
+  import { extractPostContentWithEmojiTags } from "../lib/utils/editorDocumentUtils";
+  import {
+    contentWarningStore,
+    contentWarningReasonStore,
+    getHashtagDataSnapshot,
+    hashtagPinStore,
+  } from "../stores/tagsStore.svelte";
 
   interface Props {
     rxNostr?: RxNostr;
@@ -94,6 +109,8 @@
     minEditorHeight?: number;
     onCustomEmojiSelect?: (emoji: CustomEmojiSelection) => void;
     notificationPort?: AppPostNotificationPort;
+    hostOwnedConfig?: EHagakiHostOwnedComposerOptions & { signal: AbortSignal };
+    hostCustomEmojiItems?: CustomEmojiItem[];
   }
 
   let {
@@ -105,7 +122,11 @@
     minEditorHeight = POST_EDITOR_MIN_HEIGHT,
     onCustomEmojiSelect,
     notificationPort,
+    hostOwnedConfig,
+    hostCustomEmojiItems = [],
   }: Props = $props();
+  let isHostOwned = $derived(!!hostOwnedConfig);
+  let mediaEnabled = $derived(!isHostOwned || !!hostOwnedConfig?.uploadMedia);
   let editor: any = $state(null);
   let currentEditor: TipTapEditor | null = $state(null);
   let dragOver = $state(false);
@@ -259,6 +280,35 @@
     updateUploadState: (isUploading: boolean, message?: string) => {
       updateEditorUploadState(editorState, isUploading, message);
     },
+    uploadFiles: async (params) => {
+      if (postStatus.sending || editorState.isUploading) return null;
+      if (!isHostOwned) {
+        return await defaultUploadFiles(params);
+      }
+      if (!hostOwnedConfig?.uploadMedia) {
+        updateEditorUploadState(editorState, false, $_("postComponent.media_not_supported"));
+        return null;
+      }
+      updateEditorUploadState(editorState, true, "");
+      const executor = createHostOwnedUploadExecutor({
+        uploadMedia: hostOwnedConfig.uploadMedia,
+        signal: hostOwnedConfig.signal,
+      });
+      try {
+        return await uploadHelper({
+          ...params,
+          showUploadError: (message) =>
+            updateEditorUploadState(editorState, true, message),
+          devMode: false,
+          prepareFiles: executor.prepareFiles,
+          uploadPreparedFiles: executor.uploadPreparedFiles,
+          fileUploadManager: executor.fileUploadManager,
+          deferUploadStateClear: true,
+        });
+      } finally {
+        updateEditorUploadState(editorState, false);
+      }
+    },
   });
   const postStatusHandlers = createPostStatusHandlers({
     updatePostStatus,
@@ -335,12 +385,17 @@
       placeholderText: editorPlaceholderText,
       editorContainerEl,
       currentEditor,
-      hasStoredKey,
+      hasStoredKey: hasStoredKey || isHostOwned,
       submitPost,
       onCustomEmojiSelect,
-      uploadFiles: (files: File[] | FileList) => {
-        void uploadHandlers.performUpload(files);
-      },
+      getCustomEmojiItems: isHostOwned
+        ? () => hostCustomEmojiItems
+        : undefined,
+      uploadFiles: mediaEnabled
+        ? (files: File[] | FileList) => {
+          void uploadHandlers.performUpload(files);
+        }
+        : undefined,
       eventCallbacks: {
         onContentUpdate: updateEditorContent,
         onImageFullscreenRequest: (
@@ -412,6 +467,15 @@
           submitPost,
         });
         editorSubscriptionUnsubscribe = null;
+      }
+      if (isHostOwned) {
+        updatePostStatus({
+          sending: false,
+          success: false,
+          error: false,
+          message: "",
+          completed: false,
+        });
       }
     };
   });
@@ -609,8 +673,96 @@
     currentEditor.commands.keyboardShortcut("Enter");
   }
 
+  function canStartSubmit(): boolean {
+    return !!currentEditor &&
+      editorState.canPost &&
+      !postStatus.sending &&
+      !editorState.isUploading &&
+      !postStatus.completed &&
+      (isHostOwned || !!postManager);
+  }
+
+  function createHostOwnedImageImetaMap(editorInstance: TipTapEditor): Record<string, any> {
+    if (!mediaFreePlacement) {
+      return mediaGalleryStore.getImageBlurhashMap();
+    }
+    const attributes: Record<string, { dim?: string; alt?: string; size?: number }> = {};
+    editorInstance.state.doc.descendants((node: any) => {
+      if (node.type?.name !== "image" || !node.attrs?.src || node.attrs?.isPlaceholder) return;
+      const size = Number(node.attrs.size);
+      attributes[node.attrs.src] = {
+        dim: node.attrs.dim ?? undefined,
+        alt: node.attrs.alt ?? undefined,
+        ...(Number.isFinite(size) && size > 0 ? { size } : {}),
+      };
+    });
+    return Object.fromEntries(
+      Object.entries(extractImageBlurhashMap(editorInstance)).map(([url, blurhash]) => [
+        url,
+        {
+          m: getMimeTypeFromUrl(url),
+          blurhash,
+          ...attributes[url],
+          ox: imageOxMap[url],
+          x: imageXMap[url],
+        },
+      ]),
+    );
+  }
+
+  async function submitHostOwned(editorInstance: TipTapEditor): Promise<void> {
+    const config = hostOwnedConfig;
+    if (!config || !canStartSubmit()) return;
+
+    // Capture every mutable input before entering the host handler. The handler
+    // is then free to await without observing later editor/context mutations.
+    const extraction = extractPostContentWithEmojiTags(editorInstance);
+    const content = !mediaFreePlacement && mediaGalleryStore.getContentUrls().length > 0
+      ? [extraction.content.trim(), ...mediaGalleryStore.getContentUrls()]
+        .filter(Boolean)
+        .join("\n")
+      : extraction.content;
+    const hashtagSnapshot = getHashtagDataSnapshot();
+    const snapshot = {
+      content,
+      hashtagTags: hashtagSnapshot.tags.map((tag) => [...tag]),
+      hashtags: [...hashtagSnapshot.hashtags],
+      contentWarningEnabled: contentWarningStore.value,
+      contentWarningReason: contentWarningReasonStore.value,
+      emojiTags: extraction.emojiTags.map((tag) => [...tag]),
+      imageImetaMap: createHostOwnedImageImetaMap(editorInstance),
+      replyQuote: $state.snapshot(replyQuoteState.value),
+      channel: $state.snapshot(effectiveChannelContextState.value),
+    };
+
+    postStatusHandlers.markSending();
+    try {
+      const output = await buildHostOwnedComposerOutput(snapshot);
+      const result = await config.submit(output, { signal: config.signal });
+      if (config.signal.aborted) return;
+      const eventId = getHostSubmissionEventId(result);
+      notificationPort?.notifyPostSuccess({
+        ...(eventId ? { eventId } : {}),
+        ...(output.context.reply ? { replyToEventId: output.context.reply.eventId } : {}),
+        ...(output.context.quotes.length
+          ? { quotedEventIds: output.context.quotes.map((quote) => quote.eventId) }
+          : {}),
+      });
+      postStatusHandlers.markSuccess({ success: true, ...(eventId ? { eventId } : {}) });
+    } catch {
+      if (config.signal.aborted) return;
+      notificationPort?.notifyPostError("post_error");
+      postStatusHandlers.markFailure("postComponent.post_error");
+    }
+  }
+
   export async function submitPost() {
-    if (!postManager || !currentEditor) return;
+    if (!currentEditor || !canStartSubmit()) return;
+    if (isHostOwned) {
+      await submitHostOwned(currentEditor);
+      return;
+    }
+    if (!postManager) return;
     const postPayload = postManager.preparePostPayload(currentEditor);
     if (containsSecretKey(postPayload.content)) {
       postComponentUIStore.showSecretKeyDialog(
@@ -635,12 +787,31 @@
   }
 
   export function clearContentAfterSuccess() {
-    if (postManager && currentEditor)
+    if (postManager && currentEditor) {
       postManager.clearContentAfterSuccess(currentEditor);
+      return;
+    }
+    if (currentEditor) {
+      const pinnedHashtags = hashtagPinStore.value
+        ? [...getHashtagDataSnapshot().hashtags]
+        : [];
+      currentEditor.chain().clearContent().run();
+      contentWarningStore.reset();
+      contentWarningReasonStore.reset();
+      mediaGalleryStore.clearAll();
+      clearReplyQuote();
+      if (pinnedHashtags.length > 0) {
+        currentEditor.commands.insertContent(
+          ` ${pinnedHashtags.map((hashtag) => `#${hashtag}`).join(" ")}`,
+        );
+        currentEditor.commands.focus("start");
+      }
+    }
   }
 
   // UI状態管理をストアから取得して使用
   async function confirmSendWithSecretKey() {
+    if (!canStartSubmit()) return;
     const pendingPost = postComponentUIStore.getPendingPost();
     const pendingEmojiTags = postComponentUIStore.getPendingEmojiTags();
     postComponentUIStore.hideSecretKeyDialog();
@@ -701,6 +872,7 @@
   });
 
   export function openFileDialog() {
+    if (!mediaEnabled || postStatus.sending || editorState.isUploading) return;
     fileInput?.click();
   }
 
@@ -812,14 +984,16 @@
     <MediaGallery />
   {/if}
 
-  <input
-    type="file"
-    accept="image/*,video/*"
-    multiple
-    onchange={handleFileSelect}
-    bind:this={fileInput}
-    style="display: none;"
-  />
+  {#if mediaEnabled}
+    <input
+      type="file"
+      accept="image/*,video/*"
+      multiple
+      onchange={handleFileSelect}
+      bind:this={fileInput}
+      style="display: none;"
+    />
+  {/if}
 
   {#if uploadErrorMessage}
     <div class="upload-error">{uploadErrorMessage}</div>

--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -95,7 +95,6 @@
     uploadFiles as defaultUploadFiles,
     showUploadErrorMessage,
   } from "../lib/uploadHelper";
-  import { extractImageBlurhashMap, getMimeTypeFromUrl } from "../lib/tags/imetaTag";
   import { extractPostContentWithEmojiTags } from "../lib/utils/editorDocumentUtils";
   import {
     contentWarningStore,
@@ -714,32 +713,28 @@
       (hasPostingCapability || !!postManager);
   }
 
-  function createHostOwnedImageImetaMap(editorInstance: TipTapEditor): Record<string, any> {
+  function createHostOwnedMediaImetaMap(editorInstance: TipTapEditor): Record<string, any> {
     if (!mediaFreePlacement) {
-      return mediaGalleryStore.getImageBlurhashMap();
+      return mediaGalleryStore.getMediaImetaMap();
     }
-    const attributes: Record<string, { dim?: string; alt?: string; size?: number }> = {};
+    const mediaMetadata: Record<string, any> = {};
     editorInstance.state.doc.descendants((node: any) => {
-      if (node.type?.name !== "image" || !node.attrs?.src || node.attrs?.isPlaceholder) return;
+      if ((node.type?.name !== "image" && node.type?.name !== "video") || !node.attrs?.src || node.attrs?.isPlaceholder) return;
+      const m = node.attrs.m ?? node.attrs.mimeType;
+      if (typeof m !== "string" || !m) return;
       const size = Number(node.attrs.size);
-      attributes[node.attrs.src] = {
+      mediaMetadata[node.attrs.src] = {
+        m,
+        blurhash: node.attrs.blurhash ?? undefined,
         dim: node.attrs.dim ?? undefined,
         alt: node.attrs.alt ?? undefined,
         ...(Number.isFinite(size) && size > 0 ? { size } : {}),
+        ox: node.attrs.ox ?? imageOxMap[node.attrs.src],
+        x: node.attrs.x ?? imageXMap[node.attrs.src],
+        uploadProtocol: node.attrs.uploadProtocol ?? undefined,
       };
     });
-    return Object.fromEntries(
-      Object.entries(extractImageBlurhashMap(editorInstance)).map(([url, blurhash]) => [
-        url,
-        {
-          m: getMimeTypeFromUrl(url),
-          blurhash,
-          ...attributes[url],
-          ox: imageOxMap[url],
-          x: imageXMap[url],
-        },
-      ]),
-    );
+    return mediaMetadata;
   }
 
   async function submitHostOwned(editorInstance: TipTapEditor): Promise<void> {
@@ -762,7 +757,7 @@
       contentWarningEnabled: contentWarningStore.value,
       contentWarningReason: contentWarningReasonStore.value,
       emojiTags: extraction.emojiTags.map((tag) => [...tag]),
-      imageImetaMap: createHostOwnedImageImetaMap(editorInstance),
+      mediaImetaMap: createHostOwnedMediaImetaMap(editorInstance),
       replyQuote: $state.snapshot(replyQuoteState.value),
       channel: $state.snapshot(effectiveChannelContextState.value),
     };
@@ -831,6 +826,8 @@
       contentWarningStore.reset();
       contentWarningReasonStore.reset();
       mediaGalleryStore.clearAll();
+      imageOxMap = {};
+      imageXMap = {};
       clearReplyQuote();
       if (pinnedHashtags.length > 0) {
         currentEditor.commands.insertContent(

--- a/src/lib/appEmbedController.ts
+++ b/src/lib/appEmbedController.ts
@@ -113,6 +113,7 @@ export interface AppEmbedRuntimeStateGetters {
     getChannelContextState(): ChannelContextState | null;
     getChannelContextProvenance(): ChannelContextProvenance | null;
     getRuntimeSnapshot(): AppEmbedRuntimeSnapshot;
+    isSubmissionInProgress?(): boolean;
 }
 
 export interface AppEmbedStoragePort {
@@ -315,6 +316,9 @@ export function createAppEmbedController(
 
     return {
         async applyComposerContext(payload: unknown): Promise<void> {
+            if (deps.runtime.isSubmissionInProgress?.()) {
+                throw new Error("submission_in_progress");
+            }
             const backgroundTasks = applyRemoteComposerSetContext(payload);
             state.lastNotifiedComposerContextSignature = buildComposerContextSignature(
                 buildCurrentComposerContextPayload(),

--- a/src/lib/editor/editorConfig.ts
+++ b/src/lib/editor/editorConfig.ts
@@ -13,6 +13,7 @@ import { CustomEmoji } from './customEmojiExtension';
 import UniqueID from './uniqueIdExtension';
 import { ContentTrackingExtension, MediaPasteExtension, ImageDragDropExtension, CustomEmojiDragDropExtension, SmartBackspaceExtension, ClipboardExtension, AndroidCompositionFix, HashtagSuggestion, CustomEmojiSuggestion, ToolbarCaretExtension } from '.';
 import type { CustomEmojiSelection } from '../customEmojiUsage';
+import type { CustomEmojiItem } from '../customEmoji';
 
 const MEDIA_NODE_TYPES = new Set(['image', 'video', 'customEmoji']);
 const MEDIA_FOCUS_SELECTOR = '.node-image.is-node-focused, .node-video.is-node-focused, .custom-emoji-wrapper.is-node-focused';
@@ -130,6 +131,7 @@ export interface EditorConfigOptions {
     placeholderText: string;
     onSubmitPost: () => Promise<void>;
     onCustomEmojiSelect?: (emoji: CustomEmojiSelection) => void;
+    getCustomEmojiItems?: () => CustomEmojiItem[];
     onUpdate?: () => void;
     onCreate?: (editor: Editor) => void;
     onDestroy?: () => void;
@@ -139,7 +141,7 @@ export interface EditorConfigOptions {
  * Tiptap v3のエディターストアを作成
  */
 export function createEditorStore(options: EditorConfigOptions) {
-    const { placeholderText, onSubmitPost, onCustomEmojiSelect, onUpdate, onCreate, onDestroy } = options;
+    const { placeholderText, onSubmitPost, onCustomEmojiSelect, getCustomEmojiItems, onUpdate, onCreate, onDestroy } = options;
     const placeholderState: PlaceholderState = { text: placeholderText };
 
     const editorStore = createEditor({
@@ -279,9 +281,12 @@ export function createEditorStore(options: EditorConfigOptions) {
             ContentTrackingExtension,
             HashtagSuggestion,
             Video,
-            CustomEmoji,
+            CustomEmoji.configure({
+                ...(getCustomEmojiItems ? { getItems: getCustomEmojiItems } : {}),
+            }),
             CustomEmojiSuggestion.configure({
                 onSelectEmoji: onCustomEmojiSelect,
+                ...(getCustomEmojiItems ? { getItems: getCustomEmojiItems } : {}),
             }),
             ToolbarCaretExtension,
             ClipboardExtension, // ← クリップボード処理を追加（MediaPasteExtensionの前に配置）

--- a/src/lib/editor/editorConfig.ts
+++ b/src/lib/editor/editorConfig.ts
@@ -261,6 +261,9 @@ export function createEditorStore(options: EditorConfigOptions) {
                         size: { default: null },
                         uploadProtocol: { default: null },
                         alt: { default: null },
+                        m: { default: null },
+                        ox: { default: null },
+                        x: { default: null },
                     };
                 },
                 addNodeView() {

--- a/src/lib/editor/editorDomActions.svelte.ts
+++ b/src/lib/editor/editorDomActions.svelte.ts
@@ -274,14 +274,20 @@ export function keydownAction(node: HTMLElement) {
             const rawCurrentEditor = (node as any).__currentEditor;
             const currentEditor = typeof rawCurrentEditor === 'function' ? rawCurrentEditor() : rawCurrentEditor as TipTapEditor | undefined;
 
+            const rawHasPostingCapability = (node as any).__hasPostingCapability;
+            const hasPostingCapability = typeof rawHasPostingCapability === 'function'
+                ? rawHasPostingCapability()
+                : rawHasPostingCapability as boolean | undefined;
             const rawHasStoredKey = (node as any).__hasStoredKey;
-            const hasStoredKey = typeof rawHasStoredKey === 'function' ? rawHasStoredKey() : rawHasStoredKey as boolean | undefined;
+            const hasStoredKey = typeof rawHasStoredKey === 'function'
+                ? rawHasStoredKey()
+                : rawHasStoredKey as boolean | undefined;
 
             const rawPostStatus = (node as any).__postStatus;
             const postStatus = typeof rawPostStatus === 'function' ? rawPostStatus() : rawPostStatus as { sending: boolean } | undefined;
 
             const content = currentEditor ? extractContentWithImages(currentEditor) : "";
-            if (!postStatus?.sending && content.trim() && hasStoredKey) {
+            if (!postStatus?.sending && content.trim() && (hasPostingCapability ?? hasStoredKey)) {
                 (node as any).__submitPost?.();
             }
         }

--- a/src/lib/editor/editorDomActions.svelte.ts
+++ b/src/lib/editor/editorDomActions.svelte.ts
@@ -42,11 +42,15 @@ function isPostSending(node: HTMLElement): boolean {
     return postStatus?.sending === true;
 }
 
+function canUploadFiles(node: HTMLElement): boolean {
+    return typeof (node as any).__uploadFiles === "function";
+}
+
 // fileDropAction
 export function fileDropAction(node: HTMLElement) {
     let dragOver = $state(false);
     function handleDragOver(event: DragEvent) {
-        if (isPostSending(node)) {
+        if (isPostSending(node) || !canUploadFiles(node)) {
             event.preventDefault();
             dragOver = false;
             node.classList.remove("drag-over");
@@ -85,7 +89,7 @@ export function fileDropAction(node: HTMLElement) {
         dragOver = false;
         node.classList.remove("drag-over");
 
-        if (isPostSending(node)) {
+        if (isPostSending(node) || !canUploadFiles(node)) {
             event.preventDefault();
             return;
         }
@@ -126,7 +130,7 @@ export function fileDropActionWithDragState(
 ) {
     const action = fileDropAction(node);
     function handleDragOver(event: DragEvent) {
-        if (isPostSending(node)) {
+        if (isPostSending(node) || !canUploadFiles(node)) {
             event.preventDefault();
             params.dragOver(false);
             return;
@@ -148,7 +152,7 @@ export function fileDropActionWithDragState(
     }
     function handleDrop(event: DragEvent) {
         params.dragOver(false);
-        if (isPostSending(node)) {
+        if (isPostSending(node) || !canUploadFiles(node)) {
             event.preventDefault();
         }
     }
@@ -175,6 +179,13 @@ export function pasteAction(node: HTMLElement) {
         }
 
         if (!event.clipboardData) return;
+        if (!canUploadFiles(node)) {
+            const hasMediaFile = Array.from(event.clipboardData.items).some(
+                (item) => item.kind === "file" && item.type.startsWith("image/"),
+            );
+            if (hasMediaFile) event.preventDefault();
+            return;
+        }
         const files: File[] = [];
         for (const item of event.clipboardData.items) {
             if (item.kind === "file" && item.type.startsWith("image/")) {

--- a/src/lib/editor/editorLifecycle.ts
+++ b/src/lib/editor/editorLifecycle.ts
@@ -18,6 +18,7 @@ export function initializeEditor(params: InitializeEditorParams): InitializeEdit
         placeholderText,
         editorContainerEl,
         hasStoredKey,
+        hasPostingCapability,
         submitPost,
         onCustomEmojiSelect,
         getCustomEmojiItems,
@@ -61,6 +62,7 @@ export function initializeEditor(params: InitializeEditorParams): InitializeEdit
             __uploadFiles: uploadFiles,
             __currentEditor: () => latestEditor,
             __hasStoredKey: () => hasStoredKey,
+            __hasPostingCapability: () => hasPostingCapability ?? hasStoredKey,
             __postStatus: () => editorState.postStatus,
             __submitPost: submitPost,
         });
@@ -107,6 +109,7 @@ export function cleanupEditor(params: CleanupEditorParams): void {
         delete (editorContainerEl as any).__uploadFiles;
         delete (editorContainerEl as any).__currentEditor;
         delete (editorContainerEl as any).__hasStoredKey;
+        delete (editorContainerEl as any).__hasPostingCapability;
         delete (editorContainerEl as any).__postStatus;
         delete (editorContainerEl as any).__submitPost;
     }

--- a/src/lib/editor/editorLifecycle.ts
+++ b/src/lib/editor/editorLifecycle.ts
@@ -20,6 +20,7 @@ export function initializeEditor(params: InitializeEditorParams): InitializeEdit
         hasStoredKey,
         submitPost,
         onCustomEmojiSelect,
+        getCustomEmojiItems,
         uploadFiles,
         eventCallbacks
     } = params;
@@ -32,6 +33,7 @@ export function initializeEditor(params: InitializeEditorParams): InitializeEdit
         placeholderText,
         onSubmitPost: submitPost,
         onCustomEmojiSelect,
+        getCustomEmojiItems,
         onCreate: (editorInstance: TipTapEditor | null) => {
             currentEditorStore.set(editorInstance);
         }

--- a/src/lib/editor/placeholderManager.ts
+++ b/src/lib/editor/placeholderManager.ts
@@ -142,7 +142,7 @@ function resolveImageReplacementMetadata(
 } {
     const { mFromServer, altFromServer, serverBlurhash, oxFromServer, xFromServer, dimFromServer, sizeFromServer } = extractNip94Metadata(result.nip94 || {});
     const dimensions = resolveImageDimensions(result, dimFromServer, matched);
-    const isHostOwned = result.uploadProtocol === 'custom-http';
+    const isHostOwned = result.hostOwnedMedia === true;
 
     return {
         mimeType: isHostOwned ? (mFromServer ?? matched.file.type) : undefined,
@@ -549,7 +549,7 @@ export async function replacePlaceholdersWithResults(
                         currentEditor,
                         (node: any) => node.type?.name === 'video' && node.attrs?.src === matched.placeholderId,
                         (node: any, pos: number) => {
-                            const hostMetadata = result.uploadProtocol === 'custom-http'
+                            const hostMetadata = result.hostOwnedMedia === true
                                 ? extractNip94Metadata(result.nip94 || {})
                                 : null;
                             const tr = currentEditor!.state.tr.setNodeMarkup(pos, undefined, {
@@ -563,7 +563,7 @@ export async function replacePlaceholdersWithResults(
                                 ...(hostMetadata?.sizeFromServer ? { size: hostMetadata.sizeFromServer } : {}),
                                 ...(hostMetadata?.oxFromServer ? { ox: hostMetadata.oxFromServer } : {}),
                                 ...(hostMetadata?.xFromServer ? { x: hostMetadata.xFromServer } : {}),
-                                ...(result.uploadProtocol === 'custom-http' ? { uploadProtocol: result.uploadProtocol } : {}),
+                                ...(result.hostOwnedMedia === true ? { uploadProtocol: result.uploadProtocol } : {}),
                             });
                             currentEditor!.view.dispatch(tr);
                         },
@@ -695,7 +695,7 @@ export async function replacePlaceholdersInGallery(
             },
             createMediaReplacementSuccessHandler({
                 onVideoSuccess: ({ url, matched, result }) => {
-                    const hostMetadata = result.uploadProtocol === 'custom-http'
+                    const hostMetadata = result.hostOwnedMedia === true
                         ? extractNip94Metadata(result.nip94 || {})
                         : null;
                     mediaGalleryStore.updateItem(matched.placeholderId, {
@@ -708,7 +708,7 @@ export async function replacePlaceholdersInGallery(
                         ...(hostMetadata?.sizeFromServer ? { size: parseImageSize(hostMetadata.sizeFromServer) } : {}),
                         ...(hostMetadata?.oxFromServer ? { ox: hostMetadata.oxFromServer } : {}),
                         ...(hostMetadata?.xFromServer ? { x: hostMetadata.xFromServer } : {}),
-                        ...(result.uploadProtocol === 'custom-http' ? { uploadProtocol: result.uploadProtocol } : {}),
+                        ...(result.hostOwnedMedia === true ? { uploadProtocol: result.uploadProtocol } : {}),
                     });
                 },
                 onImageSuccess: async ({ url, matched, imageMetadata }) => {

--- a/src/lib/editor/placeholderManager.ts
+++ b/src/lib/editor/placeholderManager.ts
@@ -82,6 +82,8 @@ function removeGalleryPlaceholder(
 /** NIP-94メタデータから各フィールドを抽出する */
 function extractNip94Metadata(nip94: Record<string, any>) {
     return {
+        mFromServer: nip94['m'] ?? undefined as string | undefined,
+        altFromServer: nip94['alt'] ?? undefined as string | undefined,
         serverBlurhash: nip94['blurhash'] ?? nip94['b'] ?? undefined as string | undefined,
         oxFromServer: nip94['ox'] ?? nip94['o'] ?? undefined as string | undefined,
         xFromServer: nip94['x'] ?? undefined as string | undefined,
@@ -134,12 +136,17 @@ function resolveImageReplacementMetadata(
     dim?: string;
     dimensions?: ImageDimensions;
     size?: number;
+    mimeType?: string;
+    alt?: string;
     uploadProtocol?: FileUploadResponse['uploadProtocol'];
 } {
-    const { serverBlurhash, oxFromServer, xFromServer, dimFromServer, sizeFromServer } = extractNip94Metadata(result.nip94 || {});
+    const { mFromServer, altFromServer, serverBlurhash, oxFromServer, xFromServer, dimFromServer, sizeFromServer } = extractNip94Metadata(result.nip94 || {});
     const dimensions = resolveImageDimensions(result, dimFromServer, matched);
+    const isHostOwned = result.uploadProtocol === 'custom-http';
 
     return {
+        mimeType: isHostOwned ? (mFromServer ?? matched.file.type) : undefined,
+        alt: isHostOwned ? altFromServer : undefined,
         serverBlurhash,
         oxFromServer,
         xFromServer,
@@ -273,7 +280,11 @@ interface MediaReplacementSuccessStrategy {
         matched: PlaceholderEntry;
         isVideo: boolean;
     }) => void;
-    onVideoSuccess: (url: string, matched: PlaceholderEntry) => Promise<void> | void;
+    onVideoSuccess: (context: {
+        url: string;
+        matched: PlaceholderEntry;
+        result: FileUploadResponse;
+    }) => Promise<void> | void;
     onImageSuccess: (context: {
         url: string;
         matched: PlaceholderEntry;
@@ -300,7 +311,7 @@ function createMediaReplacementSuccessHandler(
         });
 
         if (isVideo) {
-            await strategy.onVideoSuccess(url, matched);
+            await strategy.onVideoSuccess({ url, matched, result });
             return;
         }
 
@@ -533,15 +544,26 @@ export async function replacePlaceholdersWithResults(
                         });
                     }
                 },
-                onVideoSuccess: (url, matched) => {
+                onVideoSuccess: ({ url, matched, result }) => {
                     findAndExecuteOnNode(
                         currentEditor,
                         (node: any) => node.type?.name === 'video' && node.attrs?.src === matched.placeholderId,
                         (node: any, pos: number) => {
+                            const hostMetadata = result.uploadProtocol === 'custom-http'
+                                ? extractNip94Metadata(result.nip94 || {})
+                                : null;
                             const tr = currentEditor!.state.tr.setNodeMarkup(pos, undefined, {
                                 ...node.attrs,
                                 src: url,
                                 isPlaceholder: false,
+                                ...(hostMetadata?.mFromServer ? { m: hostMetadata.mFromServer } : {}),
+                                ...(hostMetadata?.altFromServer ? { alt: hostMetadata.altFromServer } : {}),
+                                ...(hostMetadata?.serverBlurhash ? { blurhash: hostMetadata.serverBlurhash } : {}),
+                                ...(hostMetadata?.dimFromServer ? { dim: hostMetadata.dimFromServer } : {}),
+                                ...(hostMetadata?.sizeFromServer ? { size: hostMetadata.sizeFromServer } : {}),
+                                ...(hostMetadata?.oxFromServer ? { ox: hostMetadata.oxFromServer } : {}),
+                                ...(hostMetadata?.xFromServer ? { x: hostMetadata.xFromServer } : {}),
+                                ...(result.uploadProtocol === 'custom-http' ? { uploadProtocol: result.uploadProtocol } : {}),
                             });
                             currentEditor!.view.dispatch(tr);
                         },
@@ -560,6 +582,18 @@ export async function replacePlaceholdersWithResults(
                             };
                             if (imageMetadata.dim) {
                                 newAttrs.dim = imageMetadata.dim;
+                            }
+                            if (imageMetadata.mimeType) {
+                                newAttrs.m = imageMetadata.mimeType;
+                            }
+                            if (imageMetadata.alt !== undefined) {
+                                newAttrs.alt = imageMetadata.alt;
+                            }
+                            if (imageMetadata.oxFromServer) {
+                                newAttrs.ox = imageMetadata.oxFromServer;
+                            }
+                            if (imageMetadata.xFromServer) {
+                                newAttrs.x = imageMetadata.xFromServer;
                             }
                             newAttrs.size = imageMetadata.size ?? null;
                             newAttrs.uploadProtocol = imageMetadata.uploadProtocol ?? null;
@@ -660,21 +694,32 @@ export async function replacePlaceholdersInGallery(
                 removeGalleryPlaceholder(entry.placeholderId, imageSizeMapStore);
             },
             createMediaReplacementSuccessHandler({
-                onVideoSuccess: (url, matched) => {
+                onVideoSuccess: ({ url, matched, result }) => {
+                    const hostMetadata = result.uploadProtocol === 'custom-http'
+                        ? extractNip94Metadata(result.nip94 || {})
+                        : null;
                     mediaGalleryStore.updateItem(matched.placeholderId, {
                         src: url,
                         isPlaceholder: false,
-                        mimeType: getMimeTypeFromUrl(url),
+                        mimeType: hostMetadata?.mFromServer ?? getMimeTypeFromUrl(url),
+                        ...(hostMetadata?.altFromServer ? { alt: hostMetadata.altFromServer } : {}),
+                        ...(hostMetadata?.serverBlurhash ? { blurhash: hostMetadata.serverBlurhash } : {}),
+                        ...(hostMetadata?.dimFromServer ? { dim: hostMetadata.dimFromServer } : {}),
+                        ...(hostMetadata?.sizeFromServer ? { size: parseImageSize(hostMetadata.sizeFromServer) } : {}),
+                        ...(hostMetadata?.oxFromServer ? { ox: hostMetadata.oxFromServer } : {}),
+                        ...(hostMetadata?.xFromServer ? { x: hostMetadata.xFromServer } : {}),
+                        ...(result.uploadProtocol === 'custom-http' ? { uploadProtocol: result.uploadProtocol } : {}),
                     });
                 },
                 onImageSuccess: async ({ url, matched, imageMetadata }) => {
-                    const mimeType = getMimeTypeFromUrl(url);
+                    const mimeType = imageMetadata.mimeType ?? getMimeTypeFromUrl(url);
 
                     mediaGalleryStore.updateItem(matched.placeholderId, {
                         src: url,
                         isPlaceholder: false,
                         blurhash: imageMetadata.blurhash,
                         mimeType,
+                        ...(imageMetadata.alt !== undefined ? { alt: imageMetadata.alt } : {}),
                         ox: imageMetadata.ox,
                         dim: imageMetadata.dim,
                         dimensions: imageMetadata.dimensions,

--- a/src/lib/editor/videoExtension.ts
+++ b/src/lib/editor/videoExtension.ts
@@ -17,6 +17,30 @@ export const Video = Node.create({
             isPlaceholder: {
                 default: false,
             },
+            alt: {
+                default: null,
+            },
+            blurhash: {
+                default: null,
+            },
+            dim: {
+                default: null,
+            },
+            size: {
+                default: null,
+            },
+            uploadProtocol: {
+                default: null,
+            },
+            m: {
+                default: null,
+            },
+            ox: {
+                default: null,
+            },
+            x: {
+                default: null,
+            },
         };
     },
 

--- a/src/lib/hostOwnedComposer.ts
+++ b/src/lib/hostOwnedComposer.ts
@@ -99,7 +99,7 @@ export async function buildHostOwnedComposerOutput(params: {
     contentWarningEnabled: boolean;
     contentWarningReason: string;
     emojiTags: string[][];
-    imageImetaMap: Record<string, {
+    mediaImetaMap: Record<string, {
         m: string;
         blurhash?: string;
         dim?: string;
@@ -132,7 +132,7 @@ export async function buildHostOwnedComposerOutput(params: {
         }
     }
 
-    for (const [url, metadata] of Object.entries(params.imageImetaMap)) {
+    for (const [url, metadata] of Object.entries(params.mediaImetaMap)) {
         if (url && metadata?.m) {
             tags.push(await createImetaTag({ url, ...metadata }));
         }

--- a/src/lib/hostOwnedComposer.ts
+++ b/src/lib/hostOwnedComposer.ts
@@ -1,0 +1,167 @@
+import { createImetaTag } from "./tags/imetaTag";
+import type {
+    ChannelContextState,
+    ReplyQuoteComposerState,
+} from "./types";
+import type {
+    EHagakiComposerContextSnapshot,
+    EHagakiComposerOutput,
+} from "../web-component/types";
+
+const HOST_OWNED_FORBIDDEN_TAGS = new Set(["e", "p", "q", "a", "k", "client"]);
+
+function cloneTag(tag: readonly string[]): string[] {
+    return tag.map((value) => String(value));
+}
+
+function snapshotReference(reference: {
+    eventId: string;
+    relayHints: string[];
+    authorPubkey: string | null;
+}) {
+    return {
+        eventId: reference.eventId,
+        relayHints: [...reference.relayHints],
+        authorPubkey: reference.authorPubkey,
+    };
+}
+
+function freezeReference(reference: EHagakiComposerContextSnapshot["reply"]) {
+    if (!reference) return null;
+    return Object.freeze({
+        eventId: reference.eventId,
+        relayHints: Object.freeze([...reference.relayHints]),
+        authorPubkey: reference.authorPubkey,
+    });
+}
+
+/**
+ * Produces a deep-frozen value at the public handoff boundary. TypeScript's
+ * `Readonly` is intentionally only an API convenience here; the runtime
+ * freeze ensures an async host handler cannot observe later composer changes
+ * or mutate the captured snapshot.
+ */
+export function freezeHostOwnedComposerOutput(
+    output: EHagakiComposerOutput,
+): EHagakiComposerOutput {
+    const channel = output.context.channel
+        ? Object.freeze({
+            eventId: output.context.channel.eventId,
+            relayHints: Object.freeze([...output.context.channel.relayHints]),
+            ...(output.context.channel.channelRelays
+                ? { channelRelays: Object.freeze([...output.context.channel.channelRelays]) }
+                : {}),
+        })
+        : null;
+    const context = Object.freeze({
+        reply: freezeReference(output.context.reply),
+        quotes: Object.freeze(output.context.quotes.map((quote) => freezeReference(quote)!)),
+        channel,
+    });
+
+    return Object.freeze({
+        content: output.content,
+        tags: Object.freeze(output.tags.map((tag) => Object.freeze([...tag]))),
+        context,
+    });
+}
+
+export function createHostOwnedContextSnapshot(params: {
+    replyQuote: ReplyQuoteComposerState;
+    channel: ChannelContextState | null;
+}): EHagakiComposerContextSnapshot {
+    return {
+        reply: params.replyQuote.reply
+            ? snapshotReference(params.replyQuote.reply)
+            : null,
+        quotes: params.replyQuote.quotes.map(snapshotReference),
+        channel: params.channel
+            ? {
+                eventId: params.channel.eventId,
+                relayHints: [...params.channel.relayHints],
+                ...(params.channel.channelRelays
+                    ? { channelRelays: [...params.channel.channelRelays] }
+                    : {}),
+            }
+            : null,
+    };
+}
+
+/**
+ * Creates only the composer-owned portion of a host submission. In
+ * particular, this intentionally does not create a Nostr event or reference
+ * tags; those require the host's final event policy.
+ */
+export async function buildHostOwnedComposerOutput(params: {
+    content: string;
+    hashtagTags: string[][];
+    hashtags: string[];
+    contentWarningEnabled: boolean;
+    contentWarningReason: string;
+    emojiTags: string[][];
+    imageImetaMap: Record<string, {
+        m: string;
+        blurhash?: string;
+        dim?: string;
+        alt?: string;
+        size?: number;
+        ox?: string;
+        x?: string;
+    }>;
+    replyQuote: ReplyQuoteComposerState;
+    channel: ChannelContextState | null;
+}): Promise<EHagakiComposerOutput> {
+    const tags = (params.hashtagTags.length > 0
+        ? params.hashtagTags
+        : params.hashtags.map((hashtag) => ["t", hashtag.toLowerCase()]))
+        .filter((tag) => !HOST_OWNED_FORBIDDEN_TAGS.has(tag[0]))
+        .map(cloneTag);
+    const hasNsfwTag = tags.some((tag) => tag[0] === "t" && tag[1] === "nsfw");
+
+    if (params.contentWarningEnabled || hasNsfwTag) {
+        const reason = params.contentWarningReason.trim();
+        tags.push(reason ? ["content-warning", reason] : ["content-warning"]);
+        if (params.contentWarningEnabled && !hasNsfwTag) {
+            tags.push(["t", "nsfw"]);
+        }
+    }
+
+    for (const emojiTag of params.emojiTags) {
+        if (!HOST_OWNED_FORBIDDEN_TAGS.has(emojiTag[0])) {
+            tags.push(cloneTag(emojiTag));
+        }
+    }
+
+    for (const [url, metadata] of Object.entries(params.imageImetaMap)) {
+        if (url && metadata?.m) {
+            tags.push(await createImetaTag({ url, ...metadata }));
+        }
+    }
+
+    return freezeHostOwnedComposerOutput({
+        content: params.content,
+        tags,
+        context: createHostOwnedContextSnapshot({
+            replyQuote: params.replyQuote,
+            channel: params.channel,
+        }),
+    });
+}
+
+export function isHostSubmissionEventId(value: unknown): value is string {
+    return typeof value === "string" && /^[0-9a-f]{64}$/i.test(value);
+}
+
+/** Accepts the documented void or `{ eventId }` success shape only. */
+export function getHostSubmissionEventId(result: unknown): string | undefined {
+    if (result === undefined) return undefined;
+    if (!result || typeof result !== "object" || Array.isArray(result)) {
+        throw new TypeError("Host-owned submit must return void or an eventId object.");
+    }
+    const eventId = (result as { eventId?: unknown }).eventId;
+    if (eventId === undefined) return undefined;
+    if (!isHostSubmissionEventId(eventId)) {
+        throw new TypeError("Host-owned submit returned an invalid eventId.");
+    }
+    return eventId;
+}

--- a/src/lib/hostOwnedUpload.ts
+++ b/src/lib/hostOwnedUpload.ts
@@ -216,6 +216,11 @@ export function createHostOwnedUploadExecutor(params: {
                         url: response.url,
                         nip94: {
                             ...imeta,
+                            m: imeta.m ?? metadata.processedType ?? file.type,
+                            ...(metadata.ox && !imeta.ox ? { ox: metadata.ox } : {}),
+                            ...(metadata.blurhash && !imeta.blurhash
+                                ? { blurhash: metadata.blurhash }
+                                : {}),
                             size: imeta.size ?? String(file.size),
                             ...(metadata.width && metadata.height
                                 ? { dim: imeta.dim ?? `${metadata.width}x${metadata.height}` }

--- a/src/lib/hostOwnedUpload.ts
+++ b/src/lib/hostOwnedUpload.ts
@@ -213,6 +213,7 @@ export function createHostOwnedUploadExecutor(params: {
                     const imeta = sanitizeImeta(response.imeta);
                     results.push({
                         success: true,
+                        hostOwnedMedia: true,
                         url: response.url,
                         nip94: {
                             ...imeta,

--- a/src/lib/hostOwnedUpload.ts
+++ b/src/lib/hostOwnedUpload.ts
@@ -1,0 +1,253 @@
+import { ImageCompressionService } from "./imageCompressionService";
+import { MimeTypeSupport } from "./mimeTypeSupport";
+import { VideoCompressionService } from "./videoCompression/videoCompressionService";
+import { calculateSHA256Hex, getImageDimensions } from "./utils/fileUtils";
+import { calculateImageDisplaySize } from "./utils/mediaNodeUtils";
+import { MAX_FILE_SIZE } from "./constants";
+import { generateBlurhashForFile } from "./tags/imetaTag";
+import type {
+    FileUploadManagerInterface,
+    FileValidationResult,
+    FileUploadResponse,
+    PlaceholderEntry,
+    PreparedUploadFile,
+    UploadHelperDependencies,
+} from "./types";
+import type {
+    EHagakiHostMediaMetadata,
+    EHagakiHostMediaUploadResult,
+} from "../web-component/types";
+
+const ALLOWED_IMETA_FIELDS = new Set([
+    "alt",
+    "blurhash",
+    "dim",
+    "m",
+    "ox",
+    "size",
+    "x",
+]);
+
+function isHttpUrl(value: unknown): value is string {
+    if (typeof value !== "string") return false;
+    try {
+        const url = new URL(value);
+        return url.protocol === "http:" || url.protocol === "https:";
+    } catch {
+        return false;
+    }
+}
+
+function sanitizeImeta(value: unknown): Record<string, string> {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+    const result: Record<string, string> = {};
+    for (const [key, field] of Object.entries(value as Record<string, unknown>)) {
+        if (ALLOWED_IMETA_FIELDS.has(key) && typeof field === "string") {
+            result[key] = field;
+        }
+    }
+    return result;
+}
+
+export interface HostOwnedUploadExecutor {
+    prepareFiles(files: File[], deps: UploadHelperDependencies): Promise<PreparedUploadFile[]>;
+    uploadPreparedFiles(files: File[], placeholders: PlaceholderEntry[]): Promise<FileUploadResponse[]>;
+    fileUploadManager: UploadHelperDependencies["FileUploadManager"];
+}
+
+/**
+ * Placeholder validation and blurhash generation do not need a transport or
+ * Nostr authentication. Keeping this small class local prevents the generic
+ * FileUploadManager from constructing a NostrAuthService in Host-owned mode.
+ */
+class HostOwnedMediaFileUploadManager implements FileUploadManagerInterface {
+    validateImageFile(file: File): FileValidationResult {
+        if (!file.type.startsWith("image/")) {
+            return { isValid: false, errorMessage: "only_images_allowed" };
+        }
+        return file.size > MAX_FILE_SIZE
+            ? { isValid: false, errorMessage: "file_too_large" }
+            : { isValid: true };
+    }
+
+    validateMediaFile(file: File): FileValidationResult {
+        if (!file.type.startsWith("image/") && !file.type.startsWith("video/")) {
+            return { isValid: false, errorMessage: "only_images_or_videos_allowed" };
+        }
+        return file.size > MAX_FILE_SIZE
+            ? { isValid: false, errorMessage: "file_too_large" }
+            : { isValid: true };
+    }
+
+    async generateBlurhashForFile(file: File): Promise<string | null> {
+        return await generateBlurhashForFile(file);
+    }
+
+    async uploadFileWithCallbacks(): Promise<FileUploadResponse> {
+        throw new Error("Host-owned media never uses eHagaki upload transport.");
+    }
+
+    async uploadMultipleFilesWithCallbacks(): Promise<FileUploadResponse[]> {
+        throw new Error("Host-owned media never uses eHagaki upload transport.");
+    }
+}
+
+/**
+ * Keeps compression in this bundle and delegates only the final, same-realm
+ * File handoff. This is intentionally a local Host-owned composition seam,
+ * not a general upload-provider layer.
+ */
+export function createHostOwnedUploadExecutor(params: {
+    uploadMedia: (
+        file: File,
+        metadata: Readonly<EHagakiHostMediaMetadata>,
+        options: { signal: AbortSignal },
+    ) => Promise<EHagakiHostMediaUploadResult> | EHagakiHostMediaUploadResult;
+    signal: AbortSignal;
+}): HostOwnedUploadExecutor {
+    const metadataByFile = new WeakMap<File, EHagakiHostMediaMetadata>();
+    const dimensionsByFile = new WeakMap<File, { width: number; height: number; displayWidth: number; displayHeight: number }>();
+
+    return {
+        fileUploadManager: HostOwnedMediaFileUploadManager,
+        async prepareFiles(files, deps) {
+            const mimeSupport = new MimeTypeSupport(
+                typeof document === "undefined" ? undefined : document,
+            );
+            const isAborted = () => params.signal.aborted || !!deps.isUploadAborted?.();
+            const imageCompression = new ImageCompressionService(
+                mimeSupport,
+                deps.localStorage,
+                isAborted,
+            );
+            const videoCompression = new VideoCompressionService(
+                deps.localStorage,
+                isAborted,
+            );
+            const prepared: PreparedUploadFile[] = [];
+
+            for (let index = 0; index < files.length; index += 1) {
+                const original = files[index];
+                if (params.signal.aborted) {
+                    throw new DOMException("The host media operation was aborted.", "AbortError");
+                }
+                if (
+                    original.size > MAX_FILE_SIZE ||
+                    (!original.type.startsWith("image/") && !original.type.startsWith("video/"))
+                ) {
+                    // Let the existing placeholder validation present the localized error.
+                    prepared.push({ file: original, index });
+                    continue;
+                }
+
+                const ox = await calculateSHA256Hex(original, deps.crypto, isAborted)
+                    .catch(() => undefined);
+                const compression = original.type.startsWith("video/")
+                    ? videoCompression
+                    : imageCompression;
+                const result = await compression.compress(original);
+                if (result.aborted || params.signal.aborted) {
+                    throw new DOMException("The host media operation was aborted.", "AbortError");
+                }
+                const dimensions = result.file.type.startsWith("image/")
+                    ? await getImageDimensions(result.file)
+                    : null;
+                metadataByFile.set(result.file, {
+                    originalName: original.name,
+                    originalSize: original.size,
+                    originalType: original.type,
+                    processedName: result.file.name,
+                    processedSize: result.file.size,
+                    processedType: result.file.type,
+                    ...(ox ? { ox } : {}),
+                    ...(dimensions ? { width: dimensions.width, height: dimensions.height } : {}),
+                });
+                if (dimensions) dimensionsByFile.set(result.file, dimensions);
+                prepared.push({
+                    file: result.file,
+                    index,
+                    ...(ox ? { ox } : {}),
+                    ...(dimensions ? { dimensions } : {}),
+                });
+            }
+
+            return prepared;
+        },
+
+        async uploadPreparedFiles(files, placeholders) {
+            const placeholderByFile = new Map(
+                placeholders.map((placeholder) => [placeholder.file, placeholder]),
+            );
+            const results: FileUploadResponse[] = [];
+            for (const file of files) {
+                if (params.signal.aborted) {
+                    results.push({ success: false, aborted: true });
+                    continue;
+                }
+                const placeholder = placeholderByFile.get(file);
+                const base = metadataByFile.get(file) ?? {
+                    originalName: file.name,
+                    originalSize: file.size,
+                    originalType: file.type,
+                    processedName: file.name,
+                    processedSize: file.size,
+                    processedType: file.type,
+                };
+                const metadata: EHagakiHostMediaMetadata = {
+                    ...base,
+                    ...(placeholder?.blurhash ? { blurhash: placeholder.blurhash } : {}),
+                };
+
+                try {
+                    const response = await params.uploadMedia(file, metadata, {
+                        signal: params.signal,
+                    });
+                    if (params.signal.aborted) {
+                        results.push({ success: false, aborted: true });
+                        continue;
+                    }
+                    if (!isHttpUrl(response?.url)) {
+                        results.push({ success: false, error: "host_media_invalid_result" });
+                        continue;
+                    }
+                    const imeta = sanitizeImeta(response.imeta);
+                    results.push({
+                        success: true,
+                        url: response.url,
+                        nip94: {
+                            ...imeta,
+                            size: imeta.size ?? String(file.size),
+                            ...(metadata.width && metadata.height
+                                ? { dim: imeta.dim ?? `${metadata.width}x${metadata.height}` }
+                                : {}),
+                        },
+                        ...(dimensionsByFile.get(file)
+                            ? { dimensions: dimensionsByFile.get(file)! }
+                            : metadata.width && metadata.height
+                                ? { dimensions: calculateImageDisplaySize(metadata.width, metadata.height) }
+                                : {}),
+                        uploadProtocol: "custom-http",
+                        sizeInfo: {
+                            originalSize: metadata.originalSize,
+                            compressedSize: file.size,
+                            wasCompressed: metadata.originalSize !== file.size,
+                            compressionRatio: metadata.originalSize
+                                ? file.size / metadata.originalSize
+                                : 1,
+                            sizeReduction: "",
+                            originalFilename: metadata.originalName,
+                            compressedFilename: file.name,
+                        },
+                    });
+                } catch (error) {
+                    results.push({
+                        success: false,
+                        ...(params.signal.aborted ? { aborted: true } : {}),
+                        error: error instanceof Error ? error.message : "host_media_upload_failed",
+                    });
+                }
+            }
+            return results;
+        },
+    };
+}

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -405,6 +405,7 @@
     "clear_editor": "Clear editor",
     "upload_image": "Upload media",
     "upload_failed": "Upload failed",
+    "media_not_supported": "Media upload is not available in this composer.",
     "nip96InvalidDestinationUrl": "The NIP-96 upload destination URL is invalid",
     "nip96UploadRequestBlocked": "The upload was stopped because the destination response could not be handled safely. Completion could not be confirmed. For a custom server, check its direct upload URL.",
     "nip96InvalidProcessingUrl": "The processing URL returned by the upload server is invalid",

--- a/src/lib/i18n/ja.json
+++ b/src/lib/i18n/ja.json
@@ -405,6 +405,7 @@
     "clear_editor": "エディターをクリア",
     "upload_image": "メディアアップロード",
     "upload_failed": "アップロードに失敗しました",
+    "media_not_supported": "このコンポーザーではメディアアップロードを利用できません。",
     "nip96InvalidDestinationUrl": "NIP-96 のアップロード先 URL が無効です",
     "nip96UploadRequestBlocked": "アップロード先の応答を安全に処理できなかったため中止しました。アップロード完了は確認できません。カスタムサーバーでは直接アップロードできる URL を確認してください。",
     "nip96InvalidProcessingUrl": "アップロードサーバーが返した処理 URL が無効です",

--- a/src/lib/postUploadUtils.ts
+++ b/src/lib/postUploadUtils.ts
@@ -22,6 +22,7 @@ interface CreatePostUploadHandlersParams {
     getImageXMap: () => Record<string, string>;
     getUploadFailedText: (key: string) => string;
     updateUploadState: (isUploading: boolean, message?: string) => void;
+    setUploadErrorMessage: (message: string) => void;
     uploadFiles?: UploadFilesExecutor;
 }
 
@@ -50,6 +51,7 @@ export function createPostUploadHandlers({
     getImageXMap,
     getUploadFailedText,
     updateUploadState,
+    setUploadErrorMessage,
     uploadFiles = uploadFilesHelper,
 }: CreatePostUploadHandlersParams) {
     const performUpload = async (files: UploadableFiles): Promise<UploadHelperResult | null> => {
@@ -62,6 +64,7 @@ export function createPostUploadHandlers({
             currentEditor: getCurrentEditor(),
             fileInput: getFileInput(),
             updateUploadState,
+            setUploadErrorMessage,
             imageOxMap: getImageOxMap(),
             imageXMap: getImageXMap(),
             getUploadFailedText,

--- a/src/lib/types/editor.ts
+++ b/src/lib/types/editor.ts
@@ -117,6 +117,7 @@ export interface InitializeEditorParams {
     editorContainerEl: HTMLElement | null;
     currentEditor: TipTapEditor | null;
     hasStoredKey: boolean;
+    hasPostingCapability?: boolean;
     submitPost: () => Promise<void>;
     onCustomEmojiSelect?: (emoji: CustomEmojiSelection) => void;
     getCustomEmojiItems?: () => CustomEmojiItem[];

--- a/src/lib/types/editor.ts
+++ b/src/lib/types/editor.ts
@@ -4,6 +4,7 @@ import type { Editor as TipTapEditor } from "@tiptap/core";
 import type { MediaGalleryItem } from "./media";
 import type { ChannelContextState } from "./nostr";
 import type { CustomEmojiSelection } from "../customEmojiUsage";
+import type { CustomEmojiItem } from "../customEmoji";
 
 // Post and Editor types
 export interface PostStatus {
@@ -118,7 +119,8 @@ export interface InitializeEditorParams {
     hasStoredKey: boolean;
     submitPost: () => Promise<void>;
     onCustomEmojiSelect?: (emoji: CustomEmojiSelection) => void;
-    uploadFiles: (files: File[] | FileList) => void;
+    getCustomEmojiItems?: () => CustomEmojiItem[];
+    uploadFiles?: (files: File[] | FileList) => void;
     eventCallbacks: EditorEventCallbacks;
 }
 

--- a/src/lib/types/upload.ts
+++ b/src/lib/types/upload.ts
@@ -42,6 +42,8 @@ export interface FileValidationResult {
 
 export interface FileUploadResponse {
     success: boolean;
+    /** Internal provenance marker for results produced by Host-owned uploadMedia. */
+    hostOwnedMedia?: boolean;
     url?: string;
     error?: string;
     errorCode?: UploadErrorCode;

--- a/src/lib/types/upload.ts
+++ b/src/lib/types/upload.ts
@@ -274,8 +274,12 @@ export interface UploadHelperParams {
     uploadCallbacks?: UploadInfoCallbacks | undefined;
     showUploadError: (msg: string, duration?: number) => void;
     updateUploadState: (isUploading: boolean, message?: string) => void;
+    /** Updates only the visible error message, without changing upload ownership. */
+    setUploadErrorMessage?: (message: string) => void;
     devMode: boolean;
     dependencies?: UploadHelperDependencies;
+    /** Optional operation-local abort/ownership predicate. */
+    isUploadAborted?: () => boolean;
     /** Local Host-owned seam: preprocessing remains in eHagaki while transport is supplied by the host. */
     prepareFiles?: (
         files: File[],

--- a/src/lib/types/upload.ts
+++ b/src/lib/types/upload.ts
@@ -260,6 +260,13 @@ export interface UploadHelperDependencies {
     resolveUploadDestination?: () => Promise<UploadDestination>;
 }
 
+export interface PreparedUploadFile {
+    file: File;
+    index: number;
+    ox?: string;
+    dimensions?: ImageDimensions;
+}
+
 export interface UploadHelperParams {
     files: File[] | FileList;
     currentEditor: TipTapEditor | null;
@@ -269,4 +276,17 @@ export interface UploadHelperParams {
     updateUploadState: (isUploading: boolean, message?: string) => void;
     devMode: boolean;
     dependencies?: UploadHelperDependencies;
+    /** Local Host-owned seam: preprocessing remains in eHagaki while transport is supplied by the host. */
+    prepareFiles?: (
+        files: File[],
+        dependencies: UploadHelperDependencies,
+    ) => Promise<PreparedUploadFile[]>;
+    uploadPreparedFiles?: (
+        files: File[],
+        placeholders: PlaceholderEntry[],
+    ) => Promise<FileUploadResponse[]>;
+    /** A local media-only manager for a transport that does not use Nostr auth. */
+    fileUploadManager?: UploadHelperDependencies["FileUploadManager"];
+    /** The UI wrapper keeps `isUploading` through its post-upload cleanup. */
+    deferUploadStateClear?: boolean;
 }

--- a/src/lib/uploadAbortHandling.ts
+++ b/src/lib/uploadAbortHandling.ts
@@ -22,6 +22,7 @@ export interface UploadAbortContext {
     devMode: boolean;
     galleryCleanup?: GalleryCleanupContext;
     notifyAbortProgress?: (fileCount: number) => void;
+    deferUploadStateClear?: boolean;
 }
 
 export interface AbortCheckpointParams {
@@ -50,13 +51,14 @@ export function handleAbortedUpload(
     context: UploadAbortContext,
     { placeholderMap, cleanupPlaceholders }: AbortCheckpointParams,
 ): UploadHelperResult {
-    context.updateUploadState(false);
-
     if (cleanupPlaceholders) {
         cleanupUploadPlaceholders(context, placeholderMap);
     }
 
     context.notifyAbortProgress?.(context.fileArray.length);
+    if (!context.deferUploadStateClear) {
+        context.updateUploadState(false);
+    }
 
     return {
         placeholderMap: cleanupPlaceholders ? [] : placeholderMap,

--- a/src/lib/uploadHelper.ts
+++ b/src/lib/uploadHelper.ts
@@ -304,10 +304,17 @@ export async function uploadHelper({
     uploadPreparedFiles,
     fileUploadManager: fileUploadManagerOverride,
     deferUploadStateClear = false,
+    isUploadAborted: operationAbortChecker,
 }: UploadHelperParams): Promise<UploadHelperResult> {
+    const effectiveDependencies = operationAbortChecker
+        ? { ...dependencies, isUploadAborted: operationAbortChecker }
+        : dependencies;
+    const isUploadAborted = operationAbortChecker
+        ?? dependencies.isUploadAborted
+        ?? isDefaultUploadAborted;
     const fileArray = Array.from(files);
     const FileUploadManagerConstructor = fileUploadManagerOverride
-        ?? dependencies.FileUploadManager;
+        ?? effectiveDependencies.FileUploadManager;
     const managedUploadCallbacks = createManagedUploadCallbacks(uploadCallbacks);
     // Host-owned transport deliberately has no eHagaki upload-destination,
     // authentication, or relay resolution path.
@@ -333,8 +340,8 @@ export async function uploadHelper({
     let fileProcessingResults;
     try {
         fileProcessingResults = prepareFiles
-            ? await prepareFiles(fileArray, dependencies)
-            : await processFilesForUpload(fileArray, dependencies);
+            ? await prepareFiles(fileArray, effectiveDependencies)
+            : await processFilesForUpload(fileArray, effectiveDependencies);
     } catch (error) {
         // 中止された場合
         if (error instanceof Error && error.message === 'Upload aborted by user') {
@@ -368,7 +375,7 @@ export async function uploadHelper({
     const galleryMode = !mediaFreePlacementStore.value;
     const galleryCleanup = createGalleryCleanupContext(
         galleryMode,
-        dependencies.imageSizeMapStore,
+        effectiveDependencies.imageSizeMapStore,
     );
     const checkAbort = createAbortCheckpointChecker({
         fileArray,
@@ -376,7 +383,7 @@ export async function uploadHelper({
         updateUploadState,
         devMode,
         galleryCleanup,
-        isUploadAborted: dependencies.isUploadAborted,
+        isUploadAborted,
         deferUploadStateClear,
         notifyAbortProgress: (fileCount) => {
             notifyUploadProgress(
@@ -445,7 +452,7 @@ export async function uploadHelper({
         placeholderMap,
         FileUploadManagerConstructor,
         devMode,
-        dependencies.isUploadAborted,
+        isUploadAborted,
     );
 
     // 中止チェック（Blurhash生成後）
@@ -461,7 +468,7 @@ export async function uploadHelper({
     const validFiles = placeholderMap.map((entry: PlaceholderEntry) => entry.file);
     let results: FileUploadResponse[] | null = null;
     const fileUploadManager = createFileUploadManager(
-        dependencies,
+        effectiveDependencies,
         FileUploadManagerConstructor,
     );
 
@@ -497,7 +504,7 @@ export async function uploadHelper({
         return abortAfterUpload;
     }
 
-    await dependencies.tick();
+    await effectiveDependencies.tick();
 
     // プレースホルダー置換・失敗時削除
     const replacementOutcome = await replaceUploadedPlaceholders({
@@ -507,9 +514,9 @@ export async function uploadHelper({
         currentEditor: currentEditor as TipTapEditor | null,
         imageOxMap,
         imageXMap,
-        imageSizeMapStore: dependencies.imageSizeMapStore,
-        calculateImageHash: dependencies.calculateImageHash,
-        getMimeTypeFromUrl: dependencies.getMimeTypeFromUrl,
+        imageSizeMapStore: effectiveDependencies.imageSizeMapStore,
+        calculateImageHash: effectiveDependencies.calculateImageHash,
+        getMimeTypeFromUrl: effectiveDependencies.getMimeTypeFromUrl,
         devMode,
     });
     const failedResults = [...replacementOutcome.failedResults];
@@ -529,7 +536,7 @@ export async function uploadHelper({
                 imageServerBlurhashMap,
                 imageOxMap,
                 imageXMap,
-                dependencies,
+                dependencies: effectiveDependencies,
             });
         } catch {
             console.warn(`${modeLabel} [dev] imetaタグ生成失敗`, {
@@ -559,6 +566,7 @@ export async function uploadHelper({
 
 export interface ShowUploadErrorMessageParams {
     updateUploadState: (isUploading: boolean, message?: string) => void;
+    setUploadErrorMessage: (message: string) => void;
     keepUploading?: boolean;
 }
 
@@ -569,7 +577,7 @@ export function showUploadErrorMessage(
 ) {
     const isUploading = params.keepUploading ?? false;
     params.updateUploadState(isUploading, message);
-    setTimeout(() => params.updateUploadState(isUploading, ""), duration);
+    setTimeout(() => params.setUploadErrorMessage(""), duration);
 }
 
 export interface PerformFileUploadParams {
@@ -578,6 +586,7 @@ export interface PerformFileUploadParams {
     fileInput?: HTMLInputElement;
     uploadCallbacks?: UploadInfoCallbacks;
     updateUploadState: (isUploading: boolean, message?: string) => void;
+    setUploadErrorMessage: (message: string) => void;
     devMode: boolean;
     imageOxMap: Record<string, string>;
     imageXMap: Record<string, string>;
@@ -592,6 +601,7 @@ export async function performFileUpload(params: PerformFileUploadParams): Promis
         fileInput,
         uploadCallbacks,
         updateUploadState,
+        setUploadErrorMessage,
         devMode,
         imageOxMap,
         imageXMap,
@@ -612,6 +622,7 @@ export async function performFileUpload(params: PerformFileUploadParams): Promis
             showUploadError: (msg: string, duration?: number) =>
                 showUploadErrorMessage(msg, duration, {
                     updateUploadState,
+                    setUploadErrorMessage,
                     keepUploading: true,
                 }),
             updateUploadState,
@@ -634,7 +645,7 @@ export async function performFileUpload(params: PerformFileUploadParams): Promis
                 (errorCode) => getUploadFailedText(`postComponent.${errorCode}`),
             ) || result.errorMessage,
             5000,
-            { updateUploadState }
+            { updateUploadState, setUploadErrorMessage }
         );
     }
     if (fileInput) fileInput.value = "";
@@ -646,6 +657,7 @@ export interface UploadFilesParams {
     currentEditor: TipTapEditor | null;
     fileInput?: HTMLInputElement;
     updateUploadState: (isUploading: boolean, message?: string) => void;
+    setUploadErrorMessage: (message: string) => void;
     imageOxMap: Record<string, string>;
     imageXMap: Record<string, string>;
     getUploadFailedText: (key: string) => string;
@@ -658,6 +670,7 @@ export async function uploadFiles(params: UploadFilesParams): Promise<UploadHelp
         currentEditor,
         fileInput,
         updateUploadState,
+        setUploadErrorMessage,
         imageOxMap,
         imageXMap,
         getUploadFailedText,
@@ -669,6 +682,7 @@ export async function uploadFiles(params: UploadFilesParams): Promise<UploadHelp
         currentEditor,
         fileInput,
         updateUploadState,
+        setUploadErrorMessage,
         devMode: import.meta.env.MODE === "development",
         imageOxMap,
         imageXMap,

--- a/src/lib/uploadHelper.ts
+++ b/src/lib/uploadHelper.ts
@@ -56,11 +56,12 @@ import { getAppStorage } from "./appStorage";
 
 function createFileUploadManager(
     dependencies: UploadHelperDependencies,
+    FileUploadManagerConstructor = dependencies.FileUploadManager,
 ): FileUploadManagerInterface {
     const isUploadAborted = dependencies.isUploadAborted ?? isDefaultUploadAborted;
 
     if (
-        dependencies.FileUploadManager ===
+        FileUploadManagerConstructor ===
         (FileUploadManager as unknown as UploadHelperDependencies["FileUploadManager"])
     ) {
         const mimeSupport = new MimeTypeSupport(
@@ -96,7 +97,7 @@ function createFileUploadManager(
         );
     }
 
-    return new dependencies.FileUploadManager();
+    return new FileUploadManagerConstructor();
 }
 
 function getCurrentUploadDestinationIdentity(): {
@@ -299,10 +300,20 @@ export async function uploadHelper({
     updateUploadState,
     devMode,
     dependencies = createDefaultDependencies(),
+    prepareFiles,
+    uploadPreparedFiles,
+    fileUploadManager: fileUploadManagerOverride,
+    deferUploadStateClear = false,
 }: UploadHelperParams): Promise<UploadHelperResult> {
     const fileArray = Array.from(files);
+    const FileUploadManagerConstructor = fileUploadManagerOverride
+        ?? dependencies.FileUploadManager;
     const managedUploadCallbacks = createManagedUploadCallbacks(uploadCallbacks);
-    const uploadDestination = await dependencies.resolveUploadDestination?.();
+    // Host-owned transport deliberately has no eHagaki upload-destination,
+    // authentication, or relay resolution path.
+    const uploadDestination = uploadPreparedFiles
+        ? undefined
+        : await dependencies.resolveUploadDestination?.();
     const endpoint = getDestinationUploadEndpoint(uploadDestination) || "";
     const imageOxMap: Record<string, string> = {};
     const imageXMap: Record<string, string> = {};
@@ -321,7 +332,9 @@ export async function uploadHelper({
     // ファイル処理
     let fileProcessingResults;
     try {
-        fileProcessingResults = await processFilesForUpload(fileArray, dependencies);
+        fileProcessingResults = prepareFiles
+            ? await prepareFiles(fileArray, dependencies)
+            : await processFilesForUpload(fileArray, dependencies);
     } catch (error) {
         // 中止された場合
         if (error instanceof Error && error.message === 'Upload aborted by user') {
@@ -330,6 +343,7 @@ export async function uploadHelper({
                     fileArray,
                     currentEditor,
                     updateUploadState,
+                    deferUploadStateClear,
                     devMode,
                     notifyAbortProgress: (fileCount) => {
                         notifyUploadProgress(
@@ -363,6 +377,7 @@ export async function uploadHelper({
         devMode,
         galleryCleanup,
         isUploadAborted: dependencies.isUploadAborted,
+        deferUploadStateClear,
         notifyAbortProgress: (fileCount) => {
             notifyUploadProgress(
                 managedUploadCallbacks,
@@ -388,7 +403,7 @@ export async function uploadHelper({
             fileProcessingResults,
             showUploadError,
             dependencies.imageSizeMapStore,
-            dependencies.FileUploadManager,
+            FileUploadManagerConstructor,
             devMode
         )
         : insertPlaceholdersIntoEditor(
@@ -397,7 +412,7 @@ export async function uploadHelper({
             currentEditor as TipTapEditor | null,
             showUploadError,
             dependencies.imageSizeMapStore,
-            dependencies.FileUploadManager,
+            FileUploadManagerConstructor,
             devMode
         );
 
@@ -428,7 +443,7 @@ export async function uploadHelper({
     // Blurhash生成
     await generateBlurhashes(
         placeholderMap,
-        dependencies.FileUploadManager,
+        FileUploadManagerConstructor,
         devMode,
         dependencies.isUploadAborted,
     );
@@ -445,25 +460,31 @@ export async function uploadHelper({
     // アップロード処理
     const validFiles = placeholderMap.map((entry: PlaceholderEntry) => entry.file);
     let results: FileUploadResponse[] | null = null;
-    const fileUploadManager = createFileUploadManager(dependencies);
+    const fileUploadManager = createFileUploadManager(
+        dependencies,
+        FileUploadManagerConstructor,
+    );
 
     try {
         const metadataList = prepareMetadataList(validFiles);
-        results = await uploadValidFiles(
-            fileUploadManager,
-            validFiles,
-            endpoint,
-            managedUploadCallbacks,
-            metadataList,
-            devMode,
-            uploadDestination,
-        );
+        results = uploadPreparedFiles
+            ? await uploadPreparedFiles(validFiles, placeholderMap)
+            : await uploadValidFiles(
+                fileUploadManager,
+                validFiles,
+                endpoint,
+                managedUploadCallbacks,
+                metadataList,
+                devMode,
+                uploadDestination,
+            );
     } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error);
         showUploadError(errorMsg, 5000);
         results = null;
     } finally {
-        updateUploadState(false);
+        // The caller owns the operation lifetime. Keeping this state true
+        // through placeholder replacement prevents submit from racing media.
     }
 
     // 中止された場合は後続処理をスキップ
@@ -520,6 +541,10 @@ export async function uploadHelper({
 
     if (fileInput) fileInput.value = "";
 
+    if (!deferUploadStateClear) {
+        updateUploadState(false);
+    }
+
     return {
         placeholderMap,
         results,
@@ -534,6 +559,7 @@ export async function uploadHelper({
 
 export interface ShowUploadErrorMessageParams {
     updateUploadState: (isUploading: boolean, message?: string) => void;
+    keepUploading?: boolean;
 }
 
 export function showUploadErrorMessage(
@@ -541,8 +567,9 @@ export function showUploadErrorMessage(
     duration = 3000,
     params: ShowUploadErrorMessageParams
 ) {
-    params.updateUploadState(false, message);
-    setTimeout(() => params.updateUploadState(false, ""), duration);
+    const isUploading = params.keepUploading ?? false;
+    params.updateUploadState(isUploading, message);
+    setTimeout(() => params.updateUploadState(isUploading, ""), duration);
 }
 
 export interface PerformFileUploadParams {
@@ -574,17 +601,27 @@ export async function performFileUpload(params: PerformFileUploadParams): Promis
 
     if (!files || files.length === 0) return null;
 
-    const result: UploadHelperResult = await uploadHelper({
-        files,
-        currentEditor,
-        fileInput,
-        uploadCallbacks,
-        showUploadError: (msg: string, duration?: number) =>
-            showUploadErrorMessage(msg, duration, { updateUploadState }),
-        updateUploadState,
-        devMode,
-        dependencies,
-    });
+    updateUploadState(true, "");
+    let result: UploadHelperResult;
+    try {
+        result = await uploadHelper({
+            files,
+            currentEditor,
+            fileInput,
+            uploadCallbacks,
+            showUploadError: (msg: string, duration?: number) =>
+                showUploadErrorMessage(msg, duration, {
+                    updateUploadState,
+                    keepUploading: true,
+                }),
+            updateUploadState,
+            devMode,
+            dependencies,
+            deferUploadStateClear: true,
+        });
+    } finally {
+        updateUploadState(false);
+    }
 
     Object.assign(imageOxMap, result.imageOxMap);
     Object.assign(imageXMap, result.imageXMap);

--- a/src/stores/mediaGalleryStore.svelte.ts
+++ b/src/stores/mediaGalleryStore.svelte.ts
@@ -60,6 +60,44 @@ export const mediaGalleryStore = {
         return result;
     },
 
+    /** 投稿用の imeta メタデータを画像・動画の双方から返す（Host-owned用） */
+    getMediaImetaMap: (): Record<string, {
+        m: string;
+        blurhash?: string;
+        ox?: string;
+        x?: string;
+        dim?: string;
+        alt?: string;
+        size?: number;
+        uploadProtocol?: 'blossom' | 'nip96' | 'custom-http';
+    }> => {
+        const result: Record<string, {
+            m: string;
+            blurhash?: string;
+            ox?: string;
+            x?: string;
+            dim?: string;
+            alt?: string;
+            size?: number;
+            uploadProtocol?: 'blossom' | 'nip96' | 'custom-http';
+        }> = {};
+        for (const item of mediaGalleryItems) {
+            if (!item.isPlaceholder && item.src && item.mimeType) {
+                result[item.src] = {
+                    m: item.mimeType,
+                    blurhash: item.blurhash,
+                    ox: item.ox,
+                    x: item.x,
+                    dim: item.dim,
+                    alt: item.alt,
+                    size: item.size,
+                    uploadProtocol: item.uploadProtocol,
+                };
+            }
+        }
+        return result;
+    },
+
     hasItems: () => mediaGalleryItems.length > 0,
 
     hasNonPlaceholderItems: () => mediaGalleryItems.some(item => !item.isPlaceholder),

--- a/src/stores/replyQuoteStore.svelte.ts
+++ b/src/stores/replyQuoteStore.svelte.ts
@@ -292,6 +292,24 @@ export function setReplyQuoteError(target: ReplyQuoteUpdateTarget, error: string
     if (matched) notifyReplyQuoteChanged();
 }
 
+/**
+ * Host-owned Composer has no relay-backed hydration source. Preserve the
+ * selected reference while making the preview a stable reference-only value.
+ */
+export function settleReplyQuoteReferencesWithoutHydration(
+    targets: ReplyQuoteHydrationTarget[],
+): void {
+    let changed = false;
+    for (const target of targets) {
+        changed = updateMatchingReferences(target, (reference) => {
+            reference.referencedEvent = null;
+            reference.loading = false;
+            reference.error = null;
+        }) || changed;
+    }
+    if (changed) notifyReplyQuoteChanged();
+}
+
 export function updateAuthorProfile(
     target: ReplyQuoteUpdateTarget,
     pubkey: string,

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -1527,7 +1527,7 @@ test("hands Host-owned output to the host without relay startup and retains its 
             previewCount: shadow.querySelectorAll(".reply-quote-preview").length,
             loadingCount: shadow.querySelectorAll(".loading-status").length,
             hasFileInput: !!shadow.querySelector('input[type="file"]'),
-            imageButtonDisabled: shadow.querySelector<HTMLButtonElement>("button.image-button")?.disabled,
+            hasImageButton: !!shadow.querySelector("button.image-button"),
             hasLoginButton: !!shadow.querySelector("button.login-btn"),
             webSocketCalls: state.webSocketCalls,
         };
@@ -1537,7 +1537,7 @@ test("hands Host-owned output to the host without relay startup and retains its 
     expect(initial.previewCount).toBe(2);
     expect(initial.loadingCount).toBe(0);
     expect(initial.hasFileInput).toBe(false);
-    expect(initial.imageButtonDisabled).toBe(true);
+    expect(initial.hasImageButton).toBe(false);
     expect(initial.hasLoginButton).toBe(false);
     expect(initial.webSocketCalls).toBe(0);
 
@@ -1610,10 +1610,247 @@ test("hands Host-owned output to the host without relay startup and retains its 
         reply,
         quotes: [quote],
     });
-    expect(result.successEvent?.detail).toMatchObject({ eventId: "b".repeat(64) });
+    expect(result.successEvent?.detail).toMatchObject({
+        eventId: "b".repeat(64),
+        replyToEventId: replyEventId,
+        quotedEventIds: [quoteEventId],
+    });
     expect(result.webSocketCalls).toBe(0);
     expect(result.reconnectedHasFileInput).toBe(false);
     expect(result.reconnectedHasLoginButton).toBe(false);
+});
+
+test("runs Host-owned media preprocessing and transport without self-upload fallback", async ({ page }) => {
+    await page.goto(hostOrigin);
+    await page.evaluate(async () => {
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        const state = {
+            uploads: [] as Array<{ name: string; metadata: any }> ,
+            outputs: [] as any[],
+        };
+        (window as any).__hostOwnedMediaState = state;
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+            setSettings(value: unknown): Promise<unknown>;
+            configureHostOwned(options: unknown): void;
+        };
+        composer.configureHostOwned({
+            uploadMedia: async (file: File, metadata: unknown) => {
+                state.uploads.push({ name: file.name, metadata });
+                return { url: "https://host.example/media/processed.png" };
+            },
+            submit: async (output: unknown) => {
+                state.outputs.push(output);
+            },
+        });
+        document.body.append(composer);
+        await composer.whenReady();
+        await composer.setSettings({
+            imageCompressionLevel: "none",
+            videoCompressionLevel: "none",
+            mediaFreePlacement: true,
+        });
+    });
+
+    const fileInput = page.locator("ehagaki-composer").locator('input[type="file"]');
+    await expect(fileInput).toHaveCount(1);
+    await fileInput.setInputFiles({
+        name: "host-input.png",
+        mimeType: "image/png",
+        buffer: Buffer.from(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+            "base64",
+        ),
+    });
+    await expect.poll(() => page.evaluate(() => (window as any).__hostOwnedMediaState.uploads.length)).toBe(1);
+    await expect(page.locator("ehagaki-composer .tiptap-editor img[src='https://host.example/media/processed.png']")).toHaveCount(1);
+
+    const editor = page.locator("ehagaki-composer .tiptap-editor");
+    await editor.click();
+    await editor.pressSequentially("host media body");
+    await page.locator("ehagaki-composer button.post-button").click();
+    await expect.poll(() => page.evaluate(() => (window as any).__hostOwnedMediaState.outputs.length)).toBe(1);
+
+    const result = await page.evaluate(() => (window as any).__hostOwnedMediaState);
+    expect(result.uploads[0].name).toBe("host-input.png");
+    expect(result.uploads[0].metadata).toMatchObject({
+        originalName: "host-input.png",
+        originalType: "image/png",
+        processedType: "image/png",
+    });
+    expect(result.outputs[0].content).toContain("host media body");
+    expect(result.outputs[0].content).toContain("https://host.example/media/processed.png");
+});
+
+test("does not let a disconnected Host-owned upload settle into a later mount", async ({ page }) => {
+    await page.goto(hostOrigin);
+    await page.evaluate(async () => {
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        type HostComposer = HTMLElement & {
+            whenReady(): Promise<void>;
+            setSettings(value: unknown): Promise<unknown>;
+            configureHostOwned(options: unknown): void;
+        };
+        let resolveOld: (() => void) | undefined;
+        const oldSettled = new Promise<void>((resolve) => { resolveOld = resolve; });
+        let resolveCurrent: (() => void) | undefined;
+        const currentSettled = new Promise<void>((resolve) => { resolveCurrent = resolve; });
+        const state = { uploads: 0, submits: 0, errors: 0 };
+        (window as any).__hostOwnedStaleState = state;
+
+        const create = () => {
+            const composer = document.createElement("ehagaki-composer") as HostComposer;
+            composer.configureHostOwned({
+                uploadMedia: async () => {
+                    state.uploads += 1;
+                    if (state.uploads === 1) {
+                        await oldSettled;
+                        return { url: "https://host.example/stale.png" };
+                    }
+                    await currentSettled;
+                    return { url: "https://host.example/current.png" };
+                },
+                submit: async () => { state.submits += 1; },
+            });
+            document.body.append(composer);
+            return composer;
+        };
+
+        const first = create();
+        await first.whenReady();
+        await first.setSettings({ imageCompressionLevel: "none", mediaFreePlacement: true });
+
+        (window as any).__hostOwnedStaleComposer = first;
+        (window as any).__hostOwnedStaleControls = {
+            releaseOld: () => resolveOld?.(),
+            releaseCurrent: () => resolveCurrent?.(),
+        };
+    });
+
+    const png = {
+        name: "stale.png",
+        mimeType: "image/png",
+        buffer: Buffer.from(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+            "base64",
+        ),
+    };
+    await page.locator("ehagaki-composer").nth(0).locator('input[type="file"]').setInputFiles(png);
+    await expect.poll(() => page.evaluate(() => (window as any).__hostOwnedStaleState.uploads)).toBe(1);
+
+    // Reconnect the same configured element, then start a second upload while
+    // the first handler is still ignoring its aborted signal.
+    await page.locator("ehagaki-composer").nth(0).evaluate((element) => element.remove());
+    await page.evaluate(async () => {
+        const composer = (window as any).__hostOwnedStaleComposer as HTMLElement & {
+            whenReady(): Promise<void>;
+            setSettings(value: unknown): Promise<unknown>;
+        };
+        document.body.append(composer);
+        await composer.whenReady();
+        await composer.setSettings({ imageCompressionLevel: "none", mediaFreePlacement: true });
+    });
+    await page.locator("ehagaki-composer").nth(0).locator('input[type="file"]').setInputFiles({ ...png, name: "current.png" });
+    await expect.poll(() => page.evaluate(() => (window as any).__hostOwnedStaleState.uploads)).toBe(2);
+
+    await page.evaluate(() => (window as any).__hostOwnedStaleControls.releaseOld());
+    await expect.poll(() => page.locator("ehagaki-composer").locator("button.post-button").isDisabled()).toBe(true);
+    await page.evaluate(() => (window as any).__hostOwnedStaleControls.releaseCurrent());
+    await expect(page.locator("ehagaki-composer .tiptap-editor img[src='https://host.example/current.png']")).toHaveCount(1);
+    const editor = page.locator("ehagaki-composer .tiptap-editor");
+    await editor.click();
+    await editor.pressSequentially("current upload body");
+    await page.locator("ehagaki-composer button.post-button").click();
+    await expect.poll(() => page.evaluate(() => (window as any).__hostOwnedStaleState.submits)).toBe(1);
+
+    const result = await page.evaluate(() => (window as any).__hostOwnedStaleState);
+
+    expect(result.uploads).toBe(2);
+    expect(result.submits).toBe(1);
+    expect(result.errors).toBe(0);
+    await expect(page.locator("ehagaki-composer img[src='https://host.example/stale.png']")).toHaveCount(0);
+    await expect(page.locator("ehagaki-composer .upload-error")).toHaveCount(0);
+});
+
+test("keeps Host-owned capability separate from a previous authenticated Web Component instance", async ({ page }) => {
+    await page.goto(hostOrigin);
+    const previousPubkey = "3".repeat(64);
+    await page.evaluate(async ({ previousPubkey, relayOrigin, componentStoragePrefix }) => {
+        const nativeWebSocket = window.WebSocket;
+        window.WebSocket = new Proxy(nativeWebSocket, {
+            construct(target, args, newTarget) {
+                const [url, protocols] = args as [string | URL, string | string[] | undefined];
+                if (/^wss?:\/\//.test(String(url))) {
+                    return Reflect.construct(
+                        target,
+                        [relayOrigin, protocols].filter((value) => value !== undefined),
+                        newTarget,
+                    );
+                }
+                return Reflect.construct(target, args, newTarget);
+            },
+        });
+        window.nostr = {
+            getPublicKey: async () => previousPubkey,
+            signEvent: async (event: any) => ({ ...event, id: "4".repeat(64), sig: "5".repeat(64) }),
+        };
+        localStorage.setItem(
+            `${componentStoragePrefix}nostr-accounts`,
+            JSON.stringify([{ pubkeyHex: previousPubkey, type: "nip07", addedAt: 1 }]),
+        );
+        localStorage.setItem(`${componentStoragePrefix}nostr-active-account`, previousPubkey);
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+
+        const self = document.createElement("ehagaki-composer") as HTMLElement & { whenReady(): Promise<void> };
+        document.body.append(self);
+        await self.whenReady();
+        (window as any).__previousAuthenticatedComposer = self;
+    }, { previousPubkey, relayOrigin, componentStoragePrefix });
+
+    const selfComposer = page.locator("ehagaki-composer");
+    await expect(selfComposer.locator(".post-history-btn")).toHaveCount(1);
+    const relayCountAfterSelf = relayConnectionCount;
+
+    await selfComposer.evaluate((element) => element.remove());
+    await page.evaluate(async () => {
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+            setCustomEmojis(catalog: unknown[]): Promise<void>;
+            configureHostOwned(options: unknown): void;
+        };
+        composer.configureHostOwned({ submit: async () => undefined });
+        document.body.append(composer);
+        await composer.whenReady();
+        await composer.setCustomEmojis([{ shortcode: "hostwave", url: "https://host.example/hostwave.webp" }]);
+    });
+
+    const hostComposer = page.locator("ehagaki-composer");
+    await expect(hostComposer.locator(".editor-account-placeholder")).toHaveCount(0);
+    await expect(hostComposer.locator(".post-history-btn")).toHaveCount(0);
+    await expect(hostComposer.locator("button.login-btn")).toHaveCount(0);
+    await expect.poll(() => relayConnectionCount).toBe(relayCountAfterSelf);
+
+    await hostComposer.locator("button.custom-emoji-button").click();
+    await expect(hostComposer.locator(".custom-emoji-picker .emoji-item img")).toHaveCount(1);
+    await hostComposer.locator(".custom-emoji-picker .emoji-item").click();
+    await page.waitForTimeout(50);
+
+    const storedUsage = await page.evaluate(async (previousPubkey) => {
+        const request = indexedDB.open("eHagakiDB");
+        const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+        const transaction = database.transaction("customEmojiUsage", "readonly");
+        const records = await new Promise<any[]>((resolve, reject) => {
+            const getAll = transaction.objectStore("customEmojiUsage").getAll();
+            getAll.onsuccess = () => resolve(getAll.result);
+            getAll.onerror = () => reject(getAll.error);
+        });
+        database.close();
+        return records.filter((record) => record.pubkeyHex === previousPubkey);
+    }, previousPubkey);
+    expect(storedUsage).toEqual([]);
 });
 
 test("loads the FFmpeg class worker, core, and WASM from a cross-origin Web Component build", async ({ page }) => {

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -1438,6 +1438,184 @@ test("queues setContext before ready and applies content and reply atomically", 
     expect(result.contentAfterInvalid).not.toContain("must not be applied");
 });
 
+test("hands Host-owned output to the host without relay startup and retains its immutable configuration on reconnect", async ({ page }) => {
+    await page.goto(hostOrigin);
+    const replyEventId = "1".repeat(64);
+    const quoteEventId = "2".repeat(64);
+    const reply = nip19.noteEncode(replyEventId);
+    const quote = nip19.noteEncode(quoteEventId);
+
+    const initial = await page.evaluate(async ({ reply, quote }) => {
+        await import(`${window.__componentOrigin}/ehagaki-composer.js`);
+        type HostComposer = HTMLElement & {
+            whenReady(): Promise<void>;
+            setContext(value: unknown): Promise<void>;
+            setCustomEmojis(catalog: unknown[]): Promise<void>;
+            configureHostOwned(options: {
+                submit: (output: unknown, options: { signal: AbortSignal }) => unknown;
+                uploadMedia?: unknown;
+            }): void;
+        };
+        const state = {
+            calls: [] as Array<{ output: any; frozen: boolean }>,
+            events: [] as Array<{ type: string; detail: any }>,
+            webSocketCalls: 0,
+            release: undefined as (() => void) | undefined,
+        };
+        (window as any).__hostOwnedTestState = state;
+        const nativeWebSocket = window.WebSocket;
+        window.WebSocket = new Proxy(nativeWebSocket, {
+            construct(target, args, newTarget) {
+                state.webSocketCalls += 1;
+                return Reflect.construct(target, args, newTarget);
+            },
+        });
+
+        const malformed = document.createElement("ehagaki-composer") as HostComposer;
+        const invalidBeforeConnect = (() => {
+            try {
+                malformed.configureHostOwned({} as any);
+                return "resolved";
+            } catch (error) {
+                return error instanceof Error ? error.name : String(error);
+            }
+        })();
+        malformed.configureHostOwned({ submit: () => undefined });
+
+        const composer = document.createElement("ehagaki-composer") as HostComposer;
+        composer.configureHostOwned({
+            async submit(output) {
+                state.calls.push({
+                    output: JSON.parse(JSON.stringify(output)),
+                    frozen: Object.isFrozen(output)
+                        && Object.isFrozen((output as any).tags)
+                        && Object.isFrozen((output as any).context)
+                        && Object.isFrozen((output as any).context.reply?.relayHints),
+                });
+                await new Promise<void>((resolve) => {
+                    state.release = resolve;
+                });
+                return { eventId: "b".repeat(64) };
+            },
+        });
+        const catalogReady = composer.setCustomEmojis([
+            { shortcode: "wave", url: "https://example.invalid/emoji/wave.webp" },
+        ]);
+        for (const type of [
+            "ehagaki-post-success",
+            "ehagaki-post-error",
+            "ehagaki-composer-context-updated",
+        ]) {
+            composer.addEventListener(type, (event) => {
+                state.events.push({ type, detail: (event as CustomEvent).detail });
+            });
+        }
+        composer.style.width = "360px";
+        composer.style.height = "600px";
+        document.body.append(composer);
+        await composer.whenReady();
+        await catalogReady;
+        await composer.setContext({
+            content: "Host-owned body #HostOwned",
+            reply,
+            quotes: [quote],
+        });
+
+        const shadow = composer.shadowRoot!;
+        return {
+            invalidBeforeConnect,
+            previewCount: shadow.querySelectorAll(".reply-quote-preview").length,
+            loadingCount: shadow.querySelectorAll(".loading-status").length,
+            hasFileInput: !!shadow.querySelector('input[type="file"]'),
+            imageButtonDisabled: shadow.querySelector<HTMLButtonElement>("button.image-button")?.disabled,
+            hasLoginButton: !!shadow.querySelector("button.login-btn"),
+            webSocketCalls: state.webSocketCalls,
+        };
+    }, { reply, quote });
+
+    expect(initial.invalidBeforeConnect).toBe("TypeError");
+    expect(initial.previewCount).toBe(2);
+    expect(initial.loadingCount).toBe(0);
+    expect(initial.hasFileInput).toBe(false);
+    expect(initial.imageButtonDisabled).toBe(true);
+    expect(initial.hasLoginButton).toBe(false);
+    expect(initial.webSocketCalls).toBe(0);
+
+    const postButton = page.locator("ehagaki-composer").locator("button.post-button");
+    await expect(postButton).toBeEnabled();
+    await postButton.click();
+    await page.waitForFunction(() => (window as any).__hostOwnedTestState.calls.length === 1);
+
+    const pending = await page.evaluate(async () => {
+        const composer = document.querySelector("ehagaki-composer") as HTMLElement & {
+            setContext(value: unknown): Promise<void>;
+            configureHostOwned(options: unknown): void;
+        };
+        const setContextResult = await composer.setContext({ content: "must stay unchanged" }).then(
+            () => "resolved",
+            (error: Error) => error.message,
+        );
+        const reconfigureResult = (() => {
+            try {
+                composer.configureHostOwned({ submit: () => undefined });
+                return "resolved";
+            } catch (error) {
+                return error instanceof Error ? error.name : String(error);
+            }
+        })();
+        return { setContextResult, reconfigureResult };
+    });
+    expect(pending.setContextResult).toBe("submission_in_progress");
+    expect(pending.reconfigureResult).toBe("InvalidStateError");
+
+    await page.evaluate(() => (window as any).__hostOwnedTestState.release?.());
+    await page.waitForFunction(() =>
+        (window as any).__hostOwnedTestState.events.some((event: { type: string }) =>
+            event.type === "ehagaki-post-success"),
+    );
+
+    const result = await page.evaluate(async () => {
+        const state = (window as any).__hostOwnedTestState;
+        const composer = document.querySelector("ehagaki-composer") as HTMLElement & {
+            whenReady(): Promise<void>;
+        };
+        composer.remove();
+        document.body.append(composer);
+        await composer.whenReady();
+        const shadow = composer.shadowRoot!;
+        return {
+            call: state.calls[0],
+            contextEvents: state.events.filter((event: { type: string }) =>
+                event.type === "ehagaki-composer-context-updated"),
+            successEvent: state.events.find((event: { type: string }) =>
+                event.type === "ehagaki-post-success"),
+            webSocketCalls: state.webSocketCalls,
+            reconnectedHasFileInput: !!shadow.querySelector('input[type="file"]'),
+            reconnectedHasLoginButton: !!shadow.querySelector("button.login-btn"),
+        };
+    });
+
+    expect(result.call.frozen).toBe(true);
+    expect(result.call.output).toMatchObject({
+        content: "Host-owned body #HostOwned",
+        context: {
+            reply: { eventId: replyEventId },
+            quotes: [{ eventId: quoteEventId }],
+        },
+    });
+    expect(result.call.output.tags.every((tag: string[]) =>
+        !["e", "p", "q", "a", "k", "client"].includes(tag[0]))).toBe(true);
+    expect(result.contextEvents.find((event: { detail: { reply?: string } }) =>
+        event.detail.reply === reply)?.detail).toMatchObject({
+        reply,
+        quotes: [quote],
+    });
+    expect(result.successEvent?.detail).toMatchObject({ eventId: "b".repeat(64) });
+    expect(result.webSocketCalls).toBe(0);
+    expect(result.reconnectedHasFileInput).toBe(false);
+    expect(result.reconnectedHasLoginButton).toBe(false);
+});
+
 test("loads the FFmpeg class worker, core, and WASM from a cross-origin Web Component build", async ({ page }) => {
     await page.goto(hostOrigin);
     const result = await page.evaluate(async (ffmpegModulePath) => {

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -1637,7 +1637,15 @@ test("runs Host-owned media preprocessing and transport without self-upload fall
         composer.configureHostOwned({
             uploadMedia: async (file: File, metadata: unknown) => {
                 state.uploads.push({ name: file.name, metadata });
-                return { url: "https://host.example/media/processed.png" };
+                return {
+                    url: "https://host.example/media/processed.png",
+                    imeta: {
+                        m: "image/webp",
+                        alt: "host supplied alt",
+                        size: "123",
+                        x: "a".repeat(64),
+                    },
+                };
             },
             submit: async (output: unknown) => {
                 state.outputs.push(output);
@@ -1680,6 +1688,13 @@ test("runs Host-owned media preprocessing and transport without self-upload fall
     });
     expect(result.outputs[0].content).toContain("host media body");
     expect(result.outputs[0].content).toContain("https://host.example/media/processed.png");
+    expect(result.outputs[0].tags).toContainEqual(expect.arrayContaining([
+        "imeta",
+        "url https://host.example/media/processed.png",
+        "m image/webp",
+        "alt host supplied alt",
+        "size 123",
+    ]));
 });
 
 test("does not let a disconnected Host-owned upload settle into a later mount", async ({ page }) => {
@@ -1695,7 +1710,7 @@ test("does not let a disconnected Host-owned upload settle into a later mount", 
         const oldSettled = new Promise<void>((resolve) => { resolveOld = resolve; });
         let resolveCurrent: (() => void) | undefined;
         const currentSettled = new Promise<void>((resolve) => { resolveCurrent = resolve; });
-        const state = { uploads: 0, submits: 0, errors: 0 };
+        const state = { uploads: 0, submits: 0, errors: 0, outputs: [] as any[] };
         (window as any).__hostOwnedStaleState = state;
 
         const create = () => {
@@ -1705,12 +1720,21 @@ test("does not let a disconnected Host-owned upload settle into a later mount", 
                     state.uploads += 1;
                     if (state.uploads === 1) {
                         await oldSettled;
-                        return { url: "https://host.example/stale.png" };
+                        return {
+                            url: "https://host.example/stale.png",
+                            imeta: { m: "image/png", alt: "stale metadata" },
+                        };
                     }
                     await currentSettled;
-                    return { url: "https://host.example/current.png" };
+                    return {
+                        url: "https://host.example/current.png",
+                        imeta: { m: "image/png", alt: "current metadata" },
+                    };
                 },
-                submit: async () => { state.submits += 1; },
+                submit: async (output: unknown) => {
+                    state.submits += 1;
+                    state.outputs.push(output);
+                },
             });
             document.body.append(composer);
             return composer;
@@ -1770,6 +1794,19 @@ test("does not let a disconnected Host-owned upload settle into a later mount", 
     expect(result.errors).toBe(0);
     await expect(page.locator("ehagaki-composer img[src='https://host.example/stale.png']")).toHaveCount(0);
     await expect(page.locator("ehagaki-composer .upload-error")).toHaveCount(0);
+    expect(result).toEqual(expect.objectContaining({
+        submits: 1,
+    }));
+    expect(result.outputs[0].tags).toEqual(expect.arrayContaining([
+        expect.arrayContaining([
+            "imeta",
+            "url https://host.example/current.png",
+            "alt current metadata",
+        ]),
+    ]));
+    expect(result.outputs[0].tags).not.toEqual(expect.arrayContaining([
+        expect.arrayContaining(["url https://host.example/stale.png"]),
+    ]));
 });
 
 test("keeps Host-owned capability separate from a previous authenticated Web Component instance", async ({ page }) => {

--- a/src/test/unit/appEmbedController.test.ts
+++ b/src/test/unit/appEmbedController.test.ts
@@ -120,6 +120,31 @@ describe('createAppEmbedController', () => {
         expect(parentFrame.notifySettingsApplied).not.toHaveBeenCalled();
     });
 
+    it('direct setContext を送信中に拒否して既存contextを変更しない', async () => {
+        const composerInput = {
+            resetContent: vi.fn(),
+            insertText: vi.fn(),
+        };
+        const { controller, sharedContent, composerContextApply } = createController({
+            composerInput: { get: vi.fn(() => composerInput) },
+            runtime: {
+                isBootstrappingApp: vi.fn(() => false),
+                hasPendingParentAuth: vi.fn(() => false),
+                getReplyQuoteState: vi.fn(createReplyQuoteState),
+                getChannelContextState: vi.fn(createChannelContextState),
+                getChannelContextProvenance: vi.fn(() => null),
+                getRuntimeSnapshot: vi.fn(createRuntimeSnapshot),
+                isSubmissionInProgress: vi.fn(() => true),
+            },
+        });
+
+        await expect(controller.applyComposerContext({ content: 'blocked' }))
+            .rejects.toThrow('submission_in_progress');
+        expect(composerInput.insertText).not.toHaveBeenCalled();
+        expect(sharedContent.updateUrlQueryContentStore).not.toHaveBeenCalled();
+        expect(composerContextApply.applyReplyQuoteSelection).not.toHaveBeenCalled();
+    });
+
     it('bootstrapping 中の composer.setContext を保留し、flush で適用する', async () => {
         const { controller, composerInput, parentFrame, setBootstrappingApp } = createController();
         setBootstrappingApp(true);

--- a/src/test/unit/editorDomActions.test.ts
+++ b/src/test/unit/editorDomActions.test.ts
@@ -419,6 +419,7 @@ describe("fileDropActionWithDragState", () => {
 
     beforeEach(() => {
         node = document.createElement("div");
+        (node as any).__uploadFiles = vi.fn();
         dragOverState = null;
         destroy = fileDropActionWithDragState(node, {
             dragOver: (v) => { dragOverState = v; },

--- a/src/test/unit/hostOwnedComposer.test.ts
+++ b/src/test/unit/hostOwnedComposer.test.ts
@@ -32,7 +32,7 @@ describe("Host-owned Composer output", () => {
             contentWarningEnabled: true,
             contentWarningReason: "warning",
             emojiTags: [["emoji", "wave", "https://example.com/wave.webp"], ["q", "x"]],
-            imageImetaMap: {},
+            mediaImetaMap: {},
             replyQuote: { reply, quotes: [{ ...reply, mode: "quote", eventId: "3".repeat(64) }] },
             channel: {
                 eventId: "4".repeat(64),
@@ -74,6 +74,52 @@ describe("Host-owned Composer output", () => {
         expect(getHostSubmissionEventId(undefined)).toBeUndefined();
         expect(getHostSubmissionEventId({ eventId: "a".repeat(64) })).toBe("a".repeat(64));
         expect(() => getHostSubmissionEventId({ eventId: "not-an-id" })).toThrow();
+    });
+
+    it("emits Host-owned image and video imeta tags with supplied metadata", async () => {
+        const output = await buildHostOwnedComposerOutput({
+            content: "media",
+            hashtagTags: [],
+            hashtags: [],
+            contentWarningEnabled: false,
+            contentWarningReason: "",
+            emojiTags: [],
+            mediaImetaMap: {
+                "https://host.example/media/abcdef": {
+                    m: "image/webp",
+                    alt: "webp image",
+                    dim: "1x1",
+                    size: 12,
+                    x: "a".repeat(64),
+                },
+                "https://host.example/media/video": {
+                    m: "video/mp4",
+                    dim: "640x360",
+                    size: 42,
+                },
+            },
+            replyQuote: { reply: null, quotes: [] },
+            channel: null,
+        });
+
+        const imageTag = output.tags.find((tag) => tag[1] === "url https://host.example/media/abcdef");
+        const videoTag = output.tags.find((tag) => tag[1] === "url https://host.example/media/video");
+        expect(imageTag).toEqual(expect.arrayContaining([
+            "imeta",
+            "url https://host.example/media/abcdef",
+            "m image/webp",
+            "size 12",
+            "x " + "a".repeat(64),
+            "dim 1x1",
+            "alt webp image",
+        ]));
+        expect(videoTag).toEqual(expect.arrayContaining([
+            "imeta",
+            "url https://host.example/media/video",
+            "m video/mp4",
+            "size 42",
+            "dim 640x360",
+        ]));
     });
 
     it("copies reference-only context even when no referenced event was hydrated", () => {

--- a/src/test/unit/hostOwnedComposer.test.ts
+++ b/src/test/unit/hostOwnedComposer.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+    buildHostOwnedComposerOutput,
+    createHostOwnedContextSnapshot,
+    getHostSubmissionEventId,
+    isHostSubmissionEventId,
+} from "../../lib/hostOwnedComposer";
+
+const reply = {
+    mode: "reply" as const,
+    eventId: "1".repeat(64),
+    relayHints: ["wss://relay.example"],
+    authorPubkey: "2".repeat(64),
+    quoteNotificationEnabled: false,
+    replyNotificationRecipients: [],
+    authorDisplayName: null,
+    authorPicture: null,
+    referencedEvent: null,
+    rootEventId: null,
+    rootRelayHint: null,
+    rootPubkey: null,
+    loading: false,
+    error: null,
+};
+
+describe("Host-owned Composer output", () => {
+    it("keeps composer-owned tags and an immutable reference snapshot without event fields", async () => {
+        const output = await buildHostOwnedComposerOutput({
+            content: "host handoff",
+            hashtagTags: [["t", "Topic"], ["client", "eHagaki"]],
+            hashtags: [],
+            contentWarningEnabled: true,
+            contentWarningReason: "warning",
+            emojiTags: [["emoji", "wave", "https://example.com/wave.webp"], ["q", "x"]],
+            imageImetaMap: {},
+            replyQuote: { reply, quotes: [{ ...reply, mode: "quote", eventId: "3".repeat(64) }] },
+            channel: {
+                eventId: "4".repeat(64),
+                relayHints: ["wss://read.example"],
+                channelRelays: ["wss://write.example"],
+                name: null,
+                about: null,
+                picture: null,
+            },
+        });
+
+        expect(output).toEqual({
+            content: "host handoff",
+            tags: [
+                ["t", "Topic"],
+                ["content-warning", "warning"],
+                ["t", "nsfw"],
+                ["emoji", "wave", "https://example.com/wave.webp"],
+            ],
+            context: {
+                reply: expect.objectContaining({ eventId: "1".repeat(64) }),
+                quotes: [expect.objectContaining({ eventId: "3".repeat(64) })],
+                channel: expect.objectContaining({ eventId: "4".repeat(64) }),
+            },
+        });
+        expect("kind" in output).toBe(false);
+        expect(output.tags.some((tag) => ["e", "p", "q", "a", "k", "client"].includes(tag[0]))).toBe(false);
+
+        expect(Object.isFrozen(output)).toBe(true);
+        expect(Object.isFrozen(output.tags)).toBe(true);
+        expect(Object.isFrozen(output.context.reply!.relayHints)).toBe(true);
+        expect(() => (output.context.reply!.relayHints as string[]).push("wss://later.example")).toThrow();
+        expect(reply.relayHints).toEqual(["wss://relay.example"]);
+    });
+
+    it("accepts only a complete Nostr event id from the host", () => {
+        expect(isHostSubmissionEventId("a".repeat(64))).toBe(true);
+        expect(isHostSubmissionEventId("not-an-id")).toBe(false);
+        expect(getHostSubmissionEventId(undefined)).toBeUndefined();
+        expect(getHostSubmissionEventId({ eventId: "a".repeat(64) })).toBe("a".repeat(64));
+        expect(() => getHostSubmissionEventId({ eventId: "not-an-id" })).toThrow();
+    });
+
+    it("copies reference-only context even when no referenced event was hydrated", () => {
+        const snapshot = createHostOwnedContextSnapshot({
+            replyQuote: { reply, quotes: [] },
+            channel: null,
+        });
+        expect(snapshot.reply).toEqual({
+            eventId: "1".repeat(64),
+            relayHints: ["wss://relay.example"],
+            authorPubkey: "2".repeat(64),
+        });
+    });
+});

--- a/src/test/unit/hostOwnedUpload.test.ts
+++ b/src/test/unit/hostOwnedUpload.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createHostOwnedUploadExecutor } from "../../lib/hostOwnedUpload";
+
+describe("Host-owned media handoff", () => {
+    it("passes the same File instance to the host and accepts only an HTTP(S) result", async () => {
+        const controller = new AbortController();
+        const file = new File(["media"], "photo.png", { type: "image/png" });
+        const uploadMedia = vi.fn(async (received: File) => {
+            expect(received).toBe(file);
+            return {
+                url: "https://media.example/photo.png",
+                imeta: { alt: "photo", ignored: "ignored" },
+            };
+        });
+        const executor = createHostOwnedUploadExecutor({
+            uploadMedia,
+            signal: controller.signal,
+        });
+
+        const [result] = await executor.uploadPreparedFiles([file], [{
+            file,
+            placeholderId: "placeholder-1",
+            blurhash: "blurhash-value",
+        }]);
+
+        expect(uploadMedia).toHaveBeenCalledWith(file, expect.objectContaining({
+            originalName: "photo.png",
+            processedName: "photo.png",
+            blurhash: "blurhash-value",
+        }), { signal: controller.signal });
+        expect(result).toMatchObject({
+            success: true,
+            url: "https://media.example/photo.png",
+            nip94: { alt: "photo" },
+            uploadProtocol: "custom-http",
+        });
+        expect(result.nip94).not.toHaveProperty("ignored");
+    });
+
+    it("does not turn invalid or aborted host responses into media nodes", async () => {
+        const invalidController = new AbortController();
+        const file = new File(["media"], "photo.png", { type: "image/png" });
+        const invalid = createHostOwnedUploadExecutor({
+            uploadMedia: async () => ({ url: "javascript:alert(1)" }),
+            signal: invalidController.signal,
+        });
+        const [invalidResult] = await invalid.uploadPreparedFiles([file], [{
+            file,
+            placeholderId: "placeholder-1",
+        }]);
+        expect(invalidResult).toMatchObject({ success: false, error: "host_media_invalid_result" });
+
+        const abortController = new AbortController();
+        const aborted = createHostOwnedUploadExecutor({
+            uploadMedia: async () => {
+                abortController.abort();
+                return { url: "https://media.example/photo.png" };
+            },
+            signal: abortController.signal,
+        });
+        const [abortedResult] = await aborted.uploadPreparedFiles([file], [{
+            file,
+            placeholderId: "placeholder-2",
+        }]);
+        expect(abortedResult).toMatchObject({ success: false, aborted: true });
+    });
+});

--- a/src/test/unit/hostOwnedUpload.test.ts
+++ b/src/test/unit/hostOwnedUpload.test.ts
@@ -5,12 +5,20 @@ import { createHostOwnedUploadExecutor } from "../../lib/hostOwnedUpload";
 describe("Host-owned media handoff", () => {
     it("passes the same File instance to the host and accepts only an HTTP(S) result", async () => {
         const controller = new AbortController();
-        const file = new File(["media"], "photo.png", { type: "image/png" });
+        const file = new File(["media"], "photo.webp", { type: "image/webp" });
         const uploadMedia = vi.fn(async (received: File) => {
             expect(received).toBe(file);
             return {
-                url: "https://media.example/photo.png",
-                imeta: { alt: "photo", ignored: "ignored" },
+                url: "https://media.example/abcdef",
+                imeta: {
+                    m: "image/webp",
+                    alt: "photo",
+                    blurhash: "server-blurhash",
+                    dim: "1x1",
+                    size: "12",
+                    x: "a".repeat(64),
+                    ignored: "ignored",
+                },
             };
         });
         const executor = createHostOwnedUploadExecutor({
@@ -25,14 +33,21 @@ describe("Host-owned media handoff", () => {
         }]);
 
         expect(uploadMedia).toHaveBeenCalledWith(file, expect.objectContaining({
-            originalName: "photo.png",
-            processedName: "photo.png",
+            originalName: "photo.webp",
+            processedName: "photo.webp",
             blurhash: "blurhash-value",
         }), { signal: controller.signal });
         expect(result).toMatchObject({
             success: true,
-            url: "https://media.example/photo.png",
-            nip94: { alt: "photo" },
+            url: "https://media.example/abcdef",
+            nip94: {
+                m: "image/webp",
+                alt: "photo",
+                blurhash: "server-blurhash",
+                dim: "1x1",
+                size: "12",
+                x: "a".repeat(64),
+            },
             uploadProtocol: "custom-http",
         });
         expect(result.nip94).not.toHaveProperty("ignored");

--- a/src/test/unit/hostOwnedUpload.test.ts
+++ b/src/test/unit/hostOwnedUpload.test.ts
@@ -39,6 +39,7 @@ describe("Host-owned media handoff", () => {
         }), { signal: controller.signal });
         expect(result).toMatchObject({
             success: true,
+            hostOwnedMedia: true,
             url: "https://media.example/abcdef",
             nip94: {
                 m: "image/webp",

--- a/src/test/unit/mediaGalleryStore.test.ts
+++ b/src/test/unit/mediaGalleryStore.test.ts
@@ -86,4 +86,31 @@ describe('mediaGalleryStore', () => {
             expect(mediaGalleryStore.items.map(i => i.id)).toEqual(['img-1', 'img-2', 'img-3']);
         });
     });
+
+    it('returns metadata only for current non-placeholder image and video items', () => {
+        mediaGalleryStore.addItem({
+            id: 'image-1',
+            type: 'image',
+            src: 'https://host.example/image',
+            isPlaceholder: false,
+            mimeType: 'image/webp',
+            alt: 'image',
+        });
+        mediaGalleryStore.addItem({
+            id: 'video-1',
+            type: 'video',
+            src: 'https://host.example/video',
+            isPlaceholder: false,
+            mimeType: 'video/mp4',
+            dim: '640x360',
+        });
+
+        expect(mediaGalleryStore.getMediaImetaMap()).toEqual({
+            'https://host.example/image': expect.objectContaining({ m: 'image/webp', alt: 'image' }),
+            'https://host.example/video': expect.objectContaining({ m: 'video/mp4', dim: '640x360' }),
+        });
+
+        mediaGalleryStore.removeItem('video-1');
+        expect(mediaGalleryStore.getMediaImetaMap()).not.toHaveProperty('https://host.example/video');
+    });
 });

--- a/src/test/unit/placeholderManager.hostOwned.test.ts
+++ b/src/test/unit/placeholderManager.hostOwned.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { replacePlaceholdersWithResults } from "../../lib/editor/placeholderManager";
+
+describe("Host-owned media metadata replacement", () => {
+    it("keeps host MIME and imeta fields on a video node without URL inference", async () => {
+        const file = new File(["video"], "clip.bin", { type: "video/mp4" });
+        let replacedAttrs: Record<string, unknown> | undefined;
+        const node = {
+            type: { name: "video" },
+            attrs: { src: "placeholder-video", isPlaceholder: true },
+            nodeSize: 1,
+        };
+        const editor: any = {
+            state: {
+                doc: {
+                    descendants: (callback: (value: typeof node, pos: number) => void) => callback(node, 1),
+                },
+                tr: {
+                    setNodeMarkup: vi.fn((_pos: number, _type: unknown, attrs: Record<string, unknown>) => {
+                        replacedAttrs = attrs;
+                        return {};
+                    }),
+                },
+            },
+            view: { dispatch: vi.fn() },
+        };
+
+        await replacePlaceholdersWithResults(
+            [{
+                success: true,
+                url: "https://host.example/media/abcdef",
+                uploadProtocol: "custom-http",
+                nip94: { m: "video/mp4", alt: "clip", size: "42", dim: "640x360", x: "a".repeat(64) },
+            }],
+            [{ file, placeholderId: "placeholder-video" }],
+            editor,
+            {},
+            {},
+            { update: vi.fn() },
+            async () => null,
+            false,
+        );
+
+        expect(replacedAttrs).toMatchObject({
+            src: "https://host.example/media/abcdef",
+            isPlaceholder: false,
+            m: "video/mp4",
+            alt: "clip",
+            size: "42",
+            dim: "640x360",
+            x: "a".repeat(64),
+            uploadProtocol: "custom-http",
+        });
+    });
+});

--- a/src/test/unit/placeholderManager.hostOwned.test.ts
+++ b/src/test/unit/placeholderManager.hostOwned.test.ts
@@ -28,6 +28,7 @@ describe("Host-owned media metadata replacement", () => {
         await replacePlaceholdersWithResults(
             [{
                 success: true,
+                hostOwnedMedia: true,
                 url: "https://host.example/media/abcdef",
                 uploadProtocol: "custom-http",
                 nip94: { m: "video/mp4", alt: "clip", size: "42", dim: "640x360", x: "a".repeat(64) },
@@ -50,6 +51,93 @@ describe("Host-owned media metadata replacement", () => {
             dim: "640x360",
             x: "a".repeat(64),
             uploadProtocol: "custom-http",
+        });
+    });
+
+    it("does not treat self-publish custom-http results as Host-owned metadata", async () => {
+        const file = new File(["png"], "original.png", { type: "image/png" });
+        let replacedImageAttrs: Record<string, unknown> | undefined;
+        const imageNode = {
+            type: { name: "image" },
+            attrs: { src: "placeholder-image", isPlaceholder: true },
+            nodeSize: 1,
+        };
+        const imageEditor: any = {
+            state: {
+                doc: { descendants: (callback: (value: typeof imageNode, pos: number) => void) => callback(imageNode, 1) },
+                tr: {
+                    setNodeMarkup: vi.fn((_pos: number, _type: unknown, attrs: Record<string, unknown>) => {
+                        replacedImageAttrs = attrs;
+                        return {};
+                    }),
+                },
+            },
+            view: { dispatch: vi.fn() },
+        };
+
+        await replacePlaceholdersWithResults(
+            [{
+                success: true,
+                url: "https://self.example/media/converted.webp",
+                uploadProtocol: "custom-http",
+                nip94: { m: "image/webp", alt: "self response alt" },
+            }],
+            [{ file, placeholderId: "placeholder-image" }],
+            imageEditor,
+            {},
+            {},
+            { update: vi.fn() },
+            async () => null,
+            false,
+        );
+
+        expect(replacedImageAttrs).toMatchObject({
+            src: "https://self.example/media/converted.webp",
+            isPlaceholder: false,
+            uploadProtocol: "custom-http",
+        });
+        expect(replacedImageAttrs).not.toHaveProperty("m");
+        expect(replacedImageAttrs).not.toHaveProperty("alt");
+
+        let replacedVideoAttrs: Record<string, unknown> | undefined;
+        const videoFile = new File(["video"], "clip.mp4", { type: "video/mp4" });
+        const videoNode = {
+            type: { name: "video" },
+            attrs: { src: "placeholder-video", isPlaceholder: true },
+            nodeSize: 1,
+        };
+        const videoEditor: any = {
+            state: {
+                doc: { descendants: (callback: (value: typeof videoNode, pos: number) => void) => callback(videoNode, 1) },
+                tr: {
+                    setNodeMarkup: vi.fn((_pos: number, _type: unknown, attrs: Record<string, unknown>) => {
+                        replacedVideoAttrs = attrs;
+                        return {};
+                    }),
+                },
+            },
+            view: { dispatch: vi.fn() },
+        };
+
+        await replacePlaceholdersWithResults(
+            [{
+                success: true,
+                url: "https://self.example/media/clip",
+                uploadProtocol: "custom-http",
+                nip94: { m: "video/mp4", alt: "self video alt", dim: "640x360" },
+            }],
+            [{ file: videoFile, placeholderId: "placeholder-video" }],
+            videoEditor,
+            {},
+            {},
+            { update: vi.fn() },
+            async () => null,
+            false,
+        );
+
+        expect(replacedVideoAttrs).toEqual({
+            src: "https://self.example/media/clip",
+            isPlaceholder: false,
         });
     });
 });

--- a/src/test/unit/postUploadUtils.test.ts
+++ b/src/test/unit/postUploadUtils.test.ts
@@ -57,6 +57,7 @@ describe('createPostUploadHandlers', () => {
             getImageXMap: () => ({}),
             getUploadFailedText: (key: string) => key,
             updateUploadState: vi.fn(),
+            setUploadErrorMessage: vi.fn(),
             uploadFiles,
         });
 
@@ -71,6 +72,7 @@ describe('createPostUploadHandlers', () => {
         let imageOxMap: Record<string, string> = { a: 'ox-a' };
         let imageXMap: Record<string, string> = { a: 'x-a' };
         const updateUploadState = vi.fn();
+        const setUploadErrorMessage = vi.fn();
         const uploadFiles = vi.fn(async (_params: unknown) => undefined);
         const handlers = createPostUploadHandlers({
             getCurrentEditor: () => editor,
@@ -79,6 +81,7 @@ describe('createPostUploadHandlers', () => {
             getImageXMap: () => imageXMap,
             getUploadFailedText: (key: string) => `translated:${key}`,
             updateUploadState,
+            setUploadErrorMessage,
             uploadFiles,
         });
 
@@ -93,6 +96,7 @@ describe('createPostUploadHandlers', () => {
             currentEditor: editor,
             fileInput,
             updateUploadState,
+            setUploadErrorMessage,
             imageOxMap: { b: 'ox-b' },
             imageXMap: { b: 'x-b' },
             getUploadFailedText: expect.any(Function),
@@ -117,6 +121,7 @@ describe('createPostUploadHandlers', () => {
             getImageXMap: () => ({}),
             getUploadFailedText: (key: string) => key,
             updateUploadState: vi.fn(),
+            setUploadErrorMessage: vi.fn(),
             uploadFiles,
         });
         const files = [new File(['content'], 'test.png', { type: 'image/png' })] as unknown as FileList;

--- a/src/test/unit/replyQuoteStore.test.ts
+++ b/src/test/unit/replyQuoteStore.test.ts
@@ -13,6 +13,7 @@ import {
     updateReplyNotificationRecipientProfile,
     setReplyNotificationRecipientEnabled,
     setReplyQuoteError,
+    settleReplyQuoteReferencesWithoutHydration,
     updateReferencedEvent,
     setReplyQuote,
 } from '../../stores/replyQuoteStore.svelte';
@@ -37,6 +38,44 @@ describe('replyQuoteStore', () => {
 
         expect(listener).toHaveBeenCalledWith(replyQuoteState.value);
         expect(replyQuoteState.value.reply?.authorPicture).toBeNull();
+        cleanup();
+    });
+
+    it('relay hydrationなしでもreplyとquoteをreference-onlyで確定する', () => {
+        const listener = vi.fn();
+        const cleanup = onReplyQuoteChanged(listener);
+        const targets = setReplyQuote({
+            reply: {
+                eventId: '11'.repeat(32),
+                relayHints: ['wss://relay.example.com'],
+                authorPubkey: '22'.repeat(32),
+            },
+            quotes: [{
+                eventId: '33'.repeat(32),
+                relayHints: [],
+                authorPubkey: null,
+            }],
+        });
+        listener.mockClear();
+
+        settleReplyQuoteReferencesWithoutHydration(targets);
+
+        expect(replyQuoteState.value.reply).toMatchObject({
+            eventId: '11'.repeat(32),
+            loading: false,
+            referencedEvent: null,
+            error: null,
+        });
+        expect(replyQuoteState.value.quotes[0]).toMatchObject({
+            eventId: '33'.repeat(32),
+            loading: false,
+            referencedEvent: null,
+            error: null,
+        });
+        expect(listener).toHaveBeenCalledWith(replyQuoteState.value);
+
+        clearReplyQuote();
+        expect(replyQuoteState.value).toEqual({ reply: null, quotes: [] });
         cleanup();
     });
 

--- a/src/test/unit/uploadHelper.test.ts
+++ b/src/test/unit/uploadHelper.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
     performFileUpload,
     resolveCurrentUploadDestination,
+    showUploadErrorMessage,
     uploadHelper,
 } from "../../lib/uploadHelper";
 import { generateBlurhashes, insertPlaceholdersIntoEditor } from "../../lib/editor/placeholderManager";
@@ -505,7 +506,80 @@ describe("uploadHelper", () => {
         });
     });
 
-    describe("uploadHelper integration", () => {
+describe("uploadHelper integration", () => {
+        it("clears an upload error without changing a later operation's pending state", () => {
+            vi.useFakeTimers();
+            let isUploading = true;
+            let errorMessage = "";
+            const updateUploadState = vi.fn((nextIsUploading: boolean, nextMessage?: string) => {
+                isUploading = nextIsUploading;
+                errorMessage = nextMessage ?? "";
+            });
+            const setUploadErrorMessage = vi.fn((nextMessage: string) => {
+                errorMessage = nextMessage;
+            });
+
+            showUploadErrorMessage("upload failed", 1000, {
+                updateUploadState,
+                setUploadErrorMessage,
+                keepUploading: true,
+            });
+            expect(isUploading).toBe(true);
+            expect(errorMessage).toBe("upload failed");
+
+            // The operation finishes before the error timer expires.
+            isUploading = false;
+            vi.advanceTimersByTime(1000);
+
+            expect(isUploading).toBe(false);
+            expect(errorMessage).toBe("");
+            expect(setUploadErrorMessage).toHaveBeenCalledWith("");
+            vi.useRealTimers();
+        });
+
+        it("leaves self-publish upload pending false after an error timer expires", async () => {
+            vi.useFakeTimers();
+            const file = createTestFile({ name: "error.png", type: "image/png", content: "content" });
+            const state = { isUploading: false, errorMessage: "" };
+            const updateUploadState = vi.fn((isUploading: boolean, message?: string) => {
+                state.isUploading = isUploading;
+                state.errorMessage = message ?? "";
+            });
+            const setUploadErrorMessage = vi.fn((message: string) => {
+                state.errorMessage = message;
+            });
+            const failingManager: FileUploadManagerInterface = {
+                validateImageFile: vi.fn(() => ({ isValid: true })),
+                validateMediaFile: vi.fn(() => ({ isValid: true })),
+                generateBlurhashForFile: vi.fn(async () => "blurhash123"),
+                uploadFileWithCallbacks: vi.fn(async () => {
+                    throw new Error("upload failed");
+                }),
+                uploadMultipleFilesWithCallbacks: vi.fn(),
+            };
+
+            await performFileUpload({
+                files: [file],
+                currentEditor,
+                updateUploadState,
+                setUploadErrorMessage,
+                devMode: false,
+                imageOxMap: {},
+                imageXMap: {},
+                dependencies: {
+                    ...mockDependencies,
+                    FileUploadManager: vi.fn(function () { return failingManager; }) as new () => FileUploadManagerInterface,
+                },
+                getUploadFailedText: (key: string) => key,
+            });
+
+            expect(state.isUploading).toBe(false);
+            vi.advanceTimersByTime(5000);
+            expect(state.isUploading).toBe(false);
+            expect(state.errorMessage).toBe("");
+            vi.useRealTimers();
+        });
+
         it("merges store updates with external progress callbacks", async () => {
             const file = createTestFile({ name: "test.png", type: "image/png", content: "content" });
             const updateUploadState = vi.fn();
@@ -558,6 +632,7 @@ describe("uploadHelper", () => {
                     onImageCompressionProgress: externalOnImageCompressionProgress,
                 },
                 updateUploadState,
+                setUploadErrorMessage: vi.fn(),
                 devMode: false,
                 imageOxMap: {},
                 imageXMap: {},
@@ -1211,5 +1286,3 @@ describe("uploadHelper", () => {
         });
     });
 });
-
-

--- a/src/test/unit/uploadHelper.test.ts
+++ b/src/test/unit/uploadHelper.test.ts
@@ -605,6 +605,40 @@ describe("uploadHelper", () => {
             expect(updateUploadState).toHaveBeenCalledWith(false);
         });
 
+        it("uses a Host-provided prepared transport without resolving an eHagaki upload destination", async () => {
+            const file = createTestFile({ name: "host.png", type: "image/png", content: "content" });
+            const resolveUploadDestination = vi.fn(async () => {
+                throw new Error("must not resolve a Host-owned destination");
+            });
+            const prepareFiles = vi.fn(async (files: File[]) =>
+                files.map((preparedFile, index) => ({ file: preparedFile, index })),
+            );
+            const uploadPreparedFiles = vi.fn(async (files: File[]) =>
+                files.map((preparedFile) => ({
+                    success: true,
+                    url: `https://host.example/${preparedFile.name}`,
+                })),
+            );
+
+            const result = await uploadHelper({
+                files: [file],
+                currentEditor,
+                showUploadError: vi.fn(),
+                updateUploadState: vi.fn(),
+                devMode: false,
+                dependencies: { ...mockDependencies, resolveUploadDestination },
+                prepareFiles,
+                uploadPreparedFiles,
+            });
+
+            expect(result.results).toEqual([
+                expect.objectContaining({ success: true, url: "https://host.example/host.png" }),
+            ]);
+            expect(prepareFiles).toHaveBeenCalledWith([file], expect.any(Object));
+            expect(uploadPreparedFiles).toHaveBeenCalledWith([file], expect.any(Array));
+            expect(resolveUploadDestination).not.toHaveBeenCalled();
+        });
+
         it("forwards a resolved blossom destination instead of falling back to the legacy upload endpoint", async () => {
             const file = createTestFile({ name: "test.png", type: "image/png", content: "content" });
             const showUploadError = vi.fn();
@@ -1177,6 +1211,5 @@ describe("uploadHelper", () => {
         });
     });
 });
-
 
 

--- a/src/web-component/element.ts
+++ b/src/web-component/element.ts
@@ -10,9 +10,11 @@ import appCss from "../app.css?inline";
 import photoSwipeCss from "photoswipe/style.css?inline";
 import {
     EHAGAKI_COMPOSER_API_VERSION,
+    type EHagakiCustomEmojiCatalogItem,
     type EHagakiComposerContext,
     type EHagakiComposerInitializationErrorDetail,
     type EHagakiComposerSettings,
+    type EHagakiHostOwnedComposerOptions,
 } from "./types";
 import { createWebComponentNotificationPort } from "./notificationPort";
 import { applyWebComponentIconAssetUrls } from "./iconAssets";
@@ -22,6 +24,7 @@ type AppInstance = {
     setEmbedSettings(
         payload: EmbedSettingsSetPayload,
     ): Promise<ReadonlyArray<AppEmbedAppliedSettingKey>>;
+    setHostCustomEmojis(catalog: EHagakiCustomEmojiCatalogItem[]): Promise<void>;
 };
 
 let activeInstance: EHagakiComposerElement | null = null;
@@ -34,6 +37,58 @@ function createError(code: EHagakiComposerInitializationErrorDetail["code"], mes
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isHttpUrl(value: unknown): value is string {
+    if (typeof value !== "string") return false;
+    try {
+        const url = new URL(value);
+        return url.protocol === "http:" || url.protocol === "https:";
+    } catch {
+        return false;
+    }
+}
+
+function validateHostOwnedOptions(
+    value: EHagakiHostOwnedComposerOptions,
+): EHagakiHostOwnedComposerOptions {
+    if (!isRecord(value) || typeof value.submit !== "function") {
+        throw new TypeError("Host-owned Composer requires a submit handler.");
+    }
+    if (value.uploadMedia !== undefined && typeof value.uploadMedia !== "function") {
+        throw new TypeError("uploadMedia must be a function when provided.");
+    }
+    return {
+        submit: value.submit,
+        ...(value.uploadMedia ? { uploadMedia: value.uploadMedia } : {}),
+    };
+}
+
+function validateCustomEmojiCatalog(
+    catalog: readonly EHagakiCustomEmojiCatalogItem[],
+): EHagakiCustomEmojiCatalogItem[] {
+    if (!Array.isArray(catalog)) {
+        throw new TypeError("Custom emoji catalog must be an array.");
+    }
+    const seen = new Set<string>();
+    const next: EHagakiCustomEmojiCatalogItem[] = [];
+    for (const item of catalog) {
+        if (!isRecord(item) || typeof item.shortcode !== "string" || !isHttpUrl(item.url)) {
+            throw new TypeError("Custom emoji catalog contains an invalid item.");
+        }
+        const shortcode = item.shortcode.replace(/^:+|:+$/g, "").trim();
+        if (!/^[\p{L}\p{N}_+-]{1,64}$/u.test(shortcode)) {
+            throw new TypeError("Custom emoji catalog contains an invalid shortcode.");
+        }
+        const setAddress = typeof item.setAddress === "string" && item.setAddress.trim()
+            ? item.setAddress.trim()
+            : null;
+        const key = `${shortcode.toLowerCase()}\u0000${item.url}\u0000${setAddress ?? ""}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        next.push({ shortcode, url: item.url, ...(setAddress ? { setAddress } : {}) });
+    }
+    return next;
 }
 
 function validateSettings(value: EHagakiComposerSettings): EmbedSettingsSetPayload {
@@ -135,6 +190,10 @@ export class EHagakiComposerElement extends HTMLElement {
     #operationQueue: Promise<void> = Promise.resolve();
     #connectionGeneration = 0;
     #assetStyleObserver: MutationObserver | null = null;
+    #hasEverConnected = false;
+    #hostOwnedOptions: EHagakiHostOwnedComposerOptions | null = null;
+    #hostCustomEmojiCatalog: EHagakiCustomEmojiCatalogItem[] = [];
+    #hostOperationAbortController: AbortController | null = null;
 
     get assetBase(): string | null {
         return this.getAttribute("asset-base");
@@ -154,6 +213,7 @@ export class EHagakiComposerElement extends HTMLElement {
     }
 
     connectedCallback(): void {
+        this.#hasEverConnected = true;
         if (this.#mountPromise) return;
         if (activeInstance && activeInstance !== this) {
             const error = createError(
@@ -174,6 +234,8 @@ export class EHagakiComposerElement extends HTMLElement {
 
     disconnectedCallback(): void {
         this.#connectionGeneration += 1;
+        this.#hostOperationAbortController?.abort();
+        this.#hostOperationAbortController = null;
         this.#assetStyleObserver?.disconnect();
         this.#assetStyleObserver = null;
         if (activeInstance === this) activeInstance = null;
@@ -204,6 +266,37 @@ export class EHagakiComposerElement extends HTMLElement {
     ): Promise<ReadonlyArray<AppEmbedAppliedSettingKey>> {
         return this.enqueue(async () =>
             this.requireApp().setEmbedSettings(validateSettings(settings)));
+    }
+
+    /**
+     * Selects Host-owned publication exactly once before this element's first
+     * connection. Reconnection intentionally reuses this immutable choice.
+     */
+    configureHostOwned(options: EHagakiHostOwnedComposerOptions): void {
+        if (this.#hasEverConnected || this.#hostOwnedOptions) {
+            throw new DOMException(
+                "Host-owned Composer configuration is immutable after it is set or connected.",
+                "InvalidStateError",
+            );
+        }
+        // Validate before committing so a malformed pre-connection call does
+        // not consume the one permitted configuration attempt.
+        const validated = validateHostOwnedOptions(options);
+        this.#hostOwnedOptions = validated;
+    }
+
+    setCustomEmojis(catalog: readonly EHagakiCustomEmojiCatalogItem[]): Promise<void> {
+        if (!this.#hostOwnedOptions) {
+            return Promise.reject(new DOMException(
+                "Custom emoji catalogs are available only in Host-owned mode.",
+                "InvalidStateError",
+            ));
+        }
+        const validated = validateCustomEmojiCatalog(catalog);
+        this.#hostCustomEmojiCatalog = validated;
+        return this.enqueue(async () => {
+            await this.requireApp().setHostCustomEmojis(validated.map((item) => ({ ...item })));
+        });
     }
 
     dispatchSafeEvent(type: string, detail: Record<string, unknown>): boolean {
@@ -268,6 +361,9 @@ export class EHagakiComposerElement extends HTMLElement {
 
             const { default: App } = await import("../App.svelte");
             if (!this.isConnected || generation !== this.#connectionGeneration) return;
+            this.#hostOperationAbortController = this.#hostOwnedOptions
+                ? new AbortController()
+                : null;
             this.#mountedApp = mount(App, {
                 target: mountTarget,
                 props: {
@@ -278,6 +374,15 @@ export class EHagakiComposerElement extends HTMLElement {
                         this.#readyResolve?.();
                         this.dispatchSafeEvent("ehagaki-ready", { apiVersion: EHAGAKI_COMPOSER_API_VERSION });
                     },
+                    ...(this.#hostOwnedOptions
+                        ? {
+                            hostOwnedConfig: {
+                                ...this.#hostOwnedOptions,
+                                customEmojis: this.#hostCustomEmojiCatalog.map((item) => ({ ...item })),
+                                signal: this.#hostOperationAbortController!.signal,
+                            },
+                        }
+                        : {}),
                 },
             });
             applyWebComponentIconAssetUrls(shadowRoot, shell, assetBase);

--- a/src/web-component/types.ts
+++ b/src/web-component/types.ts
@@ -9,6 +9,76 @@ export const EHAGAKI_COMPOSER_API_VERSION = 1;
 export type EHagakiComposerContext = EmbedComposerSetContextPayload;
 export type EHagakiComposerSettings = EmbedSettingsSetPayload;
 
+/** A reply, quote, or channel value captured with Host-owned submission. */
+export interface EHagakiComposerContextReference {
+    readonly eventId: string;
+    readonly relayHints: readonly string[];
+    readonly authorPubkey: string | null;
+}
+
+export interface EHagakiComposerContextSnapshot {
+    readonly reply: EHagakiComposerContextReference | null;
+    readonly quotes: readonly EHagakiComposerContextReference[];
+    readonly channel: {
+        readonly eventId: string;
+        readonly relayHints: readonly string[];
+        readonly channelRelays?: readonly string[];
+    } | null;
+}
+
+/**
+ * The editable composer result. It deliberately is not a Nostr event: the
+ * embedding host owns event shape, signing, tags that establish references,
+ * and publication.
+ */
+export interface EHagakiComposerOutput {
+    readonly content: string;
+    readonly tags: readonly (readonly string[])[];
+    readonly context: EHagakiComposerContextSnapshot;
+}
+
+export interface EHagakiHostSubmissionResult {
+    /** Optional host-assigned Nostr event id for the existing success event. */
+    eventId?: string;
+}
+
+export interface EHagakiHostMediaMetadata {
+    originalName: string;
+    originalSize: number;
+    originalType: string;
+    processedName: string;
+    processedSize: number;
+    processedType: string;
+    ox?: string;
+    width?: number;
+    height?: number;
+    blurhash?: string;
+}
+
+export interface EHagakiHostMediaUploadResult {
+    url: string;
+    /** Optional, already validated imeta fields such as `blurhash` or `alt`. */
+    imeta?: Record<string, string>;
+}
+
+export interface EHagakiHostOwnedComposerOptions {
+    submit: (
+        output: Readonly<EHagakiComposerOutput>,
+        options: { signal: AbortSignal },
+    ) => Promise<EHagakiHostSubmissionResult | void> | EHagakiHostSubmissionResult | void;
+    uploadMedia?: (
+        file: File,
+        metadata: Readonly<EHagakiHostMediaMetadata>,
+        options: { signal: AbortSignal },
+    ) => Promise<EHagakiHostMediaUploadResult> | EHagakiHostMediaUploadResult;
+}
+
+export interface EHagakiCustomEmojiCatalogItem {
+    shortcode: string;
+    url: string;
+    setAddress?: string | null;
+}
+
 export interface EHagakiComposerReadyDetail {
     apiVersion: typeof EHAGAKI_COMPOSER_API_VERSION;
 }


### PR DESCRIPTION
## Summary
- Adds explicit `configureHostOwned()` mode for the Direct Web Component, with immutable pre-first-connection configuration and reconnect reuse.
- Hands an immutable composer snapshot to the host while retaining context without relay hydration; Host-owned mode does not initialize eHagaki auth, guest relay, reference fetch, or upload transport.
- Makes host media upload an optional capability, preserves local preprocessing, and serializes upload/submit entry points.
- Preserves allowlisted Host-owned image and video imeta metadata (including host MIME types) through placeholder replacement, gallery/free-placement state, and Composer Output.
- Uses an internal Host-owned provenance marker instead of inferring publisher ownership from the shared `custom-http` transport protocol, preserving self-publish Custom HTTP behavior.
- Adds per-element custom emoji catalogs, documentation, and a standalone host-owned sample.

## Verification
- `npm run check` — passed (0 errors, 0 warnings)
- `npm test` — 338 passed test files, 1 skipped; 3,904 passed tests, 1 skipped
- `npm run build` — passed
- `npm run build:web-component` — passed
- `npx playwright test src/test/e2e/webComponentEmbed.spec.ts` — 90 passed, 2 skipped
- `npx playwright test src/test/e2e/webComponentEmbed.spec.ts -g "Host-owned"` — 16 passed
- `npx playwright test src/test/e2e/embedParentClientExample.spec.ts` — 4 passed
- `git diff --check` — passed

## Bundle measurement
- Same Web Component bundle remains in use: entry module is 185 B, bootstrap chunk is 102 KB raw / 29 KB gzip, and the on-connect App chunk is 2.74 MB raw / 689 KB gzip.
- The full distribution is 38.97 MB including compression WASM assets; no lightweight dedicated bundle is introduced in this PR.

Closes #156