### PR TITLE
Expose host-owned Composer sample for manual testing

### DIFF
--- a/scripts/devWebComponentSample.mjs
+++ b/scripts/devWebComponentSample.mjs
@@ -13,6 +13,7 @@ import {
 } from "./webComponentBuildRunner.mjs";
 import {
     createLanSampleUrls,
+    createSampleUrls,
     getLanIPv4Addresses,
     resolveWebComponentDevHosts,
 } from "./webComponentDevServerConfig.mjs";
@@ -237,7 +238,9 @@ async function main() {
             console.log("No non-internal LAN IPv4 address was found; use Vite's Network URL or the PC's LAN IP.");
         }
     } else {
-        console.log(`Web Component sample: http://localhost:${appPort}/ehagaki/web-component-parent-client-example.html`);
+        for (const url of createSampleUrls(appPort, "localhost")) {
+            console.log(`Web Component sample: ${url}`);
+        }
     }
 }
 

--- a/scripts/webComponentDevServerConfig.mjs
+++ b/scripts/webComponentDevServerConfig.mjs
@@ -2,6 +2,10 @@ import { networkInterfaces } from "node:os";
 
 export const LOCALHOST = "127.0.0.1";
 export const LAN_HOST = "0.0.0.0";
+const SAMPLE_PATHS = [
+    "web-component-parent-client-example.html",
+    "host-owned-composer-example.html",
+];
 
 /** @param {boolean} lanMode */
 export function resolveWebComponentDevHosts(lanMode) {
@@ -22,7 +26,10 @@ export function getLanIPv4Addresses(interfaces = networkInterfaces()) {
 
 /** @param {number} appPort @param {string[]} addresses */
 export function createLanSampleUrls(appPort, addresses) {
-    return addresses.map((address) =>
-        `http://${address}:${appPort}/ehagaki/web-component-parent-client-example.html`,
-    );
+    return addresses.flatMap((address) => createSampleUrls(appPort, address));
+}
+
+/** @param {number} appPort @param {string} host */
+export function createSampleUrls(appPort, host) {
+    return SAMPLE_PATHS.map((path) => `http://${host}:${appPort}/ehagaki/${path}`);
 }

--- a/src/test/unit/vercelRouting.test.ts
+++ b/src/test/unit/vercelRouting.test.ts
@@ -18,7 +18,7 @@ describe("Vercel routing", () => {
     it("static asset namespacesをSPA fallbackから除外する", () => {
         expect(config.rewrites).toEqual([
             {
-                source: "/((?!assets/|web-component(?:/|$)|web-component-parent-client-example\\.(?:html|js)$).*)",
+                source: "/((?!assets/|web-component(?:/|$)|web-component-parent-client-example\\.(?:html|js)$|host-owned-composer-example\\.html$).*)",
                 destination: "/index.html",
             },
         ]);
@@ -28,6 +28,7 @@ describe("Vercel routing", () => {
             "/assets/app.js",
             "/web-component-parent-client-example.html",
             "/web-component-parent-client-example.js",
+            "/host-owned-composer-example.html",
             "/web-component/ehagaki-composer.js",
             "/web-component/assets/entry.js",
             "/web-component/icons/settings.svg",

--- a/src/test/unit/webComponentDevServerConfig.test.ts
+++ b/src/test/unit/webComponentDevServerConfig.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
     createLanSampleUrls,
+    createSampleUrls,
     getLanIPv4Addresses,
     resolveWebComponentDevHosts,
 } from "../../../scripts/webComponentDevServerConfig.mjs";
@@ -32,6 +33,14 @@ describe("Web Component dev server host configuration", () => {
         })).toEqual(["192.168.1.20"]);
         expect(createLanSampleUrls(5173, ["192.168.1.20"])).toEqual([
             "http://192.168.1.20:5173/ehagaki/web-component-parent-client-example.html",
+            "http://192.168.1.20:5173/ehagaki/host-owned-composer-example.html",
+        ]);
+    });
+
+    it("creates both local manual-testing sample URLs", () => {
+        expect(createSampleUrls(5173, "localhost")).toEqual([
+            "http://localhost:5173/ehagaki/web-component-parent-client-example.html",
+            "http://localhost:5173/ehagaki/host-owned-composer-example.html",
         ]);
     });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/((?!assets/|web-component(?:/|$)|web-component-parent-client-example\\.(?:html|js)$).*)",
+      "source": "/((?!assets/|web-component(?:/|$)|web-component-parent-client-example\\.(?:html|js)$|host-owned-composer-example\\.html$).*)",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
Adds direct Vercel routing and localhost/LAN URLs for both manual-testing samples. Verified with targeted routing tests, npm run check, npm test, npm run build:web-component, npm run build, git diff --check, and Playwright manual browser checks.