### PR TITLE
Preserve composer focus and emoji picker after posting

### DIFF
--- a/app-composer-picker-playwright.html
+++ b/app-composer-picker-playwright.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>App composer picker Playwright harness</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/test/e2e/appComposerPickerHarnessEntry.ts"></script>
+  </body>
+</html>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1090,12 +1090,6 @@
     }
   });
 
-  $effect(() => {
-    if (editorState.postStatus.sending && customEmojiPickerOpen) {
-      customEmojiPickerOpen = false;
-    }
-  });
-
   async function initializeNostr(pubkeyHex?: string): Promise<void> {
     await runInitializeNostrSession({
       pubkeyHex,
@@ -1916,7 +1910,6 @@
 
   function handleCustomEmojiSelect(emoji: CustomEmojiSelection): void {
     if (editorState.postStatus.sending) {
-      customEmojiPickerOpen = false;
       return;
     }
 

--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -632,7 +632,7 @@
   }
 
   function moveCaret(direction: -1 | 1): void {
-    if (!currentEditor) return;
+    if (!currentEditor || postStatus.sending) return;
 
     revealToolbarCaret();
     const { state, view } = currentEditor;
@@ -663,7 +663,7 @@
   }
 
   export function deleteBackward(): void {
-    if (!currentEditor) return;
+    if (!currentEditor || postStatus.sending) return;
 
     revealToolbarCaret();
     const { state, view } = currentEditor;
@@ -699,7 +699,7 @@
   }
 
   export function insertLineBreak(): void {
-    if (!currentEditor) return;
+    if (!currentEditor || postStatus.sending) return;
     revealToolbarCaret();
     currentEditor.commands.keyboardShortcut("Enter");
   }
@@ -833,8 +833,8 @@
         currentEditor.commands.insertContent(
           ` ${pinnedHashtags.map((hashtag) => `#${hashtag}`).join(" ")}`,
         );
-        currentEditor.commands.focus("start");
       }
+      currentEditor.commands.focus("start");
     }
   }
 

--- a/src/lib/postManager.ts
+++ b/src/lib/postManager.ts
@@ -779,7 +779,11 @@ export class PostManager {
     if (pinEnabled && hashtags.length > 0) {
       const hashtagText = ' ' + hashtags.map(h => '#' + h).join(' ');
       editor.commands.insertContent(hashtagText);
-      editor.commands.focus('start');
     }
+
+    // 投稿成功後は、固定ハッシュタグの有無にかかわらずエディターへ戻す。
+    // 固定ハッシュタグがある場合は、復元されたハッシュタグより前に
+    // カレットを置く既存の位置を維持する。
+    editor.commands.focus('start');
   }
 }

--- a/src/test/e2e/PostEditorSendingHarness.svelte
+++ b/src/test/e2e/PostEditorSendingHarness.svelte
@@ -1,13 +1,53 @@
 <script lang="ts">
     import { onDestroy, onMount } from 'svelte';
     import PostComponent from '../../components/PostComponent.svelte';
+    import CustomEmojiPicker from '../../components/CustomEmojiPicker.svelte';
+    import type { CustomEmojiSelection } from '../../lib/customEmojiUsage';
     import { editorState, resetPostStatus, updatePostStatus } from '../../stores/editorStore.svelte';
     import { isLoadingProfileStore, profileDataStore, profileLoadedStore } from '../../stores/profileStore.svelte';
 
     let sending = $derived(editorState.postStatus.sending);
