### PR TITLE
Prioritize channel names in draft list

### DIFF
--- a/src/components/DraftListDialog.svelte
+++ b/src/components/DraftListDialog.svelte
@@ -664,10 +664,19 @@
         min-width: 3em;
     }
 
+    .channel-context .context-name {
+        flex: 0 1 auto;
+        min-width: 0;
+    }
+
     .context-detail {
         flex: 0 1 auto;
         min-width: 0;
         color: var(--text-muted);
+    }
+
+    .channel-context .context-detail {
+        flex: 1 1 0;
     }
 
     .draft-timestamp {


### PR DESCRIPTION
## Summary\n- Prioritize full channel-name width in draft context rows.\n- Allocate only the remaining width to channel descriptions.\n- Keep reply and quote context layout unchanged.\n\n## Verification\n- npm run test\n- npm run check\n- npm run build\n- Real-browser geometry checks at 800px and 360px, including long channel names and fixed draft-row UI