### PR TITLE
Remove unused spacing in host-owned Composer

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -559,7 +559,11 @@
   }
 
   const composerLayoutMetrics = useComposerLayoutMetrics({
-    setupViewportListener,
+    setupViewportListener: () =>
+      setupViewportListener({
+        hasHeader: !isHostOwnedComposer,
+        hasFooter: !isHostOwnedComposer,
+      }),
     getComposerScrollRegionEl: () => composerScrollRegionEl,
     getComposerScrollContentEl: () => composerScrollContentEl,
     getCustomEmojiPickerRegionEl: () => customEmojiPickerRegionEl,

--- a/src/stores/uiStore.svelte.ts
+++ b/src/stores/uiStore.svelte.ts
@@ -63,8 +63,11 @@ function isVirtualKeyboardOverlayActive(): boolean {
     return isNonPwaAndroidChrome() && virtualKeyboard?.overlaysContent === true;
 }
 
-function getFooterReservedHeight(isKeyboardOpen: boolean): number {
-    return isKeyboardOpen ? 0 : FOOTER_HEIGHT;
+function getFooterReservedHeight(
+    isKeyboardOpen: boolean,
+    hasFooter: boolean,
+): number {
+    return isKeyboardOpen || !hasFooter ? 0 : FOOTER_HEIGHT;
 }
 
 function getContainerKeyboardInset(
@@ -121,6 +124,7 @@ function syncLayoutCssVariables(
         getAppRuntimeEnvironment().layoutMode === "container";
     const footerReservedHeight = getFooterReservedHeight(
         isComposerKeyboardActive,
+        layoutCapabilities.hasFooter,
     );
     const usesKeyboardOverlay = viewportMetrics.usesKeyboardOverlay === true;
     const shouldUseKeyboardViewportHeight =
@@ -142,9 +146,10 @@ function syncLayoutCssVariables(
             : shouldUseKeyboardViewportHeight || shouldUseKeyboardOverlay,
     );
 
-    const keyboardButtonBarBottom = `${isComposerKeyboardActive ? effectiveKeyboardInset : FOOTER_HEIGHT}px`;
-    const reasonInputBottom = `${(isComposerKeyboardActive ? effectiveKeyboardInset : FOOTER_HEIGHT) + KEYBOARD_BUTTON_BAR_HEIGHT}px`;
-    const footerBottom = isComposerKeyboardActive
+    const closedLayoutBottom = layoutCapabilities.hasFooter ? FOOTER_HEIGHT : 0;
+    const keyboardButtonBarBottom = `${isComposerKeyboardActive ? effectiveKeyboardInset : closedLayoutBottom}px`;
+    const reasonInputBottom = `${(isComposerKeyboardActive ? effectiveKeyboardInset : closedLayoutBottom) + KEYBOARD_BUTTON_BAR_HEIGHT}px`;
+    const footerBottom = !layoutCapabilities.hasFooter || isComposerKeyboardActive
         ? `${-FOOTER_HEIGHT}px`
         : "0px";
 
@@ -203,7 +208,7 @@ function syncLayoutCssVariables(
     );
     setRootStyleProperty(
         "--main-content-top-spacing",
-        `${MAIN_CONTENT_TOP_SPACING}px`,
+        `${layoutCapabilities.hasHeader ? MAIN_CONTENT_TOP_SPACING : 0}px`,
     );
     setRootStyleProperty(
         "--composer-bottom-reserved-height",
@@ -281,6 +286,11 @@ export const reasonInputVisibleStore = {
 };
 
 // --- bottomPosition ストア ---
+const layoutCapabilities = $state({
+    hasHeader: true,
+    hasFooter: true,
+});
+
 let bottomPosition = $state(FOOTER_HEIGHT);
 
 // --- keyboardHeight ストア ---
@@ -327,7 +337,14 @@ interface VirtualKeyboardInfo {
  * コンポーネントの$effect内で呼び出す
  * @returns クリーンアップ関数
  */
-export function setupViewportListener(): (() => void) | undefined {
+export function setupViewportListener(
+    capabilities: Partial<typeof layoutCapabilities> = {},
+): (() => void) | undefined {
+    layoutCapabilities.hasHeader = capabilities.hasHeader ?? true;
+    layoutCapabilities.hasFooter = capabilities.hasFooter ?? true;
+    bottomPosition = layoutCapabilities.hasFooter ? FOOTER_HEIGHT : 0;
+    syncLayoutCssVariables(false);
+
     if (typeof window === "undefined" || !window.visualViewport) {
         return undefined;
     }

--- a/src/test/e2e/webComponentDevServer.spec.ts
+++ b/src/test/e2e/webComponentDevServer.spec.ts
@@ -132,6 +132,24 @@ test("serves the Web Component sample through the local dev proxy", async ({ pag
         consoleErrors.length = 0;
         await expect(page.locator("#log")).toContainText("ready: {\"mediaEnabled\":false}");
         await expect(page.locator("ehagaki-composer")).toBeVisible();
+        const closedHostOwnedGeometry = await page.locator("ehagaki-composer").evaluate((element) => {
+            const shadow = element.shadowRoot!;
+            const content = shadow.querySelector<HTMLElement>(".main-content")!;
+            const buttonBar = shadow.querySelector<HTMLElement>(".footer-button-bar")!;
+            const component = element.getBoundingClientRect();
+            const buttonBarRect = buttonBar.getBoundingClientRect();
+            return {
+                topSpacing: getComputedStyle(content).paddingTop,
+                buttonBarHeight: buttonBarRect.height,
+                buttonBarBottom: buttonBarRect.bottom,
+                componentBottom: component.bottom,
+                footerPresent: !!shadow.querySelector(".footer-bar"),
+            };
+        });
+        expect(closedHostOwnedGeometry.topSpacing).toBe("0px");
+        expect(closedHostOwnedGeometry.buttonBarHeight).toBe(50);
+        expect(Math.abs(closedHostOwnedGeometry.buttonBarBottom - closedHostOwnedGeometry.componentBottom)).toBeLessThanOrEqual(1);
+        expect(closedHostOwnedGeometry.footerPresent).toBe(false);
         await expect.poll(() => page.locator("ehagaki-composer").evaluate((element) => {
             const shadow = element.shadowRoot!;
             const icons = [
@@ -155,6 +173,22 @@ test("serves the Web Component sample through the local dev proxy", async ({ pag
         expect(sampleIconState).toHaveLength(3);
         expect(sampleIconState.every((mask) => mask !== "none" && mask.includes(`${origin}/ehagaki/web-component/icons/`))).toBe(true);
         expect(sampleIconState.every((mask) => !mask.includes(`${origin}/ehagaki/web-component/assets/icons/`))).toBe(true);
+
+        await page.locator("ehagaki-composer .content-warning-icon").click();
+        await expect.poll(() => page.locator("ehagaki-composer").evaluate((element) => {
+            const reason = element.shadowRoot!.querySelector<HTMLElement>(".reason-input-container");
+            return reason?.getBoundingClientRect().height ?? 0;
+        })).toBe(50);
+        const hostOwnedWarningGeometry = await page.locator("ehagaki-composer").evaluate((element) => {
+            const shadow = element.shadowRoot!;
+            const reason = shadow.querySelector<HTMLElement>(".reason-input-container")!;
+            const buttonBar = shadow.querySelector<HTMLElement>(".footer-button-bar")!;
+            return {
+                reasonBottom: reason.getBoundingClientRect().bottom,
+                buttonBarTop: buttonBar.getBoundingClientRect().top,
+            };
+        });
+        expect(Math.abs(hostOwnedWarningGeometry.reasonBottom - hostOwnedWarningGeometry.buttonBarTop)).toBeLessThanOrEqual(1);
 
         const sampleEditor = page.locator("ehagaki-composer .tiptap-editor");
         await sampleEditor.click();

--- a/src/test/unit/uiStore.test.ts
+++ b/src/test/unit/uiStore.test.ts
@@ -975,6 +975,45 @@ describe('uiStore', () => {
         cancelAnimationFrameSpy.mockRestore();
     });
 
+    it('header/footerなしのcontainer layoutは下端と上端の余白を予約しない', async () => {
+        const runtime = await import('../../lib/appRuntimeEnvironment');
+        const layoutTarget = document.createElement('div');
+        Object.defineProperty(layoutTarget, 'getBoundingClientRect', {
+            configurable: true,
+            value: vi.fn(() => ({ bottom: 800, height: 800 })),
+        });
+        runtime.configureAppRuntimeEnvironment({
+            layoutMode: 'container',
+            styleTarget: layoutTarget,
+            layoutTarget,
+            overlayTarget: layoutTarget,
+            themeTarget: layoutTarget,
+        });
+
+        const requestAnimationFrameSpy = vi
+            .spyOn(window, 'requestAnimationFrame')
+            .mockImplementation((callback: FrameRequestCallback) => {
+                callback(0);
+                return 1;
+            });
+        const cancelAnimationFrameSpy = vi
+            .spyOn(window, 'cancelAnimationFrame')
+            .mockImplementation(() => { });
+        createVisualViewportMock(800);
+
+        const { setupViewportListener } = await import('../../stores/uiStore.svelte');
+        const cleanup = setupViewportListener({ hasHeader: false, hasFooter: false });
+
+        expect(layoutTarget.style.getPropertyValue('--main-content-top-spacing')).toBe('0px');
+        expect(layoutTarget.style.getPropertyValue('--keyboard-button-bar-bottom')).toBe('0px');
+        expect(layoutTarget.style.getPropertyValue('--reason-input-bottom')).toBe('50px');
+        expect(layoutTarget.style.getPropertyValue('--composer-bottom-reserved-height')).toBe('50px');
+
+        cleanup?.();
+        requestAnimationFrameSpy.mockRestore();
+        cancelAnimationFrameSpy.mockRestore();
+    });
+
     it('reason input の表示状態を CSS 変数へ同期する', async () => {
         const {
             REASON_INPUT_HEIGHT,


### PR DESCRIPTION
## Summary
- pass header/footer layout capabilities into viewport layout synchronization
- remove host-owned top spacing and footer reservation while preserving keyboard inset behavior
- add unit and manual-sample geometry regression coverage

## Validation
- npm run check
- npm test
- npm run build
- npm run build:web-component
- npx playwright test --config=playwright.web-component-dev.config.ts
- npx playwright test src/test/e2e/webComponentEmbed.spec.ts --project=desktop-chromium
- npx playwright test src/test/e2e/webComponentEmbed.spec.ts --project=mobile-chromium
- npx playwright test src/test/e2e/webComponentEmbed.spec.ts --project=mobile-webkit
- git diff --check