+    let pickerOpen = $state(false);
+    let postComponentRef: any = $state(null);
+
+    const pickerEmoji = {
+        shortcode: 'sending-safe',
+        shortcodeLower: 'sending-safe',
+        src: 'https://example.com/sending-safe.webp',
+        identityKey: 'sending-safe\u0000https://example.com/sending-safe.webp',
+        setAddress: null,
+        sortIndex: 0,
+        sourceType: 'kind10030' as const,
+        sourceAddress: null,
+    };
 
     function toggleSending(): void {
         updatePostStatus({ ...editorState.postStatus, sending: !editorState.postStatus.sending });
+    }
+
+    function completePost(): void {
+        updatePostStatus({
+            sending: false,
+            success: true,
+            error: false,
+            message: 'postComponent.post_success',
+            completed: true,
+        });
+        postComponentRef?.clearContentAfterSuccess?.();
+    }
+
+    function failPost(): void {
+        updatePostStatus({
+            sending: false,
+            success: false,
+            error: true,
+            message: 'postComponent.post_error',
+            completed: false,
+        });
+    }
+
+    function selectPickerEmoji(emoji: CustomEmojiSelection): void {
+        postComponentRef?.insertCustomEmoji?.(emoji);
     }
 
     onMount(() => {
@@ -40,6 +80,24 @@
     <button type="button" data-testid="toggle-sending" onclick={toggleSending}>
         Toggle sending
     </button>
+    <button type="button" data-testid="toggle-picker" onclick={() => (pickerOpen = !pickerOpen)}>
+        Toggle picker
+    </button>
+    <button type="button" data-testid="complete-post" onclick={completePost}>
+        Complete post
+    </button>
+    <button type="button" data-testid="fail-post" onclick={failPost}>
+        Fail post
+    </button>
     <output data-testid="sending-state">{sending ? 'sending' : 'idle'}</output>
-    <PostComponent hasStoredKey={true} />
+    <PostComponent bind:this={postComponentRef} hasStoredKey={true} />
+    {#if pickerOpen}
+        <div data-testid="custom-emoji-picker-host">
+            <CustomEmojiPicker
+                open={pickerOpen}
+                hostCustomEmojiItems={[pickerEmoji]}
+                onSelect={selectPickerEmoji}
+            />
+        </div>
+    {/if}
 </main>

--- a/src/test/e2e/appComposerPickerHarnessEntry.ts
+++ b/src/test/e2e/appComposerPickerHarnessEntry.ts
@@ -1,0 +1,57 @@
+import '../../app.css';
+import '../../i18n';
+import { mount } from 'svelte';
+import App from '../../App.svelte';
+import { STORAGE_KEYS } from '../../lib/constants';
+import { updateAuthState } from '../../stores/authStore.svelte';
+import { editorState, updatePostStatus } from '../../stores/editorStore.svelte';
+
+const target = document.getElementById('app');
+
+if (!target) {
+    throw new Error('App composer picker harness mount target was not found.');
+}
+
+const TEST_PUBKEY = 'a'.repeat(64);
+
+// Keep the unrelated first-visit welcome dialog from intercepting the composer
+// interaction this harness is meant to exercise.
+localStorage.setItem(STORAGE_KEYS.FIRST_VISIT, '1');
+
+type HarnessWindow = Window & typeof globalThis & {
+    __APP_COMPOSER_PICKER_HARNESS__?: {
+        setAuthenticated(): void;
+        setSending(): void;
+        setIdle(): void;
+    };
+};
+
+updateAuthState({
+    type: 'nsec',
+    isInitialized: true,
+    isValid: true,
+    pubkey: TEST_PUBKEY,
+    npub: 'npub1testappcomposer',
+    nprofile: 'nprofile1testappcomposer',
+});
+
+mount(App, { target });
+
+(window as HarnessWindow).__APP_COMPOSER_PICKER_HARNESS__ = {
+    setAuthenticated: () => {
+        updateAuthState({
+            type: 'nsec',
+            isInitialized: true,
+            isValid: true,
+            pubkey: TEST_PUBKEY,
+            npub: 'npub1testappcomposer',
+            nprofile: 'nprofile1testappcomposer',
+        });
+    },
+    setSending: () => {
+        updatePostStatus({ ...editorState.postStatus, sending: true });
+    },
+    setIdle: () => {
+        updatePostStatus({ ...editorState.postStatus, sending: false });
+    },
+};

--- a/src/test/e2e/postEditorSending.spec.ts
+++ b/src/test/e2e/postEditorSending.spec.ts
@@ -122,4 +122,58 @@ test.describe('post editor sending state', () => {
         expect(fallbackGeometry.width).toBeLessThanOrEqual(wrapperGeometry.width + 0.5);
         expect(fallbackGeometry.height).toBeLessThanOrEqual(wrapperGeometry.height + 0.5);
     });
+
+    test('preserves the open picker and restores editor focus after a successful post', async ({ page }) => {
+        await page.goto('post-editor-sending-playwright.html');
+
+        const editorContainer = page.getByRole('textbox', { name: '投稿エディター' });
+        const editor = editorContainer.locator('.tiptap-editor');
+        const pickerToggle = page.getByTestId('toggle-picker');
+        const pickerHost = page.getByTestId('custom-emoji-picker-host');
+
+        await editor.click();
+        await page.keyboard.type('投稿成功後にクリアされる本文');
+        await pickerToggle.click();
+        await expect(pickerHost).toBeVisible();
+        await expect(page.getByAltText(':sending-safe:')).toBeVisible();
+
+        const pickerIdentity = await pickerHost.locator('.custom-emoji-picker').elementHandle();
+        if (!pickerIdentity) throw new Error('Custom emoji picker was not mounted.');
+
+        await page.getByTestId('toggle-sending').click();
+        await expect(editor).toHaveAttribute('contenteditable', 'false');
+        await expect(pickerHost).toBeVisible();
+
+        const contentBeforePickerSelection = await editor.textContent();
+        await page.getByAltText(':sending-safe:').click();
+        await expect(editor).toHaveText(contentBeforePickerSelection ?? '');
+
+        await page.getByTestId('complete-post').click();
+        await expect(editor).toHaveAttribute('contenteditable', 'true');
+        await expect(editor).toHaveText('');
+        await expect(pickerHost).toBeVisible();
+        await expect.poll(() => editor.evaluate((element) => document.activeElement === element)).toBe(true);
+        expect(await pickerHost.evaluate((element, picker) => element.querySelector('.custom-emoji-picker') === picker, pickerIdentity)).toBe(true);
+    });
+
+    test('preserves a closed picker after a failed post', async ({ page }) => {
+        await page.goto('post-editor-sending-playwright.html');
+
+        const editor = page.getByRole('textbox', { name: '投稿エディター' }).locator('.tiptap-editor');
+        await editor.click();
+        await page.keyboard.type('失敗する本文');
+
+        await page.getByTestId('toggle-sending').click();
+        await page.getByTestId('fail-post').click();
+
+        await expect(page.getByTestId('custom-emoji-picker-host')).toHaveCount(0);
+        await expect(editor).toHaveText('失敗する本文');
+
+        await page.goto('post-editor-sending-playwright.html');
+        await page.getByTestId('toggle-picker').click();
+        await expect(page.getByTestId('custom-emoji-picker-host')).toBeVisible();
+        await page.getByTestId('toggle-sending').click();
+        await page.getByTestId('fail-post').click();
+        await expect(page.getByTestId('custom-emoji-picker-host')).toBeVisible();
+    });
 });

--- a/src/test/e2e/postEditorSending.spec.ts
+++ b/src/test/e2e/postEditorSending.spec.ts
@@ -176,4 +176,52 @@ test.describe('post editor sending state', () => {
         await page.getByTestId('fail-post').click();
         await expect(page.getByTestId('custom-emoji-picker-host')).toBeVisible();
     });
+
+    test('preserves the App picker when the App post status enters and leaves sending', async ({ page }) => {
+        await page.goto('app-composer-picker-playwright.html');
+
+        const pickerButton = page.getByRole('button', { name: 'カスタム絵文字' });
+        const pickerRegion = page.locator('.custom-emoji-picker-region');
+
+        await expect(pickerButton).toBeVisible();
+        const welcomeDialog = page.locator('.welcome-dialog');
+        if (await welcomeDialog.isVisible().catch(() => false)) {
+            await welcomeDialog.getByRole('button', { name: 'はじめる' }).click();
+        }
+        await page.evaluate(() => {
+            const harness = (window as Window & typeof globalThis & {
+                __APP_COMPOSER_PICKER_HARNESS__?: { setAuthenticated(): void };
+            }).__APP_COMPOSER_PICKER_HARNESS__;
+            if (!harness) throw new Error('App composer picker harness is not ready.');
+            harness.setAuthenticated();
+        });
+        await expect(pickerButton).toBeEnabled();
+
+        await pickerButton.click();
+        await expect(pickerRegion).toBeVisible();
+
+        const pickerIdentity = await pickerRegion.locator('.custom-emoji-picker').elementHandle();
+        if (!pickerIdentity) throw new Error('App custom emoji picker was not mounted.');
+
+        await page.evaluate(() => {
+            const harness = (window as Window & typeof globalThis & {
+                __APP_COMPOSER_PICKER_HARNESS__?: { setSending(): void };
+            }).__APP_COMPOSER_PICKER_HARNESS__;
+            if (!harness) throw new Error('App composer picker harness is not ready.');
+            harness.setSending();
+        });
+        await expect(pickerRegion).toBeVisible();
+        await expect(pickerButton).toBeDisabled();
+
+        await page.evaluate(() => {
+            const harness = (window as Window & typeof globalThis & {
+                __APP_COMPOSER_PICKER_HARNESS__?: { setIdle(): void };
+            }).__APP_COMPOSER_PICKER_HARNESS__;
+            if (!harness) throw new Error('App composer picker harness is not ready.');
+            harness.setIdle();
+        });
+        await expect(pickerRegion).toBeVisible();
+        await expect(pickerButton).toBeEnabled();
+        expect(await pickerRegion.evaluate((element, picker) => element.querySelector('.custom-emoji-picker') === picker, pickerIdentity)).toBe(true);
+    });
 });

--- a/src/test/unit/accessibilityComponent.test.ts
+++ b/src/test/unit/accessibilityComponent.test.ts
@@ -276,7 +276,14 @@ describe('accessibility component tests', () => {
             src: 'https://example.com/test.webp',
             setAddress: null,
         });
+
+        const selectionBeforePickerActions = editor.state.selection.toJSON();
+        (component as any).moveCaretLeft();
+        (component as any).moveCaretRight();
+        (component as any).deleteBackward();
+        (component as any).insertLineBreak();
         expect(editor.getJSON()).toEqual(contentBeforeInput);
+        expect(editor.state.selection.toJSON()).toEqual(selectionBeforePickerActions);
 
         updatePostStatus({ ...editorState.postStatus, sending: false });
         await tick();

--- a/src/test/unit/postManager.test.ts
+++ b/src/test/unit/postManager.test.ts
@@ -409,6 +409,7 @@ describe('PostManager editor state helpers', () => {
 
             expect(mockEditor.clearContent).toHaveBeenCalled();
             expect(mockEditor.insertContent).not.toHaveBeenCalled();
+            expect(mockEditor.focus).toHaveBeenCalledWith('start');
             expect(mockDeps.contentWarningStore?.reset).toHaveBeenCalled();
             expect(mockDeps.contentWarningReasonStore?.reset).toHaveBeenCalled();
             expect(mockDeps.mediaGalleryStore?.clearAll).toHaveBeenCalled();
@@ -440,6 +441,7 @@ describe('PostManager editor state helpers', () => {
 
             expect(mockEditor.clearContent).toHaveBeenCalled();
             expect(mockEditor.insertContent).not.toHaveBeenCalled();
+            expect(mockEditor.focus).toHaveBeenCalledWith('start');
         });
     });
 


### PR DESCRIPTION
## Summary\n- restore composer focus after successful content clearing, including pinned-hashtag and host-owned paths\n- preserve custom emoji picker visibility during sending and after success/failure\n- block picker-driven editor mutations while sending\n\n## Verification\n- npm run test -- src/test/unit/postManager.test.ts src/test/unit/postComponentUtils.test.ts src/test/unit/accessibilityComponent.test.ts\n- npm run check\n- npm test\n- npm run build\n- npx playwright test src/test/e2e/postEditorSending.spec.ts --project=desktop-chromium --project=mobile-chromium --project=mobile-webkit\n- git diff --check