### PR TITLE
Add iOS media compression diagnostics

### DIFF
--- a/media-compression-debug-playwright.html
+++ b/media-compression-debug-playwright.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Media compression debug harness</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/test/e2e/mediaCompressionDebugHarnessEntry.ts"></script>
+  </body>
+</html>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
                 '**/webComponentEmbed.spec.ts',
                 '**/webComponentParentClientExample.spec.ts',
                 '**/postEditorSending.spec.ts',
+                '**/mediaCompressionDebug.spec.ts',
             ],
             use: {
                 ...devices['iPhone 13'],

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -29,6 +29,7 @@
   } from "./lib/embedStorageService";
   import HeaderComponent from "./components/HeaderComponent.svelte";
   import FooterComponent from "./components/FooterComponent.svelte";
+  import MediaCompressionDebugPanel from "./components/MediaCompressionDebugPanel.svelte";
   import KeyboardButtonBar from "./components/KeyboardButtonBar.svelte";
   import ReasonInput from "./components/ReasonInput.svelte";
   import ChannelContextPreview from "./components/ChannelContextPreview.svelte";
@@ -147,6 +148,7 @@
     POST_EDITOR_MIN_HEIGHT,
   } from "./lib/postLayoutUtils";
   import { setupViewportListener } from "./stores/uiStore.svelte";
+  import { isMediaCompressionDebugEnabled } from "./lib/videoCompression/mediaCompressionDiagnostics";
   import {
     runAppInitializationBootstrap,
     registerNip46VisibilityHandler,
@@ -224,6 +226,7 @@
   import { uploadDestinationStore } from "./stores/uploadDestinationStore.svelte";
 
   const appRuntimeEnvironment = getAppRuntimeEnvironment();
+  const mediaCompressionDebugEnabled = isMediaCompressionDebugEnabled();
   interface Props {
     /** The iframe transport remains the default for the PWA and iframe entry. */
     notificationPort?: AppPostNotificationPort & AppEmbedNotificationPort;
@@ -2083,6 +2086,9 @@
           onOpenSettingsDialog={handleOpenSettingsFromFooter}
           onOpenLogoutDialog={logoutDialog.open}
         />
+      {/if}
+      {#if mediaCompressionDebugEnabled}
+        <MediaCompressionDebugPanel />
       {/if}
       <ConfirmDialog
         open={showStaleAssetReloadPrompt}

--- a/src/components/MediaCompressionDebugPanel.svelte
+++ b/src/components/MediaCompressionDebugPanel.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import type {
+    VideoDecodeBenchmarkOptions,
+    VideoDecodeBenchmarkResult,
+  } from "../lib/videoCompression/videoDecodeBenchmark";
   import {
     addRawVideoEncoderBenchmarkRecord,
     addVideoDecodeBenchmarkRecord,
@@ -13,18 +17,26 @@
     subscribeToMediaCompressionDiagnostics,
   } from "../lib/videoCompression/mediaCompressionDiagnostics";
   import { runRawVideoEncoderBenchmark } from "../lib/videoCompression/rawVideoEncoderBenchmark";
-  import { runVideoDecodeBenchmark } from "../lib/videoCompression/videoDecodeBenchmark";
+
+  type VideoDecodeBenchmarkRunner = (
+    file: File,
+    options?: VideoDecodeBenchmarkOptions,
+  ) => Promise<VideoDecodeBenchmarkResult>;
+  type VideoDecodeBenchmarkLoader = () => Promise<VideoDecodeBenchmarkRunner>;
 
   interface Props {
     /** Harness injection only; production uses the native WebCodecs benchmark. */
     rawVideoEncoderBenchmarkRunner?: typeof runRawVideoEncoderBenchmark;
-    /** Harness injection only; production decodes with MediaBunny's public sample API. */
-    videoDecodeBenchmarkRunner?: typeof runVideoDecodeBenchmark;
+    /** Harness injection only; production loads the decoder benchmark on demand. */
+    videoDecodeBenchmarkRunner?: VideoDecodeBenchmarkRunner;
+    /** Test-only injection for the dynamic-import failure path. */
+    videoDecodeBenchmarkLoader?: VideoDecodeBenchmarkLoader;
   }
 
   let {
     rawVideoEncoderBenchmarkRunner = runRawVideoEncoderBenchmark,
-    videoDecodeBenchmarkRunner = runVideoDecodeBenchmark,
+    videoDecodeBenchmarkRunner,
+    videoDecodeBenchmarkLoader,
   }: Props = $props();
 
   let expanded = $state(false);
@@ -105,7 +117,11 @@
     videoDecodeBenchmarkStatus = "running";
     videoDecodeRunController = new AbortController();
     try {
-      const result = await videoDecodeBenchmarkRunner(file, { signal: videoDecodeRunController.signal });
+      const runner = videoDecodeBenchmarkRunner
+        ?? (videoDecodeBenchmarkLoader
+          ? await videoDecodeBenchmarkLoader()
+          : (await import("../lib/videoCompression/videoDecodeBenchmark")).runVideoDecodeBenchmark);
+      const result = await runner(file, { signal: videoDecodeRunController.signal });
       addVideoDecodeBenchmarkRecord(result);
       videoDecodeBenchmarkStatus = result.status;
     } catch {

--- a/src/components/MediaCompressionDebugPanel.svelte
+++ b/src/components/MediaCompressionDebugPanel.svelte
@@ -2,29 +2,40 @@
   import { onMount } from "svelte";
   import {
     addRawVideoEncoderBenchmarkRecord,
+    addVideoDecodeBenchmarkRecord,
     clearMediaCompressionDiagnosticRecords,
     formatMediaCompressionDiagnostics,
     getAacCustomEncoderState,
     getMediaCompressionDiagnosticRecords,
     isMediaCompressionDebugEnabled,
     isMediaCompressionDebugRawVideoEncoderEnabled,
+    isMediaCompressionDebugVideoDecodeBenchmarkEnabled,
     subscribeToMediaCompressionDiagnostics,
   } from "../lib/videoCompression/mediaCompressionDiagnostics";
   import { runRawVideoEncoderBenchmark } from "../lib/videoCompression/rawVideoEncoderBenchmark";
+  import { runVideoDecodeBenchmark } from "../lib/videoCompression/videoDecodeBenchmark";
 
   interface Props {
     /** Harness injection only; production uses the native WebCodecs benchmark. */
     rawVideoEncoderBenchmarkRunner?: typeof runRawVideoEncoderBenchmark;
+    /** Harness injection only; production decodes with MediaBunny's public sample API. */
+    videoDecodeBenchmarkRunner?: typeof runVideoDecodeBenchmark;
   }
 
-  let { rawVideoEncoderBenchmarkRunner = runRawVideoEncoderBenchmark }: Props = $props();
+  let {
+    rawVideoEncoderBenchmarkRunner = runRawVideoEncoderBenchmark,
+    videoDecodeBenchmarkRunner = runVideoDecodeBenchmark,
+  }: Props = $props();
 
   let expanded = $state(false);
   let records = $state(getMediaCompressionDiagnosticRecords());
   let aacState = $state(getAacCustomEncoderState());
   let copyStatus = $state("");
   let rawBenchmarkStatus = $state<"idle" | "running" | "completed" | "failed">("idle");
+  let videoDecodeBenchmarkStatus = $state<"idle" | "running" | "completed" | "failed">("idle");
   let rawRunController: AbortController | null = null;
+  let videoDecodeRunController: AbortController | null = null;
+  let videoDecodeInput: HTMLInputElement | undefined = $state();
 
   const diagnosticText = $derived.by(() => {
     void records;
@@ -39,6 +50,8 @@
     });
     return () => {
       rawRunController?.abort();
+      videoDecodeRunController?.abort();
+      if (videoDecodeInput) videoDecodeInput.value = "";
       unsubscribe();
     };
   });
@@ -78,6 +91,29 @@
       rawRunController = null;
     }
   }
+
+  function selectVideoDecodeBenchmarkFile(): void {
+    if (videoDecodeBenchmarkStatus !== "running") videoDecodeInput?.click();
+  }
+
+  async function runVideoDecodeBenchmarkForSelectedFile(event: Event): Promise<void> {
+    const input = event.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = "";
+    if (!file || videoDecodeBenchmarkStatus === "running") return;
+
+    videoDecodeBenchmarkStatus = "running";
+    videoDecodeRunController = new AbortController();
+    try {
+      const result = await videoDecodeBenchmarkRunner(file, { signal: videoDecodeRunController.signal });
+      addVideoDecodeBenchmarkRecord(result);
+      videoDecodeBenchmarkStatus = result.status;
+    } catch {
+      videoDecodeBenchmarkStatus = "failed";
+    } finally {
+      videoDecodeRunController = null;
+    }
+  }
 </script>
 
 {#if isMediaCompressionDebugEnabled()}
@@ -107,10 +143,28 @@
               {rawBenchmarkStatus === "running" ? "Running raw VideoEncoder benchmark…" : "Run raw VideoEncoder benchmark"}
             </button>
           {/if}
+          {#if isMediaCompressionDebugVideoDecodeBenchmarkEnabled()}
+            <input
+              bind:this={videoDecodeInput}
+              class="media-debug-file-input"
+              type="file"
+              accept="video/*"
+              aria-label="Select video for decode benchmark"
+              onchange={runVideoDecodeBenchmarkForSelectedFile}
+            />
+            <button
+              type="button"
+              disabled={videoDecodeBenchmarkStatus === "running"}
+              onclick={selectVideoDecodeBenchmarkFile}
+            >
+              {videoDecodeBenchmarkStatus === "running" ? "Running video decode benchmark…" : "Run video decode benchmark"}
+            </button>
+          {/if}
           <button type="button" onclick={copyDiagnostics}>Copy</button>
           <button type="button" onclick={clearDiagnostics}>Clear</button>
           {#if copyStatus}<span role="status">{copyStatus}</span>{/if}
           {#if rawBenchmarkStatus !== "idle"}<span role="status">Raw benchmark: {rawBenchmarkStatus}</span>{/if}
+          {#if videoDecodeBenchmarkStatus !== "idle"}<span role="status">Video decode benchmark: {videoDecodeBenchmarkStatus}</span>{/if}
         </div>
         <pre>{diagnosticText}</pre>
       </div>
@@ -180,6 +234,10 @@
 
   .media-debug-actions span {
     color: var(--text-light);
+  }
+
+  .media-debug-file-input {
+    display: none;
   }
 
   pre {

--- a/src/components/MediaCompressionDebugPanel.svelte
+++ b/src/components/MediaCompressionDebugPanel.svelte
@@ -8,10 +8,15 @@
     RealVideoPipelineBenchmarkOptions,
     RealVideoPipelineBenchmarkResult,
   } from "../lib/videoCompression/realVideoPipelineBenchmark";
+  import type {
+    LegacyLikeCanvasPipelineBenchmarkOptions,
+    LegacyLikeCanvasPipelineBenchmarkResult,
+  } from "../lib/videoCompression/legacyLikeCanvasPipelineBenchmark";
   import {
     addRawVideoEncoderBenchmarkRecord,
     addVideoDecodeBenchmarkRecord,
     addRealVideoPipelineBenchmarkRecord,
+    addLegacyLikeCanvasPipelineBenchmarkRecord,
     clearMediaCompressionDiagnosticRecords,
     formatMediaCompressionDiagnostics,
     getAacCustomEncoderState,
@@ -34,6 +39,11 @@
     options?: RealVideoPipelineBenchmarkOptions,
   ) => Promise<RealVideoPipelineBenchmarkResult>;
   type RealVideoPipelineBenchmarkLoader = () => Promise<RealVideoPipelineBenchmarkRunner>;
+  type LegacyLikeCanvasPipelineBenchmarkRunner = (
+    file: File,
+    options?: LegacyLikeCanvasPipelineBenchmarkOptions,
+  ) => Promise<LegacyLikeCanvasPipelineBenchmarkResult>;
+  type LegacyLikeCanvasPipelineBenchmarkLoader = () => Promise<LegacyLikeCanvasPipelineBenchmarkRunner>;
   type RawVideoEncoderBenchmarkRunner = typeof runRawVideoEncoderBenchmark;
   type RawVideoEncoderBenchmarkOptions = Parameters<RawVideoEncoderBenchmarkRunner>[0];
 
@@ -50,6 +60,10 @@
     realVideoPipelineBenchmarkRunner?: RealVideoPipelineBenchmarkRunner;
     /** Test-only injection for the real pipeline benchmark dynamic-import failure path. */
     realVideoPipelineBenchmarkLoader?: RealVideoPipelineBenchmarkLoader;
+    /** Harness injection only; production loads the legacy-like Canvas benchmark on demand. */
+    legacyLikeCanvasPipelineBenchmarkRunner?: LegacyLikeCanvasPipelineBenchmarkRunner;
+    /** Test-only injection for the legacy-like Canvas benchmark dynamic-import failure path. */
+    legacyLikeCanvasPipelineBenchmarkLoader?: LegacyLikeCanvasPipelineBenchmarkLoader;
   }
 
   let {
@@ -62,6 +76,8 @@
     videoDecodeBenchmarkLoader,
     realVideoPipelineBenchmarkRunner,
     realVideoPipelineBenchmarkLoader,
+    legacyLikeCanvasPipelineBenchmarkRunner,
+    legacyLikeCanvasPipelineBenchmarkLoader,
   }: Props = $props();
 
   let expanded = $state(false);
@@ -72,12 +88,19 @@
   let offscreenCanvasBenchmarkStatus = $state<"idle" | "running" | "completed" | "failed">("idle");
   let videoDecodeBenchmarkStatus = $state<"idle" | "running" | "completed" | "failed">("idle");
   let realVideoPipelineBenchmarkStatus = $state<"idle" | "running" | "completed" | "failed">("idle");
+  let legacyLikeCanvasPipelineBenchmarkStatus = $state<"idle" | "running" | "completed" | "failed">("idle");
   let rawRunController: AbortController | null = null;
   let offscreenCanvasRunController: AbortController | null = null;
   let videoDecodeRunController: AbortController | null = null;
   let realVideoPipelineRunController: AbortController | null = null;
+  let legacyLikeCanvasPipelineRunController: AbortController | null = null;
   let videoDecodeInput: HTMLInputElement | undefined = $state();
   let realVideoPipelineInput: HTMLInputElement | undefined = $state();
+  let legacyLikeCanvasPipelineInput: HTMLInputElement | undefined = $state();
+
+  const videoPipelineBenchmarkRunning = $derived(
+    realVideoPipelineBenchmarkStatus === "running" || legacyLikeCanvasPipelineBenchmarkStatus === "running",
+  );
 
   const diagnosticText = $derived.by(() => {
     void records;
@@ -95,8 +118,10 @@
       offscreenCanvasRunController?.abort();
       videoDecodeRunController?.abort();
       realVideoPipelineRunController?.abort();
+      legacyLikeCanvasPipelineRunController?.abort();
       if (videoDecodeInput) videoDecodeInput.value = "";
       if (realVideoPipelineInput) realVideoPipelineInput.value = "";
+      if (legacyLikeCanvasPipelineInput) legacyLikeCanvasPipelineInput.value = "";
       unsubscribe();
     };
   });
@@ -181,14 +206,14 @@
   }
 
   function selectRealVideoPipelineBenchmarkFile(): void {
-    if (realVideoPipelineBenchmarkStatus !== "running") realVideoPipelineInput?.click();
+    if (!videoPipelineBenchmarkRunning) realVideoPipelineInput?.click();
   }
 
   async function runRealVideoPipelineBenchmarkForSelectedFile(event: Event): Promise<void> {
     const input = event.currentTarget as HTMLInputElement;
     const file = input.files?.[0];
     input.value = "";
-    if (!file || realVideoPipelineBenchmarkStatus === "running") return;
+    if (!file || videoPipelineBenchmarkRunning) return;
 
     realVideoPipelineBenchmarkStatus = "running";
     realVideoPipelineRunController = new AbortController();
@@ -204,6 +229,33 @@
       realVideoPipelineBenchmarkStatus = "failed";
     } finally {
       realVideoPipelineRunController = null;
+    }
+  }
+
+  function selectLegacyLikeCanvasPipelineBenchmarkFile(): void {
+    if (!videoPipelineBenchmarkRunning) legacyLikeCanvasPipelineInput?.click();
+  }
+
+  async function runLegacyLikeCanvasPipelineBenchmarkForSelectedFile(event: Event): Promise<void> {
+    const input = event.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = "";
+    if (!file || videoPipelineBenchmarkRunning) return;
+
+    legacyLikeCanvasPipelineBenchmarkStatus = "running";
+    legacyLikeCanvasPipelineRunController = new AbortController();
+    try {
+      const runner = legacyLikeCanvasPipelineBenchmarkRunner
+        ?? (legacyLikeCanvasPipelineBenchmarkLoader
+          ? await legacyLikeCanvasPipelineBenchmarkLoader()
+          : (await import("../lib/videoCompression/legacyLikeCanvasPipelineBenchmark")).runLegacyLikeCanvasPipelineBenchmark);
+      const result = await runner(file, { signal: legacyLikeCanvasPipelineRunController.signal });
+      addLegacyLikeCanvasPipelineBenchmarkRecord(result);
+      legacyLikeCanvasPipelineBenchmarkStatus = result.status;
+    } catch {
+      legacyLikeCanvasPipelineBenchmarkStatus = "failed";
+    } finally {
+      legacyLikeCanvasPipelineRunController = null;
     }
   }
 </script>
@@ -265,15 +317,30 @@
               class="media-debug-file-input"
               type="file"
               accept="video/*"
-              aria-label="Select video for real pipeline benchmark"
+              aria-label="Select video for MediaBunny transform pipeline benchmark"
               onchange={runRealVideoPipelineBenchmarkForSelectedFile}
             />
             <button
               type="button"
-              disabled={realVideoPipelineBenchmarkStatus === "running"}
+              disabled={videoPipelineBenchmarkRunning}
               onclick={selectRealVideoPipelineBenchmarkFile}
             >
-              {realVideoPipelineBenchmarkStatus === "running" ? "Running real video pipeline benchmark…" : "Run real video pipeline benchmark"}
+              {realVideoPipelineBenchmarkStatus === "running" ? "Running MediaBunny transform pipeline benchmark…" : "Run MediaBunny transform pipeline benchmark"}
+            </button>
+            <input
+              bind:this={legacyLikeCanvasPipelineInput}
+              class="media-debug-file-input"
+              type="file"
+              accept="video/*"
+              aria-label="Select video for legacy-like Canvas pipeline benchmark"
+              onchange={runLegacyLikeCanvasPipelineBenchmarkForSelectedFile}
+            />
+            <button
+              type="button"
+              disabled={videoPipelineBenchmarkRunning}
+              onclick={selectLegacyLikeCanvasPipelineBenchmarkFile}
+            >
+              {legacyLikeCanvasPipelineBenchmarkStatus === "running" ? "Running legacy-like Canvas pipeline benchmark…" : "Run legacy-like Canvas pipeline benchmark"}
             </button>
           {/if}
           <button type="button" onclick={copyDiagnostics}>Copy</button>
@@ -282,7 +349,8 @@
           {#if rawBenchmarkStatus !== "idle"}<span role="status">Raw benchmark: {rawBenchmarkStatus}</span>{/if}
           {#if offscreenCanvasBenchmarkStatus !== "idle"}<span role="status">OffscreenCanvas benchmark: {offscreenCanvasBenchmarkStatus}</span>{/if}
           {#if videoDecodeBenchmarkStatus !== "idle"}<span role="status">Video decode benchmark: {videoDecodeBenchmarkStatus}</span>{/if}
-          {#if realVideoPipelineBenchmarkStatus !== "idle"}<span role="status">Real video pipeline benchmark: {realVideoPipelineBenchmarkStatus}</span>{/if}
+          {#if realVideoPipelineBenchmarkStatus !== "idle"}<span role="status">MediaBunny transform pipeline benchmark: {realVideoPipelineBenchmarkStatus}</span>{/if}
+          {#if legacyLikeCanvasPipelineBenchmarkStatus !== "idle"}<span role="status">Legacy-like Canvas pipeline benchmark: {legacyLikeCanvasPipelineBenchmarkStatus}</span>{/if}
         </div>
         <pre>{diagnosticText}</pre>
       </div>

--- a/src/components/MediaCompressionDebugPanel.svelte
+++ b/src/components/MediaCompressionDebugPanel.svelte
@@ -4,9 +4,14 @@
     VideoDecodeBenchmarkOptions,
     VideoDecodeBenchmarkResult,
   } from "../lib/videoCompression/videoDecodeBenchmark";
+  import type {
+    RealVideoPipelineBenchmarkOptions,
+    RealVideoPipelineBenchmarkResult,
+  } from "../lib/videoCompression/realVideoPipelineBenchmark";
   import {
     addRawVideoEncoderBenchmarkRecord,
     addVideoDecodeBenchmarkRecord,
+    addRealVideoPipelineBenchmarkRecord,
     clearMediaCompressionDiagnosticRecords,
     formatMediaCompressionDiagnostics,
     getAacCustomEncoderState,
@@ -14,6 +19,7 @@
     isMediaCompressionDebugEnabled,
     isMediaCompressionDebugRawVideoEncoderEnabled,
     isMediaCompressionDebugVideoDecodeBenchmarkEnabled,
+    isMediaCompressionDebugVideoPipelineBenchmarkEnabled,
     subscribeToMediaCompressionDiagnostics,
   } from "../lib/videoCompression/mediaCompressionDiagnostics";
   import { runRawVideoEncoderBenchmark } from "../lib/videoCompression/rawVideoEncoderBenchmark";
@@ -23,6 +29,11 @@
     options?: VideoDecodeBenchmarkOptions,
   ) => Promise<VideoDecodeBenchmarkResult>;
   type VideoDecodeBenchmarkLoader = () => Promise<VideoDecodeBenchmarkRunner>;
+  type RealVideoPipelineBenchmarkRunner = (
+    file: File,
+    options?: RealVideoPipelineBenchmarkOptions,
+  ) => Promise<RealVideoPipelineBenchmarkResult>;
+  type RealVideoPipelineBenchmarkLoader = () => Promise<RealVideoPipelineBenchmarkRunner>;
   type RawVideoEncoderBenchmarkRunner = typeof runRawVideoEncoderBenchmark;
   type RawVideoEncoderBenchmarkOptions = Parameters<RawVideoEncoderBenchmarkRunner>[0];
 
@@ -35,6 +46,10 @@
     videoDecodeBenchmarkRunner?: VideoDecodeBenchmarkRunner;
     /** Test-only injection for the dynamic-import failure path. */
     videoDecodeBenchmarkLoader?: VideoDecodeBenchmarkLoader;
+    /** Harness injection only; production loads the real pipeline benchmark on demand. */
+    realVideoPipelineBenchmarkRunner?: RealVideoPipelineBenchmarkRunner;
+    /** Test-only injection for the real pipeline benchmark dynamic-import failure path. */
+    realVideoPipelineBenchmarkLoader?: RealVideoPipelineBenchmarkLoader;
   }
 
   let {
@@ -45,6 +60,8 @@
     }),
     videoDecodeBenchmarkRunner,
     videoDecodeBenchmarkLoader,
+    realVideoPipelineBenchmarkRunner,
+    realVideoPipelineBenchmarkLoader,
   }: Props = $props();
 
   let expanded = $state(false);
@@ -54,10 +71,13 @@
   let rawBenchmarkStatus = $state<"idle" | "running" | "completed" | "failed">("idle");
   let offscreenCanvasBenchmarkStatus = $state<"idle" | "running" | "completed" | "failed">("idle");
   let videoDecodeBenchmarkStatus = $state<"idle" | "running" | "completed" | "failed">("idle");
+  let realVideoPipelineBenchmarkStatus = $state<"idle" | "running" | "completed" | "failed">("idle");
   let rawRunController: AbortController | null = null;
   let offscreenCanvasRunController: AbortController | null = null;
   let videoDecodeRunController: AbortController | null = null;
+  let realVideoPipelineRunController: AbortController | null = null;
   let videoDecodeInput: HTMLInputElement | undefined = $state();
+  let realVideoPipelineInput: HTMLInputElement | undefined = $state();
 
   const diagnosticText = $derived.by(() => {
     void records;
@@ -74,7 +94,9 @@
       rawRunController?.abort();
       offscreenCanvasRunController?.abort();
       videoDecodeRunController?.abort();
+      realVideoPipelineRunController?.abort();
       if (videoDecodeInput) videoDecodeInput.value = "";
+      if (realVideoPipelineInput) realVideoPipelineInput.value = "";
       unsubscribe();
     };
   });
@@ -157,6 +179,33 @@
       videoDecodeRunController = null;
     }
   }
+
+  function selectRealVideoPipelineBenchmarkFile(): void {
+    if (realVideoPipelineBenchmarkStatus !== "running") realVideoPipelineInput?.click();
+  }
+
+  async function runRealVideoPipelineBenchmarkForSelectedFile(event: Event): Promise<void> {
+    const input = event.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = "";
+    if (!file || realVideoPipelineBenchmarkStatus === "running") return;
+
+    realVideoPipelineBenchmarkStatus = "running";
+    realVideoPipelineRunController = new AbortController();
+    try {
+      const runner = realVideoPipelineBenchmarkRunner
+        ?? (realVideoPipelineBenchmarkLoader
+          ? await realVideoPipelineBenchmarkLoader()
+          : (await import("../lib/videoCompression/realVideoPipelineBenchmark")).runRealVideoPipelineBenchmark);
+      const result = await runner(file, { signal: realVideoPipelineRunController.signal });
+      addRealVideoPipelineBenchmarkRecord(result);
+      realVideoPipelineBenchmarkStatus = result.status;
+    } catch {
+      realVideoPipelineBenchmarkStatus = "failed";
+    } finally {
+      realVideoPipelineRunController = null;
+    }
+  }
 </script>
 
 {#if isMediaCompressionDebugEnabled()}
@@ -210,12 +259,30 @@
               {videoDecodeBenchmarkStatus === "running" ? "Running video decode benchmark…" : "Run video decode benchmark"}
             </button>
           {/if}
+          {#if isMediaCompressionDebugVideoPipelineBenchmarkEnabled()}
+            <input
+              bind:this={realVideoPipelineInput}
+              class="media-debug-file-input"
+              type="file"
+              accept="video/*"
+              aria-label="Select video for real pipeline benchmark"
+              onchange={runRealVideoPipelineBenchmarkForSelectedFile}
+            />
+            <button
+              type="button"
+              disabled={realVideoPipelineBenchmarkStatus === "running"}
+              onclick={selectRealVideoPipelineBenchmarkFile}
+            >
+              {realVideoPipelineBenchmarkStatus === "running" ? "Running real video pipeline benchmark…" : "Run real video pipeline benchmark"}
+            </button>
+          {/if}
           <button type="button" onclick={copyDiagnostics}>Copy</button>
           <button type="button" onclick={clearDiagnostics}>Clear</button>
           {#if copyStatus}<span role="status">{copyStatus}</span>{/if}
           {#if rawBenchmarkStatus !== "idle"}<span role="status">Raw benchmark: {rawBenchmarkStatus}</span>{/if}
           {#if offscreenCanvasBenchmarkStatus !== "idle"}<span role="status">OffscreenCanvas benchmark: {offscreenCanvasBenchmarkStatus}</span>{/if}
           {#if videoDecodeBenchmarkStatus !== "idle"}<span role="status">Video decode benchmark: {videoDecodeBenchmarkStatus}</span>{/if}
+          {#if realVideoPipelineBenchmarkStatus !== "idle"}<span role="status">Real video pipeline benchmark: {realVideoPipelineBenchmarkStatus}</span>{/if}
         </div>
         <pre>{diagnosticText}</pre>
       </div>

--- a/src/components/MediaCompressionDebugPanel.svelte
+++ b/src/components/MediaCompressionDebugPanel.svelte
@@ -1,18 +1,30 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import {
+    addRawVideoEncoderBenchmarkRecord,
     clearMediaCompressionDiagnosticRecords,
     formatMediaCompressionDiagnostics,
     getAacCustomEncoderState,
     getMediaCompressionDiagnosticRecords,
     isMediaCompressionDebugEnabled,
+    isMediaCompressionDebugRawVideoEncoderEnabled,
     subscribeToMediaCompressionDiagnostics,
   } from "../lib/videoCompression/mediaCompressionDiagnostics";
+  import { runRawVideoEncoderBenchmark } from "../lib/videoCompression/rawVideoEncoderBenchmark";
+
+  interface Props {
+    /** Harness injection only; production uses the native WebCodecs benchmark. */
+    rawVideoEncoderBenchmarkRunner?: typeof runRawVideoEncoderBenchmark;
+  }
+
+  let { rawVideoEncoderBenchmarkRunner = runRawVideoEncoderBenchmark }: Props = $props();
 
   let expanded = $state(false);
   let records = $state(getMediaCompressionDiagnosticRecords());
   let aacState = $state(getAacCustomEncoderState());
   let copyStatus = $state("");
+  let rawBenchmarkStatus = $state<"idle" | "running" | "completed" | "failed">("idle");
+  let rawRunController: AbortController | null = null;
 
   const diagnosticText = $derived.by(() => {
     void records;
@@ -25,7 +37,10 @@
       records = [...getMediaCompressionDiagnosticRecords()];
       aacState = getAacCustomEncoderState();
     });
-    return unsubscribe;
+    return () => {
+      rawRunController?.abort();
+      unsubscribe();
+    };
   });
 
   async function copyDiagnostics(): Promise<void> {
@@ -47,6 +62,22 @@
     clearMediaCompressionDiagnosticRecords();
     copyStatus = "";
   }
+
+  async function runRawBenchmark(): Promise<void> {
+    if (rawBenchmarkStatus === "running") return;
+
+    rawBenchmarkStatus = "running";
+    rawRunController = new AbortController();
+    try {
+      const result = await rawVideoEncoderBenchmarkRunner({ signal: rawRunController.signal });
+      addRawVideoEncoderBenchmarkRecord(result);
+      rawBenchmarkStatus = result.status;
+    } catch {
+      rawBenchmarkStatus = "failed";
+    } finally {
+      rawRunController = null;
+    }
+  }
 </script>
 
 {#if isMediaCompressionDebugEnabled()}
@@ -67,9 +98,19 @@
           Clear removes displayed records only. Reload the page to reset AAC custom registration and the session.
         </p>
         <div class="media-debug-actions">
+          {#if isMediaCompressionDebugRawVideoEncoderEnabled()}
+            <button
+              type="button"
+              disabled={rawBenchmarkStatus === "running"}
+              onclick={runRawBenchmark}
+            >
+              {rawBenchmarkStatus === "running" ? "Running raw VideoEncoder benchmark…" : "Run raw VideoEncoder benchmark"}
+            </button>
+          {/if}
           <button type="button" onclick={copyDiagnostics}>Copy</button>
           <button type="button" onclick={clearDiagnostics}>Clear</button>
           {#if copyStatus}<span role="status">{copyStatus}</span>{/if}
+          {#if rawBenchmarkStatus !== "idle"}<span role="status">Raw benchmark: {rawBenchmarkStatus}</span>{/if}
         </div>
         <pre>{diagnosticText}</pre>
       </div>
@@ -131,6 +172,7 @@
   .media-debug-actions {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 6px;
     margin-bottom: 8px;
     font-family: system-ui, sans-serif;

--- a/src/components/MediaCompressionDebugPanel.svelte
+++ b/src/components/MediaCompressionDebugPanel.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import {
+    clearMediaCompressionDiagnosticRecords,
+    formatMediaCompressionDiagnostics,
+    getAacCustomEncoderState,
+    getMediaCompressionDiagnosticRecords,
+    isMediaCompressionDebugEnabled,
+    subscribeToMediaCompressionDiagnostics,
+  } from "../lib/videoCompression/mediaCompressionDiagnostics";
+
+  let expanded = $state(false);
+  let records = $state(getMediaCompressionDiagnosticRecords());
+  let aacState = $state(getAacCustomEncoderState());
+  let copyStatus = $state("");
+
+  const diagnosticText = $derived.by(() => {
+    void records;
+    void aacState;
+    return formatMediaCompressionDiagnostics();
+  });
+
+  onMount(() => {
+    const unsubscribe = subscribeToMediaCompressionDiagnostics(() => {
+      records = [...getMediaCompressionDiagnosticRecords()];
+      aacState = getAacCustomEncoderState();
+    });
+    return unsubscribe;
+  });
+
+  async function copyDiagnostics(): Promise<void> {
+    copyStatus = "";
+    if (!navigator.clipboard?.writeText) {
+      copyStatus = "Clipboard unavailable";
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(diagnosticText);
+      copyStatus = "Copied";
+    } catch {
+      copyStatus = "Copy failed";
+    }
+  }
+
+  function clearDiagnostics(): void {
+    clearMediaCompressionDiagnosticRecords();
+    copyStatus = "";
+  }
+</script>
+
+{#if isMediaCompressionDebugEnabled()}
+  <section class="media-debug-panel" aria-label="Media Compression Debug">
+    <button
+      class="media-debug-toggle"
+      type="button"
+      aria-expanded={expanded}
+      onclick={() => (expanded = !expanded)}
+    >
+      <span>Media Compression Debug</span>
+      <span aria-hidden="true">{expanded ? "−" : "+"}</span>
+    </button>
+
+    {#if expanded}
+      <div class="media-debug-content">
+        <p class="media-debug-note">
+          Clear removes displayed records only. Reload the page to reset AAC custom registration and the session.
+        </p>
+        <div class="media-debug-actions">
+          <button type="button" onclick={copyDiagnostics}>Copy</button>
+          <button type="button" onclick={clearDiagnostics}>Clear</button>
+          {#if copyStatus}<span role="status">{copyStatus}</span>{/if}
+        </div>
+        <pre>{diagnosticText}</pre>
+      </div>
+    {/if}
+  </section>
+{/if}
+
+<style>
+  .media-debug-panel {
+    position: fixed;
+    z-index: 1000;
+    top: 8px;
+    right: 8px;
+    width: min(320px, calc(100vw - 16px));
+    max-width: calc(100vw - 16px);
+    color: var(--text);
+    background: var(--dialog-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: 0 4px 18px rgb(0 0 0 / 25%);
+    font: 12px/1.35 ui-monospace, SFMono-Regular, Consolas, monospace;
+    overflow: hidden;
+  }
+
+  .media-debug-toggle,
+  .media-debug-actions button {
+    min-height: 36px;
+    padding: 6px 10px;
+    color: inherit;
+    background: var(--btn-bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font: inherit;
+  }
+
+  .media-debug-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    border: 0;
+    border-radius: 0;
+    text-align: left;
+  }
+
+  .media-debug-content {
+    max-height: min(70dvh, 680px);
+    padding: 8px;
+    overflow: auto;
+    overscroll-behavior: contain;
+  }
+
+  .media-debug-note {
+    margin: 0 0 8px;
+    color: var(--text-light);
+    font-family: system-ui, sans-serif;
+  }
+
+  .media-debug-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 8px;
+    font-family: system-ui, sans-serif;
+  }
+
+  .media-debug-actions span {
+    color: var(--text-light);
+  }
+
+  pre {
+    margin: 0;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+</style>

--- a/src/components/MediaCompressionDebugPanel.svelte
+++ b/src/components/MediaCompressionDebugPanel.svelte
@@ -23,10 +23,14 @@
     options?: VideoDecodeBenchmarkOptions,
   ) => Promise<VideoDecodeBenchmarkResult>;
   type VideoDecodeBenchmarkLoader = () => Promise<VideoDecodeBenchmarkRunner>;
+  type RawVideoEncoderBenchmarkRunner = typeof runRawVideoEncoderBenchmark;
+  type RawVideoEncoderBenchmarkOptions = Parameters<RawVideoEncoderBenchmarkRunner>[0];
 
   interface Props {
     /** Harness injection only; production uses the native WebCodecs benchmark. */
-    rawVideoEncoderBenchmarkRunner?: typeof runRawVideoEncoderBenchmark;
+    rawVideoEncoderBenchmarkRunner?: RawVideoEncoderBenchmarkRunner;
+    /** Harness injection only; production uses the same benchmark with an OffscreenCanvas source. */
+    offscreenCanvasVideoEncoderBenchmarkRunner?: RawVideoEncoderBenchmarkRunner;
     /** Harness injection only; production loads the decoder benchmark on demand. */
     videoDecodeBenchmarkRunner?: VideoDecodeBenchmarkRunner;
     /** Test-only injection for the dynamic-import failure path. */
@@ -35,6 +39,10 @@
 
   let {
     rawVideoEncoderBenchmarkRunner = runRawVideoEncoderBenchmark,
+    offscreenCanvasVideoEncoderBenchmarkRunner = (options: RawVideoEncoderBenchmarkOptions = {}) => runRawVideoEncoderBenchmark({
+      ...options,
+      canvasSource: "offscreen-canvas",
+    }),
     videoDecodeBenchmarkRunner,
     videoDecodeBenchmarkLoader,
   }: Props = $props();
@@ -44,8 +52,10 @@
   let aacState = $state(getAacCustomEncoderState());
   let copyStatus = $state("");
   let rawBenchmarkStatus = $state<"idle" | "running" | "completed" | "failed">("idle");
+  let offscreenCanvasBenchmarkStatus = $state<"idle" | "running" | "completed" | "failed">("idle");
   let videoDecodeBenchmarkStatus = $state<"idle" | "running" | "completed" | "failed">("idle");
   let rawRunController: AbortController | null = null;
+  let offscreenCanvasRunController: AbortController | null = null;
   let videoDecodeRunController: AbortController | null = null;
   let videoDecodeInput: HTMLInputElement | undefined = $state();
 
@@ -62,6 +72,7 @@
     });
     return () => {
       rawRunController?.abort();
+      offscreenCanvasRunController?.abort();
       videoDecodeRunController?.abort();
       if (videoDecodeInput) videoDecodeInput.value = "";
       unsubscribe();
@@ -101,6 +112,22 @@
       rawBenchmarkStatus = "failed";
     } finally {
       rawRunController = null;
+    }
+  }
+
+  async function runOffscreenCanvasBenchmark(): Promise<void> {
+    if (offscreenCanvasBenchmarkStatus === "running") return;
+
+    offscreenCanvasBenchmarkStatus = "running";
+    offscreenCanvasRunController = new AbortController();
+    try {
+      const result = await offscreenCanvasVideoEncoderBenchmarkRunner({ signal: offscreenCanvasRunController.signal });
+      addRawVideoEncoderBenchmarkRecord(result);
+      offscreenCanvasBenchmarkStatus = result.status;
+    } catch {
+      offscreenCanvasBenchmarkStatus = "failed";
+    } finally {
+      offscreenCanvasRunController = null;
     }
   }
 
@@ -156,7 +183,14 @@
               disabled={rawBenchmarkStatus === "running"}
               onclick={runRawBenchmark}
             >
-              {rawBenchmarkStatus === "running" ? "Running raw VideoEncoder benchmark…" : "Run raw VideoEncoder benchmark"}
+              {rawBenchmarkStatus === "running" ? "Running HTMLCanvas VideoEncoder benchmark…" : "Run HTMLCanvas VideoEncoder benchmark"}
+            </button>
+            <button
+              type="button"
+              disabled={offscreenCanvasBenchmarkStatus === "running"}
+              onclick={runOffscreenCanvasBenchmark}
+            >
+              {offscreenCanvasBenchmarkStatus === "running" ? "Running OffscreenCanvas VideoEncoder benchmark…" : "Run OffscreenCanvas VideoEncoder benchmark"}
             </button>
           {/if}
           {#if isMediaCompressionDebugVideoDecodeBenchmarkEnabled()}
@@ -180,6 +214,7 @@
           <button type="button" onclick={clearDiagnostics}>Clear</button>
           {#if copyStatus}<span role="status">{copyStatus}</span>{/if}
           {#if rawBenchmarkStatus !== "idle"}<span role="status">Raw benchmark: {rawBenchmarkStatus}</span>{/if}
+          {#if offscreenCanvasBenchmarkStatus !== "idle"}<span role="status">OffscreenCanvas benchmark: {offscreenCanvasBenchmarkStatus}</span>{/if}
           {#if videoDecodeBenchmarkStatus !== "idle"}<span role="status">Video decode benchmark: {videoDecodeBenchmarkStatus}</span>{/if}
         </div>
         <pre>{diagnosticText}</pre>

--- a/src/lib/videoCompression/legacyLikeCanvasPipelineBenchmark.ts
+++ b/src/lib/videoCompression/legacyLikeCanvasPipelineBenchmark.ts
@@ -4,45 +4,46 @@ import {
     Input,
     VideoSampleSink,
     type InputVideoTrack,
-    type VideoSampleTransformOptions,
 } from 'mediabunny';
 
 import { RAW_VIDEO_ENCODER_BENCHMARK_CONFIG, RAW_VIDEO_ENCODER_BENCHMARK_QUEUE_LIMIT } from './rawVideoEncoderBenchmark';
+import {
+    REAL_VIDEO_PIPELINE_BENCHMARK_TARGET,
+    REAL_VIDEO_PIPELINE_KEY_FRAME_INTERVAL,
+    type RealVideoPipelineBenchmarkEncoderConstructor,
+    type RealVideoPipelineBenchmarkInputLike,
+    type RealVideoPipelineBenchmarkSinkLike,
+    type RealVideoPipelineBenchmarkTrackLike,
+} from './realVideoPipelineBenchmark';
 
-export const REAL_VIDEO_PIPELINE_BENCHMARK_TARGET = {
-    width: RAW_VIDEO_ENCODER_BENCHMARK_CONFIG.width,
-    height: RAW_VIDEO_ENCODER_BENCHMARK_CONFIG.height,
-    fit: 'fill',
-    rotate: 0,
-    alpha: 'discard',
-} as const satisfies VideoSampleTransformOptions;
-
-export const REAL_VIDEO_PIPELINE_KEY_FRAME_INTERVAL = 5;
-
-export type RealVideoPipelineBenchmarkFailureStage =
+export type LegacyLikeCanvasPipelineBenchmarkFailureStage =
     | 'no-video-track'
     | 'decode-unavailable'
     | 'encoder-unavailable'
     | 'config-unsupported'
-    | 'transform-failure'
+    | 'canvas-unavailable'
+    | 'canvas-context-unavailable'
+    | 'source-frame-failure'
+    | 'canvas-draw-failure'
     | 'encode-failure'
     | 'flush-failure'
     | 'aborted'
     | 'setup-failure';
 
-export interface RealVideoPipelineBenchmarkTimings {
+export interface LegacyLikeCanvasPipelineBenchmarkTimings {
     inputTrackSetup: number;
     sampleWaitIteration: number;
-    videoTransform: number;
-    videoFrameCreation: number;
+    sourceVideoFrameAcquisition: number;
+    canvasDrawRotationResize: number;
+    outputVideoFrameCreation: number;
     encodeSubmissionSync: number;
     backpressureWait: number;
     flushWait: number;
     benchmarkTotalWall: number;
 }
 
-export interface RealVideoPipelineBenchmarkResult {
-    pipelineKind: 'mediabunny-transform';
+export interface LegacyLikeCanvasPipelineBenchmarkResult {
+    pipelineKind: 'legacy-like-html-canvas';
     status: 'completed' | 'failed';
     input: {
         mime: string;
@@ -55,13 +56,7 @@ export interface RealVideoPipelineBenchmarkResult {
         displayHeight: number | null;
         rotation: number | null;
     };
-    target: {
-        width: number;
-        height: number;
-        fit: 'fill';
-        rotate: 0;
-        alpha: 'discard';
-    };
+    target: typeof REAL_VIDEO_PIPELINE_BENCHMARK_TARGET;
     capabilities: {
         decode: boolean | null;
         avcEncode: boolean | null;
@@ -74,73 +69,55 @@ export interface RealVideoPipelineBenchmarkResult {
     deltaChunks: number;
     maxQueueSize: number;
     throughput: number | null;
-    timings: RealVideoPipelineBenchmarkTimings;
+    timings: LegacyLikeCanvasPipelineBenchmarkTimings;
     failure?: {
-        stage: RealVideoPipelineBenchmarkFailureStage;
+        stage: LegacyLikeCanvasPipelineBenchmarkFailureStage;
         message: string;
     };
 }
 
-export interface RealVideoPipelineBenchmarkSampleLike {
-    timestamp: number;
-    duration: number;
-    codedWidth: number;
-    codedHeight: number;
-    rotation: number;
-    setTimestamp(timestamp: number): void;
-    transform(options: VideoSampleTransformOptions): Promise<RealVideoPipelineBenchmarkSampleLike>;
-    toVideoFrame(): { close(): void };
+export interface LegacyLikeCanvasPipelineBenchmarkFrameLike {
+    readonly displayWidth: number;
+    readonly displayHeight: number;
     close(): void;
 }
 
-export interface RealVideoPipelineBenchmarkTrackLike {
-    canDecode(): Promise<boolean>;
-    getCodec(): Promise<string | null>;
-    getCodedWidth(): Promise<number>;
-    getCodedHeight(): Promise<number>;
-    getDisplayWidth(): Promise<number>;
-    getDisplayHeight(): Promise<number>;
-    getRotation(): Promise<number>;
-    getFirstTimestamp(): Promise<number>;
+export interface LegacyLikeCanvasPipelineBenchmarkSampleLike {
+    timestamp: number;
+    duration: number;
+    setTimestamp(timestamp: number): void;
+    toVideoFrame(): LegacyLikeCanvasPipelineBenchmarkFrameLike;
+    close(): void;
 }
 
-export interface RealVideoPipelineBenchmarkInputLike {
-    getVideoTracks(): Promise<RealVideoPipelineBenchmarkTrackLike[]>;
-    getDurationFromMetadata(): Promise<number | null>;
-    dispose(): void;
+export interface LegacyLikeCanvasPipelineBenchmarkSinkLike extends Omit<RealVideoPipelineBenchmarkSinkLike, 'samples'> {
+    samples(): AsyncIterable<LegacyLikeCanvasPipelineBenchmarkSampleLike>;
 }
 
-export interface RealVideoPipelineBenchmarkSinkLike {
-    samples(): AsyncIterable<RealVideoPipelineBenchmarkSampleLike>;
-}
-
-export interface RealVideoPipelineBenchmarkOptions {
+export interface LegacyLikeCanvasPipelineBenchmarkOptions {
     signal?: AbortSignal;
     now?: () => number;
     VideoEncoder?: RealVideoPipelineBenchmarkEncoderConstructor | null;
     createInput?: (file: File) => RealVideoPipelineBenchmarkInputLike;
-    createVideoSampleSink?: (track: RealVideoPipelineBenchmarkTrackLike) => RealVideoPipelineBenchmarkSinkLike;
+    createVideoSampleSink?: (track: RealVideoPipelineBenchmarkTrackLike) => LegacyLikeCanvasPipelineBenchmarkSinkLike;
+    createCanvas?: () => HTMLCanvasElement | null;
+    createOutputVideoFrame?: (
+        canvas: HTMLCanvasElement,
+        init: VideoFrameInit,
+    ) => LegacyLikeCanvasPipelineBenchmarkFrameLike;
 }
 
-interface RealVideoPipelineBenchmarkEncoder extends EventTarget {
+interface LegacyLikeCanvasPipelineBenchmarkEncoder extends EventTarget {
     readonly encodeQueueSize: number;
     configure(config: VideoEncoderConfig): void;
-    encode(frame: { close(): void }, options?: VideoEncoderEncodeOptions): void;
+    encode(frame: LegacyLikeCanvasPipelineBenchmarkFrameLike, options?: VideoEncoderEncodeOptions): void;
     flush(): Promise<void>;
     close(): void;
 }
 
-export interface RealVideoPipelineBenchmarkEncoderConstructor {
-    new(init: {
-        output: (chunk: { byteLength: number; type: EncodedVideoChunkType }) => void;
-        error: (error: unknown) => void;
-    }): RealVideoPipelineBenchmarkEncoder;
-    isConfigSupported(config: VideoEncoderConfig): Promise<{ supported?: boolean; config?: VideoEncoderConfig }>;
-}
-
-class RealVideoPipelineBenchmarkAbortError extends Error {
+class LegacyLikeCanvasPipelineBenchmarkAbortError extends Error {
     constructor() {
-        super('Real video pipeline benchmark was aborted.');
+        super('Legacy-like Canvas pipeline benchmark was aborted.');
         this.name = 'AbortError';
     }
 }
@@ -150,12 +127,13 @@ function shortErrorMessage(error: unknown): string {
     return message.replace(/[\r\n]+/g, ' ').slice(0, 240);
 }
 
-function createTimings(): RealVideoPipelineBenchmarkTimings {
+function createTimings(): LegacyLikeCanvasPipelineBenchmarkTimings {
     return {
         inputTrackSetup: 0,
         sampleWaitIteration: 0,
-        videoTransform: 0,
-        videoFrameCreation: 0,
+        sourceVideoFrameAcquisition: 0,
+        canvasDrawRotationResize: 0,
+        outputVideoFrameCreation: 0,
         encodeSubmissionSync: 0,
         backpressureWait: 0,
         flushWait: 0,
@@ -163,9 +141,9 @@ function createTimings(): RealVideoPipelineBenchmarkTimings {
     };
 }
 
-function createResult(file: File): RealVideoPipelineBenchmarkResult {
+function createResult(file: File): LegacyLikeCanvasPipelineBenchmarkResult {
     return {
-        pipelineKind: 'mediabunny-transform',
+        pipelineKind: 'legacy-like-html-canvas',
         status: 'failed',
         input: {
             mime: file.type || 'unknown',
@@ -178,7 +156,7 @@ function createResult(file: File): RealVideoPipelineBenchmarkResult {
             displayHeight: null,
             rotation: null,
         },
-        target: { ...REAL_VIDEO_PIPELINE_BENCHMARK_TARGET },
+        target: REAL_VIDEO_PIPELINE_BENCHMARK_TARGET,
         capabilities: { decode: null, avcEncode: null },
         samplesProcessed: 0,
         framesSubmitted: 0,
@@ -196,16 +174,30 @@ function createProductionInput(file: File): RealVideoPipelineBenchmarkInputLike 
     return new Input({ source: new BlobSource(file), formats: ALL_FORMATS });
 }
 
-function createProductionVideoSampleSink(track: RealVideoPipelineBenchmarkTrackLike): RealVideoPipelineBenchmarkSinkLike {
-    return new VideoSampleSink(track as InputVideoTrack);
+function createProductionVideoSampleSink(track: RealVideoPipelineBenchmarkTrackLike): LegacyLikeCanvasPipelineBenchmarkSinkLike {
+    return new VideoSampleSink(track as InputVideoTrack) as unknown as LegacyLikeCanvasPipelineBenchmarkSinkLike;
+}
+
+function createProductionCanvas(): HTMLCanvasElement | null {
+    return typeof document === 'undefined' ? null : document.createElement('canvas');
+}
+
+function createProductionOutputVideoFrame(
+    canvas: HTMLCanvasElement,
+    init: VideoFrameInit,
+): LegacyLikeCanvasPipelineBenchmarkFrameLike {
+    if (typeof globalThis.VideoFrame !== 'function') {
+        throw new Error('VideoFrame is unavailable.');
+    }
+    return new globalThis.VideoFrame(canvas, init);
 }
 
 function throwIfAborted(signal: AbortSignal | undefined): void {
-    if (signal?.aborted) throw new RealVideoPipelineBenchmarkAbortError();
+    if (signal?.aborted) throw new LegacyLikeCanvasPipelineBenchmarkAbortError();
 }
 
 async function waitForEncoderQueue(
-    encoder: RealVideoPipelineBenchmarkEncoder,
+    encoder: LegacyLikeCanvasPipelineBenchmarkEncoder,
     queueLimit: number,
     signal: AbortSignal | undefined,
     callbackError: () => unknown,
@@ -226,7 +218,7 @@ async function waitForEncoderQueue(
         const onDequeue = () => {
             if (encoder.encodeQueueSize < queueLimit) finish(resolve);
         };
-        const onAbort = () => finish(() => reject(new RealVideoPipelineBenchmarkAbortError()));
+        const onAbort = () => finish(() => reject(new LegacyLikeCanvasPipelineBenchmarkAbortError()));
         const rejectForEncoderError = (error: unknown) => finish(() => reject(error));
         encoder.addEventListener('dequeue', onDequeue);
         signal?.addEventListener('abort', onAbort, { once: true });
@@ -237,38 +229,84 @@ async function waitForEncoderQueue(
     });
 }
 
+function resetCanvasTransform(context: CanvasRenderingContext2D): void {
+    if (typeof context.resetTransform === 'function') context.resetTransform();
+    else context.setTransform(1, 0, 0, 1, 0, 0);
+}
+
+/**
+ * Mirrors the v1.44.2 CanvasSink target-case geometry without reusing its private
+ * APIs: a 90° rotation is baked into a reused portrait canvas before encoding.
+ */
+export function drawLegacyLikeCanvasFrame(
+    context: CanvasRenderingContext2D,
+    sourceFrame: LegacyLikeCanvasPipelineBenchmarkFrameLike,
+    rotation: number,
+): void {
+    const { width: targetWidth, height: targetHeight } = REAL_VIDEO_PIPELINE_BENCHMARK_TARGET;
+    if (!sourceFrame.displayWidth || !sourceFrame.displayHeight) {
+        throw new Error('Source VideoFrame has no drawable dimensions.');
+    }
+
+    resetCanvasTransform(context);
+    context.clearRect(0, 0, targetWidth, targetHeight);
+    context.save();
+    const rotationInRadians = rotation * Math.PI / 180;
+    const aspectRatioChange = rotation % 180 === 0 ? 1 : targetWidth / targetHeight;
+    context.translate(targetWidth / 2, targetHeight / 2);
+    context.rotate(rotationInRadians);
+    context.scale(1 / aspectRatioChange, aspectRatioChange);
+    context.translate(-targetWidth / 2, -targetHeight / 2);
+    context.drawImage(
+        sourceFrame as unknown as CanvasImageSource,
+        0,
+        0,
+        sourceFrame.displayWidth,
+        sourceFrame.displayHeight,
+        0,
+        0,
+        targetWidth,
+        targetHeight,
+    );
+    context.restore();
+}
+
 function classifyFailure(
     error: unknown,
-    phase: 'setup' | 'transform' | 'encode' | 'flush',
+    phase: 'setup' | 'source-frame' | 'canvas-draw' | 'encode' | 'flush',
     signal: AbortSignal | undefined,
-): RealVideoPipelineBenchmarkFailureStage {
-    if (signal?.aborted || error instanceof RealVideoPipelineBenchmarkAbortError) return 'aborted';
-    if (phase === 'transform') return 'transform-failure';
+): LegacyLikeCanvasPipelineBenchmarkFailureStage {
+    if (signal?.aborted || error instanceof LegacyLikeCanvasPipelineBenchmarkAbortError) return 'aborted';
+    if (phase === 'source-frame') return 'source-frame-failure';
+    if (phase === 'canvas-draw') return 'canvas-draw-failure';
     if (phase === 'encode') return 'encode-failure';
     if (phase === 'flush') return 'flush-failure';
     return 'setup-failure';
 }
 
 /**
- * Runs MediaBunny's public decode and VideoSample.transform pipeline directly into
- * native WebCodecs. It deliberately does not use Conversion, Output, muxing, or files.
+ * Runs a diagnostic-only, legacy-like HTMLCanvas path for the portrait MOV case.
+ * It uses only current MediaBunny public APIs and deliberately never calls
+ * VideoSample.transform(), Conversion, muxing, audio, or file output.
  */
-export async function runRealVideoPipelineBenchmark(
+export async function runLegacyLikeCanvasPipelineBenchmark(
     file: File,
-    options: RealVideoPipelineBenchmarkOptions = {},
-): Promise<RealVideoPipelineBenchmarkResult> {
+    options: LegacyLikeCanvasPipelineBenchmarkOptions = {},
+): Promise<LegacyLikeCanvasPipelineBenchmarkResult> {
     const now = options.now ?? (() => performance.now());
     const result = createResult(file);
     const createInput = options.createInput ?? createProductionInput;
     const createVideoSampleSink = options.createVideoSampleSink ?? createProductionVideoSampleSink;
+    const createCanvas = options.createCanvas ?? createProductionCanvas;
+    const createOutputVideoFrame = options.createOutputVideoFrame ?? createProductionOutputVideoFrame;
     const VideoEncoderConstructor = options.VideoEncoder === undefined
         ? (globalThis.VideoEncoder as unknown as RealVideoPipelineBenchmarkEncoderConstructor | undefined)
         : options.VideoEncoder ?? undefined;
     let input: RealVideoPipelineBenchmarkInputLike | undefined;
     let inputDisposed = false;
-    let encoder: RealVideoPipelineBenchmarkEncoder | undefined;
+    let encoder: LegacyLikeCanvasPipelineBenchmarkEncoder | undefined;
     let callbackError: unknown;
-    let phase: 'setup' | 'transform' | 'encode' | 'flush' = 'setup';
+    let phase: 'setup' | 'source-frame' | 'canvas-draw' | 'encode' | 'flush' = 'setup';
     const waitingRejectors = new Set<(error: unknown) => void>();
     const benchmarkStartedAt = now();
 
@@ -286,7 +324,7 @@ export async function runRealVideoPipelineBenchmark(
         waitingRejectors.clear();
     };
     const abortInput = () => {
-        rejectWaiters(new RealVideoPipelineBenchmarkAbortError());
+        rejectWaiters(new LegacyLikeCanvasPipelineBenchmarkAbortError());
         disposeInput();
     };
     options.signal?.addEventListener('abort', abortInput, { once: true });
@@ -347,13 +385,29 @@ export async function runRealVideoPipelineBenchmark(
             result.failure = { stage: 'config-unsupported', message: shortErrorMessage(error) };
             return result;
         }
-        result.timings.inputTrackSetup = Math.max(0, now() - setupStartedAt);
         if (!support.supported) {
             result.capabilities.avcEncode = false;
+            result.timings.inputTrackSetup = Math.max(0, now() - setupStartedAt);
             result.failure = { stage: 'config-unsupported', message: 'VideoEncoder does not support the fixed AVC configuration.' };
             return result;
         }
         result.capabilities.avcEncode = true;
+
+        const canvas = createCanvas();
+        if (!canvas) {
+            result.timings.inputTrackSetup = Math.max(0, now() - setupStartedAt);
+            result.failure = { stage: 'canvas-unavailable', message: 'HTMLCanvasElement is unavailable.' };
+            return result;
+        }
+        canvas.width = REAL_VIDEO_PIPELINE_BENCHMARK_TARGET.width;
+        canvas.height = REAL_VIDEO_PIPELINE_BENCHMARK_TARGET.height;
+        const context = canvas.getContext('2d', { alpha: false });
+        if (!context) {
+            result.timings.inputTrackSetup = Math.max(0, now() - setupStartedAt);
+            result.failure = { stage: 'canvas-context-unavailable', message: 'Canvas 2D context is unavailable.' };
+            return result;
+        }
+        result.timings.inputTrackSetup = Math.max(0, now() - setupStartedAt);
 
         encoder = new VideoEncoderConstructor({
             output: (chunk) => {
@@ -366,7 +420,7 @@ export async function runRealVideoPipelineBenchmark(
                 callbackError ??= error;
                 rejectWaiters(error);
             },
-        });
+        }) as unknown as LegacyLikeCanvasPipelineBenchmarkEncoder;
         encoder.configure({ ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG });
 
         const sink = createVideoSampleSink(track);
@@ -383,15 +437,23 @@ export async function runRealVideoPipelineBenchmark(
             result.samplesProcessed += 1;
             try {
                 throwIfAborted(options.signal);
-                sample.setTimestamp(Math.max(sample.timestamp - firstTimestamp, 0));
-                phase = 'transform';
-                const transformStartedAt = now();
-                const transformedSample = await sample.transform(REAL_VIDEO_PIPELINE_BENCHMARK_TARGET);
-                result.timings.videoTransform += Math.max(0, now() - transformStartedAt);
+                const normalizedTimestamp = Math.max(sample.timestamp - firstTimestamp, 0);
+                sample.setTimestamp(normalizedTimestamp);
+                phase = 'source-frame';
+                const sourceFrameStartedAt = now();
+                const sourceFrame = sample.toVideoFrame();
+                result.timings.sourceVideoFrameAcquisition += Math.max(0, now() - sourceFrameStartedAt);
                 try {
-                    const frameStartedAt = now();
-                    const frame = transformedSample.toVideoFrame();
-                    result.timings.videoFrameCreation += Math.max(0, now() - frameStartedAt);
+                    phase = 'canvas-draw';
+                    const canvasDrawStartedAt = now();
+                    drawLegacyLikeCanvasFrame(context, sourceFrame, rotation);
+                    result.timings.canvasDrawRotationResize += Math.max(0, now() - canvasDrawStartedAt);
+                    const outputFrameStartedAt = now();
+                    const outputFrame = createOutputVideoFrame(canvas, {
+                        timestamp: Math.round(normalizedTimestamp * 1_000_000),
+                        duration: Math.round(sample.duration * 1_000_000),
+                    });
+                    result.timings.outputVideoFrameCreation += Math.max(0, now() - outputFrameStartedAt);
                     try {
                         phase = 'encode';
                         const waitStartedAt = now();
@@ -404,22 +466,21 @@ export async function runRealVideoPipelineBenchmark(
                         );
                         result.timings.backpressureWait += Math.max(0, now() - waitStartedAt);
                         const encodeStartedAt = now();
-                        const keyFrameInterval = Math.floor(sample.timestamp / REAL_VIDEO_PIPELINE_KEY_FRAME_INTERVAL);
+                        const keyFrameInterval = Math.floor(normalizedTimestamp / REAL_VIDEO_PIPELINE_KEY_FRAME_INTERVAL);
                         const keyFrame = keyFrameInterval !== lastKeyFrameInterval;
                         lastKeyFrameInterval = keyFrameInterval;
-                        encoder.encode(frame, { keyFrame });
+                        encoder.encode(outputFrame, { keyFrame });
                         result.timings.encodeSubmissionSync += Math.max(0, now() - encodeStartedAt);
                         result.framesSubmitted += 1;
                         result.maxQueueSize = Math.max(result.maxQueueSize, encoder.encodeQueueSize);
                         if (callbackError) throw callbackError;
                     } finally {
-                        frame.close();
+                        outputFrame.close();
                     }
                 } finally {
-                    transformedSample.close();
+                    sourceFrame.close();
                 }
             } catch (error) {
-                phase = phase === 'transform' ? 'transform' : 'encode';
                 throw error;
             } finally {
                 sample.close();
@@ -446,7 +507,7 @@ export async function runRealVideoPipelineBenchmark(
         return result;
     } finally {
         options.signal?.removeEventListener('abort', abortInput);
-        rejectWaiters(new RealVideoPipelineBenchmarkAbortError());
+        rejectWaiters(new LegacyLikeCanvasPipelineBenchmarkAbortError());
         if (result.timings.benchmarkTotalWall === 0) {
             result.timings.benchmarkTotalWall = Math.max(0, now() - benchmarkStartedAt);
         }

--- a/src/lib/videoCompression/mediaCompressionDiagnostics.ts
+++ b/src/lib/videoCompression/mediaCompressionDiagnostics.ts
@@ -1,4 +1,5 @@
 import type { RawVideoEncoderBenchmarkResult } from './rawVideoEncoderBenchmark';
+import type { VideoDecodeBenchmarkResult } from './videoDecodeBenchmark';
 
 export type AacCustomEncoderState = 'not-loaded' | 'loading' | 'registered' | 'failed';
 
@@ -166,6 +167,7 @@ type DiagnosticListener = () => void;
 
 const records: MediaCompressionDiagnosticRecord[] = [];
 const rawVideoEncoderBenchmarkRecords: RawVideoEncoderBenchmarkResult[] = [];
+const videoDecodeBenchmarkRecords: VideoDecodeBenchmarkResult[] = [];
 const listeners = new Set<DiagnosticListener>();
 let conversionSequence = 0;
 let aacCustomEncoderState: AacCustomEncoderState = 'not-loaded';
@@ -198,6 +200,12 @@ export function isMediaCompressionDebugRawVideoEncoderEnabled(search?: string): 
     const locationSearch = search ?? (isBrowser() ? window.location.search : '');
     const params = new URLSearchParams(locationSearch);
     return params.get('media-debug') === '1' && params.get('media-debug-raw-video-encoder') === '1';
+}
+
+export function isMediaCompressionDebugVideoDecodeBenchmarkEnabled(search?: string): boolean {
+    const locationSearch = search ?? (isBrowser() ? window.location.search : '');
+    const params = new URLSearchParams(locationSearch);
+    return params.get('media-debug') === '1' && params.get('media-debug-video-decode-benchmark') === '1';
 }
 
 export function getMediaCompressionVideoDiagnosticMode(search?: string): MediaCompressionVideoDiagnosticMode {
@@ -270,8 +278,17 @@ export function getRawVideoEncoderBenchmarkRecords(): RawVideoEncoderBenchmarkRe
     return rawVideoEncoderBenchmarkRecords;
 }
 
+export function getVideoDecodeBenchmarkRecords(): VideoDecodeBenchmarkResult[] {
+    return videoDecodeBenchmarkRecords;
+}
+
 export function addRawVideoEncoderBenchmarkRecord(result: RawVideoEncoderBenchmarkResult): void {
     rawVideoEncoderBenchmarkRecords.push(result);
+    notify();
+}
+
+export function addVideoDecodeBenchmarkRecord(result: VideoDecodeBenchmarkResult): void {
+    videoDecodeBenchmarkRecords.push(result);
     notify();
 }
 
@@ -283,6 +300,7 @@ export function subscribeToMediaCompressionDiagnostics(listener: DiagnosticListe
 export function clearMediaCompressionDiagnosticRecords(): void {
     records.length = 0;
     rawVideoEncoderBenchmarkRecords.length = 0;
+    videoDecodeBenchmarkRecords.length = 0;
     notify();
 }
 
@@ -506,6 +524,45 @@ function formatRawVideoEncoderBenchmark(record: RawVideoEncoderBenchmarkResult, 
     return lines;
 }
 
+function formatDecodeOffset(value: number | undefined | null): string {
+    return value === undefined || value === null ? 'not reached' : `+${value.toFixed(1)} ms`;
+}
+
+function formatVideoDecodeBenchmark(record: VideoDecodeBenchmarkResult, index: number): string[] {
+    const firstSample = record.decode.firstSample;
+    const lines = [
+        `Video Decode Benchmark #${index + 1}`,
+        `status: ${record.status}`,
+        'Input',
+        `mime: ${record.input.mime}`,
+        `size: ${record.input.size} bytes`,
+        `duration: ${record.input.duration === null ? 'unknown' : `${record.input.duration.toFixed(3)} s`}`,
+        `video codec: ${formatValue(record.input.videoCodec)}`,
+        `source size: ${record.input.displayWidth === null || record.input.displayHeight === null
+            ? 'unknown'
+            : `${record.input.displayWidth}x${record.input.displayHeight}`}`,
+        'Decode',
+        `samples decoded: ${record.decode.samplesDecoded}`,
+        `first sample format: ${formatValue(firstSample?.format)}`,
+        `first sample size: ${firstSample ? `${firstSample.codedWidth}x${firstSample.codedHeight} coded / ${firstSample.displayWidth}x${firstSample.displayHeight} display` : 'not recorded'}`,
+        `sample #1: ${formatDecodeOffset(record.decode.milestoneOffsets[1])}`,
+        `sample #100: ${formatDecodeOffset(record.decode.milestoneOffsets[100])}`,
+        `sample #300: ${formatDecodeOffset(record.decode.milestoneOffsets[300])}`,
+        `sample #500: ${formatDecodeOffset(record.decode.milestoneOffsets[500])}`,
+        `sample #627: ${formatDecodeOffset(record.decode.milestoneOffsets[627])}`,
+        `last sample: ${formatDecodeOffset(record.decode.lastSampleOffset)}`,
+        'Timing',
+        `input / track setup: ${formatDuration(record.timing.inputTrackSetup)}`,
+        `decode wall: ${formatDuration(record.timing.decodeWall)}`,
+        `throughput: ${record.timing.throughput === null ? 'not recorded' : `${record.timing.throughput.toFixed(2)} fps`}`,
+    ];
+    if (record.failure) {
+        lines.push(`failure: ${record.failure.stage}: ${record.failure.message}`);
+    }
+    lines.push('No resize, video encode, audio, muxing, or file output is performed by this benchmark.', '');
+    return lines;
+}
+
 export function formatMediaCompressionDiagnostics(): string {
     const lines = [
         'Media Compression Debug',
@@ -518,6 +575,7 @@ export function formatMediaCompressionDiagnostics(): string {
             : []),
         `Video latency: ${getMediaCompressionVideoDiagnosticMode() === 'realtime' ? 'realtime' : 'quality (default)'}`,
         `Raw native VideoEncoder benchmark: ${isMediaCompressionDebugRawVideoEncoderEnabled() ? 'enabled (manual run)' : 'disabled'}`,
+        `Video decode benchmark: ${isMediaCompressionDebugVideoDecodeBenchmarkEnabled() ? 'enabled (manual run)' : 'disabled'}`,
         ...formatEnvironment(getMediaCompressionEnvironment()),
         '',
     ];
@@ -628,6 +686,10 @@ export function formatMediaCompressionDiagnostics(): string {
 
     rawVideoEncoderBenchmarkRecords.forEach((record, index) => {
         lines.push(...formatRawVideoEncoderBenchmark(record, index));
+    });
+
+    videoDecodeBenchmarkRecords.forEach((record, index) => {
+        lines.push(...formatVideoDecodeBenchmark(record, index));
     });
 
     lines.push('Reload the page before Conversion #1 to test AAC capability before the custom encoder is registered.');

--- a/src/lib/videoCompression/mediaCompressionDiagnostics.ts
+++ b/src/lib/videoCompression/mediaCompressionDiagnostics.ts
@@ -621,7 +621,7 @@ function formatRealVideoPipelineBenchmark(record: RealVideoPipelineBenchmarkResu
         `fit: ${record.target.fit}`,
         `transform rotate: ${record.target.rotate}°`,
         `alpha: ${record.target.alpha}`,
-        `key frame interval: 2 s`,
+        `key frame interval: 5 s`,
         'Capabilities',
         `decode: ${formatBoolean(record.capabilities.decode ?? undefined)}`,
         `AVC encode: ${formatBoolean(record.capabilities.avcEncode ?? undefined)}`,

--- a/src/lib/videoCompression/mediaCompressionDiagnostics.ts
+++ b/src/lib/videoCompression/mediaCompressionDiagnostics.ts
@@ -2,6 +2,10 @@ export type AacCustomEncoderState = 'not-loaded' | 'loading' | 'registered' | 'f
 
 export type AudioPath = 'native-aac' | 'custom-aac' | 'packet-copy' | 'unavailable' | 'unknown';
 
+export type MediaCompressionAudioDiagnosticMode = 'normal' | 'force-packet-copy';
+
+export type MediaCompressionAudioEncodingMode = 'quality' | 'bitrate' | 'default' | 'packet-copy';
+
 export interface AudioPathClassification {
     path: AudioPath;
     reason?: string;
@@ -85,8 +89,9 @@ export interface MediaCompressionAudioDiagnostic {
     decode?: boolean;
     targetSampleRate?: number;
     targetChannels?: number;
-    targetBitrate?: number | null;
+    configuredBitrate?: number | null;
     quality?: string;
+    effectiveEncodingMode?: MediaCompressionAudioEncodingMode;
     nativeCapabilityBeforeRegistration?: boolean;
     capabilityBeforeSelection?: boolean;
     capabilityAfterRegistration?: boolean;
@@ -94,10 +99,14 @@ export interface MediaCompressionAudioDiagnostic {
     customRegistration?: 'not-needed' | 'success' | 'failure' | 'unknown';
     audioPath?: AudioPath;
     reason?: string;
+    outputCodec?: string | null;
+    outputSampleRate?: number;
+    outputChannels?: number;
 }
 
 export interface MediaCompressionDiagnosticRecord {
     conversionId: number;
+    audioDiagnosticMode: MediaCompressionAudioDiagnosticMode;
     input: {
         mime: string;
         size: number;
@@ -151,6 +160,16 @@ function isBrowser(): boolean {
 export function isMediaCompressionDebugEnabled(search?: string): boolean {
     const locationSearch = search ?? (isBrowser() ? window.location.search : '');
     return new URLSearchParams(locationSearch).get('media-debug') === '1';
+}
+
+export function isMediaCompressionDebugAudioCopyEnabled(search?: string): boolean {
+    const locationSearch = search ?? (isBrowser() ? window.location.search : '');
+    const params = new URLSearchParams(locationSearch);
+    return params.get('media-debug') === '1' && params.get('media-debug-audio') === 'copy';
+}
+
+export function getMediaCompressionAudioDiagnosticMode(search?: string): MediaCompressionAudioDiagnosticMode {
+    return isMediaCompressionDebugAudioCopyEnabled(search) ? 'force-packet-copy' : 'normal';
 }
 
 function notify(): void {
@@ -330,6 +349,7 @@ export function startMediaCompressionDiagnostic(file: File): MediaCompressionDia
     environment ??= readEnvironment();
     const record: MediaCompressionDiagnosticRecord = {
         conversionId: ++conversionSequence,
+        audioDiagnosticMode: getMediaCompressionAudioDiagnosticMode(),
         input: { mime: file.type || 'unknown', size: file.size },
         tracks: { videoCount: 0, audioCount: 0 },
         video: [],
@@ -387,6 +407,12 @@ export function formatMediaCompressionDiagnostics(): string {
     const lines = [
         'Media Compression Debug',
         'Keep this data on the device. It is not sent to a server.',
+        `Diagnostic A/B mode: ${getMediaCompressionAudioDiagnosticMode() === 'force-packet-copy'
+            ? 'Forced audio packet copy'
+            : 'Normal audio transcode'}`,
+        ...(getMediaCompressionAudioDiagnosticMode() === 'force-packet-copy'
+            ? ['Diagnostic A/B mode: audio is being packet-copied instead of transcoded.']
+            : []),
         ...formatEnvironment(getMediaCompressionEnvironment()),
         '',
     ];
@@ -397,6 +423,7 @@ export function formatMediaCompressionDiagnostics(): string {
 
     for (const record of records) {
         lines.push(`Conversion #${record.conversionId}`);
+        lines.push(`audio diagnostic mode: ${record.audioDiagnosticMode}`);
         lines.push('Input');
         lines.push(`mime: ${formatValue(record.input.mime)}`);
         lines.push(`size: ${record.input.size} bytes`);
@@ -420,9 +447,10 @@ export function formatMediaCompressionDiagnostics(): string {
             lines.push(`Audio #${index + 1}`);
             lines.push(`codec: ${formatValue(audio.codec)}`);
             lines.push(`source: ${formatValue(audio.sourceSampleRate)} Hz / ${formatValue(audio.sourceChannels)}ch`);
-            lines.push(`target: ${formatValue(audio.targetSampleRate)} Hz / ${formatValue(audio.targetChannels)}ch`);
+            lines.push(`${record.audioDiagnosticMode === 'force-packet-copy' ? 'normal target' : 'target'}: ${formatValue(audio.targetSampleRate)} Hz / ${formatValue(audio.targetChannels)}ch`);
             lines.push(`decode: ${formatBoolean(audio.decode)}`);
-            lines.push(`target bitrate: ${formatValue(audio.targetBitrate)}`);
+            lines.push(`effective audio encoding mode: ${formatValue(audio.effectiveEncodingMode)}`);
+            lines.push(`configured audio bitrate: ${formatValue(audio.configuredBitrate)}`);
             lines.push(`MediaBunny audio Quality: ${formatValue(audio.quality)}`);
             lines.push(`native AAC before registration: ${formatBoolean(audio.nativeCapabilityBeforeRegistration)}`);
             lines.push(`AAC capability before selection: ${formatBoolean(audio.capabilityBeforeSelection)}`);
@@ -431,6 +459,8 @@ export function formatMediaCompressionDiagnostics(): string {
             lines.push(`AAC after registration: ${formatBoolean(audio.capabilityAfterRegistration)}`);
             lines.push(`audio path: ${formatValue(audio.audioPath)}`);
             if (audio.reason) lines.push(`reason: ${audio.reason}`);
+            lines.push(`output codec: ${formatValue(audio.outputCodec)}`);
+            lines.push(`output audio: ${formatValue(audio.outputSampleRate)} Hz / ${formatValue(audio.outputChannels)}ch`);
         });
 
         lines.push('Conversion');

--- a/src/lib/videoCompression/mediaCompressionDiagnostics.ts
+++ b/src/lib/videoCompression/mediaCompressionDiagnostics.ts
@@ -1,4 +1,5 @@
 import type { RawVideoEncoderBenchmarkResult } from './rawVideoEncoderBenchmark';
+import type { RealVideoPipelineBenchmarkResult } from './realVideoPipelineBenchmark';
 import type { VideoDecodeBenchmarkResult } from './videoDecodeBenchmark';
 
 export type AacCustomEncoderState = 'not-loaded' | 'loading' | 'registered' | 'failed';
@@ -173,6 +174,7 @@ type DiagnosticListener = () => void;
 const records: MediaCompressionDiagnosticRecord[] = [];
 const rawVideoEncoderBenchmarkRecords: RawVideoEncoderBenchmarkResult[] = [];
 const videoDecodeBenchmarkRecords: VideoDecodeBenchmarkResult[] = [];
+const realVideoPipelineBenchmarkRecords: RealVideoPipelineBenchmarkResult[] = [];
 const listeners = new Set<DiagnosticListener>();
 let conversionSequence = 0;
 let aacCustomEncoderState: AacCustomEncoderState = 'not-loaded';
@@ -223,6 +225,12 @@ export function isMediaCompressionDebugVideoDecodeBenchmarkEnabled(search?: stri
     const locationSearch = search ?? (isBrowser() ? window.location.search : '');
     const params = new URLSearchParams(locationSearch);
     return params.get('media-debug') === '1' && params.get('media-debug-video-decode-benchmark') === '1';
+}
+
+export function isMediaCompressionDebugVideoPipelineBenchmarkEnabled(search?: string): boolean {
+    const locationSearch = search ?? (isBrowser() ? window.location.search : '');
+    const params = new URLSearchParams(locationSearch);
+    return params.get('media-debug') === '1' && params.get('media-debug-video-pipeline-benchmark') === '1';
 }
 
 export function getMediaCompressionVideoDiagnosticMode(search?: string): MediaCompressionVideoDiagnosticMode {
@@ -299,6 +307,10 @@ export function getVideoDecodeBenchmarkRecords(): VideoDecodeBenchmarkResult[] {
     return videoDecodeBenchmarkRecords;
 }
 
+export function getRealVideoPipelineBenchmarkRecords(): RealVideoPipelineBenchmarkResult[] {
+    return realVideoPipelineBenchmarkRecords;
+}
+
 export function addRawVideoEncoderBenchmarkRecord(result: RawVideoEncoderBenchmarkResult): void {
     rawVideoEncoderBenchmarkRecords.push(result);
     notify();
@@ -306,6 +318,11 @@ export function addRawVideoEncoderBenchmarkRecord(result: RawVideoEncoderBenchma
 
 export function addVideoDecodeBenchmarkRecord(result: VideoDecodeBenchmarkResult): void {
     videoDecodeBenchmarkRecords.push(result);
+    notify();
+}
+
+export function addRealVideoPipelineBenchmarkRecord(result: RealVideoPipelineBenchmarkResult): void {
+    realVideoPipelineBenchmarkRecords.push(result);
     notify();
 }
 
@@ -318,6 +335,7 @@ export function clearMediaCompressionDiagnosticRecords(): void {
     records.length = 0;
     rawVideoEncoderBenchmarkRecords.length = 0;
     videoDecodeBenchmarkRecords.length = 0;
+    realVideoPipelineBenchmarkRecords.length = 0;
     notify();
 }
 
@@ -582,6 +600,57 @@ function formatVideoDecodeBenchmark(record: VideoDecodeBenchmarkResult, index: n
     return lines;
 }
 
+function formatRealVideoPipelineBenchmark(record: RealVideoPipelineBenchmarkResult, index: number): string[] {
+    const lines = [
+        `Real Video Pipeline Benchmark #${index + 1}`,
+        `status: ${record.status}`,
+        'Input',
+        `mime: ${record.input.mime}`,
+        `size: ${record.input.size} bytes`,
+        `duration: ${record.input.duration === null ? 'unknown' : `${record.input.duration.toFixed(3)} s`}`,
+        `video codec: ${formatValue(record.input.videoCodec)}`,
+        `coded size: ${record.input.codedWidth === null || record.input.codedHeight === null
+            ? 'unknown'
+            : `${record.input.codedWidth}x${record.input.codedHeight}`}`,
+        `source display: ${record.input.displayWidth === null || record.input.displayHeight === null
+            ? 'unknown'
+            : `${record.input.displayWidth}x${record.input.displayHeight}`}`,
+        `source rotation: ${formatValue(record.input.rotation)}°`,
+        'Target',
+        `target: ${record.target.width}x${record.target.height}`,
+        `fit: ${record.target.fit}`,
+        `transform rotate: ${record.target.rotate}°`,
+        `alpha: ${record.target.alpha}`,
+        `key frame interval: 2 s`,
+        'Capabilities',
+        `decode: ${formatBoolean(record.capabilities.decode ?? undefined)}`,
+        `AVC encode: ${formatBoolean(record.capabilities.avcEncode ?? undefined)}`,
+        'Counts',
+        `samples processed: ${record.samplesProcessed}`,
+        `frames submitted: ${record.framesSubmitted}`,
+        `encoded chunks: ${record.encodedChunks}`,
+        `encoded bytes: ${record.encodedBytes}`,
+        `key chunks: ${record.keyChunks}`,
+        `delta chunks: ${record.deltaChunks}`,
+        `max queue size: ${record.maxQueueSize}`,
+        `throughput: ${record.throughput === null ? 'not recorded' : `${record.throughput.toFixed(2)} fps`}`,
+        'Timing (overlaps; do not sum)',
+        `input / track setup: ${formatDuration(record.timings.inputTrackSetup)}`,
+        `sample wait / iteration: ${formatDuration(record.timings.sampleWaitIteration)}`,
+        `video transform: ${formatDuration(record.timings.videoTransform)}`,
+        `VideoFrame creation: ${formatDuration(record.timings.videoFrameCreation)}`,
+        `encode() submission sync: ${formatDuration(record.timings.encodeSubmissionSync)}`,
+        `backpressure wait: ${formatDuration(record.timings.backpressureWait)}`,
+        `flush wait: ${formatDuration(record.timings.flushWait)}`,
+        `benchmark total wall: ${formatDuration(record.timings.benchmarkTotalWall)}`,
+    ];
+    if (record.failure) {
+        lines.push(`failure: ${record.failure.stage}: ${record.failure.message}`);
+    }
+    lines.push('Uses MediaBunny public Input/VideoSampleSink/VideoSample.transform only; no Conversion, audio, muxing, Blob, or file output.', '');
+    return lines;
+}
+
 export function formatMediaCompressionDiagnostics(): string {
     const lines = [
         'Media Compression Debug',
@@ -596,6 +665,7 @@ export function formatMediaCompressionDiagnostics(): string {
         `Video rate control: ${getMediaCompressionVideoRateControlMode()}`,
         `Raw native VideoEncoder benchmark: ${isMediaCompressionDebugRawVideoEncoderEnabled() ? 'enabled (manual run)' : 'disabled'}`,
         `Video decode benchmark: ${isMediaCompressionDebugVideoDecodeBenchmarkEnabled() ? 'enabled (manual run)' : 'disabled'}`,
+        `Real video pipeline benchmark: ${isMediaCompressionDebugVideoPipelineBenchmarkEnabled() ? 'enabled (manual run)' : 'disabled'}`,
         ...formatEnvironment(getMediaCompressionEnvironment()),
         '',
     ];
@@ -717,6 +787,10 @@ export function formatMediaCompressionDiagnostics(): string {
 
     videoDecodeBenchmarkRecords.forEach((record, index) => {
         lines.push(...formatVideoDecodeBenchmark(record, index));
+    });
+
+    realVideoPipelineBenchmarkRecords.forEach((record, index) => {
+        lines.push(...formatRealVideoPipelineBenchmark(record, index));
     });
 
     lines.push('Reload the page before Conversion #1 to test AAC capability before the custom encoder is registered.');

--- a/src/lib/videoCompression/mediaCompressionDiagnostics.ts
+++ b/src/lib/videoCompression/mediaCompressionDiagnostics.ts
@@ -1,4 +1,5 @@
 import type { RawVideoEncoderBenchmarkResult } from './rawVideoEncoderBenchmark';
+import type { LegacyLikeCanvasPipelineBenchmarkResult } from './legacyLikeCanvasPipelineBenchmark';
 import type { RealVideoPipelineBenchmarkResult } from './realVideoPipelineBenchmark';
 import type { VideoDecodeBenchmarkResult } from './videoDecodeBenchmark';
 
@@ -175,6 +176,7 @@ const records: MediaCompressionDiagnosticRecord[] = [];
 const rawVideoEncoderBenchmarkRecords: RawVideoEncoderBenchmarkResult[] = [];
 const videoDecodeBenchmarkRecords: VideoDecodeBenchmarkResult[] = [];
 const realVideoPipelineBenchmarkRecords: RealVideoPipelineBenchmarkResult[] = [];
+const legacyLikeCanvasPipelineBenchmarkRecords: LegacyLikeCanvasPipelineBenchmarkResult[] = [];
 const listeners = new Set<DiagnosticListener>();
 let conversionSequence = 0;
 let aacCustomEncoderState: AacCustomEncoderState = 'not-loaded';
@@ -311,6 +313,10 @@ export function getRealVideoPipelineBenchmarkRecords(): RealVideoPipelineBenchma
     return realVideoPipelineBenchmarkRecords;
 }
 
+export function getLegacyLikeCanvasPipelineBenchmarkRecords(): LegacyLikeCanvasPipelineBenchmarkResult[] {
+    return legacyLikeCanvasPipelineBenchmarkRecords;
+}
+
 export function addRawVideoEncoderBenchmarkRecord(result: RawVideoEncoderBenchmarkResult): void {
     rawVideoEncoderBenchmarkRecords.push(result);
     notify();
@@ -326,6 +332,11 @@ export function addRealVideoPipelineBenchmarkRecord(result: RealVideoPipelineBen
     notify();
 }
 
+export function addLegacyLikeCanvasPipelineBenchmarkRecord(result: LegacyLikeCanvasPipelineBenchmarkResult): void {
+    legacyLikeCanvasPipelineBenchmarkRecords.push(result);
+    notify();
+}
+
 export function subscribeToMediaCompressionDiagnostics(listener: DiagnosticListener): () => void {
     listeners.add(listener);
     return () => listeners.delete(listener);
@@ -336,6 +347,7 @@ export function clearMediaCompressionDiagnosticRecords(): void {
     rawVideoEncoderBenchmarkRecords.length = 0;
     videoDecodeBenchmarkRecords.length = 0;
     realVideoPipelineBenchmarkRecords.length = 0;
+    legacyLikeCanvasPipelineBenchmarkRecords.length = 0;
     notify();
 }
 
@@ -603,6 +615,7 @@ function formatVideoDecodeBenchmark(record: VideoDecodeBenchmarkResult, index: n
 function formatRealVideoPipelineBenchmark(record: RealVideoPipelineBenchmarkResult, index: number): string[] {
     const lines = [
         `Real Video Pipeline Benchmark #${index + 1}`,
+        `pipeline kind: ${record.pipelineKind}`,
         `status: ${record.status}`,
         'Input',
         `mime: ${record.input.mime}`,
@@ -648,6 +661,60 @@ function formatRealVideoPipelineBenchmark(record: RealVideoPipelineBenchmarkResu
         lines.push(`failure: ${record.failure.stage}: ${record.failure.message}`);
     }
     lines.push('Uses MediaBunny public Input/VideoSampleSink/VideoSample.transform only; no Conversion, audio, muxing, Blob, or file output.', '');
+    return lines;
+}
+
+function formatLegacyLikeCanvasPipelineBenchmark(record: LegacyLikeCanvasPipelineBenchmarkResult, index: number): string[] {
+    const lines = [
+        `Legacy-like Canvas Pipeline Benchmark #${index + 1}`,
+        `pipeline kind: ${record.pipelineKind}`,
+        `status: ${record.status}`,
+        'Input',
+        `mime: ${record.input.mime}`,
+        `size: ${record.input.size} bytes`,
+        `duration: ${record.input.duration === null ? 'unknown' : `${record.input.duration.toFixed(3)} s`}`,
+        `video codec: ${formatValue(record.input.videoCodec)}`,
+        `coded size: ${record.input.codedWidth === null || record.input.codedHeight === null
+            ? 'unknown'
+            : `${record.input.codedWidth}x${record.input.codedHeight}`}`,
+        `source display: ${record.input.displayWidth === null || record.input.displayHeight === null
+            ? 'unknown'
+            : `${record.input.displayWidth}x${record.input.displayHeight}`}`,
+        `source rotation: ${formatValue(record.input.rotation)}°`,
+        'Target',
+        `target: ${record.target.width}x${record.target.height}`,
+        `fit: ${record.target.fit}`,
+        `rotation baked into Canvas: ${record.input.rotation === null ? 'unknown' : `${record.input.rotation}°`}`,
+        `alpha: ${record.target.alpha}`,
+        'canvas: reused HTMLCanvasElement 2D context',
+        'key frame interval: 5 s',
+        'Capabilities',
+        `decode: ${formatBoolean(record.capabilities.decode ?? undefined)}`,
+        `AVC encode: ${formatBoolean(record.capabilities.avcEncode ?? undefined)}`,
+        'Counts',
+        `samples processed: ${record.samplesProcessed}`,
+        `frames submitted: ${record.framesSubmitted}`,
+        `encoded chunks: ${record.encodedChunks}`,
+        `encoded bytes: ${record.encodedBytes}`,
+        `key chunks: ${record.keyChunks}`,
+        `delta chunks: ${record.deltaChunks}`,
+        `max queue size: ${record.maxQueueSize}`,
+        `throughput: ${record.throughput === null ? 'not recorded' : `${record.throughput.toFixed(2)} fps`}`,
+        'Timing (overlaps; do not sum)',
+        `input / track setup: ${formatDuration(record.timings.inputTrackSetup)}`,
+        `sample wait / iteration: ${formatDuration(record.timings.sampleWaitIteration)}`,
+        `source VideoFrame acquisition: ${formatDuration(record.timings.sourceVideoFrameAcquisition)}`,
+        `Canvas draw / rotation / resize: ${formatDuration(record.timings.canvasDrawRotationResize)}`,
+        `output VideoFrame creation: ${formatDuration(record.timings.outputVideoFrameCreation)}`,
+        `encode() submission sync: ${formatDuration(record.timings.encodeSubmissionSync)}`,
+        `backpressure wait: ${formatDuration(record.timings.backpressureWait)}`,
+        `flush wait: ${formatDuration(record.timings.flushWait)}`,
+        `benchmark total wall: ${formatDuration(record.timings.benchmarkTotalWall)}`,
+    ];
+    if (record.failure) {
+        lines.push(`failure: ${record.failure.stage}: ${record.failure.message}`);
+    }
+    lines.push('Uses MediaBunny public Input/VideoSampleSink/toVideoFrame plus a reused HTMLCanvasElement and native WebCodecs; no VideoSample.transform, Conversion, audio, muxing, Blob, or file output.', '');
     return lines;
 }
 
@@ -791,6 +858,10 @@ export function formatMediaCompressionDiagnostics(): string {
 
     realVideoPipelineBenchmarkRecords.forEach((record, index) => {
         lines.push(...formatRealVideoPipelineBenchmark(record, index));
+    });
+
+    legacyLikeCanvasPipelineBenchmarkRecords.forEach((record, index) => {
+        lines.push(...formatLegacyLikeCanvasPipelineBenchmark(record, index));
     });
 
     lines.push('Reload the page before Conversion #1 to test AAC capability before the custom encoder is registered.');

--- a/src/lib/videoCompression/mediaCompressionDiagnostics.ts
+++ b/src/lib/videoCompression/mediaCompressionDiagnostics.ts
@@ -508,6 +508,7 @@ function formatRawVideoEncoderBenchmark(record: RawVideoEncoderBenchmarkResult, 
     const lines = [
         `Raw VideoEncoder Benchmark #${index + 1}`,
         `status: ${record.status}`,
+        `canvas/source kind: ${record.canvasSource}`,
         `source: ${record.source}`,
         'config',
         `codec: ${record.config.codec}`,

--- a/src/lib/videoCompression/mediaCompressionDiagnostics.ts
+++ b/src/lib/videoCompression/mediaCompressionDiagnostics.ts
@@ -6,6 +6,8 @@ export type MediaCompressionAudioDiagnosticMode = 'normal' | 'force-packet-copy'
 
 export type MediaCompressionAudioEncodingMode = 'quality' | 'bitrate' | 'default' | 'packet-copy';
 
+export type MediaCompressionVideoDiagnosticMode = 'default-quality' | 'realtime';
+
 export interface AudioPathClassification {
     path: AudioPath;
     reason?: string;
@@ -50,10 +52,13 @@ export type MediaCompressionTimingKey =
     | 'video capability'
     | 'audio preparation'
     | 'aac custom load/register'
+    | 'input video stats scan'
     | 'conversion.init'
     | 'conversion.execute'
     | 'compressed File creation'
     | 'output audio preservation verification'
+    | 'output video stats scan'
+    | 'diagnostic total'
     | 'total compression';
 
 export interface MediaCompressionEnvironment {
@@ -80,6 +85,15 @@ export interface MediaCompressionVideoDiagnostic {
     compressionLevel?: string;
     quality?: string;
     avcEncode?: boolean;
+    inputPacketStats?: MediaCompressionVideoPacketStats | null;
+    outputPacketStats?: MediaCompressionVideoPacketStats | null;
+}
+
+export interface MediaCompressionVideoPacketStats {
+    packetCount: number;
+    averagePacketRate: number;
+    averageBitrate: number;
+    duration?: number | null;
 }
 
 export interface MediaCompressionAudioDiagnostic {
@@ -107,6 +121,7 @@ export interface MediaCompressionAudioDiagnostic {
 export interface MediaCompressionDiagnosticRecord {
     conversionId: number;
     audioDiagnosticMode: MediaCompressionAudioDiagnosticMode;
+    videoDiagnosticMode: MediaCompressionVideoDiagnosticMode;
     input: {
         mime: string;
         size: number;
@@ -166,6 +181,18 @@ export function isMediaCompressionDebugAudioCopyEnabled(search?: string): boolea
     const locationSearch = search ?? (isBrowser() ? window.location.search : '');
     const params = new URLSearchParams(locationSearch);
     return params.get('media-debug') === '1' && params.get('media-debug-audio') === 'copy';
+}
+
+export function isMediaCompressionDebugVideoRealtimeEnabled(search?: string): boolean {
+    const locationSearch = search ?? (isBrowser() ? window.location.search : '');
+    const params = new URLSearchParams(locationSearch);
+    return params.get('media-debug') === '1'
+        && params.get('media-debug-audio') === 'copy'
+        && params.get('media-debug-video-latency') === 'realtime';
+}
+
+export function getMediaCompressionVideoDiagnosticMode(search?: string): MediaCompressionVideoDiagnosticMode {
+    return isMediaCompressionDebugVideoRealtimeEnabled(search) ? 'realtime' : 'default-quality';
 }
 
 export function getMediaCompressionAudioDiagnosticMode(search?: string): MediaCompressionAudioDiagnosticMode {
@@ -274,10 +301,13 @@ export interface MediaCompressionDiagnosticSession {
     setConversion(value: Partial<MediaCompressionDiagnosticRecord['conversion']>): void;
     setResult(value: Partial<MediaCompressionDiagnosticRecord['result']>): void;
     setError(error: unknown): void;
+    measureDiagnosticScan<T>(key: 'input video stats scan' | 'output video stats scan', task: () => Promise<T>): Promise<T>;
     finish(result: { file: File; wasCompressed: boolean; wasSkipped?: boolean; aborted?: boolean }): void;
 }
 
 class DiagnosticSession implements MediaCompressionDiagnosticSession {
+    private diagnosticOverhead = 0;
+
     constructor(private record: MediaCompressionDiagnosticRecord, private startedAt: number) { }
 
     get conversionId(): number {
@@ -332,6 +362,20 @@ class DiagnosticSession implements MediaCompressionDiagnosticSession {
         notify();
     }
 
+    async measureDiagnosticScan<T>(
+        key: 'input video stats scan' | 'output video stats scan',
+        task: () => Promise<T>,
+    ): Promise<T> {
+        const startedAt = now();
+        try {
+            return await task();
+        } finally {
+            const duration = durationSince(startedAt);
+            this.diagnosticOverhead += duration;
+            this.setTiming(key, duration);
+        }
+    }
+
     finish(result: { file: File; wasCompressed: boolean; wasSkipped?: boolean; aborted?: boolean }): void {
         this.setResult({
             outputSize: result.file.size,
@@ -339,7 +383,8 @@ class DiagnosticSession implements MediaCompressionDiagnosticSession {
             wasSkipped: result.wasSkipped ?? false,
         });
         this.setConversion({ aborted: result.aborted ?? false });
-        this.setTiming('total compression', durationSince(this.startedAt));
+        this.setTiming('diagnostic total', durationSince(this.startedAt));
+        this.setTiming('total compression', Math.max(0, durationSince(this.startedAt) - this.diagnosticOverhead));
     }
 }
 
@@ -350,6 +395,7 @@ export function startMediaCompressionDiagnostic(file: File): MediaCompressionDia
     const record: MediaCompressionDiagnosticRecord = {
         conversionId: ++conversionSequence,
         audioDiagnosticMode: getMediaCompressionAudioDiagnosticMode(),
+        videoDiagnosticMode: getMediaCompressionVideoDiagnosticMode(),
         input: { mime: file.type || 'unknown', size: file.size },
         tracks: { videoCount: 0, audioCount: 0 },
         video: [],
@@ -413,6 +459,7 @@ export function formatMediaCompressionDiagnostics(): string {
         ...(getMediaCompressionAudioDiagnosticMode() === 'force-packet-copy'
             ? ['Diagnostic A/B mode: audio is being packet-copied instead of transcoded.']
             : []),
+        `Video latency: ${getMediaCompressionVideoDiagnosticMode() === 'realtime' ? 'realtime' : 'quality (default)'}`,
         ...formatEnvironment(getMediaCompressionEnvironment()),
         '',
     ];
@@ -424,6 +471,8 @@ export function formatMediaCompressionDiagnostics(): string {
     for (const record of records) {
         lines.push(`Conversion #${record.conversionId}`);
         lines.push(`audio diagnostic mode: ${record.audioDiagnosticMode}`);
+        lines.push(`video diagnostic mode: ${record.videoDiagnosticMode}`);
+        lines.push(`video latency mode: ${record.videoDiagnosticMode === 'realtime' ? 'realtime' : 'quality (MediaBunny default)'}`);
         lines.push('Input');
         lines.push(`mime: ${formatValue(record.input.mime)}`);
         lines.push(`size: ${record.input.size} bytes`);
@@ -441,6 +490,22 @@ export function formatMediaCompressionDiagnostics(): string {
             lines.push(`AVC encode: ${formatBoolean(video.avcEncode)}`);
             lines.push(`compression level: ${formatValue(video.compressionLevel)}`);
             lines.push(`MediaBunny video Quality: ${formatValue(video.quality)}`);
+            if (video.inputPacketStats) {
+                lines.push(`input frames: ${video.inputPacketStats.packetCount}`);
+                lines.push(`input FPS: ${video.inputPacketStats.averagePacketRate.toFixed(2)}`);
+                lines.push(`input bitrate: ${video.inputPacketStats.averageBitrate} bps`);
+                lines.push(`input duration: ${formatValue(video.inputPacketStats.duration)} s`);
+            } else {
+                lines.push('input packet stats: not recorded');
+            }
+            if (video.outputPacketStats) {
+                lines.push(`output frames: ${video.outputPacketStats.packetCount}`);
+                lines.push(`output FPS: ${video.outputPacketStats.averagePacketRate.toFixed(2)}`);
+                lines.push(`output bitrate: ${video.outputPacketStats.averageBitrate} bps`);
+                lines.push(`output duration: ${formatValue(video.outputPacketStats.duration)} s`);
+            } else {
+                lines.push('output packet stats: not recorded');
+            }
         });
 
         record.audio.forEach((audio, index) => {
@@ -483,10 +548,13 @@ export function formatMediaCompressionDiagnostics(): string {
             'video capability',
             'audio preparation',
             'aac custom load/register',
+            'input video stats scan',
             'conversion.init',
             'conversion.execute',
             'compressed File creation',
             'output audio preservation verification',
+            'output video stats scan',
+            'diagnostic total',
             'total compression',
         ] as const) {
             lines.push(`${key}: ${formatDuration(record.timing[key])}`);

--- a/src/lib/videoCompression/mediaCompressionDiagnostics.ts
+++ b/src/lib/videoCompression/mediaCompressionDiagnostics.ts
@@ -1,3 +1,5 @@
+import type { RawVideoEncoderBenchmarkResult } from './rawVideoEncoderBenchmark';
+
 export type AacCustomEncoderState = 'not-loaded' | 'loading' | 'registered' | 'failed';
 
 export type AudioPath = 'native-aac' | 'custom-aac' | 'packet-copy' | 'unavailable' | 'unknown';
@@ -163,6 +165,7 @@ export interface MediaCompressionDiagnosticRecord {
 type DiagnosticListener = () => void;
 
 const records: MediaCompressionDiagnosticRecord[] = [];
+const rawVideoEncoderBenchmarkRecords: RawVideoEncoderBenchmarkResult[] = [];
 const listeners = new Set<DiagnosticListener>();
 let conversionSequence = 0;
 let aacCustomEncoderState: AacCustomEncoderState = 'not-loaded';
@@ -189,6 +192,12 @@ export function isMediaCompressionDebugVideoRealtimeEnabled(search?: string): bo
     return params.get('media-debug') === '1'
         && params.get('media-debug-audio') === 'copy'
         && params.get('media-debug-video-latency') === 'realtime';
+}
+
+export function isMediaCompressionDebugRawVideoEncoderEnabled(search?: string): boolean {
+    const locationSearch = search ?? (isBrowser() ? window.location.search : '');
+    const params = new URLSearchParams(locationSearch);
+    return params.get('media-debug') === '1' && params.get('media-debug-raw-video-encoder') === '1';
 }
 
 export function getMediaCompressionVideoDiagnosticMode(search?: string): MediaCompressionVideoDiagnosticMode {
@@ -257,6 +266,15 @@ export function getMediaCompressionDiagnosticRecords(): MediaCompressionDiagnost
     return records;
 }
 
+export function getRawVideoEncoderBenchmarkRecords(): RawVideoEncoderBenchmarkResult[] {
+    return rawVideoEncoderBenchmarkRecords;
+}
+
+export function addRawVideoEncoderBenchmarkRecord(result: RawVideoEncoderBenchmarkResult): void {
+    rawVideoEncoderBenchmarkRecords.push(result);
+    notify();
+}
+
 export function subscribeToMediaCompressionDiagnostics(listener: DiagnosticListener): () => void {
     listeners.add(listener);
     return () => listeners.delete(listener);
@@ -264,6 +282,7 @@ export function subscribeToMediaCompressionDiagnostics(listener: DiagnosticListe
 
 export function clearMediaCompressionDiagnosticRecords(): void {
     records.length = 0;
+    rawVideoEncoderBenchmarkRecords.length = 0;
     notify();
 }
 
@@ -449,6 +468,44 @@ function formatEnvironment(value: MediaCompressionEnvironment | null): string[] 
     ];
 }
 
+function formatRawVideoEncoderBenchmark(record: RawVideoEncoderBenchmarkResult, index: number): string[] {
+    const lines = [
+        `Raw VideoEncoder Benchmark #${index + 1}`,
+        `status: ${record.status}`,
+        `source: ${record.source}`,
+        'config',
+        `codec: ${record.config.codec}`,
+        `size: ${record.config.width}x${record.config.height}`,
+        `framerate: ${record.config.framerate}`,
+        `bitrate: ${record.config.bitrate} bps`,
+        'latencyMode: omitted/default',
+        'hardwareAcceleration: omitted/default',
+        'bitrateMode: omitted/default',
+        `frames requested: ${record.frameCount}`,
+        `queue limit: ${record.queueLimit}`,
+        `max queue size: ${record.maxQueueSize}`,
+        `frames submitted: ${record.framesSubmitted}`,
+        `encoded chunks: ${record.chunks}`,
+        `encoded bytes: ${record.bytes}`,
+        `key chunks: ${record.keyChunks}`,
+        `delta chunks: ${record.deltaChunks}`,
+        `throughput: ${record.throughput === undefined ? 'not recorded' : `${record.throughput.toFixed(2)} fps`}`,
+        'Timing (overlaps; do not sum)',
+        `config support check: ${formatDuration(record.timings.configSupportCheck)}`,
+        `encoder setup/configure: ${formatDuration(record.timings.encoderSetupConfigure)}`,
+        `benchmark wall: ${formatDuration(record.timings.benchmarkWall)}`,
+        `frame preparation sync: ${formatDuration(record.timings.framePreparationSync)}`,
+        `encode() submission sync: ${formatDuration(record.timings.encodeSubmissionSync)}`,
+        `backpressure wait: ${formatDuration(record.timings.backpressureWait)}`,
+        `flush wait: ${formatDuration(record.timings.flushWait)}`,
+    ];
+    if (record.failure) {
+        lines.push(`failure: ${record.failure.stage}: ${record.failure.message}`);
+    }
+    lines.push('No MediaBunny, audio, muxing, Blob, or file output is used by this benchmark.', '');
+    return lines;
+}
+
 export function formatMediaCompressionDiagnostics(): string {
     const lines = [
         'Media Compression Debug',
@@ -460,6 +517,7 @@ export function formatMediaCompressionDiagnostics(): string {
             ? ['Diagnostic A/B mode: audio is being packet-copied instead of transcoded.']
             : []),
         `Video latency: ${getMediaCompressionVideoDiagnosticMode() === 'realtime' ? 'realtime' : 'quality (default)'}`,
+        `Raw native VideoEncoder benchmark: ${isMediaCompressionDebugRawVideoEncoderEnabled() ? 'enabled (manual run)' : 'disabled'}`,
         ...formatEnvironment(getMediaCompressionEnvironment()),
         '',
     ];
@@ -567,6 +625,10 @@ export function formatMediaCompressionDiagnostics(): string {
         lines.push(`output audio preserved: ${formatBoolean(record.result.outputAudioPreserved)}`);
         lines.push('');
     }
+
+    rawVideoEncoderBenchmarkRecords.forEach((record, index) => {
+        lines.push(...formatRawVideoEncoderBenchmark(record, index));
+    });
 
     lines.push('Reload the page before Conversion #1 to test AAC capability before the custom encoder is registered.');
     return lines.join('\n');

--- a/src/lib/videoCompression/mediaCompressionDiagnostics.ts
+++ b/src/lib/videoCompression/mediaCompressionDiagnostics.ts
@@ -11,6 +11,8 @@ export type MediaCompressionAudioEncodingMode = 'quality' | 'bitrate' | 'default
 
 export type MediaCompressionVideoDiagnosticMode = 'default-quality' | 'realtime';
 
+export type MediaCompressionVideoRateControlMode = 'subjective-quality' | 'explicit-bitrate';
+
 export interface AudioPathClassification {
     path: AudioPath;
     reason?: string;
@@ -87,6 +89,8 @@ export interface MediaCompressionVideoDiagnostic {
     targetHeight?: number;
     compressionLevel?: string;
     quality?: string;
+    configuredBitrate?: number;
+    bitrateMode?: 'constant' | 'variable';
     avcEncode?: boolean;
     inputPacketStats?: MediaCompressionVideoPacketStats | null;
     outputPacketStats?: MediaCompressionVideoPacketStats | null;
@@ -125,6 +129,7 @@ export interface MediaCompressionDiagnosticRecord {
     conversionId: number;
     audioDiagnosticMode: MediaCompressionAudioDiagnosticMode;
     videoDiagnosticMode: MediaCompressionVideoDiagnosticMode;
+    videoRateControlMode: MediaCompressionVideoRateControlMode;
     input: {
         mime: string;
         size: number;
@@ -194,6 +199,18 @@ export function isMediaCompressionDebugVideoRealtimeEnabled(search?: string): bo
     return params.get('media-debug') === '1'
         && params.get('media-debug-audio') === 'copy'
         && params.get('media-debug-video-latency') === 'realtime';
+}
+
+export function isMediaCompressionDebugVideoBitrateEnabled(search?: string): boolean {
+    const locationSearch = search ?? (isBrowser() ? window.location.search : '');
+    const params = new URLSearchParams(locationSearch);
+    return params.get('media-debug') === '1'
+        && params.get('media-debug-audio') === 'copy'
+        && params.get('media-debug-video-rate-control') === 'bitrate';
+}
+
+export function getMediaCompressionVideoRateControlMode(search?: string): MediaCompressionVideoRateControlMode {
+    return isMediaCompressionDebugVideoBitrateEnabled(search) ? 'explicit-bitrate' : 'subjective-quality';
 }
 
 export function isMediaCompressionDebugRawVideoEncoderEnabled(search?: string): boolean {
@@ -433,6 +450,7 @@ export function startMediaCompressionDiagnostic(file: File): MediaCompressionDia
         conversionId: ++conversionSequence,
         audioDiagnosticMode: getMediaCompressionAudioDiagnosticMode(),
         videoDiagnosticMode: getMediaCompressionVideoDiagnosticMode(),
+        videoRateControlMode: getMediaCompressionVideoRateControlMode(),
         input: { mime: file.type || 'unknown', size: file.size },
         tracks: { videoCount: 0, audioCount: 0 },
         video: [],
@@ -574,6 +592,7 @@ export function formatMediaCompressionDiagnostics(): string {
             ? ['Diagnostic A/B mode: audio is being packet-copied instead of transcoded.']
             : []),
         `Video latency: ${getMediaCompressionVideoDiagnosticMode() === 'realtime' ? 'realtime' : 'quality (default)'}`,
+        `Video rate control: ${getMediaCompressionVideoRateControlMode()}`,
         `Raw native VideoEncoder benchmark: ${isMediaCompressionDebugRawVideoEncoderEnabled() ? 'enabled (manual run)' : 'disabled'}`,
         `Video decode benchmark: ${isMediaCompressionDebugVideoDecodeBenchmarkEnabled() ? 'enabled (manual run)' : 'disabled'}`,
         ...formatEnvironment(getMediaCompressionEnvironment()),
@@ -588,6 +607,7 @@ export function formatMediaCompressionDiagnostics(): string {
         lines.push(`Conversion #${record.conversionId}`);
         lines.push(`audio diagnostic mode: ${record.audioDiagnosticMode}`);
         lines.push(`video diagnostic mode: ${record.videoDiagnosticMode}`);
+        lines.push(`video rate control: ${record.videoRateControlMode}`);
         lines.push(`video latency mode: ${record.videoDiagnosticMode === 'realtime' ? 'realtime' : 'quality (MediaBunny default)'}`);
         lines.push('Input');
         lines.push(`mime: ${formatValue(record.input.mime)}`);
@@ -606,6 +626,12 @@ export function formatMediaCompressionDiagnostics(): string {
             lines.push(`AVC encode: ${formatBoolean(video.avcEncode)}`);
             lines.push(`compression level: ${formatValue(video.compressionLevel)}`);
             lines.push(`MediaBunny video Quality: ${formatValue(video.quality)}`);
+            if (video.configuredBitrate !== undefined) {
+                lines.push(`configured video bitrate: ${video.configuredBitrate} bps`);
+            }
+            if (video.bitrateMode !== undefined) {
+                lines.push(`bitrate mode: ${video.bitrateMode}`);
+            }
             if (video.inputPacketStats) {
                 lines.push(`input frames: ${video.inputPacketStats.packetCount}`);
                 lines.push(`input FPS: ${video.inputPacketStats.averagePacketRate.toFixed(2)}`);

--- a/src/lib/videoCompression/mediaCompressionDiagnostics.ts
+++ b/src/lib/videoCompression/mediaCompressionDiagnostics.ts
@@ -1,0 +1,475 @@
+export type AacCustomEncoderState = 'not-loaded' | 'loading' | 'registered' | 'failed';
+
+export type AudioPath = 'native-aac' | 'custom-aac' | 'packet-copy' | 'unavailable' | 'unknown';
+
+export interface AudioPathClassification {
+    path: AudioPath;
+    reason?: string;
+}
+
+/**
+ * Classifies the public AAC decision points without inspecting MediaBunny internals.
+ * A custom encoder registered before this conversion is known to win over native AAC
+ * for a matching configuration in MediaBunny 1.55.1.
+ */
+export function classifyMediaCompressionAudioPath(params: {
+    decodeAvailable: boolean;
+    stateAtStart: AacCustomEncoderState;
+    capabilityBeforeSelection: boolean;
+    capabilityAfterRegistration?: boolean;
+    registrationSucceeded?: boolean;
+}): AudioPathClassification {
+    if (!params.decodeAvailable) return { path: 'packet-copy', reason: 'decode-unavailable' };
+    if (params.stateAtStart === 'not-loaded' && params.capabilityBeforeSelection) {
+        return { path: 'native-aac' };
+    }
+    if (
+        params.stateAtStart === 'not-loaded'
+        && !params.capabilityBeforeSelection
+        && params.registrationSucceeded === true
+        && params.capabilityAfterRegistration === true
+    ) {
+        return { path: 'custom-aac' };
+    }
+    if (params.stateAtStart === 'registered' && params.capabilityBeforeSelection) {
+        return { path: 'custom-aac' };
+    }
+    if (params.capabilityAfterRegistration === false || !params.capabilityBeforeSelection) {
+        return { path: 'packet-copy', reason: 'aac-encode-unavailable' };
+    }
+    return { path: 'unknown' };
+}
+
+export type MediaCompressionTimingKey =
+    | 'input / track inspection'
+    | 'video option construction'
+    | 'video capability'
+    | 'audio preparation'
+    | 'aac custom load/register'
+    | 'conversion.init'
+    | 'conversion.execute'
+    | 'compressed File creation'
+    | 'output audio preservation verification'
+    | 'total compression';
+
+export interface MediaCompressionEnvironment {
+    userAgent: string;
+    platform: string;
+    userAgentData?: {
+        brands: string[];
+        mobile: boolean;
+        platform: string;
+    };
+    VideoEncoder: 'available' | 'unavailable';
+    VideoDecoder: 'available' | 'unavailable';
+    AudioEncoder: 'available' | 'unavailable';
+    AudioDecoder: 'available' | 'unavailable';
+}
+
+export interface MediaCompressionVideoDiagnostic {
+    codec?: string | null;
+    displayWidth?: number;
+    displayHeight?: number;
+    decode?: boolean;
+    targetWidth?: number;
+    targetHeight?: number;
+    compressionLevel?: string;
+    quality?: string;
+    avcEncode?: boolean;
+}
+
+export interface MediaCompressionAudioDiagnostic {
+    codec?: string | null;
+    sourceSampleRate?: number;
+    sourceChannels?: number;
+    decode?: boolean;
+    targetSampleRate?: number;
+    targetChannels?: number;
+    targetBitrate?: number | null;
+    quality?: string;
+    nativeCapabilityBeforeRegistration?: boolean;
+    capabilityBeforeSelection?: boolean;
+    capabilityAfterRegistration?: boolean;
+    customImport?: 'yes' | 'no' | 'already registered' | 'already loading' | 'failed' | 'unknown';
+    customRegistration?: 'not-needed' | 'success' | 'failure' | 'unknown';
+    audioPath?: AudioPath;
+    reason?: string;
+}
+
+export interface MediaCompressionDiagnosticRecord {
+    conversionId: number;
+    input: {
+        mime: string;
+        size: number;
+        duration?: number | null;
+    };
+    tracks: {
+        videoCount: number;
+        audioCount: number;
+    };
+    video: MediaCompressionVideoDiagnostic[];
+    audio: MediaCompressionAudioDiagnostic[];
+    aac: {
+        stateAtStart: AacCustomEncoderState;
+        loadRegisterDuration?: number;
+    };
+    conversion: {
+        isValid?: boolean;
+        discardedTracks: Array<{ type: 'video' | 'audio' | 'other'; reason?: string }>;
+        discardedVideoCount: number;
+        discardedAudioCount: number;
+        execute?: 'success' | 'failure';
+        aborted?: boolean;
+        fallback?: boolean;
+        fallbackReason?: string;
+    };
+    result: {
+        outputSize?: number;
+        wasCompressed?: boolean;
+        wasSkipped?: boolean;
+        outputAudioPreserved?: boolean;
+    };
+    timing: Partial<Record<MediaCompressionTimingKey, number>>;
+    error?: {
+        name: string;
+        message: string;
+    };
+}
+
+type DiagnosticListener = () => void;
+
+const records: MediaCompressionDiagnosticRecord[] = [];
+const listeners = new Set<DiagnosticListener>();
+let conversionSequence = 0;
+let aacCustomEncoderState: AacCustomEncoderState = 'not-loaded';
+let environment: MediaCompressionEnvironment | null = null;
+
+function isBrowser(): boolean {
+    return typeof window !== 'undefined' && typeof navigator !== 'undefined';
+}
+
+export function isMediaCompressionDebugEnabled(search?: string): boolean {
+    const locationSearch = search ?? (isBrowser() ? window.location.search : '');
+    return new URLSearchParams(locationSearch).get('media-debug') === '1';
+}
+
+function notify(): void {
+    for (const listener of listeners) {
+        listener();
+    }
+}
+
+function readEnvironment(): MediaCompressionEnvironment | null {
+    if (!isBrowser() || !isMediaCompressionDebugEnabled()) return null;
+
+    const userAgentData = 'userAgentData' in navigator
+        ? (navigator as Navigator & {
+            userAgentData?: {
+                brands?: Array<{ brand: string; version: string }>;
+                mobile?: boolean;
+                platform?: string;
+            };
+        }).userAgentData
+        : undefined;
+
+    return {
+        userAgent: navigator.userAgent,
+        platform: navigator.platform,
+        ...(userAgentData
+            ? {
+                userAgentData: {
+                    brands: (userAgentData.brands ?? []).map(({ brand, version }) => `${brand} ${version}`),
+                    mobile: userAgentData.mobile === true,
+                    platform: userAgentData.platform ?? '',
+                },
+            }
+            : {}),
+        VideoEncoder: typeof globalThis.VideoEncoder === 'function' ? 'available' : 'unavailable',
+        VideoDecoder: typeof globalThis.VideoDecoder === 'function' ? 'available' : 'unavailable',
+        AudioEncoder: typeof globalThis.AudioEncoder === 'function' ? 'available' : 'unavailable',
+        AudioDecoder: typeof globalThis.AudioDecoder === 'function' ? 'available' : 'unavailable',
+    };
+}
+
+export function getMediaCompressionEnvironment(): MediaCompressionEnvironment | null {
+    if (!environment && isMediaCompressionDebugEnabled()) {
+        environment = readEnvironment();
+    }
+    return environment;
+}
+
+export function getAacCustomEncoderState(): AacCustomEncoderState {
+    return aacCustomEncoderState;
+}
+
+export function setAacCustomEncoderState(state: AacCustomEncoderState): void {
+    aacCustomEncoderState = state;
+    if (isMediaCompressionDebugEnabled()) notify();
+}
+
+export function getMediaCompressionDiagnosticRecords(): MediaCompressionDiagnosticRecord[] {
+    return records;
+}
+
+export function subscribeToMediaCompressionDiagnostics(listener: DiagnosticListener): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+}
+
+export function clearMediaCompressionDiagnosticRecords(): void {
+    records.length = 0;
+    notify();
+}
+
+function now(): number {
+    return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+function durationSince(start: number): number {
+    return Math.max(0, now() - start);
+}
+
+function ensureVideo(record: MediaCompressionDiagnosticRecord, index: number): MediaCompressionVideoDiagnostic {
+    record.video[index] ??= {};
+    return record.video[index];
+}
+
+function ensureAudio(record: MediaCompressionDiagnosticRecord, index: number): MediaCompressionAudioDiagnostic {
+    record.audio[index] ??= {};
+    return record.audio[index];
+}
+
+function shortErrorMessage(error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.replace(/[\r\n]+/g, ' ').slice(0, 240);
+}
+
+export interface MediaCompressionDiagnosticSession {
+    readonly conversionId: number;
+    setInputDuration(duration: number | null): void;
+    setTrackCounts(videoCount: number, audioCount: number): void;
+    setVideo(index: number, value: Partial<MediaCompressionVideoDiagnostic>): void;
+    setAudio(index: number, value: Partial<MediaCompressionAudioDiagnostic>): void;
+    setAac(value: Partial<MediaCompressionDiagnosticRecord['aac']>): void;
+    setTiming(key: MediaCompressionTimingKey, duration: number): void;
+    setConversion(value: Partial<MediaCompressionDiagnosticRecord['conversion']>): void;
+    setResult(value: Partial<MediaCompressionDiagnosticRecord['result']>): void;
+    setError(error: unknown): void;
+    finish(result: { file: File; wasCompressed: boolean; wasSkipped?: boolean; aborted?: boolean }): void;
+}
+
+class DiagnosticSession implements MediaCompressionDiagnosticSession {
+    constructor(private record: MediaCompressionDiagnosticRecord, private startedAt: number) { }
+
+    get conversionId(): number {
+        return this.record.conversionId;
+    }
+
+    setInputDuration(duration: number | null): void {
+        this.record.input.duration = duration;
+        notify();
+    }
+
+    setTrackCounts(videoCount: number, audioCount: number): void {
+        this.record.tracks = { videoCount, audioCount };
+        notify();
+    }
+
+    setVideo(index: number, value: Partial<MediaCompressionVideoDiagnostic>): void {
+        Object.assign(ensureVideo(this.record, index), value);
+        notify();
+    }
+
+    setAudio(index: number, value: Partial<MediaCompressionAudioDiagnostic>): void {
+        Object.assign(ensureAudio(this.record, index), value);
+        notify();
+    }
+
+    setAac(value: Partial<MediaCompressionDiagnosticRecord['aac']>): void {
+        Object.assign(this.record.aac, value);
+        notify();
+    }
+
+    setTiming(key: MediaCompressionTimingKey, duration: number): void {
+        this.record.timing[key] = Math.max(0, duration);
+        notify();
+    }
+
+    setConversion(value: Partial<MediaCompressionDiagnosticRecord['conversion']>): void {
+        Object.assign(this.record.conversion, value);
+        notify();
+    }
+
+    setResult(value: Partial<MediaCompressionDiagnosticRecord['result']>): void {
+        Object.assign(this.record.result, value);
+        notify();
+    }
+
+    setError(error: unknown): void {
+        this.record.error = {
+            name: error instanceof Error && error.name ? error.name : 'Error',
+            message: shortErrorMessage(error),
+        };
+        notify();
+    }
+
+    finish(result: { file: File; wasCompressed: boolean; wasSkipped?: boolean; aborted?: boolean }): void {
+        this.setResult({
+            outputSize: result.file.size,
+            wasCompressed: result.wasCompressed,
+            wasSkipped: result.wasSkipped ?? false,
+        });
+        this.setConversion({ aborted: result.aborted ?? false });
+        this.setTiming('total compression', durationSince(this.startedAt));
+    }
+}
+
+export function startMediaCompressionDiagnostic(file: File): MediaCompressionDiagnosticSession | null {
+    if (!isMediaCompressionDebugEnabled()) return null;
+
+    environment ??= readEnvironment();
+    const record: MediaCompressionDiagnosticRecord = {
+        conversionId: ++conversionSequence,
+        input: { mime: file.type || 'unknown', size: file.size },
+        tracks: { videoCount: 0, audioCount: 0 },
+        video: [],
+        audio: [],
+        aac: { stateAtStart: aacCustomEncoderState },
+        conversion: {
+            discardedTracks: [],
+            discardedVideoCount: 0,
+            discardedAudioCount: 0,
+        },
+        result: {},
+        timing: {},
+    };
+    records.push(record);
+    notify();
+    return new DiagnosticSession(record, now());
+}
+
+function formatValue(value: unknown): string {
+    if (value === undefined || value === null || value === '') return 'unknown';
+    return String(value);
+}
+
+function formatBoolean(value: boolean | undefined): string {
+    return value === undefined ? 'unknown' : String(value);
+}
+
+function formatDuration(value: number | undefined): string {
+    return value === undefined ? 'not recorded' : `${value.toFixed(1)} ms`;
+}
+
+function formatEnvironment(value: MediaCompressionEnvironment | null): string[] {
+    if (!value) return ['Environment', 'not recorded'];
+
+    return [
+        'Environment',
+        `userAgent: ${value.userAgent}`,
+        `platform: ${value.platform}`,
+        ...(value.userAgentData
+            ? [
+                `userAgentData.platform: ${value.userAgentData.platform || 'unknown'}`,
+                `userAgentData.mobile: ${value.userAgentData.mobile}`,
+                `userAgentData.brands: ${value.userAgentData.brands.join(', ') || 'unknown'}`,
+            ]
+            : []),
+        `VideoEncoder: ${value.VideoEncoder}`,
+        `VideoDecoder: ${value.VideoDecoder}`,
+        `AudioEncoder: ${value.AudioEncoder}`,
+        `AudioDecoder: ${value.AudioDecoder}`,
+        `AAC custom state: ${aacCustomEncoderState}`,
+    ];
+}
+
+export function formatMediaCompressionDiagnostics(): string {
+    const lines = [
+        'Media Compression Debug',
+        'Keep this data on the device. It is not sent to a server.',
+        ...formatEnvironment(getMediaCompressionEnvironment()),
+        '',
+    ];
+
+    if (records.length === 0) {
+        lines.push('No conversions recorded.');
+    }
+
+    for (const record of records) {
+        lines.push(`Conversion #${record.conversionId}`);
+        lines.push('Input');
+        lines.push(`mime: ${formatValue(record.input.mime)}`);
+        lines.push(`size: ${record.input.size} bytes`);
+        lines.push(`duration: ${record.input.duration === undefined ? 'not recorded' : `${formatValue(record.input.duration)} s`}`);
+        lines.push(`video tracks: ${record.tracks.videoCount}`);
+        lines.push(`audio tracks: ${record.tracks.audioCount}`);
+        lines.push(`AAC custom state at start: ${record.aac.stateAtStart}`);
+
+        record.video.forEach((video, index) => {
+            lines.push(`Video #${index + 1}`);
+            lines.push(`codec: ${formatValue(video.codec)}`);
+            lines.push(`source: ${formatValue(video.displayWidth)}x${formatValue(video.displayHeight)}`);
+            lines.push(`target: ${formatValue(video.targetWidth)}x${formatValue(video.targetHeight)}`);
+            lines.push(`decode: ${formatBoolean(video.decode)}`);
+            lines.push(`AVC encode: ${formatBoolean(video.avcEncode)}`);
+            lines.push(`compression level: ${formatValue(video.compressionLevel)}`);
+            lines.push(`MediaBunny video Quality: ${formatValue(video.quality)}`);
+        });
+
+        record.audio.forEach((audio, index) => {
+            lines.push(`Audio #${index + 1}`);
+            lines.push(`codec: ${formatValue(audio.codec)}`);
+            lines.push(`source: ${formatValue(audio.sourceSampleRate)} Hz / ${formatValue(audio.sourceChannels)}ch`);
+            lines.push(`target: ${formatValue(audio.targetSampleRate)} Hz / ${formatValue(audio.targetChannels)}ch`);
+            lines.push(`decode: ${formatBoolean(audio.decode)}`);
+            lines.push(`target bitrate: ${formatValue(audio.targetBitrate)}`);
+            lines.push(`MediaBunny audio Quality: ${formatValue(audio.quality)}`);
+            lines.push(`native AAC before registration: ${formatBoolean(audio.nativeCapabilityBeforeRegistration)}`);
+            lines.push(`AAC capability before selection: ${formatBoolean(audio.capabilityBeforeSelection)}`);
+            lines.push(`custom import: ${formatValue(audio.customImport)}`);
+            lines.push(`custom registration: ${formatValue(audio.customRegistration)}`);
+            lines.push(`AAC after registration: ${formatBoolean(audio.capabilityAfterRegistration)}`);
+            lines.push(`audio path: ${formatValue(audio.audioPath)}`);
+            if (audio.reason) lines.push(`reason: ${audio.reason}`);
+        });
+
+        lines.push('Conversion');
+        lines.push(`isValid: ${formatBoolean(record.conversion.isValid)}`);
+        lines.push(`discarded tracks: ${record.conversion.discardedTracks.length}`);
+        lines.push(`discarded video: ${record.conversion.discardedVideoCount}`);
+        lines.push(`discarded audio: ${record.conversion.discardedAudioCount}`);
+        lines.push(`execute: ${formatValue(record.conversion.execute)}`);
+        lines.push(`aborted: ${formatBoolean(record.conversion.aborted)}`);
+        lines.push(`original fallback: ${formatBoolean(record.conversion.fallback)}`);
+        lines.push(`fallback reason: ${formatValue(record.conversion.fallbackReason)}`);
+        if (record.error) {
+            lines.push(`error: ${record.error.name}: ${record.error.message}`);
+        }
+
+        lines.push('Timing');
+        for (const key of [
+            'input / track inspection',
+            'video option construction',
+            'video capability',
+            'audio preparation',
+            'aac custom load/register',
+            'conversion.init',
+            'conversion.execute',
+            'compressed File creation',
+            'output audio preservation verification',
+            'total compression',
+        ] as const) {
+            lines.push(`${key}: ${formatDuration(record.timing[key])}`);
+        }
+
+        lines.push('Result');
+        lines.push(`wasCompressed: ${formatBoolean(record.result.wasCompressed)}`);
+        lines.push(`wasSkipped: ${formatBoolean(record.result.wasSkipped)}`);
+        lines.push(`output size: ${formatValue(record.result.outputSize)} bytes`);
+        lines.push(`output audio preserved: ${formatBoolean(record.result.outputAudioPreserved)}`);
+        lines.push('');
+    }
+
+    lines.push('Reload the page before Conversion #1 to test AAC capability before the custom encoder is registered.');
+    return lines.join('\n');
+}

--- a/src/lib/videoCompression/mediabunnyCompression.ts
+++ b/src/lib/videoCompression/mediabunnyCompression.ts
@@ -25,6 +25,7 @@ import { createCompressedFile, devWarn } from './compressionUtils';
 import {
     classifyMediaCompressionAudioPath,
     getAacCustomEncoderState,
+    isMediaCompressionDebugAudioCopyEnabled,
     setAacCustomEncoderState,
     startMediaCompressionDiagnostic,
     type MediaCompressionDiagnosticSession,
@@ -153,6 +154,7 @@ export class MediaBunnyCompression extends BaseCompression {
         options: any,
         quality: Quality | undefined,
         diagnostic: MediaCompressionDiagnosticSession | null,
+        forcePacketCopy: boolean,
         trackIndex: number,
     ): Promise<ConversionAudioOptions> {
         const codec = await track.getCodec();
@@ -165,27 +167,48 @@ export class MediaBunnyCompression extends BaseCompression {
             sourceSampleRate,
             decode: canDecode,
         });
+
+        const numberOfChannels = options.audioChannels ?? sourceChannels;
+        const sampleRate = options.audioSampleRate ?? sourceSampleRate;
+        const bitrate = this.parseAudioBitrate(options.audioBitrate);
+        const effectiveEncodingMode = quality ? 'quality' as const : bitrate ? 'bitrate' as const : 'default' as const;
+        const encoderOptions = {
+            numberOfChannels,
+            sampleRate,
+            ...(quality ? { quality } : bitrate ? { bitrate } : {}),
+        };
+
+        diagnostic?.setAudio(trackIndex, {
+            targetChannels: numberOfChannels,
+            targetSampleRate: sampleRate,
+            configuredBitrate: bitrate,
+            quality: getQualityLabel(options.mediabunnyAudioQualityFactor),
+            effectiveEncodingMode: forcePacketCopy ? 'packet-copy' : effectiveEncodingMode,
+        });
+
+        if (forcePacketCopy) {
+            const nativeCapability = codec && canDecode ? await canEncodeAudio('aac', encoderOptions) : undefined;
+            diagnostic?.setAudio(trackIndex, {
+                nativeCapabilityBeforeRegistration: getAacCustomEncoderState() === 'not-loaded'
+                    ? nativeCapability
+                    : undefined,
+                capabilityBeforeSelection: nativeCapability,
+                audioPath: 'packet-copy',
+                reason: 'debug-forced-packet-copy',
+            });
+            this.log('Media debug audio mode is forcing packet copy without transcoding.', { codec });
+            return {};
+        }
+
         if (!codec || !canDecode) {
             this.log('Audio decode is unavailable; preserving packets without transcoding.', { codec });
             diagnostic?.setAudio(trackIndex, { audioPath: 'packet-copy', reason: 'decode-unavailable' });
             return {};
         }
 
-        const numberOfChannels = options.audioChannels ?? sourceChannels;
-        const sampleRate = options.audioSampleRate ?? sourceSampleRate;
-        const bitrate = this.parseAudioBitrate(options.audioBitrate);
-        const encoderOptions = {
-            numberOfChannels,
-            sampleRate,
-            ...(quality ? { quality } : bitrate ? { bitrate } : {}),
-        };
         const stateAtStart = getAacCustomEncoderState();
         const nativeCapability = await canEncodeAudio('aac', encoderOptions);
         diagnostic?.setAudio(trackIndex, {
-            targetChannels: numberOfChannels,
-            targetSampleRate: sampleRate,
-            targetBitrate: bitrate,
-            quality: getQualityLabel(options.mediabunnyAudioQualityFactor),
             nativeCapabilityBeforeRegistration: stateAtStart === 'not-loaded' ? nativeCapability : undefined,
             capabilityBeforeSelection: nativeCapability,
             ...(stateAtStart === 'registered'
@@ -268,10 +291,24 @@ export class MediaBunnyCompression extends BaseCompression {
         return { options: videoOptions, dimensions: { width, height } };
     }
 
-    private async outputPreservesAudio(file: File, expectedTrackCount: number): Promise<boolean> {
+    private async outputPreservesAudio(
+        file: File,
+        expectedTrackCount: number,
+        diagnostic: MediaCompressionDiagnosticSession | null,
+    ): Promise<boolean> {
         const input = new Input({ source: new BlobSource(file), formats: ALL_FORMATS });
         try {
-            return (await input.getAudioTracks()).length >= expectedTrackCount;
+            const audioTracks = await input.getAudioTracks();
+            if (diagnostic) {
+                for (const [index, track] of audioTracks.entries()) {
+                    diagnostic.setAudio(index, {
+                        outputCodec: await track.getCodec(),
+                        outputSampleRate: await track.getSampleRate(),
+                        outputChannels: await track.getNumberOfChannels(),
+                    });
+                }
+            }
+            return audioTracks.length >= expectedTrackCount;
         } finally {
             input.dispose();
         }
@@ -280,6 +317,7 @@ export class MediaBunnyCompression extends BaseCompression {
     public async compressWithMediabunny(file: File, options: any): Promise<VideoCompressionResult> {
         let input: Input | null = null;
         const diagnostic = startMediaCompressionDiagnostic(file);
+        const forceAudioPacketCopy = isMediaCompressionDebugAudioCopyEnabled();
         const finish = (result: VideoCompressionResult): VideoCompressionResult => {
             diagnostic?.finish(result);
             return result;
@@ -345,6 +383,7 @@ export class MediaBunnyCompression extends BaseCompression {
                         options,
                         audioQuality,
                         diagnostic,
+                        forceAudioPacketCopy,
                         Math.max(0, audioTracks.indexOf(track)),
                     );
                     if (diagnostic && audioPreparationStartedAt !== null) {
@@ -415,7 +454,7 @@ export class MediaBunnyCompression extends BaseCompression {
             const audioVerificationStartedAt = diagnostic ? performance.now() : null;
             const audioPreserved = audioTracks.length === 0
                 ? true
-                : await this.outputPreservesAudio(result.file, audioTracks.length);
+                : await this.outputPreservesAudio(result.file, audioTracks.length, diagnostic);
             diagnostic?.setResult({ outputAudioPreserved: audioPreserved });
             if (diagnostic && audioVerificationStartedAt !== null) {
                 diagnostic.setTiming(

--- a/src/lib/videoCompression/mediabunnyCompression.ts
+++ b/src/lib/videoCompression/mediabunnyCompression.ts
@@ -26,9 +26,11 @@ import {
     classifyMediaCompressionAudioPath,
     getAacCustomEncoderState,
     isMediaCompressionDebugAudioCopyEnabled,
+    isMediaCompressionDebugVideoRealtimeEnabled,
     setAacCustomEncoderState,
     startMediaCompressionDiagnostic,
     type MediaCompressionDiagnosticSession,
+    type MediaCompressionVideoPacketStats,
 } from './mediaCompressionDiagnostics';
 
 let aacEncoderRegistration: Promise<void> | null = null;
@@ -135,6 +137,7 @@ export class MediaBunnyCompression extends BaseCompression {
         track: InputVideoTrack,
         dimensions: { width: number; height: number },
         quality: Quality | undefined,
+        videoLatencyMode: 'realtime' | undefined,
         diagnostic: MediaCompressionDiagnosticSession | null,
         trackIndex: number,
     ): Promise<boolean> {
@@ -144,6 +147,7 @@ export class MediaBunnyCompression extends BaseCompression {
         const canEncode = await canEncodeVideo('avc', {
             ...dimensions,
             ...(quality ? { quality } : {}),
+            ...(videoLatencyMode ? { latencyMode: videoLatencyMode } : {}),
         });
         diagnostic?.setVideo(trackIndex, { avcEncode: canEncode });
         return canEncode;
@@ -246,6 +250,7 @@ export class MediaBunnyCompression extends BaseCompression {
         track: InputVideoTrack,
         options: any,
         quality: Quality | undefined,
+        videoLatencyMode: 'realtime' | undefined,
         diagnostic: MediaCompressionDiagnosticSession | null,
         trackIndex: number,
     ): Promise<{ options: ConversionVideoOptions; dimensions: { width: number; height: number } }> {
@@ -256,6 +261,7 @@ export class MediaBunnyCompression extends BaseCompression {
             codec: 'avc',
             forceTranscode: true,
             ...(quality ? { quality } : {}),
+            ...(videoLatencyMode ? { latencyMode: videoLatencyMode } : {}),
         };
         if (typeof options.maxSize === 'number' && Number.isFinite(options.maxSize)) {
             if (displayWidth > displayHeight) {
@@ -289,6 +295,58 @@ export class MediaBunnyCompression extends BaseCompression {
         });
 
         return { options: videoOptions, dimensions: { width, height } };
+    }
+
+    private async collectVideoPacketStats(
+        getTrack: () => Promise<InputVideoTrack | null>,
+        diagnostic: MediaCompressionDiagnosticSession,
+        trackIndex: number,
+        side: 'input' | 'output',
+    ): Promise<void> {
+        const timingKey = side === 'input' ? 'input video stats scan' : 'output video stats scan';
+        try {
+            const stats = await diagnostic.measureDiagnosticScan(timingKey, async (): Promise<MediaCompressionVideoPacketStats | null> => {
+                const track = await getTrack();
+                if (!track) return null;
+                const [packetStats, duration] = await Promise.all([
+                    track.computePacketStats(),
+                    track.getDurationFromMetadata(),
+                ]);
+                return { ...packetStats, duration };
+            });
+            diagnostic.setVideo(trackIndex, side === 'input'
+                ? { inputPacketStats: stats }
+                : { outputPacketStats: stats });
+        } catch {
+            diagnostic.setVideo(trackIndex, side === 'input'
+                ? { inputPacketStats: null }
+                : { outputPacketStats: null });
+        }
+    }
+
+    private async collectOutputVideoPacketStats(
+        file: File,
+        diagnostic: MediaCompressionDiagnosticSession,
+    ): Promise<void> {
+        try {
+            const stats = await diagnostic.measureDiagnosticScan('output video stats scan', async (): Promise<MediaCompressionVideoPacketStats | null> => {
+                const input = new Input({ source: new BlobSource(file), formats: ALL_FORMATS });
+                try {
+                    const track = (await input.getVideoTracks())[0];
+                    if (!track) return null;
+                    const [packetStats, duration] = await Promise.all([
+                        track.computePacketStats(),
+                        track.getDurationFromMetadata(),
+                    ]);
+                    return { ...packetStats, duration };
+                } finally {
+                    input.dispose();
+                }
+            });
+            diagnostic.setVideo(0, { outputPacketStats: stats });
+        } catch {
+            diagnostic.setVideo(0, { outputPacketStats: null });
+        }
     }
 
     private async outputPreservesAudio(
@@ -337,20 +395,24 @@ export class MediaBunnyCompression extends BaseCompression {
                     'input / track inspection',
                     inspectionStartedAt === null ? 0 : Math.max(0, performance.now() - inspectionStartedAt),
                 );
+                if (videoTracks[0]) {
+                    await this.collectVideoPacketStats(async () => videoTracks[0], diagnostic, 0, 'input');
+                }
             }
             const videoQuality = getQualityFromFactor(options?.mediabunnyVideoQualityFactor);
             const audioQuality = getQualityFromFactor(options?.mediabunnyAudioQualityFactor);
+            const videoLatencyMode = isMediaCompressionDebugVideoRealtimeEnabled() ? 'realtime' as const : undefined;
 
             const videoOptionsStartedAt = diagnostic ? performance.now() : null;
             const videoOptions = videoTracks.length > 0
-                ? await this.buildVideoOptions(videoTracks[0], options, videoQuality, diagnostic, 0)
+                ? await this.buildVideoOptions(videoTracks[0], options, videoQuality, videoLatencyMode, diagnostic, 0)
                 : null;
             if (diagnostic && videoOptionsStartedAt !== null) {
                 diagnostic.setTiming('video option construction', Math.max(0, performance.now() - videoOptionsStartedAt));
             }
             const videoCapabilityStartedAt = diagnostic ? performance.now() : null;
             const videoCanTranscode = videoOptions
-                ? await this.canTranscodeVideo(videoTracks[0], videoOptions.dimensions, videoQuality, diagnostic, 0)
+                ? await this.canTranscodeVideo(videoTracks[0], videoOptions.dimensions, videoQuality, videoLatencyMode, diagnostic, 0)
                 : false;
             if (diagnostic && videoCapabilityStartedAt !== null) {
                 diagnostic.setTiming('video capability', Math.max(0, performance.now() - videoCapabilityStartedAt));
@@ -373,6 +435,7 @@ export class MediaBunnyCompression extends BaseCompression {
                         track,
                         options,
                         videoQuality,
+                        videoLatencyMode,
                         diagnostic,
                         videoTracks.indexOf(track),
                     )).options),
@@ -466,6 +529,10 @@ export class MediaBunnyCompression extends BaseCompression {
                 devWarn(this.context, 'MediaBunny output lost input audio; keeping the original file.');
                 diagnostic?.setConversion({ fallback: true, fallbackReason: 'output-audio-not-preserved' });
                 return finish({ file, wasCompressed: false, wasSkipped: true });
+            }
+
+            if (diagnostic) {
+                await this.collectOutputVideoPacketStats(result.file, diagnostic);
             }
 
             this.updateProgress(100);

--- a/src/lib/videoCompression/mediabunnyCompression.ts
+++ b/src/lib/videoCompression/mediabunnyCompression.ts
@@ -12,11 +12,11 @@ import {
     QUALITY_HIGH,
     QUALITY_MEDIUM,
     QUALITY_VERY_LOW,
+    Quality,
     type ConversionAudioOptions,
     type ConversionVideoOptions,
     type InputAudioTrack,
     type InputVideoTrack,
-    type Quality,
 } from 'mediabunny';
 import type { VideoCompressionResult } from '../types';
 import { isDefaultUploadAborted, type UploadAbortChecker } from '../uploadAbortUtils';
@@ -26,10 +26,12 @@ import {
     classifyMediaCompressionAudioPath,
     getAacCustomEncoderState,
     isMediaCompressionDebugAudioCopyEnabled,
+    isMediaCompressionDebugVideoBitrateEnabled,
     isMediaCompressionDebugVideoRealtimeEnabled,
     setAacCustomEncoderState,
     startMediaCompressionDiagnostic,
     type MediaCompressionDiagnosticSession,
+    type MediaCompressionVideoRateControlMode,
     type MediaCompressionVideoPacketStats,
 } from './mediaCompressionDiagnostics';
 
@@ -52,6 +54,8 @@ function getQualityLabel(factor: number | null | undefined): string | undefined 
     if (factor === 2) return 'high';
     return undefined;
 }
+
+const MEDIA_DEBUG_VIDEO_BITRATE = 400_000;
 
 function getCompressionLevel(options: any): string | undefined {
     if (options?.maxSize === 1280 && options?.mediabunnyVideoQualityFactor === 2) return 'high';
@@ -251,6 +255,7 @@ export class MediaBunnyCompression extends BaseCompression {
         options: any,
         quality: Quality | undefined,
         videoLatencyMode: 'realtime' | undefined,
+        videoRateControlMode: MediaCompressionVideoRateControlMode,
         diagnostic: MediaCompressionDiagnosticSession | null,
         trackIndex: number,
     ): Promise<{ options: ConversionVideoOptions; dimensions: { width: number; height: number } }> {
@@ -292,6 +297,9 @@ export class MediaBunnyCompression extends BaseCompression {
             targetHeight: height,
             compressionLevel: getCompressionLevel(options),
             quality: getQualityLabel(options?.mediabunnyVideoQualityFactor),
+            ...(videoRateControlMode === 'explicit-bitrate'
+                ? { configuredBitrate: MEDIA_DEBUG_VIDEO_BITRATE, bitrateMode: 'variable' as const }
+                : {}),
         });
 
         return { options: videoOptions, dimensions: { width, height } };
@@ -400,19 +408,25 @@ export class MediaBunnyCompression extends BaseCompression {
                 }
             }
             const videoQuality = getQualityFromFactor(options?.mediabunnyVideoQualityFactor);
+            const videoRateControlMode = isMediaCompressionDebugVideoBitrateEnabled()
+                ? 'explicit-bitrate' as const
+                : 'subjective-quality' as const;
+            const effectiveVideoQuality = videoRateControlMode === 'explicit-bitrate'
+                ? new Quality({ bitrate: MEDIA_DEBUG_VIDEO_BITRATE, bitrateMode: 'variable' })
+                : videoQuality;
             const audioQuality = getQualityFromFactor(options?.mediabunnyAudioQualityFactor);
             const videoLatencyMode = isMediaCompressionDebugVideoRealtimeEnabled() ? 'realtime' as const : undefined;
 
             const videoOptionsStartedAt = diagnostic ? performance.now() : null;
             const videoOptions = videoTracks.length > 0
-                ? await this.buildVideoOptions(videoTracks[0], options, videoQuality, videoLatencyMode, diagnostic, 0)
+                ? await this.buildVideoOptions(videoTracks[0], options, effectiveVideoQuality, videoLatencyMode, videoRateControlMode, diagnostic, 0)
                 : null;
             if (diagnostic && videoOptionsStartedAt !== null) {
                 diagnostic.setTiming('video option construction', Math.max(0, performance.now() - videoOptionsStartedAt));
             }
             const videoCapabilityStartedAt = diagnostic ? performance.now() : null;
             const videoCanTranscode = videoOptions
-                ? await this.canTranscodeVideo(videoTracks[0], videoOptions.dimensions, videoQuality, videoLatencyMode, diagnostic, 0)
+                ? await this.canTranscodeVideo(videoTracks[0], videoOptions.dimensions, effectiveVideoQuality, videoLatencyMode, diagnostic, 0)
                 : false;
             if (diagnostic && videoCapabilityStartedAt !== null) {
                 diagnostic.setTiming('video capability', Math.max(0, performance.now() - videoCapabilityStartedAt));
@@ -434,8 +448,9 @@ export class MediaBunnyCompression extends BaseCompression {
                     : (await this.buildVideoOptions(
                         track,
                         options,
-                        videoQuality,
+                        effectiveVideoQuality,
                         videoLatencyMode,
+                        videoRateControlMode,
                         diagnostic,
                         videoTracks.indexOf(track),
                     )).options),

--- a/src/lib/videoCompression/mediabunnyCompression.ts
+++ b/src/lib/videoCompression/mediabunnyCompression.ts
@@ -22,6 +22,13 @@ import type { VideoCompressionResult } from '../types';
 import { isDefaultUploadAborted, type UploadAbortChecker } from '../uploadAbortUtils';
 import { BaseCompression } from './baseCompression';
 import { createCompressedFile, devWarn } from './compressionUtils';
+import {
+    classifyMediaCompressionAudioPath,
+    getAacCustomEncoderState,
+    setAacCustomEncoderState,
+    startMediaCompressionDiagnostic,
+    type MediaCompressionDiagnosticSession,
+} from './mediaCompressionDiagnostics';
 
 let aacEncoderRegistration: Promise<void> | null = null;
 
@@ -36,13 +43,70 @@ function getQualityFromFactor(factor: number | null | undefined): Quality | unde
     return undefined;
 }
 
-async function registerAacEncoder(): Promise<void> {
-    if (!aacEncoderRegistration) {
-        aacEncoderRegistration = import('@mediabunny/aac-encoder').then(({ registerAacEncoder }) => {
-            registerAacEncoder();
+function getQualityLabel(factor: number | null | undefined): string | undefined {
+    if (factor === 0.3) return 'very-low';
+    if (factor === 1) return 'medium';
+    if (factor === 2) return 'high';
+    return undefined;
+}
+
+function getCompressionLevel(options: any): string | undefined {
+    if (options?.maxSize === 1280 && options?.mediabunnyVideoQualityFactor === 2) return 'high';
+    if (options?.maxSize === 640 && options?.mediabunnyVideoQualityFactor === 1) return 'medium';
+    if (options?.maxSize === 320 && options?.mediabunnyVideoQualityFactor === 0.3) return 'low';
+    return undefined;
+}
+
+async function registerAacEncoder(
+    diagnostic: MediaCompressionDiagnosticSession | null,
+    audioTrackIndex: number,
+): Promise<void> {
+    if (diagnostic) {
+        diagnostic.setAudio(audioTrackIndex, {
+            customImport: aacEncoderRegistration
+                ? getAacCustomEncoderState() === 'registered'
+                    ? 'already registered'
+                    : getAacCustomEncoderState() === 'failed'
+                        ? 'failed'
+                        : 'already loading'
+                : 'yes',
+            customRegistration: aacEncoderRegistration
+                ? getAacCustomEncoderState() === 'failed' ? 'failure' : 'not-needed'
+                : 'unknown',
         });
     }
+
+    if (!aacEncoderRegistration) {
+        setAacCustomEncoderState('loading');
+        const startedAt = diagnostic ? performance.now() : null;
+        aacEncoderRegistration = import('@mediabunny/aac-encoder')
+            .then(({ registerAacEncoder }) => {
+                registerAacEncoder();
+                setAacCustomEncoderState('registered');
+                if (diagnostic) diagnostic.setAudio(audioTrackIndex, { customRegistration: 'success' });
+            })
+            .catch((error) => {
+                setAacCustomEncoderState('failed');
+                diagnostic?.setAudio(audioTrackIndex, { customRegistration: 'failure', customImport: 'failed' });
+                if (diagnostic && startedAt !== null) {
+                    diagnostic.setAac({ loadRegisterDuration: Math.max(0, performance.now() - startedAt) });
+                    diagnostic.setTiming('aac custom load/register', Math.max(0, performance.now() - startedAt));
+                }
+                throw error;
+            });
+        await aacEncoderRegistration;
+        if (diagnostic && startedAt !== null) {
+            diagnostic.setAac({ loadRegisterDuration: Math.max(0, performance.now() - startedAt) });
+            diagnostic.setTiming('aac custom load/register', Math.max(0, performance.now() - startedAt));
+        }
+        return;
+    }
+
+    const startedAt = diagnostic ? performance.now() : null;
     await aacEncoderRegistration;
+    if (diagnostic && startedAt !== null) {
+        diagnostic.setTiming('aac custom load/register', Math.max(0, performance.now() - startedAt));
+    }
 }
 
 export class MediaBunnyCompression extends BaseCompression {
@@ -70,38 +134,85 @@ export class MediaBunnyCompression extends BaseCompression {
         track: InputVideoTrack,
         dimensions: { width: number; height: number },
         quality: Quality | undefined,
+        diagnostic: MediaCompressionDiagnosticSession | null,
+        trackIndex: number,
     ): Promise<boolean> {
-        if (!await track.canDecode()) return false;
-        return canEncodeVideo('avc', {
+        const canDecode = await track.canDecode();
+        diagnostic?.setVideo(trackIndex, { decode: canDecode });
+        if (!canDecode) return false;
+        const canEncode = await canEncodeVideo('avc', {
             ...dimensions,
             ...(quality ? { quality } : {}),
         });
+        diagnostic?.setVideo(trackIndex, { avcEncode: canEncode });
+        return canEncode;
     }
 
     private async buildAudioOptions(
         track: InputAudioTrack,
         options: any,
         quality: Quality | undefined,
+        diagnostic: MediaCompressionDiagnosticSession | null,
+        trackIndex: number,
     ): Promise<ConversionAudioOptions> {
-        if (!track.codec || !await canDecodeAudio(track.codec)) {
-            this.log('Audio decode is unavailable; preserving packets without transcoding.', { codec: track.codec });
+        const codec = await track.getCodec();
+        const sourceChannels = await track.getNumberOfChannels();
+        const sourceSampleRate = await track.getSampleRate();
+        const canDecode = codec ? await canDecodeAudio(codec) : false;
+        diagnostic?.setAudio(trackIndex, {
+            codec,
+            sourceChannels,
+            sourceSampleRate,
+            decode: canDecode,
+        });
+        if (!codec || !canDecode) {
+            this.log('Audio decode is unavailable; preserving packets without transcoding.', { codec });
+            diagnostic?.setAudio(trackIndex, { audioPath: 'packet-copy', reason: 'decode-unavailable' });
             return {};
         }
 
-        const numberOfChannels = options.audioChannels ?? track.numberOfChannels;
-        const sampleRate = options.audioSampleRate ?? track.sampleRate;
+        const numberOfChannels = options.audioChannels ?? sourceChannels;
+        const sampleRate = options.audioSampleRate ?? sourceSampleRate;
         const bitrate = this.parseAudioBitrate(options.audioBitrate);
         const encoderOptions = {
             numberOfChannels,
             sampleRate,
             ...(quality ? { quality } : bitrate ? { bitrate } : {}),
         };
+        const stateAtStart = getAacCustomEncoderState();
+        const nativeCapability = await canEncodeAudio('aac', encoderOptions);
+        diagnostic?.setAudio(trackIndex, {
+            targetChannels: numberOfChannels,
+            targetSampleRate: sampleRate,
+            targetBitrate: bitrate,
+            quality: getQualityLabel(options.mediabunnyAudioQualityFactor),
+            nativeCapabilityBeforeRegistration: stateAtStart === 'not-loaded' ? nativeCapability : undefined,
+            capabilityBeforeSelection: nativeCapability,
+            ...(stateAtStart === 'registered'
+                ? { customImport: 'already registered' as const, customRegistration: 'not-needed' as const }
+                : stateAtStart === 'not-loaded' && nativeCapability
+                    ? { customImport: 'no' as const, customRegistration: 'not-needed' as const }
+                    : {}),
+        });
 
-        if (!await canEncodeAudio('aac', encoderOptions)) {
-            await registerAacEncoder();
+        if (!nativeCapability) {
+            await registerAacEncoder(diagnostic, trackIndex);
         }
-        if (!await canEncodeAudio('aac', encoderOptions)) {
-            this.log('AAC encoding is unavailable; preserving packets without transcoding.', { codec: track.codec });
+        const canEncode = await canEncodeAudio('aac', encoderOptions);
+        const audioPath = classifyMediaCompressionAudioPath({
+            decodeAvailable: true,
+            stateAtStart,
+            capabilityBeforeSelection: nativeCapability,
+            capabilityAfterRegistration: !nativeCapability ? canEncode : undefined,
+            registrationSucceeded: getAacCustomEncoderState() === 'registered',
+        });
+        diagnostic?.setAudio(trackIndex, {
+            capabilityAfterRegistration: !nativeCapability ? canEncode : undefined,
+            audioPath: audioPath.path,
+            ...(audioPath.reason ? { reason: audioPath.reason } : {}),
+        });
+        if (!canEncode) {
+            this.log('AAC encoding is unavailable; preserving packets without transcoding.', { codec });
             return {};
         }
 
@@ -112,9 +223,12 @@ export class MediaBunnyCompression extends BaseCompression {
         track: InputVideoTrack,
         options: any,
         quality: Quality | undefined,
+        diagnostic: MediaCompressionDiagnosticSession | null,
+        trackIndex: number,
     ): Promise<{ options: ConversionVideoOptions; dimensions: { width: number; height: number } }> {
         const displayWidth = await track.getDisplayWidth();
         const displayHeight = await track.getDisplayHeight();
+        const codec = diagnostic ? await track.getCodec() : undefined;
         const videoOptions: ConversionVideoOptions = {
             codec: 'avc',
             forceTranscode: true,
@@ -141,6 +255,16 @@ export class MediaBunnyCompression extends BaseCompression {
             width = ceilToMultipleOfTwo(Math.round(height * (displayWidth / displayHeight)));
         }
 
+        diagnostic?.setVideo(trackIndex, {
+            codec,
+            displayWidth,
+            displayHeight,
+            targetWidth: width,
+            targetHeight: height,
+            compressionLevel: getCompressionLevel(options),
+            quality: getQualityLabel(options?.mediabunnyVideoQualityFactor),
+        });
+
         return { options: videoOptions, dimensions: { width, height } };
     }
 
@@ -155,67 +279,170 @@ export class MediaBunnyCompression extends BaseCompression {
 
     public async compressWithMediabunny(file: File, options: any): Promise<VideoCompressionResult> {
         let input: Input | null = null;
+        const diagnostic = startMediaCompressionDiagnostic(file);
+        const finish = (result: VideoCompressionResult): VideoCompressionResult => {
+            diagnostic?.finish(result);
+            return result;
+        };
         try {
             this.abortRequested = false;
             this.abortController = new AbortController();
             input = new Input({ source: new BlobSource(file), formats: ALL_FORMATS });
 
+            const inspectionStartedAt = diagnostic ? performance.now() : null;
             const videoTracks = await input.getVideoTracks();
             const audioTracks = await input.getAudioTracks();
+            diagnostic?.setTrackCounts(videoTracks.length, audioTracks.length);
+            if (diagnostic) {
+                diagnostic.setInputDuration(await input.getDurationFromMetadata());
+                diagnostic.setTiming(
+                    'input / track inspection',
+                    inspectionStartedAt === null ? 0 : Math.max(0, performance.now() - inspectionStartedAt),
+                );
+            }
             const videoQuality = getQualityFromFactor(options?.mediabunnyVideoQualityFactor);
             const audioQuality = getQualityFromFactor(options?.mediabunnyAudioQualityFactor);
 
+            const videoOptionsStartedAt = diagnostic ? performance.now() : null;
             const videoOptions = videoTracks.length > 0
-                ? await this.buildVideoOptions(videoTracks[0], options, videoQuality)
+                ? await this.buildVideoOptions(videoTracks[0], options, videoQuality, diagnostic, 0)
                 : null;
-            if (!videoOptions || !await this.canTranscodeVideo(videoTracks[0], videoOptions.dimensions, videoQuality)) {
+            if (diagnostic && videoOptionsStartedAt !== null) {
+                diagnostic.setTiming('video option construction', Math.max(0, performance.now() - videoOptionsStartedAt));
+            }
+            const videoCapabilityStartedAt = diagnostic ? performance.now() : null;
+            const videoCanTranscode = videoOptions
+                ? await this.canTranscodeVideo(videoTracks[0], videoOptions.dimensions, videoQuality, diagnostic, 0)
+                : false;
+            if (diagnostic && videoCapabilityStartedAt !== null) {
+                diagnostic.setTiming('video capability', Math.max(0, performance.now() - videoCapabilityStartedAt));
+            }
+            if (!videoOptions || !videoCanTranscode) {
                 this.log('Required video decode or AVC encode capability is unavailable; skipping compression.');
-                return { file, wasCompressed: false, wasSkipped: true };
+                diagnostic?.setConversion({ fallback: true, fallbackReason: 'video-capability-unavailable' });
+                return finish({ file, wasCompressed: false, wasSkipped: true });
             }
 
             const target = new BufferTarget();
             const output = new Output({ target, format: new Mp4OutputFormat({ fastStart: 'in-memory' }) });
+            const conversionInitStartedAt = diagnostic ? performance.now() : null;
             const conversion = await Conversion.init({
                 input,
                 output,
                 video: async (track) => (track === videoTracks[0]
                     ? videoOptions.options
-                    : (await this.buildVideoOptions(track, options, videoQuality)).options),
-                audio: (track) => this.buildAudioOptions(track, options, audioQuality),
+                    : (await this.buildVideoOptions(
+                        track,
+                        options,
+                        videoQuality,
+                        diagnostic,
+                        videoTracks.indexOf(track),
+                    )).options),
+                audio: async (track) => {
+                    const audioPreparationStartedAt = diagnostic ? performance.now() : null;
+                    const result = await this.buildAudioOptions(
+                        track,
+                        options,
+                        audioQuality,
+                        diagnostic,
+                        Math.max(0, audioTracks.indexOf(track)),
+                    );
+                    if (diagnostic && audioPreparationStartedAt !== null) {
+                        diagnostic.setTiming(
+                            'audio preparation',
+                            Math.max(0, performance.now() - audioPreparationStartedAt),
+                        );
+                    }
+                    return result;
+                },
                 showWarnings: false,
+            });
+            if (diagnostic && conversionInitStartedAt !== null) {
+                diagnostic.setTiming('conversion.init', Math.max(0, performance.now() - conversionInitStartedAt));
+            }
+
+            const discardedTracks = conversion.discardedTracks.map(({ track, reason }) => ({
+                type: track.isVideoTrack() ? 'video' as const : track.isAudioTrack() ? 'audio' as const : 'other' as const,
+                reason,
+            }));
+            diagnostic?.setConversion({
+                isValid: conversion.isValid,
+                discardedTracks,
+                discardedVideoCount: discardedTracks.filter(({ type }) => type === 'video').length,
+                discardedAudioCount: discardedTracks.filter(({ type }) => type === 'audio').length,
             });
 
             if (!conversion.isValid || conversion.discardedTracks.some(({ track }) => track.isVideoTrack() || track.isAudioTrack())) {
                 devWarn(this.context, 'MediaBunny cannot preserve all required tracks; skipping compression.', conversion.discardedTracks);
-                return { file, wasCompressed: false, wasSkipped: true };
+                diagnostic?.setConversion({ fallback: true, fallbackReason: 'conversion-invalid-or-discarded-track' });
+                return finish({ file, wasCompressed: false, wasSkipped: true });
             }
 
             conversion.onProgress = (progress) => this.updateProgress(progress * 100);
             this.abortController.signal.addEventListener('abort', () => void conversion.cancel(), { once: true });
-            await conversion.execute();
+            const conversionExecuteStartedAt = diagnostic ? performance.now() : null;
+            try {
+                await conversion.execute();
+                diagnostic?.setConversion({ execute: 'success' });
+            } catch (error) {
+                diagnostic?.setConversion({ execute: 'failure' });
+                throw error;
+            } finally {
+                if (diagnostic && conversionExecuteStartedAt !== null) {
+                    diagnostic.setTiming('conversion.execute', Math.max(0, performance.now() - conversionExecuteStartedAt));
+                }
+            }
 
             const aborted = this.abortRequested
                 ? { file, wasCompressed: false, wasSkipped: true, aborted: true }
                 : this.checkAbort(file);
-            if (aborted) return aborted;
+            if (aborted) {
+                diagnostic?.setConversion({ fallback: true, fallbackReason: 'aborted' });
+                return finish(aborted);
+            }
             if (!target.buffer) throw new Error('MediaBunny did not produce an output buffer.');
 
+            const fileCreationStartedAt = diagnostic ? performance.now() : null;
             const result = createCompressedFile(new Blob([target.buffer], { type: 'video/mp4' }), file, this.context);
-            if (!result.wasCompressed) return result;
-            if (audioTracks.length > 0 && !await this.outputPreservesAudio(result.file, audioTracks.length)) {
+            if (diagnostic && fileCreationStartedAt !== null) {
+                diagnostic.setTiming('compressed File creation', Math.max(0, performance.now() - fileCreationStartedAt));
+            }
+            diagnostic?.setResult({ outputSize: result.file.size, wasCompressed: result.wasCompressed });
+            if (!result.wasCompressed) {
+                diagnostic?.setConversion({ fallback: true, fallbackReason: 'compressed-output-not-smaller' });
+                return finish(result);
+            }
+            const audioVerificationStartedAt = diagnostic ? performance.now() : null;
+            const audioPreserved = audioTracks.length === 0
+                ? true
+                : await this.outputPreservesAudio(result.file, audioTracks.length);
+            diagnostic?.setResult({ outputAudioPreserved: audioPreserved });
+            if (diagnostic && audioVerificationStartedAt !== null) {
+                diagnostic.setTiming(
+                    'output audio preservation verification',
+                    Math.max(0, performance.now() - audioVerificationStartedAt),
+                );
+            }
+            if (audioTracks.length > 0 && !audioPreserved) {
                 devWarn(this.context, 'MediaBunny output lost input audio; keeping the original file.');
-                return { file, wasCompressed: false, wasSkipped: true };
+                diagnostic?.setConversion({ fallback: true, fallbackReason: 'output-audio-not-preserved' });
+                return finish({ file, wasCompressed: false, wasSkipped: true });
             }
 
             this.updateProgress(100);
-            return result;
+            return finish(result);
         } catch (error) {
+            diagnostic?.setError(error);
+            diagnostic?.setConversion({ execute: 'failure', fallback: true, fallbackReason: 'compression-error' });
             const aborted = this.abortRequested
                 ? { file, wasCompressed: false, wasSkipped: true, aborted: true }
                 : this.checkAbort(file);
-            if (aborted) return aborted;
+            if (aborted) {
+                diagnostic?.setConversion({ fallbackReason: 'aborted' });
+                return finish(aborted);
+            }
             devWarn(this.context, 'MediaBunny compression failed; keeping the original file.', error);
-            return { file, wasCompressed: false, wasSkipped: true };
+            return finish({ file, wasCompressed: false, wasSkipped: true });
         } finally {
             input?.dispose();
             this.abortController = null;

--- a/src/lib/videoCompression/rawVideoEncoderBenchmark.ts
+++ b/src/lib/videoCompression/rawVideoEncoderBenchmark.ts
@@ -10,6 +10,9 @@ export const RAW_VIDEO_ENCODER_BENCHMARK_FRAME_COUNT = 627;
 export const RAW_VIDEO_ENCODER_BENCHMARK_QUEUE_LIMIT = 4;
 export const RAW_VIDEO_ENCODER_BENCHMARK_SOURCE = 'canvas-2d synthetic pattern';
 
+export const RAW_VIDEO_ENCODER_BENCHMARK_CANVAS_SOURCES = ['html-canvas', 'offscreen-canvas'] as const;
+export type RawVideoEncoderBenchmarkCanvasSource = typeof RAW_VIDEO_ENCODER_BENCHMARK_CANVAS_SOURCES[number];
+
 export type RawVideoEncoderBenchmarkFailureStage =
     | 'api-unavailable'
     | 'config-unsupported'
@@ -32,6 +35,7 @@ export interface RawVideoEncoderBenchmarkTimings {
 export interface RawVideoEncoderBenchmarkResult {
     status: 'completed' | 'failed';
     source: typeof RAW_VIDEO_ENCODER_BENCHMARK_SOURCE;
+    canvasSource: RawVideoEncoderBenchmarkCanvasSource;
     config: VideoEncoderConfig;
     frameCount: number;
     queueLimit: number;
@@ -69,8 +73,17 @@ interface RawVideoEncoderBenchmarkOptions {
     /** Test-only overrides keep the production benchmark fixed at 627 frames. */
     frameCount?: number;
     queueLimit?: number;
+    canvasSource?: RawVideoEncoderBenchmarkCanvasSource;
     VideoEncoder?: RawVideoEncoderConstructor | null;
     VideoFrame?: { new(source: CanvasImageSource, init: VideoFrameInit): { close(): void } } | null;
+    OffscreenCanvas?: { new(width: number, height: number): {
+        width: number;
+        height: number;
+        getContext(contextId: '2d'): {
+            fillStyle: string;
+            fillRect(x: number, y: number, width: number, height: number): void;
+        } | null;
+    } } | null;
     createFrame?: (frameIndex: number, timestamp: number, duration: number) => { close(): void };
     now?: () => number;
     signal?: AbortSignal;
@@ -108,6 +121,7 @@ function makeFailure(
     stage: RawVideoEncoderBenchmarkFailureStage,
     message: string,
     timings: RawVideoEncoderBenchmarkTimings,
+    canvasSource: RawVideoEncoderBenchmarkCanvasSource,
     frameCount: number,
     queueLimit: number,
     statistics: Pick<RawVideoEncoderBenchmarkResult, 'maxQueueSize' | 'framesSubmitted' | 'chunks' | 'bytes' | 'keyChunks' | 'deltaChunks'>,
@@ -115,6 +129,7 @@ function makeFailure(
     return {
         status: 'failed',
         source: RAW_VIDEO_ENCODER_BENCHMARK_SOURCE,
+        canvasSource,
         config: { ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG },
         frameCount,
         queueLimit,
@@ -126,12 +141,30 @@ function makeFailure(
 
 function createSyntheticFrameFactory(
     VideoFrameConstructor: RawVideoEncoderBenchmarkOptions['VideoFrame'],
+    canvasSource: RawVideoEncoderBenchmarkCanvasSource,
+    OffscreenCanvasConstructor: RawVideoEncoderBenchmarkOptions['OffscreenCanvas'],
 ): (frameIndex: number, timestamp: number, duration: number) => { close(): void } {
-    if (!VideoFrameConstructor || typeof document === 'undefined') {
-        throw new Error('VideoFrame or Canvas 2D is unavailable.');
+    if (!VideoFrameConstructor) {
+        throw new Error('VideoFrame is unavailable.');
     }
 
-    const canvas = document.createElement('canvas');
+    type SyntheticCanvas = CanvasImageSource & {
+        width: number;
+        height: number;
+        getContext(contextId: '2d'): {
+            fillStyle: CanvasRenderingContext2D['fillStyle'];
+            fillRect(x: number, y: number, width: number, height: number): void;
+        } | null;
+    };
+    let canvas: SyntheticCanvas | null;
+    if (canvasSource === 'offscreen-canvas') {
+        const Constructor = OffscreenCanvasConstructor ?? (globalThis.OffscreenCanvas as RawVideoEncoderBenchmarkOptions['OffscreenCanvas']);
+        if (!Constructor) throw new Error('OffscreenCanvas unavailable.');
+        canvas = new Constructor(RAW_VIDEO_ENCODER_BENCHMARK_CONFIG.width, RAW_VIDEO_ENCODER_BENCHMARK_CONFIG.height) as SyntheticCanvas;
+    } else {
+        canvas = typeof document === 'undefined' ? null : document.createElement('canvas') as SyntheticCanvas;
+    }
+    if (!canvas) throw new Error('HTMLCanvasElement is unavailable.');
     canvas.width = RAW_VIDEO_ENCODER_BENCHMARK_CONFIG.width;
     canvas.height = RAW_VIDEO_ENCODER_BENCHMARK_CONFIG.height;
     const context = canvas.getContext('2d');
@@ -187,6 +220,7 @@ function classifyFailure(error: unknown, phase: 'configure' | 'setup' | 'encode'
 export async function runRawVideoEncoderBenchmark(
     options: RawVideoEncoderBenchmarkOptions = {},
 ): Promise<RawVideoEncoderBenchmarkResult> {
+    const canvasSource = options.canvasSource ?? 'html-canvas';
     const frameCount = options.frameCount ?? RAW_VIDEO_ENCODER_BENCHMARK_FRAME_COUNT;
     const queueLimit = options.queueLimit ?? RAW_VIDEO_ENCODER_BENCHMARK_QUEUE_LIMIT;
     const now = options.now ?? (() => performance.now());
@@ -200,7 +234,7 @@ export async function runRawVideoEncoderBenchmark(
         : options.VideoFrame ?? undefined;
 
     if (!VideoEncoderConstructor || (!options.createFrame && !VideoFrameConstructor)) {
-        return makeFailure('api-unavailable', 'VideoEncoder or VideoFrame is unavailable.', timings, frameCount, queueLimit, statistics);
+        return makeFailure('api-unavailable', 'VideoEncoder or VideoFrame is unavailable.', timings, canvasSource, frameCount, queueLimit, statistics);
     }
 
     const supportStartedAt = now();
@@ -209,11 +243,11 @@ export async function runRawVideoEncoderBenchmark(
         support = await VideoEncoderConstructor.isConfigSupported({ ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG });
     } catch (error) {
         timings.configSupportCheck = Math.max(0, now() - supportStartedAt);
-        return makeFailure('config-unsupported', shortErrorMessage(error), timings, frameCount, queueLimit, statistics);
+        return makeFailure('config-unsupported', shortErrorMessage(error), timings, canvasSource, frameCount, queueLimit, statistics);
     }
     timings.configSupportCheck = Math.max(0, now() - supportStartedAt);
     if (!support.supported) {
-        return makeFailure('config-unsupported', 'VideoEncoder does not support the fixed AVC configuration.', timings, frameCount, queueLimit, statistics);
+        return makeFailure('config-unsupported', 'VideoEncoder does not support the fixed AVC configuration.', timings, canvasSource, frameCount, queueLimit, statistics);
     }
 
     let encoder: RawVideoEncoderLike | undefined;
@@ -242,7 +276,11 @@ export async function runRawVideoEncoderBenchmark(
         encoder.configure({ ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG });
         let createFrame: (frameIndex: number, timestamp: number, duration: number) => { close(): void };
         phase = 'setup';
-        createFrame = options.createFrame ?? createSyntheticFrameFactory(VideoFrameConstructor);
+        createFrame = options.createFrame ?? createSyntheticFrameFactory(
+            VideoFrameConstructor,
+            canvasSource,
+            options.OffscreenCanvas ?? (globalThis.OffscreenCanvas as RawVideoEncoderBenchmarkOptions['OffscreenCanvas']),
+        );
         timings.encoderSetupConfigure = Math.max(0, now() - setupStartedAt);
 
         const benchmarkStartedAt = now();
@@ -303,6 +341,7 @@ export async function runRawVideoEncoderBenchmark(
         return {
             status: 'completed',
             source: RAW_VIDEO_ENCODER_BENCHMARK_SOURCE,
+            canvasSource,
             config: { ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG },
             frameCount,
             queueLimit,
@@ -315,6 +354,7 @@ export async function runRawVideoEncoderBenchmark(
             classifyFailure(error, phase),
             shortErrorMessage(error),
             timings,
+            canvasSource,
             frameCount,
             queueLimit,
             statistics,

--- a/src/lib/videoCompression/rawVideoEncoderBenchmark.ts
+++ b/src/lib/videoCompression/rawVideoEncoderBenchmark.ts
@@ -1,5 +1,5 @@
 export const RAW_VIDEO_ENCODER_BENCHMARK_CONFIG = {
-    codec: 'avc1.42001E',
+    codec: 'avc1.64001E',
     width: 360,
     height: 640,
     framerate: 30,

--- a/src/lib/videoCompression/rawVideoEncoderBenchmark.ts
+++ b/src/lib/videoCompression/rawVideoEncoderBenchmark.ts
@@ -1,0 +1,330 @@
+export const RAW_VIDEO_ENCODER_BENCHMARK_CONFIG = {
+    codec: 'avc1.42001E',
+    width: 360,
+    height: 640,
+    framerate: 30,
+    bitrate: 400_000,
+} as const satisfies VideoEncoderConfig;
+
+export const RAW_VIDEO_ENCODER_BENCHMARK_FRAME_COUNT = 627;
+export const RAW_VIDEO_ENCODER_BENCHMARK_QUEUE_LIMIT = 4;
+export const RAW_VIDEO_ENCODER_BENCHMARK_SOURCE = 'canvas-2d synthetic pattern';
+
+export type RawVideoEncoderBenchmarkFailureStage =
+    | 'api-unavailable'
+    | 'config-unsupported'
+    | 'configure-failure'
+    | 'setup-failure'
+    | 'encode-failure'
+    | 'flush-failure'
+    | 'aborted';
+
+export interface RawVideoEncoderBenchmarkTimings {
+    configSupportCheck: number;
+    encoderSetupConfigure: number;
+    benchmarkWall: number;
+    framePreparationSync: number;
+    encodeSubmissionSync: number;
+    backpressureWait: number;
+    flushWait: number;
+}
+
+export interface RawVideoEncoderBenchmarkResult {
+    status: 'completed' | 'failed';
+    source: typeof RAW_VIDEO_ENCODER_BENCHMARK_SOURCE;
+    config: VideoEncoderConfig;
+    frameCount: number;
+    queueLimit: number;
+    maxQueueSize: number;
+    timings: RawVideoEncoderBenchmarkTimings;
+    framesSubmitted: number;
+    chunks: number;
+    bytes: number;
+    keyChunks: number;
+    deltaChunks: number;
+    throughput?: number;
+    failure?: {
+        stage: RawVideoEncoderBenchmarkFailureStage;
+        message: string;
+    };
+}
+
+export interface RawVideoEncoderLike extends EventTarget {
+    readonly encodeQueueSize: number;
+    configure(config: VideoEncoderConfig): void;
+    encode(frame: { close(): void }, options?: VideoEncoderEncodeOptions): void;
+    flush(): Promise<void>;
+    close(): void;
+}
+
+export interface RawVideoEncoderConstructor {
+    new(init: {
+        output: (chunk: { byteLength: number; type: EncodedVideoChunkType }) => void;
+        error: (error: unknown) => void;
+    }): RawVideoEncoderLike;
+    isConfigSupported(config: VideoEncoderConfig): Promise<{ supported?: boolean; config?: VideoEncoderConfig }>;
+}
+
+interface RawVideoEncoderBenchmarkOptions {
+    /** Test-only overrides keep the production benchmark fixed at 627 frames. */
+    frameCount?: number;
+    queueLimit?: number;
+    VideoEncoder?: RawVideoEncoderConstructor | null;
+    VideoFrame?: { new(source: CanvasImageSource, init: VideoFrameInit): { close(): void } } | null;
+    createFrame?: (frameIndex: number, timestamp: number, duration: number) => { close(): void };
+    now?: () => number;
+    signal?: AbortSignal;
+}
+
+class BenchmarkAbortError extends Error {
+    constructor() {
+        super('Raw VideoEncoder benchmark was aborted.');
+        this.name = 'AbortError';
+    }
+}
+
+function shortErrorMessage(error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.replace(/[\r\n]+/g, ' ').slice(0, 240);
+}
+
+function createTimings(): RawVideoEncoderBenchmarkTimings {
+    return {
+        configSupportCheck: 0,
+        encoderSetupConfigure: 0,
+        benchmarkWall: 0,
+        framePreparationSync: 0,
+        encodeSubmissionSync: 0,
+        backpressureWait: 0,
+        flushWait: 0,
+    };
+}
+
+export function rawVideoEncoderTimestampForFrame(frameIndex: number): number {
+    return Math.round(frameIndex * 1_000_000 / RAW_VIDEO_ENCODER_BENCHMARK_CONFIG.framerate);
+}
+
+function makeFailure(
+    stage: RawVideoEncoderBenchmarkFailureStage,
+    message: string,
+    timings: RawVideoEncoderBenchmarkTimings,
+    frameCount: number,
+    queueLimit: number,
+    statistics: Pick<RawVideoEncoderBenchmarkResult, 'maxQueueSize' | 'framesSubmitted' | 'chunks' | 'bytes' | 'keyChunks' | 'deltaChunks'>,
+): RawVideoEncoderBenchmarkResult {
+    return {
+        status: 'failed',
+        source: RAW_VIDEO_ENCODER_BENCHMARK_SOURCE,
+        config: { ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG },
+        frameCount,
+        queueLimit,
+        timings,
+        ...statistics,
+        failure: { stage, message },
+    };
+}
+
+function createSyntheticFrameFactory(
+    VideoFrameConstructor: RawVideoEncoderBenchmarkOptions['VideoFrame'],
+): (frameIndex: number, timestamp: number, duration: number) => { close(): void } {
+    if (!VideoFrameConstructor || typeof document === 'undefined') {
+        throw new Error('VideoFrame or Canvas 2D is unavailable.');
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = RAW_VIDEO_ENCODER_BENCHMARK_CONFIG.width;
+    canvas.height = RAW_VIDEO_ENCODER_BENCHMARK_CONFIG.height;
+    const context = canvas.getContext('2d');
+    if (!context) throw new Error('Canvas 2D is unavailable.');
+
+    return (frameIndex, timestamp, duration) => {
+        const { width, height } = RAW_VIDEO_ENCODER_BENCHMARK_CONFIG;
+        const barHeight = 64;
+        const movingX = (frameIndex * 7) % width;
+        const movingY = (frameIndex * 5) % (height - 120);
+
+        context.fillStyle = '#10243d';
+        context.fillRect(0, 0, width, height);
+        context.fillStyle = '#284f73';
+        context.fillRect(0, 0, width, barHeight);
+        context.fillStyle = '#f4c95d';
+        context.fillRect(0, height - barHeight, width, barHeight);
+        context.fillStyle = '#ef8354';
+        context.fillRect(movingX, movingY, 84, 84);
+        context.fillStyle = '#4fb286';
+        context.fillRect(width - movingX - 48, height - movingY - 140, 48, 48);
+        context.fillStyle = '#ffffff';
+        context.fillRect((frameIndex * 13) % width, 96, 4, height - 192);
+
+        return new VideoFrameConstructor(canvas, { timestamp, duration });
+    };
+}
+
+function createStatistics() {
+    return {
+        maxQueueSize: 0,
+        framesSubmitted: 0,
+        chunks: 0,
+        bytes: 0,
+        keyChunks: 0,
+        deltaChunks: 0,
+    };
+}
+
+function classifyFailure(error: unknown, phase: 'configure' | 'setup' | 'encode' | 'flush'): RawVideoEncoderBenchmarkFailureStage {
+    if (error instanceof BenchmarkAbortError || (error instanceof DOMException && error.name === 'AbortError')) {
+        return 'aborted';
+    }
+    if (phase === 'configure') return 'configure-failure';
+    if (phase === 'setup') return 'setup-failure';
+    return phase === 'flush' ? 'flush-failure' : 'encode-failure';
+}
+
+/**
+ * Runs a deliberately small, native WebCodecs-only encoder benchmark. It does not
+ * inspect or configure MediaBunny, mux output, or create a file.
+ */
+export async function runRawVideoEncoderBenchmark(
+    options: RawVideoEncoderBenchmarkOptions = {},
+): Promise<RawVideoEncoderBenchmarkResult> {
+    const frameCount = options.frameCount ?? RAW_VIDEO_ENCODER_BENCHMARK_FRAME_COUNT;
+    const queueLimit = options.queueLimit ?? RAW_VIDEO_ENCODER_BENCHMARK_QUEUE_LIMIT;
+    const now = options.now ?? (() => performance.now());
+    const timings = createTimings();
+    const statistics = createStatistics();
+    const VideoEncoderConstructor = options.VideoEncoder === undefined
+        ? (globalThis.VideoEncoder as unknown as RawVideoEncoderConstructor | undefined)
+        : options.VideoEncoder ?? undefined;
+    const VideoFrameConstructor = options.VideoFrame === undefined
+        ? (globalThis.VideoFrame as unknown as RawVideoEncoderBenchmarkOptions['VideoFrame'])
+        : options.VideoFrame ?? undefined;
+
+    if (!VideoEncoderConstructor || (!options.createFrame && !VideoFrameConstructor)) {
+        return makeFailure('api-unavailable', 'VideoEncoder or VideoFrame is unavailable.', timings, frameCount, queueLimit, statistics);
+    }
+
+    const supportStartedAt = now();
+    let support: { supported?: boolean };
+    try {
+        support = await VideoEncoderConstructor.isConfigSupported({ ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG });
+    } catch (error) {
+        timings.configSupportCheck = Math.max(0, now() - supportStartedAt);
+        return makeFailure('config-unsupported', shortErrorMessage(error), timings, frameCount, queueLimit, statistics);
+    }
+    timings.configSupportCheck = Math.max(0, now() - supportStartedAt);
+    if (!support.supported) {
+        return makeFailure('config-unsupported', 'VideoEncoder does not support the fixed AVC configuration.', timings, frameCount, queueLimit, statistics);
+    }
+
+    let encoder: RawVideoEncoderLike | undefined;
+    let phase: 'configure' | 'setup' | 'encode' | 'flush' = 'configure';
+    let callbackError: unknown;
+    const waitingRejectors = new Set<(error: unknown) => void>();
+    const rejectWaiters = (error: unknown) => {
+        for (const reject of waitingRejectors) reject(error);
+        waitingRejectors.clear();
+    };
+
+    try {
+        const setupStartedAt = now();
+        encoder = new VideoEncoderConstructor({
+            output: (chunk) => {
+                statistics.chunks += 1;
+                statistics.bytes += chunk.byteLength;
+                if (chunk.type === 'key') statistics.keyChunks += 1;
+                else statistics.deltaChunks += 1;
+            },
+            error: (error) => {
+                callbackError ??= error;
+                rejectWaiters(error);
+            },
+        });
+        encoder.configure({ ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG });
+        let createFrame: (frameIndex: number, timestamp: number, duration: number) => { close(): void };
+        phase = 'setup';
+        createFrame = options.createFrame ?? createSyntheticFrameFactory(VideoFrameConstructor);
+        timings.encoderSetupConfigure = Math.max(0, now() - setupStartedAt);
+
+        const benchmarkStartedAt = now();
+        for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
+            if (options.signal?.aborted) throw new BenchmarkAbortError();
+            phase = 'encode';
+            if (encoder.encodeQueueSize >= queueLimit) {
+                const activeEncoder = encoder;
+                const waitStartedAt = now();
+                await new Promise<void>((resolve, reject) => {
+                    const onDequeue = () => {
+                        if (activeEncoder.encodeQueueSize < queueLimit) finish(resolve);
+                    };
+                    const onAbort = () => finish(() => reject(new BenchmarkAbortError()));
+                    const rejectForEncoderError = (error: unknown) => finish(() => reject(error));
+                    let finished = false;
+                    const finish = (complete: () => void) => {
+                        if (finished) return;
+                        finished = true;
+                        activeEncoder.removeEventListener('dequeue', onDequeue);
+                        options.signal?.removeEventListener('abort', onAbort);
+                        waitingRejectors.delete(rejectForEncoderError);
+                        complete();
+                    };
+                    activeEncoder.addEventListener('dequeue', onDequeue);
+                    options.signal?.addEventListener('abort', onAbort, { once: true });
+                    waitingRejectors.add(rejectForEncoderError);
+                    if (callbackError) rejectForEncoderError(callbackError);
+                    else onDequeue();
+                });
+                timings.backpressureWait += Math.max(0, now() - waitStartedAt);
+            }
+
+            const timestamp = rawVideoEncoderTimestampForFrame(frameIndex);
+            const nextTimestamp = rawVideoEncoderTimestampForFrame(frameIndex + 1);
+            const framePreparationStartedAt = now();
+            const frame = createFrame(frameIndex, timestamp, nextTimestamp - timestamp);
+            timings.framePreparationSync += Math.max(0, now() - framePreparationStartedAt);
+            try {
+                const encodeStartedAt = now();
+                encoder.encode(frame);
+                timings.encodeSubmissionSync += Math.max(0, now() - encodeStartedAt);
+                statistics.framesSubmitted += 1;
+                statistics.maxQueueSize = Math.max(statistics.maxQueueSize, encoder.encodeQueueSize);
+            } finally {
+                frame.close();
+            }
+            if (callbackError) throw callbackError;
+        }
+
+        phase = 'flush';
+        const flushStartedAt = now();
+        await encoder.flush();
+        timings.flushWait = Math.max(0, now() - flushStartedAt);
+        if (callbackError) throw callbackError;
+        timings.benchmarkWall = Math.max(0, now() - benchmarkStartedAt);
+
+        return {
+            status: 'completed',
+            source: RAW_VIDEO_ENCODER_BENCHMARK_SOURCE,
+            config: { ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG },
+            frameCount,
+            queueLimit,
+            timings,
+            ...statistics,
+            throughput: timings.benchmarkWall > 0 ? statistics.framesSubmitted / (timings.benchmarkWall / 1_000) : undefined,
+        };
+    } catch (error) {
+        return makeFailure(
+            classifyFailure(error, phase),
+            shortErrorMessage(error),
+            timings,
+            frameCount,
+            queueLimit,
+            statistics,
+        );
+    } finally {
+        rejectWaiters(new BenchmarkAbortError());
+        try {
+            encoder?.close();
+        } catch {
+            // Closing an encoder already closed by the browser is safe to ignore.
+        }
+    }
+}

--- a/src/lib/videoCompression/realVideoPipelineBenchmark.ts
+++ b/src/lib/videoCompression/realVideoPipelineBenchmark.ts
@@ -17,7 +17,7 @@ export const REAL_VIDEO_PIPELINE_BENCHMARK_TARGET = {
     alpha: 'discard',
 } as const satisfies VideoSampleTransformOptions;
 
-const REAL_VIDEO_PIPELINE_KEY_FRAME_INTERVAL = 2;
+const REAL_VIDEO_PIPELINE_KEY_FRAME_INTERVAL = 5;
 
 export type RealVideoPipelineBenchmarkFailureStage =
     | 'no-video-track'
@@ -402,7 +402,7 @@ export async function runRealVideoPipelineBenchmark(
                         );
                         result.timings.backpressureWait += Math.max(0, now() - waitStartedAt);
                         const encodeStartedAt = now();
-                        const keyFrameInterval = Math.floor(sample.timestamp / 1_000_000 / REAL_VIDEO_PIPELINE_KEY_FRAME_INTERVAL);
+                        const keyFrameInterval = Math.floor(sample.timestamp / REAL_VIDEO_PIPELINE_KEY_FRAME_INTERVAL);
                         const keyFrame = keyFrameInterval !== lastKeyFrameInterval;
                         lastKeyFrameInterval = keyFrameInterval;
                         encoder.encode(frame, { keyFrame });

--- a/src/lib/videoCompression/realVideoPipelineBenchmark.ts
+++ b/src/lib/videoCompression/realVideoPipelineBenchmark.ts
@@ -1,0 +1,458 @@
+import {
+    ALL_FORMATS,
+    BlobSource,
+    Input,
+    VideoSampleSink,
+    type InputVideoTrack,
+    type VideoSampleTransformOptions,
+} from 'mediabunny';
+
+import { RAW_VIDEO_ENCODER_BENCHMARK_CONFIG, RAW_VIDEO_ENCODER_BENCHMARK_QUEUE_LIMIT } from './rawVideoEncoderBenchmark';
+
+export const REAL_VIDEO_PIPELINE_BENCHMARK_TARGET = {
+    width: RAW_VIDEO_ENCODER_BENCHMARK_CONFIG.width,
+    height: RAW_VIDEO_ENCODER_BENCHMARK_CONFIG.height,
+    fit: 'fill',
+    rotate: 0,
+    alpha: 'discard',
+} as const satisfies VideoSampleTransformOptions;
+
+const REAL_VIDEO_PIPELINE_KEY_FRAME_INTERVAL = 2;
+
+export type RealVideoPipelineBenchmarkFailureStage =
+    | 'no-video-track'
+    | 'decode-unavailable'
+    | 'encoder-unavailable'
+    | 'config-unsupported'
+    | 'transform-failure'
+    | 'encode-failure'
+    | 'flush-failure'
+    | 'aborted'
+    | 'setup-failure';
+
+export interface RealVideoPipelineBenchmarkTimings {
+    inputTrackSetup: number;
+    sampleWaitIteration: number;
+    videoTransform: number;
+    videoFrameCreation: number;
+    encodeSubmissionSync: number;
+    backpressureWait: number;
+    flushWait: number;
+    benchmarkTotalWall: number;
+}
+
+export interface RealVideoPipelineBenchmarkResult {
+    status: 'completed' | 'failed';
+    input: {
+        mime: string;
+        size: number;
+        duration: number | null;
+        videoCodec: string | null;
+        codedWidth: number | null;
+        codedHeight: number | null;
+        displayWidth: number | null;
+        displayHeight: number | null;
+        rotation: number | null;
+    };
+    target: {
+        width: number;
+        height: number;
+        fit: 'fill';
+        rotate: 0;
+        alpha: 'discard';
+    };
+    capabilities: {
+        decode: boolean | null;
+        avcEncode: boolean | null;
+    };
+    samplesProcessed: number;
+    framesSubmitted: number;
+    encodedChunks: number;
+    encodedBytes: number;
+    keyChunks: number;
+    deltaChunks: number;
+    maxQueueSize: number;
+    throughput: number | null;
+    timings: RealVideoPipelineBenchmarkTimings;
+    failure?: {
+        stage: RealVideoPipelineBenchmarkFailureStage;
+        message: string;
+    };
+}
+
+export interface RealVideoPipelineBenchmarkSampleLike {
+    timestamp: number;
+    duration: number;
+    codedWidth: number;
+    codedHeight: number;
+    rotation: number;
+    setTimestamp(timestamp: number): void;
+    transform(options: VideoSampleTransformOptions): Promise<RealVideoPipelineBenchmarkSampleLike>;
+    toVideoFrame(): { close(): void };
+    close(): void;
+}
+
+export interface RealVideoPipelineBenchmarkTrackLike {
+    canDecode(): Promise<boolean>;
+    getCodec(): Promise<string | null>;
+    getCodedWidth(): Promise<number>;
+    getCodedHeight(): Promise<number>;
+    getDisplayWidth(): Promise<number>;
+    getDisplayHeight(): Promise<number>;
+    getRotation(): Promise<number>;
+    getFirstTimestamp(): Promise<number>;
+}
+
+export interface RealVideoPipelineBenchmarkInputLike {
+    getVideoTracks(): Promise<RealVideoPipelineBenchmarkTrackLike[]>;
+    getDurationFromMetadata(): Promise<number | null>;
+    dispose(): void;
+}
+
+export interface RealVideoPipelineBenchmarkSinkLike {
+    samples(): AsyncIterable<RealVideoPipelineBenchmarkSampleLike>;
+}
+
+export interface RealVideoPipelineBenchmarkOptions {
+    signal?: AbortSignal;
+    now?: () => number;
+    VideoEncoder?: RealVideoPipelineBenchmarkEncoderConstructor | null;
+    createInput?: (file: File) => RealVideoPipelineBenchmarkInputLike;
+    createVideoSampleSink?: (track: RealVideoPipelineBenchmarkTrackLike) => RealVideoPipelineBenchmarkSinkLike;
+}
+
+interface RealVideoPipelineBenchmarkEncoder extends EventTarget {
+    readonly encodeQueueSize: number;
+    configure(config: VideoEncoderConfig): void;
+    encode(frame: { close(): void }, options?: VideoEncoderEncodeOptions): void;
+    flush(): Promise<void>;
+    close(): void;
+}
+
+export interface RealVideoPipelineBenchmarkEncoderConstructor {
+    new(init: {
+        output: (chunk: { byteLength: number; type: EncodedVideoChunkType }) => void;
+        error: (error: unknown) => void;
+    }): RealVideoPipelineBenchmarkEncoder;
+    isConfigSupported(config: VideoEncoderConfig): Promise<{ supported?: boolean; config?: VideoEncoderConfig }>;
+}
+
+class RealVideoPipelineBenchmarkAbortError extends Error {
+    constructor() {
+        super('Real video pipeline benchmark was aborted.');
+        this.name = 'AbortError';
+    }
+}
+
+function shortErrorMessage(error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.replace(/[\r\n]+/g, ' ').slice(0, 240);
+}
+
+function createTimings(): RealVideoPipelineBenchmarkTimings {
+    return {
+        inputTrackSetup: 0,
+        sampleWaitIteration: 0,
+        videoTransform: 0,
+        videoFrameCreation: 0,
+        encodeSubmissionSync: 0,
+        backpressureWait: 0,
+        flushWait: 0,
+        benchmarkTotalWall: 0,
+    };
+}
+
+function createResult(file: File): RealVideoPipelineBenchmarkResult {
+    return {
+        status: 'failed',
+        input: {
+            mime: file.type || 'unknown',
+            size: file.size,
+            duration: null,
+            videoCodec: null,
+            codedWidth: null,
+            codedHeight: null,
+            displayWidth: null,
+            displayHeight: null,
+            rotation: null,
+        },
+        target: { ...REAL_VIDEO_PIPELINE_BENCHMARK_TARGET },
+        capabilities: { decode: null, avcEncode: null },
+        samplesProcessed: 0,
+        framesSubmitted: 0,
+        encodedChunks: 0,
+        encodedBytes: 0,
+        keyChunks: 0,
+        deltaChunks: 0,
+        maxQueueSize: 0,
+        throughput: null,
+        timings: createTimings(),
+    };
+}
+
+function createProductionInput(file: File): RealVideoPipelineBenchmarkInputLike {
+    return new Input({ source: new BlobSource(file), formats: ALL_FORMATS });
+}
+
+function createProductionVideoSampleSink(track: RealVideoPipelineBenchmarkTrackLike): RealVideoPipelineBenchmarkSinkLike {
+    return new VideoSampleSink(track as InputVideoTrack);
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+    if (signal?.aborted) throw new RealVideoPipelineBenchmarkAbortError();
+}
+
+async function waitForEncoderQueue(
+    encoder: RealVideoPipelineBenchmarkEncoder,
+    queueLimit: number,
+    signal: AbortSignal | undefined,
+    callbackError: () => unknown,
+    waitingRejectors: Set<(error: unknown) => void>,
+): Promise<void> {
+    if (encoder.encodeQueueSize < queueLimit) return;
+
+    await new Promise<void>((resolve, reject) => {
+        let finished = false;
+        const finish = (complete: () => void) => {
+            if (finished) return;
+            finished = true;
+            encoder.removeEventListener('dequeue', onDequeue);
+            signal?.removeEventListener('abort', onAbort);
+            waitingRejectors.delete(rejectForEncoderError);
+            complete();
+        };
+        const onDequeue = () => {
+            if (encoder.encodeQueueSize < queueLimit) finish(resolve);
+        };
+        const onAbort = () => finish(() => reject(new RealVideoPipelineBenchmarkAbortError()));
+        const rejectForEncoderError = (error: unknown) => finish(() => reject(error));
+        encoder.addEventListener('dequeue', onDequeue);
+        signal?.addEventListener('abort', onAbort, { once: true });
+        waitingRejectors.add(rejectForEncoderError);
+        const error = callbackError();
+        if (error) rejectForEncoderError(error);
+        else onDequeue();
+    });
+}
+
+function classifyFailure(
+    error: unknown,
+    phase: 'setup' | 'transform' | 'encode' | 'flush',
+    signal: AbortSignal | undefined,
+): RealVideoPipelineBenchmarkFailureStage {
+    if (signal?.aborted || error instanceof RealVideoPipelineBenchmarkAbortError) return 'aborted';
+    if (phase === 'transform') return 'transform-failure';
+    if (phase === 'encode') return 'encode-failure';
+    if (phase === 'flush') return 'flush-failure';
+    return 'setup-failure';
+}
+
+/**
+ * Runs MediaBunny's public decode and VideoSample.transform pipeline directly into
+ * native WebCodecs. It deliberately does not use Conversion, Output, muxing, or files.
+ */
+export async function runRealVideoPipelineBenchmark(
+    file: File,
+    options: RealVideoPipelineBenchmarkOptions = {},
+): Promise<RealVideoPipelineBenchmarkResult> {
+    const now = options.now ?? (() => performance.now());
+    const result = createResult(file);
+    const createInput = options.createInput ?? createProductionInput;
+    const createVideoSampleSink = options.createVideoSampleSink ?? createProductionVideoSampleSink;
+    const VideoEncoderConstructor = options.VideoEncoder === undefined
+        ? (globalThis.VideoEncoder as unknown as RealVideoPipelineBenchmarkEncoderConstructor | undefined)
+        : options.VideoEncoder ?? undefined;
+    let input: RealVideoPipelineBenchmarkInputLike | undefined;
+    let inputDisposed = false;
+    let encoder: RealVideoPipelineBenchmarkEncoder | undefined;
+    let callbackError: unknown;
+    let phase: 'setup' | 'transform' | 'encode' | 'flush' = 'setup';
+    const waitingRejectors = new Set<(error: unknown) => void>();
+    const benchmarkStartedAt = now();
+
+    const disposeInput = () => {
+        if (!input || inputDisposed) return;
+        inputDisposed = true;
+        try {
+            input.dispose();
+        } catch {
+            // Cleanup errors must not replace the benchmark result.
+        }
+    };
+    const rejectWaiters = (error: unknown) => {
+        for (const reject of waitingRejectors) reject(error);
+        waitingRejectors.clear();
+    };
+    const abortInput = () => {
+        rejectWaiters(new RealVideoPipelineBenchmarkAbortError());
+        disposeInput();
+    };
+    options.signal?.addEventListener('abort', abortInput, { once: true });
+
+    try {
+        throwIfAborted(options.signal);
+        const setupStartedAt = now();
+        input = createInput(file);
+        const [videoTracks, duration] = await Promise.all([
+            input.getVideoTracks(),
+            input.getDurationFromMetadata(),
+        ]);
+        throwIfAborted(options.signal);
+        result.input.duration = duration;
+
+        const track = videoTracks[0];
+        if (!track) {
+            result.timings.inputTrackSetup = Math.max(0, now() - setupStartedAt);
+            result.failure = { stage: 'no-video-track', message: 'The input has no video track.' };
+            return result;
+        }
+
+        const [canDecode, videoCodec, codedWidth, codedHeight, displayWidth, displayHeight, rotation, firstTimestamp] = await Promise.all([
+            track.canDecode(),
+            track.getCodec(),
+            track.getCodedWidth(),
+            track.getCodedHeight(),
+            track.getDisplayWidth(),
+            track.getDisplayHeight(),
+            track.getRotation(),
+            track.getFirstTimestamp(),
+        ]);
+        result.input.videoCodec = videoCodec;
+        result.input.codedWidth = codedWidth;
+        result.input.codedHeight = codedHeight;
+        result.input.displayWidth = displayWidth;
+        result.input.displayHeight = displayHeight;
+        result.input.rotation = rotation;
+        result.capabilities.decode = canDecode;
+        if (!canDecode) {
+            result.timings.inputTrackSetup = Math.max(0, now() - setupStartedAt);
+            result.failure = { stage: 'decode-unavailable', message: 'This video track cannot be decoded by this browser.' };
+            return result;
+        }
+        if (!VideoEncoderConstructor) {
+            result.capabilities.avcEncode = false;
+            result.timings.inputTrackSetup = Math.max(0, now() - setupStartedAt);
+            result.failure = { stage: 'encoder-unavailable', message: 'VideoEncoder is unavailable.' };
+            return result;
+        }
+
+        let support: { supported?: boolean };
+        try {
+            support = await VideoEncoderConstructor.isConfigSupported({ ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG });
+        } catch (error) {
+            result.capabilities.avcEncode = false;
+            result.timings.inputTrackSetup = Math.max(0, now() - setupStartedAt);
+            result.failure = { stage: 'config-unsupported', message: shortErrorMessage(error) };
+            return result;
+        }
+        result.timings.inputTrackSetup = Math.max(0, now() - setupStartedAt);
+        if (!support.supported) {
+            result.capabilities.avcEncode = false;
+            result.failure = { stage: 'config-unsupported', message: 'VideoEncoder does not support the fixed AVC configuration.' };
+            return result;
+        }
+        result.capabilities.avcEncode = true;
+
+        encoder = new VideoEncoderConstructor({
+            output: (chunk) => {
+                result.encodedChunks += 1;
+                result.encodedBytes += chunk.byteLength;
+                if (chunk.type === 'key') result.keyChunks += 1;
+                else result.deltaChunks += 1;
+            },
+            error: (error) => {
+                callbackError ??= error;
+                rejectWaiters(error);
+            },
+        });
+        encoder.configure({ ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG });
+
+        const sink = createVideoSampleSink(track);
+        const iterator = sink.samples()[Symbol.asyncIterator]();
+        let lastKeyFrameInterval = -1;
+        while (true) {
+            throwIfAborted(options.signal);
+            const sampleWaitStartedAt = now();
+            const next = await iterator.next();
+            result.timings.sampleWaitIteration += Math.max(0, now() - sampleWaitStartedAt);
+            if (next.done) break;
+
+            const sample = next.value;
+            result.samplesProcessed += 1;
+            try {
+                throwIfAborted(options.signal);
+                sample.setTimestamp(Math.max(sample.timestamp - firstTimestamp, 0));
+                phase = 'transform';
+                const transformStartedAt = now();
+                const transformedSample = await sample.transform(REAL_VIDEO_PIPELINE_BENCHMARK_TARGET);
+                result.timings.videoTransform += Math.max(0, now() - transformStartedAt);
+                try {
+                    const frameStartedAt = now();
+                    const frame = transformedSample.toVideoFrame();
+                    result.timings.videoFrameCreation += Math.max(0, now() - frameStartedAt);
+                    try {
+                        phase = 'encode';
+                        const waitStartedAt = now();
+                        await waitForEncoderQueue(
+                            encoder,
+                            RAW_VIDEO_ENCODER_BENCHMARK_QUEUE_LIMIT,
+                            options.signal,
+                            () => callbackError,
+                            waitingRejectors,
+                        );
+                        result.timings.backpressureWait += Math.max(0, now() - waitStartedAt);
+                        const encodeStartedAt = now();
+                        const keyFrameInterval = Math.floor(sample.timestamp / 1_000_000 / REAL_VIDEO_PIPELINE_KEY_FRAME_INTERVAL);
+                        const keyFrame = keyFrameInterval !== lastKeyFrameInterval;
+                        lastKeyFrameInterval = keyFrameInterval;
+                        encoder.encode(frame, { keyFrame });
+                        result.timings.encodeSubmissionSync += Math.max(0, now() - encodeStartedAt);
+                        result.framesSubmitted += 1;
+                        result.maxQueueSize = Math.max(result.maxQueueSize, encoder.encodeQueueSize);
+                        if (callbackError) throw callbackError;
+                    } finally {
+                        frame.close();
+                    }
+                } finally {
+                    transformedSample.close();
+                }
+            } catch (error) {
+                phase = phase === 'transform' ? 'transform' : 'encode';
+                throw error;
+            } finally {
+                sample.close();
+            }
+        }
+
+        phase = 'flush';
+        const flushStartedAt = now();
+        await encoder.flush();
+        result.timings.flushWait = Math.max(0, now() - flushStartedAt);
+        if (callbackError) throw callbackError;
+        result.timings.benchmarkTotalWall = Math.max(0, now() - benchmarkStartedAt);
+        result.throughput = result.timings.benchmarkTotalWall > 0
+            ? result.framesSubmitted / (result.timings.benchmarkTotalWall / 1_000)
+            : null;
+        result.status = 'completed';
+        return result;
+    } catch (error) {
+        result.failure = {
+            stage: classifyFailure(error, phase, options.signal),
+            message: shortErrorMessage(error),
+        };
+        result.timings.benchmarkTotalWall = Math.max(0, now() - benchmarkStartedAt);
+        return result;
+    } finally {
+        options.signal?.removeEventListener('abort', abortInput);
+        rejectWaiters(new RealVideoPipelineBenchmarkAbortError());
+        if (result.timings.benchmarkTotalWall === 0) {
+            result.timings.benchmarkTotalWall = Math.max(0, now() - benchmarkStartedAt);
+        }
+        try {
+            encoder?.close();
+        } catch {
+            // Closing an encoder already closed by the browser is safe to ignore.
+        }
+        disposeInput();
+    }
+}

--- a/src/lib/videoCompression/videoDecodeBenchmark.ts
+++ b/src/lib/videoCompression/videoDecodeBenchmark.ts
@@ -1,0 +1,247 @@
+import {
+    ALL_FORMATS,
+    BlobSource,
+    Input,
+    VideoSampleSink,
+} from 'mediabunny';
+
+export const VIDEO_DECODE_BENCHMARK_MILESTONES = [1, 100, 300, 500, 627] as const;
+
+export type VideoDecodeBenchmarkFailureStage =
+    | 'no-video-track'
+    | 'decoder-unavailable'
+    | 'decode-failure'
+    | 'setup-failure'
+    | 'aborted';
+
+export interface VideoDecodeBenchmarkSampleMetadata {
+    format: string | null;
+    codedWidth: number;
+    codedHeight: number;
+    displayWidth: number;
+    displayHeight: number;
+}
+
+export interface VideoDecodeBenchmarkResult {
+    status: 'completed' | 'failed';
+    input: {
+        mime: string;
+        size: number;
+        duration: number | null;
+        videoCodec: string | null;
+        displayWidth: number | null;
+        displayHeight: number | null;
+    };
+    decode: {
+        samplesDecoded: number;
+        firstSample: VideoDecodeBenchmarkSampleMetadata | null;
+        milestoneOffsets: Partial<Record<(typeof VIDEO_DECODE_BENCHMARK_MILESTONES)[number], number>>;
+        lastSampleOffset: number | null;
+    };
+    timing: {
+        inputTrackSetup: number;
+        decodeWall: number;
+        throughput: number | null;
+    };
+    failure?: {
+        stage: VideoDecodeBenchmarkFailureStage;
+        message: string;
+    };
+}
+
+export interface VideoDecodeBenchmarkSampleLike {
+    format: string | null;
+    codedWidth: number;
+    codedHeight: number;
+    displayWidth: number;
+    displayHeight: number;
+    close(): void;
+}
+
+export interface VideoDecodeBenchmarkTrackLike {
+    canDecode(): Promise<boolean>;
+    getCodec(): Promise<string | null>;
+    getDisplayWidth(): Promise<number>;
+    getDisplayHeight(): Promise<number>;
+}
+
+export interface VideoDecodeBenchmarkInputLike {
+    getVideoTracks(): Promise<VideoDecodeBenchmarkTrackLike[]>;
+    getDurationFromMetadata(): Promise<number | null>;
+    dispose(): void;
+}
+
+export interface VideoDecodeBenchmarkSinkLike {
+    samples(): AsyncIterable<VideoDecodeBenchmarkSampleLike>;
+}
+
+export interface VideoDecodeBenchmarkOptions {
+    signal?: AbortSignal;
+    /** Test-only overrides keep production on MediaBunny's public APIs. */
+    now?: () => number;
+    createInput?: (file: File) => VideoDecodeBenchmarkInputLike;
+    createVideoSampleSink?: (track: VideoDecodeBenchmarkTrackLike) => VideoDecodeBenchmarkSinkLike;
+}
+
+class BenchmarkAbortError extends Error {
+    constructor() {
+        super('Video decode benchmark was aborted.');
+        this.name = 'AbortError';
+    }
+}
+
+function shortErrorMessage(error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.replace(/[\r\n]+/g, ' ').slice(0, 240);
+}
+
+function createResult(file: File): VideoDecodeBenchmarkResult {
+    return {
+        status: 'failed',
+        input: {
+            mime: file.type || 'unknown',
+            size: file.size,
+            duration: null,
+            videoCodec: null,
+            displayWidth: null,
+            displayHeight: null,
+        },
+        decode: {
+            samplesDecoded: 0,
+            firstSample: null,
+            milestoneOffsets: {},
+            lastSampleOffset: null,
+        },
+        timing: {
+            inputTrackSetup: 0,
+            decodeWall: 0,
+            throughput: null,
+        },
+    };
+}
+
+function createProductionInput(file: File): VideoDecodeBenchmarkInputLike {
+    return new Input({ source: new BlobSource(file), formats: ALL_FORMATS });
+}
+
+function createProductionVideoSampleSink(track: VideoDecodeBenchmarkTrackLike): VideoDecodeBenchmarkSinkLike {
+    // The default caller receives an InputVideoTrack from Input.getVideoTracks().
+    // The structural test seam intentionally exposes only the public track methods.
+    return new VideoSampleSink(track as never);
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+    if (signal?.aborted) throw new BenchmarkAbortError();
+}
+
+/**
+ * Decodes one input video track with MediaBunny's public sample API. It deliberately
+ * performs no packet-stat scan, resize, encode, audio work, muxing, or file output.
+ */
+export async function runVideoDecodeBenchmark(
+    file: File,
+    options: VideoDecodeBenchmarkOptions = {},
+): Promise<VideoDecodeBenchmarkResult> {
+    const now = options.now ?? (() => performance.now());
+    const result = createResult(file);
+    const createInput = options.createInput ?? createProductionInput;
+    const createVideoSampleSink = options.createVideoSampleSink ?? createProductionVideoSampleSink;
+    let input: VideoDecodeBenchmarkInputLike | undefined;
+    let inputDisposed = false;
+    let phase: 'setup' | 'decode' = 'setup';
+
+    const disposeInput = () => {
+        if (!input || inputDisposed) return;
+        inputDisposed = true;
+        try {
+            input.dispose();
+        } catch {
+            // Abort/cleanup must not turn a completed diagnostic result into a thrown error.
+        }
+    };
+    const abortInput = () => disposeInput();
+    options.signal?.addEventListener('abort', abortInput, { once: true });
+
+    try {
+        throwIfAborted(options.signal);
+        const setupStartedAt = now();
+        input = createInput(file);
+        const [videoTracks, duration] = await Promise.all([
+            input.getVideoTracks(),
+            input.getDurationFromMetadata(),
+        ]);
+        throwIfAborted(options.signal);
+
+        const track = videoTracks[0];
+        if (!track) {
+            result.timing.inputTrackSetup = Math.max(0, now() - setupStartedAt);
+            result.failure = { stage: 'no-video-track', message: 'The input has no video track.' };
+            return result;
+        }
+
+        const [canDecode, videoCodec, displayWidth, displayHeight] = await Promise.all([
+            track.canDecode(),
+            track.getCodec(),
+            track.getDisplayWidth(),
+            track.getDisplayHeight(),
+        ]);
+        throwIfAborted(options.signal);
+        result.input.duration = duration;
+        result.input.videoCodec = videoCodec;
+        result.input.displayWidth = displayWidth;
+        result.input.displayHeight = displayHeight;
+
+        if (!canDecode) {
+            result.timing.inputTrackSetup = Math.max(0, now() - setupStartedAt);
+            result.failure = { stage: 'decoder-unavailable', message: 'This video track cannot be decoded by this browser.' };
+            return result;
+        }
+
+        const sink = createVideoSampleSink(track);
+        result.timing.inputTrackSetup = Math.max(0, now() - setupStartedAt);
+        phase = 'decode';
+        const decodeStartedAt = now();
+
+        for await (const sample of sink.samples()) {
+            try {
+                throwIfAborted(options.signal);
+                result.decode.samplesDecoded += 1;
+                const sampleOffset = Math.max(0, now() - decodeStartedAt);
+                result.decode.lastSampleOffset = sampleOffset;
+                if (!result.decode.firstSample) {
+                    result.decode.firstSample = {
+                        format: sample.format,
+                        codedWidth: sample.codedWidth,
+                        codedHeight: sample.codedHeight,
+                        displayWidth: sample.displayWidth,
+                        displayHeight: sample.displayHeight,
+                    };
+                }
+                if (VIDEO_DECODE_BENCHMARK_MILESTONES.includes(result.decode.samplesDecoded as never)) {
+                    result.decode.milestoneOffsets[result.decode.samplesDecoded as (typeof VIDEO_DECODE_BENCHMARK_MILESTONES)[number]] = sampleOffset;
+                }
+            } finally {
+                sample.close();
+            }
+        }
+
+        throwIfAborted(options.signal);
+        result.timing.decodeWall = Math.max(0, now() - decodeStartedAt);
+        result.timing.throughput = result.timing.decodeWall > 0
+            ? result.decode.samplesDecoded / (result.timing.decodeWall / 1_000)
+            : null;
+        result.status = 'completed';
+        return result;
+    } catch (error) {
+        result.failure = {
+            stage: options.signal?.aborted || error instanceof BenchmarkAbortError
+                ? 'aborted'
+                : phase === 'decode' ? 'decode-failure' : 'setup-failure',
+            message: shortErrorMessage(error),
+        };
+        return result;
+    } finally {
+        options.signal?.removeEventListener('abort', abortInput);
+        disposeInput();
+    }
+}

--- a/src/test/e2e/mediaCompressionDebug.spec.ts
+++ b/src/test/e2e/mediaCompressionDebug.spec.ts
@@ -16,6 +16,8 @@ test.describe('media compression debug panel', () => {
         await toggle.click();
         await expect(toggle).toHaveAttribute('aria-expanded', 'true');
         await expect(panel.locator('pre')).toContainText('Conversion #1');
+        await expect(panel.locator('pre')).toContainText('Normal audio transcode');
+        await expect(panel.locator('pre')).toContainText('effective audio encoding mode: quality');
         await expect(panel.locator('pre')).toContainText('audio path: native-aac');
 
         const geometry = await panel.evaluate((element) => {
@@ -38,5 +40,31 @@ test.describe('media compression debug panel', () => {
         await page.getByRole('button', { name: 'Clear' }).click();
         await expect(panel.locator('pre')).toContainText('No conversions recorded.');
         await expect(panel.locator('pre')).toContainText('Reload the page before Conversion #1');
+    });
+
+    test('shows forced audio packet-copy mode without changing the narrow layout', async ({ page }) => {
+        await page.setViewportSize({ width: 360, height: 740 });
+        await page.goto('media-compression-debug-playwright.html?media-debug=1&media-debug-audio=copy');
+        const panel = page.locator('.media-debug-panel');
+        const toggle = page.getByRole('button', { name: /Media Compression Debug/ });
+        await toggle.click();
+
+        await expect(panel.locator('pre')).toContainText('Forced audio packet copy');
+        await expect(panel.locator('pre')).toContainText('audio diagnostic mode: force-packet-copy');
+        await expect(panel.locator('pre')).toContainText('effective audio encoding mode: packet-copy');
+        await expect(panel.locator('pre')).toContainText('audio path: packet-copy');
+        await expect(panel.locator('pre')).toContainText('reason: debug-forced-packet-copy');
+        await expect(panel.locator('pre')).toContainText('output audio: 48000 Hz / 2ch');
+
+        const geometry = await panel.evaluate((element) => {
+            const rect = element.getBoundingClientRect();
+            return {
+                right: rect.right,
+                documentWidth: document.documentElement.scrollWidth,
+                viewportWidth: window.innerWidth,
+            };
+        });
+        expect(geometry.right).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
+        expect(geometry.documentWidth).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
     });
 });

--- a/src/test/e2e/mediaCompressionDebug.spec.ts
+++ b/src/test/e2e/mediaCompressionDebug.spec.ts
@@ -18,6 +18,7 @@ test.describe('media compression debug panel', () => {
         await expect(page.getByRole('button', { name: 'Run video decode benchmark' })).toHaveCount(0);
         await expect(panel.locator('pre')).toContainText('Conversion #1');
         await expect(panel.locator('pre')).toContainText('Normal audio transcode');
+        await expect(panel.locator('pre')).toContainText('video rate control: subjective-quality');
         await expect(panel.locator('pre')).toContainText('effective audio encoding mode: quality');
         await expect(panel.locator('pre')).toContainText('audio path: native-aac');
 
@@ -69,6 +70,33 @@ test.describe('media compression debug panel', () => {
         });
         expect(geometry.right).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
         expect(geometry.documentWidth).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
+    });
+
+    test('shows explicit variable-bitrate video rate control only for the complete A/B query', async ({ page }) => {
+        await page.setViewportSize({ width: 360, height: 740 });
+        await page.goto('media-compression-debug-playwright.html?media-debug=1&media-debug-audio=copy&media-debug-video-rate-control=bitrate');
+        const panel = page.locator('.media-debug-panel');
+        await page.getByRole('button', { name: /Media Compression Debug/ }).click();
+
+        await expect(panel.locator('pre')).toContainText('Forced audio packet copy');
+        await expect(panel.locator('pre')).toContainText('video rate control: explicit-bitrate');
+        await expect(panel.locator('pre')).toContainText('configured video bitrate: 400000 bps');
+        await expect(panel.locator('pre')).toContainText('bitrate mode: variable');
+        await expect(panel.locator('pre')).toContainText('audio path: packet-copy');
+        await expect(panel.locator('pre')).toContainText('target: 640x360');
+
+        const geometry = await panel.evaluate((element) => ({
+            right: element.getBoundingClientRect().right,
+            documentWidth: document.documentElement.scrollWidth,
+            viewportWidth: window.innerWidth,
+        }));
+        expect(geometry.right).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
+        expect(geometry.documentWidth).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
+
+        await page.getByRole('button', { name: 'Copy' }).click();
+        await expect(page.getByRole('status').filter({ hasText: /Copied|Copy failed|Clipboard unavailable/ })).toBeVisible();
+        await page.getByRole('button', { name: 'Clear' }).click();
+        await expect(panel.locator('pre')).toContainText('No conversions recorded.');
     });
 
     test('shows the realtime video latency experiment with packet stats', async ({ page }) => {

--- a/src/test/e2e/mediaCompressionDebug.spec.ts
+++ b/src/test/e2e/mediaCompressionDebug.spec.ts
@@ -16,6 +16,7 @@ test.describe('media compression debug panel', () => {
         await toggle.click();
         await expect(toggle).toHaveAttribute('aria-expanded', 'true');
         await expect(page.getByRole('button', { name: 'Run video decode benchmark' })).toHaveCount(0);
+        await expect(page.getByRole('button', { name: 'Run real video pipeline benchmark' })).toHaveCount(0);
         await expect(panel.locator('pre')).toContainText('Conversion #1');
         await expect(panel.locator('pre')).toContainText('Normal audio transcode');
         await expect(panel.locator('pre')).toContainText('video rate control: subjective-quality');
@@ -226,5 +227,47 @@ test.describe('media compression debug panel', () => {
         await expect(page.getByRole('status').filter({ hasText: /Copied|Copy failed|Clipboard unavailable/ })).toBeVisible();
         await page.getByRole('button', { name: 'Clear' }).click();
         await expect(panel.locator('pre')).not.toContainText('Video Decode Benchmark #1');
+    });
+
+    test('runs the real video pipeline benchmark only after its full query gate and file selection', async ({ page }) => {
+        await page.goto('media-compression-debug-playwright.html?media-debug-video-pipeline-benchmark=1');
+        await expect(page.locator('.media-debug-panel')).toHaveCount(0);
+
+        await page.setViewportSize({ width: 360, height: 740 });
+        await page.goto('media-compression-debug-playwright.html?media-debug=1&media-debug-video-pipeline-benchmark=1');
+        const panel = page.locator('.media-debug-panel');
+        await page.getByRole('button', { name: /Media Compression Debug/ }).click();
+        const runButton = page.getByRole('button', { name: /real video pipeline benchmark/ });
+        await expect(runButton).toBeVisible();
+        await expect(panel.locator('pre')).toContainText('Real video pipeline benchmark: enabled (manual run)');
+
+        const fileChooserPromise = page.waitForEvent('filechooser');
+        await runButton.click();
+        const fileChooser = await fileChooserPromise;
+        await fileChooser.setFiles({
+            name: 'private.mov',
+            mimeType: 'video/quicktime',
+            buffer: Buffer.from('video'),
+        });
+        await expect(runButton).toBeDisabled();
+        await expect(page.locator('[role="status"]').filter({ hasText: 'Real video pipeline benchmark:' })).toHaveText('Real video pipeline benchmark: running');
+        await page.evaluate(() => {
+            (window as Window & { completeRealVideoPipelineBenchmark?: () => void }).completeRealVideoPipelineBenchmark?.();
+        });
+
+        await expect(page.locator('[role="status"]').filter({ hasText: 'Real video pipeline benchmark:' })).toHaveText('Real video pipeline benchmark: completed');
+        await expect(panel.locator('pre')).toContainText('Real Video Pipeline Benchmark #1');
+        await expect(panel.locator('pre')).toContainText('source display: 1080x1920');
+        await expect(panel.locator('pre')).toContainText('target: 360x640');
+        await expect(panel.locator('pre')).toContainText('samples processed: 627');
+        await expect(panel.locator('pre')).toContainText('encoded chunks: 627');
+        await expect(panel.locator('pre')).toContainText('key chunks: 1');
+        await expect(panel.locator('pre')).toContainText('Timing (overlaps; do not sum)');
+        await expect(panel.locator('pre')).not.toContainText('private.mov');
+
+        await page.getByRole('button', { name: 'Copy' }).click();
+        await expect(page.getByRole('status').filter({ hasText: /Copied|Copy failed|Clipboard unavailable/ })).toBeVisible();
+        await page.getByRole('button', { name: 'Clear' }).click();
+        await expect(panel.locator('pre')).not.toContainText('Real Video Pipeline Benchmark #1');
     });
 });

--- a/src/test/e2e/mediaCompressionDebug.spec.ts
+++ b/src/test/e2e/mediaCompressionDebug.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('media compression debug panel', () => {
+    test('is query-gated and supports expand, Copy, Clear, and narrow viewports', async ({ page }) => {
+        await page.goto('media-compression-debug-playwright.html');
+        await expect(page.locator('.media-debug-panel')).toHaveCount(0);
+
+        await page.setViewportSize({ width: 360, height: 740 });
+        await page.goto('media-compression-debug-playwright.html?media-debug=1');
+        const panel = page.locator('.media-debug-panel');
+        const toggle = page.getByRole('button', { name: /Media Compression Debug/ });
+        await expect(panel).toBeVisible();
+        await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+        await expect(panel.locator('pre')).toHaveCount(0);
+
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+        await expect(panel.locator('pre')).toContainText('Conversion #1');
+        await expect(panel.locator('pre')).toContainText('audio path: native-aac');
+
+        const geometry = await panel.evaluate((element) => {
+            const rect = element.getBoundingClientRect();
+            return {
+                right: rect.right,
+                bottom: rect.bottom,
+                viewportWidth: window.innerWidth,
+                viewportHeight: window.innerHeight,
+                documentWidth: document.documentElement.scrollWidth,
+            };
+        });
+        expect(geometry.right).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
+        expect(geometry.bottom).toBeLessThanOrEqual(geometry.viewportHeight + 0.5);
+        expect(geometry.documentWidth).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
+
+        await page.getByRole('button', { name: 'Copy' }).click();
+        await expect(page.getByRole('status')).toHaveText(/Copied|Copy failed|Clipboard unavailable/);
+
+        await page.getByRole('button', { name: 'Clear' }).click();
+        await expect(panel.locator('pre')).toContainText('No conversions recorded.');
+        await expect(panel.locator('pre')).toContainText('Reload the page before Conversion #1');
+    });
+});

--- a/src/test/e2e/mediaCompressionDebug.spec.ts
+++ b/src/test/e2e/mediaCompressionDebug.spec.ts
@@ -51,6 +51,8 @@ test.describe('media compression debug panel', () => {
 
         await expect(panel.locator('pre')).toContainText('Forced audio packet copy');
         await expect(panel.locator('pre')).toContainText('audio diagnostic mode: force-packet-copy');
+        await expect(panel.locator('pre')).toContainText('Video latency: quality (default)');
+        await expect(panel.locator('pre')).toContainText('video latency mode: quality (MediaBunny default)');
         await expect(panel.locator('pre')).toContainText('effective audio encoding mode: packet-copy');
         await expect(panel.locator('pre')).toContainText('audio path: packet-copy');
         await expect(panel.locator('pre')).toContainText('reason: debug-forced-packet-copy');
@@ -66,5 +68,33 @@ test.describe('media compression debug panel', () => {
         });
         expect(geometry.right).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
         expect(geometry.documentWidth).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
+    });
+
+    test('shows the realtime video latency experiment with packet stats', async ({ page }) => {
+        await page.setViewportSize({ width: 360, height: 740 });
+        await page.goto('media-compression-debug-playwright.html?media-debug=1&media-debug-audio=copy&media-debug-video-latency=realtime');
+        const panel = page.locator('.media-debug-panel');
+        await page.getByRole('button', { name: /Media Compression Debug/ }).click();
+
+        await expect(panel.locator('pre')).toContainText('Forced audio packet copy');
+        await expect(panel.locator('pre')).toContainText('Video latency: realtime');
+        await expect(panel.locator('pre')).toContainText('video diagnostic mode: realtime');
+        await expect(panel.locator('pre')).toContainText('input frames: 627');
+        await expect(panel.locator('pre')).toContainText('output frames: 620');
+        await expect(panel.locator('pre')).toContainText('input video stats scan:');
+        await expect(panel.locator('pre')).toContainText('output video stats scan:');
+
+        const geometry = await panel.evaluate((element) => ({
+            right: element.getBoundingClientRect().right,
+            documentWidth: document.documentElement.scrollWidth,
+            viewportWidth: window.innerWidth,
+        }));
+        expect(geometry.right).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
+        expect(geometry.documentWidth).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
+
+        await page.getByRole('button', { name: 'Copy' }).click();
+        await expect(page.getByRole('status')).toHaveText(/Copied|Copy failed|Clipboard unavailable/);
+        await page.getByRole('button', { name: 'Clear' }).click();
+        await expect(panel.locator('pre')).toContainText('No conversions recorded.');
     });
 });

--- a/src/test/e2e/mediaCompressionDebug.spec.ts
+++ b/src/test/e2e/mediaCompressionDebug.spec.ts
@@ -97,4 +97,44 @@ test.describe('media compression debug panel', () => {
         await page.getByRole('button', { name: 'Clear' }).click();
         await expect(panel.locator('pre')).toContainText('No conversions recorded.');
     });
+
+    test('runs the raw WebCodecs benchmark only when its full query gate is present', async ({ page }) => {
+        await page.goto('media-compression-debug-playwright.html?media-debug-raw-video-encoder=1');
+        await expect(page.locator('.media-debug-panel')).toHaveCount(0);
+
+        await page.setViewportSize({ width: 360, height: 740 });
+        await page.goto('media-compression-debug-playwright.html?media-debug=1&media-debug-raw-video-encoder=1');
+        const panel = page.locator('.media-debug-panel');
+        await page.getByRole('button', { name: /Media Compression Debug/ }).click();
+        const runButton = page.getByRole('button', { name: 'Run raw VideoEncoder benchmark' });
+        await expect(runButton).toBeVisible();
+        await expect(panel.locator('pre')).toContainText('Raw native VideoEncoder benchmark: enabled (manual run)');
+        await expect(panel.locator('pre')).toContainText('Normal audio transcode');
+
+        await runButton.click();
+        await expect(page.getByRole('button', { name: /raw VideoEncoder benchmark/ })).toBeDisabled();
+        await expect(page.locator('[role="status"]').filter({ hasText: 'Raw benchmark:' })).toHaveText('Raw benchmark: running');
+        await page.evaluate(() => {
+            (window as Window & { completeRawVideoEncoderBenchmark?: () => void }).completeRawVideoEncoderBenchmark?.();
+        });
+
+        await expect(page.locator('[role="status"]').filter({ hasText: 'Raw benchmark:' })).toHaveText('Raw benchmark: completed');
+        await expect(panel.locator('pre')).toContainText('Raw VideoEncoder Benchmark #1');
+        await expect(panel.locator('pre')).toContainText('codec: avc1.42001E');
+        await expect(panel.locator('pre')).toContainText('frames submitted: 3');
+        await expect(panel.locator('pre')).toContainText('Timing (overlaps; do not sum)');
+
+        const geometry = await panel.evaluate((element) => ({
+            right: element.getBoundingClientRect().right,
+            documentWidth: document.documentElement.scrollWidth,
+            viewportWidth: window.innerWidth,
+        }));
+        expect(geometry.right).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
+        expect(geometry.documentWidth).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
+
+        await page.getByRole('button', { name: 'Copy' }).click();
+        await expect(page.getByRole('status').filter({ hasText: /Copied|Copy failed|Clipboard unavailable/ })).toBeVisible();
+        await page.getByRole('button', { name: 'Clear' }).click();
+        await expect(panel.locator('pre')).not.toContainText('Raw VideoEncoder Benchmark #1');
+    });
 });

--- a/src/test/e2e/mediaCompressionDebug.spec.ts
+++ b/src/test/e2e/mediaCompressionDebug.spec.ts
@@ -15,6 +15,7 @@ test.describe('media compression debug panel', () => {
 
         await toggle.click();
         await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+        await expect(page.getByRole('button', { name: 'Run video decode benchmark' })).toHaveCount(0);
         await expect(panel.locator('pre')).toContainText('Conversion #1');
         await expect(panel.locator('pre')).toContainText('Normal audio transcode');
         await expect(panel.locator('pre')).toContainText('effective audio encoding mode: quality');

--- a/src/test/e2e/mediaCompressionDebug.spec.ts
+++ b/src/test/e2e/mediaCompressionDebug.spec.ts
@@ -135,13 +135,15 @@ test.describe('media compression debug panel', () => {
         await page.goto('media-compression-debug-playwright.html?media-debug=1&media-debug-raw-video-encoder=1');
         const panel = page.locator('.media-debug-panel');
         await page.getByRole('button', { name: /Media Compression Debug/ }).click();
-        const runButton = page.getByRole('button', { name: 'Run raw VideoEncoder benchmark' });
+        const runButton = page.getByRole('button', { name: /HTMLCanvas VideoEncoder benchmark/ });
+        const offscreenRunButton = page.getByRole('button', { name: /OffscreenCanvas VideoEncoder benchmark/ });
         await expect(runButton).toBeVisible();
+        await expect(offscreenRunButton).toBeVisible();
         await expect(panel.locator('pre')).toContainText('Raw native VideoEncoder benchmark: enabled (manual run)');
         await expect(panel.locator('pre')).toContainText('Normal audio transcode');
 
         await runButton.click();
-        await expect(page.getByRole('button', { name: /raw VideoEncoder benchmark/ })).toBeDisabled();
+        await expect(runButton).toBeDisabled();
         await expect(page.locator('[role="status"]').filter({ hasText: 'Raw benchmark:' })).toHaveText('Raw benchmark: running');
         await page.evaluate(() => {
             (window as Window & { completeRawVideoEncoderBenchmark?: () => void }).completeRawVideoEncoderBenchmark?.();
@@ -150,8 +152,20 @@ test.describe('media compression debug panel', () => {
         await expect(page.locator('[role="status"]').filter({ hasText: 'Raw benchmark:' })).toHaveText('Raw benchmark: completed');
         await expect(panel.locator('pre')).toContainText('Raw VideoEncoder Benchmark #1');
         await expect(panel.locator('pre')).toContainText('codec: avc1.64001E');
+        await expect(panel.locator('pre')).toContainText('canvas/source kind: html-canvas');
         await expect(panel.locator('pre')).toContainText('frames submitted: 3');
         await expect(panel.locator('pre')).toContainText('Timing (overlaps; do not sum)');
+
+        await offscreenRunButton.click();
+        await expect(offscreenRunButton).toBeDisabled();
+        await expect(page.locator('[role="status"]').filter({ hasText: 'OffscreenCanvas benchmark:' })).toHaveText('OffscreenCanvas benchmark: running');
+        await page.evaluate(() => {
+            (window as Window & { completeOffscreenCanvasVideoEncoderBenchmark?: () => void }).completeOffscreenCanvasVideoEncoderBenchmark?.();
+        });
+
+        await expect(page.locator('[role="status"]').filter({ hasText: 'OffscreenCanvas benchmark:' })).toHaveText('OffscreenCanvas benchmark: completed');
+        await expect(panel.locator('pre')).toContainText('Raw VideoEncoder Benchmark #2');
+        await expect(panel.locator('pre')).toContainText('canvas/source kind: offscreen-canvas');
 
         const geometry = await panel.evaluate((element) => ({
             right: element.getBoundingClientRect().right,
@@ -165,6 +179,7 @@ test.describe('media compression debug panel', () => {
         await expect(page.getByRole('status').filter({ hasText: /Copied|Copy failed|Clipboard unavailable/ })).toBeVisible();
         await page.getByRole('button', { name: 'Clear' }).click();
         await expect(panel.locator('pre')).not.toContainText('Raw VideoEncoder Benchmark #1');
+        await expect(panel.locator('pre')).not.toContainText('Raw VideoEncoder Benchmark #2');
     });
 
     test('runs the manual decode benchmark only when its full query gate is present', async ({ page }) => {

--- a/src/test/e2e/mediaCompressionDebug.spec.ts
+++ b/src/test/e2e/mediaCompressionDebug.spec.ts
@@ -137,4 +137,50 @@ test.describe('media compression debug panel', () => {
         await page.getByRole('button', { name: 'Clear' }).click();
         await expect(panel.locator('pre')).not.toContainText('Raw VideoEncoder Benchmark #1');
     });
+
+    test('runs the manual decode benchmark only when its full query gate is present', async ({ page }) => {
+        await page.goto('media-compression-debug-playwright.html?media-debug-video-decode-benchmark=1');
+        await expect(page.locator('.media-debug-panel')).toHaveCount(0);
+
+        await page.setViewportSize({ width: 360, height: 740 });
+        await page.goto('media-compression-debug-playwright.html?media-debug=1&media-debug-video-decode-benchmark=1');
+        const panel = page.locator('.media-debug-panel');
+        await page.getByRole('button', { name: /Media Compression Debug/ }).click();
+        const runButton = page.getByRole('button', { name: 'Run video decode benchmark' });
+        await expect(runButton).toBeVisible();
+        await expect(panel.locator('pre')).toContainText('Video decode benchmark: enabled (manual run)');
+
+        const fileChooserPromise = page.waitForEvent('filechooser');
+        await runButton.click();
+        const fileChooser = await fileChooserPromise;
+        await fileChooser.setFiles({
+            name: 'private.mov',
+            mimeType: 'video/quicktime',
+            buffer: Buffer.from('video'),
+        });
+        await expect(page.getByRole('button', { name: /video decode benchmark/ })).toBeDisabled();
+        await expect(page.locator('[role="status"]').filter({ hasText: 'Video decode benchmark:' })).toHaveText('Video decode benchmark: running');
+        await page.evaluate(() => {
+            (window as Window & { completeVideoDecodeBenchmark?: () => void }).completeVideoDecodeBenchmark?.();
+        });
+
+        await expect(page.locator('[role="status"]').filter({ hasText: 'Video decode benchmark:' })).toHaveText('Video decode benchmark: completed');
+        await expect(panel.locator('pre')).toContainText('Video Decode Benchmark #1');
+        await expect(panel.locator('pre')).toContainText('samples decoded: 627');
+        await expect(panel.locator('pre')).toContainText('sample #627: +6270.0 ms');
+        await expect(panel.locator('pre')).not.toContainText('private.mov');
+
+        const geometry = await panel.evaluate((element) => ({
+            right: element.getBoundingClientRect().right,
+            documentWidth: document.documentElement.scrollWidth,
+            viewportWidth: window.innerWidth,
+        }));
+        expect(geometry.right).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
+        expect(geometry.documentWidth).toBeLessThanOrEqual(geometry.viewportWidth + 0.5);
+
+        await page.getByRole('button', { name: 'Copy' }).click();
+        await expect(page.getByRole('status').filter({ hasText: /Copied|Copy failed|Clipboard unavailable/ })).toBeVisible();
+        await page.getByRole('button', { name: 'Clear' }).click();
+        await expect(panel.locator('pre')).not.toContainText('Video Decode Benchmark #1');
+    });
 });

--- a/src/test/e2e/mediaCompressionDebug.spec.ts
+++ b/src/test/e2e/mediaCompressionDebug.spec.ts
@@ -120,7 +120,7 @@ test.describe('media compression debug panel', () => {
 
         await expect(page.locator('[role="status"]').filter({ hasText: 'Raw benchmark:' })).toHaveText('Raw benchmark: completed');
         await expect(panel.locator('pre')).toContainText('Raw VideoEncoder Benchmark #1');
-        await expect(panel.locator('pre')).toContainText('codec: avc1.42001E');
+        await expect(panel.locator('pre')).toContainText('codec: avc1.64001E');
         await expect(panel.locator('pre')).toContainText('frames submitted: 3');
         await expect(panel.locator('pre')).toContainText('Timing (overlaps; do not sum)');
 

--- a/src/test/e2e/mediaCompressionDebug.spec.ts
+++ b/src/test/e2e/mediaCompressionDebug.spec.ts
@@ -16,7 +16,8 @@ test.describe('media compression debug panel', () => {
         await toggle.click();
         await expect(toggle).toHaveAttribute('aria-expanded', 'true');
         await expect(page.getByRole('button', { name: 'Run video decode benchmark' })).toHaveCount(0);
-        await expect(page.getByRole('button', { name: 'Run real video pipeline benchmark' })).toHaveCount(0);
+        await expect(page.getByRole('button', { name: 'Run MediaBunny transform pipeline benchmark' })).toHaveCount(0);
+        await expect(page.getByRole('button', { name: 'Run legacy-like Canvas pipeline benchmark' })).toHaveCount(0);
         await expect(panel.locator('pre')).toContainText('Conversion #1');
         await expect(panel.locator('pre')).toContainText('Normal audio transcode');
         await expect(panel.locator('pre')).toContainText('video rate control: subjective-quality');
@@ -237,26 +238,30 @@ test.describe('media compression debug panel', () => {
         await page.goto('media-compression-debug-playwright.html?media-debug=1&media-debug-video-pipeline-benchmark=1');
         const panel = page.locator('.media-debug-panel');
         await page.getByRole('button', { name: /Media Compression Debug/ }).click();
-        const runButton = page.getByRole('button', { name: /real video pipeline benchmark/ });
-        await expect(runButton).toBeVisible();
+        const transformRunButton = page.getByRole('button', { name: /MediaBunny transform pipeline benchmark/ });
+        const canvasRunButton = page.getByRole('button', { name: /legacy-like Canvas pipeline benchmark/ });
+        await expect(transformRunButton).toBeVisible();
+        await expect(canvasRunButton).toBeVisible();
         await expect(panel.locator('pre')).toContainText('Real video pipeline benchmark: enabled (manual run)');
 
         const fileChooserPromise = page.waitForEvent('filechooser');
-        await runButton.click();
+        await transformRunButton.click();
         const fileChooser = await fileChooserPromise;
         await fileChooser.setFiles({
             name: 'private.mov',
             mimeType: 'video/quicktime',
             buffer: Buffer.from('video'),
         });
-        await expect(runButton).toBeDisabled();
-        await expect(page.locator('[role="status"]').filter({ hasText: 'Real video pipeline benchmark:' })).toHaveText('Real video pipeline benchmark: running');
+        await expect(transformRunButton).toBeDisabled();
+        await expect(canvasRunButton).toBeDisabled();
+        await expect(page.locator('[role="status"]').filter({ hasText: 'MediaBunny transform pipeline benchmark:' })).toHaveText('MediaBunny transform pipeline benchmark: running');
         await page.evaluate(() => {
             (window as Window & { completeRealVideoPipelineBenchmark?: () => void }).completeRealVideoPipelineBenchmark?.();
         });
 
-        await expect(page.locator('[role="status"]').filter({ hasText: 'Real video pipeline benchmark:' })).toHaveText('Real video pipeline benchmark: completed');
+        await expect(page.locator('[role="status"]').filter({ hasText: 'MediaBunny transform pipeline benchmark:' })).toHaveText('MediaBunny transform pipeline benchmark: completed');
         await expect(panel.locator('pre')).toContainText('Real Video Pipeline Benchmark #1');
+        await expect(panel.locator('pre')).toContainText('pipeline kind: mediabunny-transform');
         await expect(panel.locator('pre')).toContainText('source display: 1080x1920');
         await expect(panel.locator('pre')).toContainText('target: 360x640');
         await expect(panel.locator('pre')).toContainText('samples processed: 627');
@@ -264,6 +269,25 @@ test.describe('media compression debug panel', () => {
         await expect(panel.locator('pre')).toContainText('key chunks: 1');
         await expect(panel.locator('pre')).toContainText('Timing (overlaps; do not sum)');
         await expect(panel.locator('pre')).not.toContainText('private.mov');
+
+        const canvasFileChooserPromise = page.waitForEvent('filechooser');
+        await canvasRunButton.click();
+        const canvasFileChooser = await canvasFileChooserPromise;
+        await canvasFileChooser.setFiles({
+            name: 'private.mov',
+            mimeType: 'video/quicktime',
+            buffer: Buffer.from('video'),
+        });
+        await expect(canvasRunButton).toBeDisabled();
+        await expect(transformRunButton).toBeDisabled();
+        await expect(page.locator('[role="status"]').filter({ hasText: 'Legacy-like Canvas pipeline benchmark:' })).toHaveText('Legacy-like Canvas pipeline benchmark: running');
+        await page.evaluate(() => {
+            (window as Window & { completeLegacyLikeCanvasPipelineBenchmark?: () => void }).completeLegacyLikeCanvasPipelineBenchmark?.();
+        });
+        await expect(page.locator('[role="status"]').filter({ hasText: 'Legacy-like Canvas pipeline benchmark:' })).toHaveText('Legacy-like Canvas pipeline benchmark: completed');
+        await expect(panel.locator('pre')).toContainText('Legacy-like Canvas Pipeline Benchmark #1');
+        await expect(panel.locator('pre')).toContainText('pipeline kind: legacy-like-html-canvas');
+        await expect(panel.locator('pre')).toContainText('Canvas draw / rotation / resize: 500.0 ms');
 
         await page.getByRole('button', { name: 'Copy' }).click();
         await expect(page.getByRole('status').filter({ hasText: /Copied|Copy failed|Clipboard unavailable/ })).toBeVisible();

--- a/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
+++ b/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
@@ -4,6 +4,7 @@ import MediaCompressionDebugPanel from '../../components/MediaCompressionDebugPa
 import {
     isMediaCompressionDebugAudioCopyEnabled,
     isMediaCompressionDebugRawVideoEncoderEnabled,
+    isMediaCompressionDebugVideoDecodeBenchmarkEnabled,
     isMediaCompressionDebugVideoRealtimeEnabled,
     startMediaCompressionDiagnostic,
 } from '../../lib/videoCompression/mediaCompressionDiagnostics';
@@ -12,10 +13,12 @@ import {
     RAW_VIDEO_ENCODER_BENCHMARK_SOURCE,
     type RawVideoEncoderBenchmarkResult,
 } from '../../lib/videoCompression/rawVideoEncoderBenchmark';
+import type { VideoDecodeBenchmarkResult } from '../../lib/videoCompression/videoDecodeBenchmark';
 
 declare global {
     interface Window {
         completeRawVideoEncoderBenchmark?: () => void;
+        completeVideoDecodeBenchmark?: () => void;
     }
 }
 
@@ -29,6 +32,7 @@ const session = startMediaCompressionDiagnostic(new File(['diagnostic'], 'ignore
 const forceAudioPacketCopy = isMediaCompressionDebugAudioCopyEnabled();
 const realtimeVideoLatency = isMediaCompressionDebugVideoRealtimeEnabled();
 const rawVideoEncoderBenchmark = isMediaCompressionDebugRawVideoEncoderEnabled();
+const videoDecodeBenchmark = isMediaCompressionDebugVideoDecodeBenchmarkEnabled();
 session?.setTrackCounts(1, 1);
 session?.setVideo(0, {
     codec: 'avc',
@@ -108,4 +112,35 @@ const rawVideoEncoderBenchmarkRunner = rawVideoEncoderBenchmark
     })
     : undefined;
 
-mount(MediaCompressionDebugPanel, { target, props: { rawVideoEncoderBenchmarkRunner } });
+const videoDecodeBenchmarkRunner = videoDecodeBenchmark
+    ? () => new Promise<VideoDecodeBenchmarkResult>((resolve) => {
+        window.completeVideoDecodeBenchmark = () => {
+            resolve({
+                status: 'completed',
+                input: {
+                    mime: 'video/quicktime',
+                    size: 39_681_322,
+                    duration: 20.9,
+                    videoCodec: 'avc',
+                    displayWidth: 1080,
+                    displayHeight: 1920,
+                },
+                decode: {
+                    samplesDecoded: 627,
+                    firstSample: {
+                        format: 'NV12',
+                        codedWidth: 1080,
+                        codedHeight: 1920,
+                        displayWidth: 1080,
+                        displayHeight: 1920,
+                    },
+                    milestoneOffsets: { 1: 10, 100: 1000, 300: 3000, 500: 5000, 627: 6270 },
+                    lastSampleOffset: 6270,
+                },
+                timing: { inputTrackSetup: 12, decodeWall: 6280, throughput: 99.84 },
+            });
+        };
+    })
+    : undefined;
+
+mount(MediaCompressionDebugPanel, { target, props: { rawVideoEncoderBenchmarkRunner, videoDecodeBenchmarkRunner } });

--- a/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
+++ b/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
@@ -1,7 +1,10 @@
 import '../../app.css';
 import { mount } from 'svelte';
 import MediaCompressionDebugPanel from '../../components/MediaCompressionDebugPanel.svelte';
-import { startMediaCompressionDiagnostic } from '../../lib/videoCompression/mediaCompressionDiagnostics';
+import {
+    isMediaCompressionDebugAudioCopyEnabled,
+    startMediaCompressionDiagnostic,
+} from '../../lib/videoCompression/mediaCompressionDiagnostics';
 
 const target = document.getElementById('app');
 
@@ -10,6 +13,7 @@ if (!target) {
 }
 
 const session = startMediaCompressionDiagnostic(new File(['diagnostic'], 'ignored.mp4', { type: 'video/mp4' }));
+const forceAudioPacketCopy = isMediaCompressionDebugAudioCopyEnabled();
 session?.setTrackCounts(1, 1);
 session?.setVideo(0, {
     codec: 'avc',
@@ -33,7 +37,13 @@ session?.setAudio(0, {
     capabilityBeforeSelection: true,
     customImport: 'no',
     customRegistration: 'not-needed',
-    audioPath: 'native-aac',
+    effectiveEncodingMode: forceAudioPacketCopy ? 'packet-copy' : 'quality',
+    configuredBitrate: 64000,
+    audioPath: forceAudioPacketCopy ? 'packet-copy' : 'native-aac',
+    reason: forceAudioPacketCopy ? 'debug-forced-packet-copy' : undefined,
+    outputCodec: 'aac',
+    outputSampleRate: forceAudioPacketCopy ? 48000 : 44100,
+    outputChannels: 2,
 });
 session?.setConversion({ isValid: true, execute: 'success' });
 session?.finish({

--- a/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
+++ b/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
@@ -4,6 +4,7 @@ import MediaCompressionDebugPanel from '../../components/MediaCompressionDebugPa
 import {
     isMediaCompressionDebugAudioCopyEnabled,
     isMediaCompressionDebugRawVideoEncoderEnabled,
+    isMediaCompressionDebugVideoBitrateEnabled,
     isMediaCompressionDebugVideoDecodeBenchmarkEnabled,
     isMediaCompressionDebugVideoRealtimeEnabled,
     startMediaCompressionDiagnostic,
@@ -32,6 +33,7 @@ const session = startMediaCompressionDiagnostic(new File(['diagnostic'], 'ignore
 const forceAudioPacketCopy = isMediaCompressionDebugAudioCopyEnabled();
 const realtimeVideoLatency = isMediaCompressionDebugVideoRealtimeEnabled();
 const rawVideoEncoderBenchmark = isMediaCompressionDebugRawVideoEncoderEnabled();
+const videoBitrateRateControl = isMediaCompressionDebugVideoBitrateEnabled();
 const videoDecodeBenchmark = isMediaCompressionDebugVideoDecodeBenchmarkEnabled();
 session?.setTrackCounts(1, 1);
 session?.setVideo(0, {
@@ -44,6 +46,7 @@ session?.setVideo(0, {
     avcEncode: true,
     compressionLevel: 'medium',
     quality: 'medium',
+    ...(videoBitrateRateControl ? { configuredBitrate: 400_000, bitrateMode: 'variable' as const } : {}),
     inputPacketStats: {
         packetCount: 627,
         averagePacketRate: 30,

--- a/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
+++ b/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
@@ -3,6 +3,7 @@ import { mount } from 'svelte';
 import MediaCompressionDebugPanel from '../../components/MediaCompressionDebugPanel.svelte';
 import {
     isMediaCompressionDebugAudioCopyEnabled,
+    isMediaCompressionDebugVideoRealtimeEnabled,
     startMediaCompressionDiagnostic,
 } from '../../lib/videoCompression/mediaCompressionDiagnostics';
 
@@ -14,6 +15,7 @@ if (!target) {
 
 const session = startMediaCompressionDiagnostic(new File(['diagnostic'], 'ignored.mp4', { type: 'video/mp4' }));
 const forceAudioPacketCopy = isMediaCompressionDebugAudioCopyEnabled();
+const realtimeVideoLatency = isMediaCompressionDebugVideoRealtimeEnabled();
 session?.setTrackCounts(1, 1);
 session?.setVideo(0, {
     codec: 'avc',
@@ -25,6 +27,18 @@ session?.setVideo(0, {
     avcEncode: true,
     compressionLevel: 'medium',
     quality: 'medium',
+    inputPacketStats: {
+        packetCount: 627,
+        averagePacketRate: 30,
+        averageBitrate: 4_000_000,
+        duration: 20.9,
+    },
+    outputPacketStats: {
+        packetCount: realtimeVideoLatency ? 620 : 627,
+        averagePacketRate: realtimeVideoLatency ? 29.7 : 30,
+        averageBitrate: realtimeVideoLatency ? 3_900_000 : 4_000_000,
+        duration: 20.9,
+    },
 });
 session?.setAudio(0, {
     codec: 'aac',

--- a/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
+++ b/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
@@ -16,6 +16,7 @@ import {
     type RawVideoEncoderBenchmarkResult,
 } from '../../lib/videoCompression/rawVideoEncoderBenchmark';
 import type { VideoDecodeBenchmarkResult } from '../../lib/videoCompression/videoDecodeBenchmark';
+import type { LegacyLikeCanvasPipelineBenchmarkResult } from '../../lib/videoCompression/legacyLikeCanvasPipelineBenchmark';
 import type { RealVideoPipelineBenchmarkResult } from '../../lib/videoCompression/realVideoPipelineBenchmark';
 
 declare global {
@@ -24,6 +25,7 @@ declare global {
         completeOffscreenCanvasVideoEncoderBenchmark?: () => void;
         completeVideoDecodeBenchmark?: () => void;
         completeRealVideoPipelineBenchmark?: () => void;
+        completeLegacyLikeCanvasPipelineBenchmark?: () => void;
     }
 }
 
@@ -187,6 +189,7 @@ const realVideoPipelineBenchmarkRunner = realVideoPipelineBenchmark
     ? () => new Promise<RealVideoPipelineBenchmarkResult>((resolve) => {
         window.completeRealVideoPipelineBenchmark = () => {
             resolve({
+                pipelineKind: 'mediabunny-transform',
                 status: 'completed',
                 input: {
                     mime: 'video/quicktime',
@@ -224,6 +227,49 @@ const realVideoPipelineBenchmarkRunner = realVideoPipelineBenchmark
     })
     : undefined;
 
+const legacyLikeCanvasPipelineBenchmarkRunner = realVideoPipelineBenchmark
+    ? () => new Promise<LegacyLikeCanvasPipelineBenchmarkResult>((resolve) => {
+        window.completeLegacyLikeCanvasPipelineBenchmark = () => {
+            resolve({
+                pipelineKind: 'legacy-like-html-canvas',
+                status: 'completed',
+                input: {
+                    mime: 'video/quicktime',
+                    size: 39_681_321,
+                    duration: 20.905,
+                    videoCodec: 'avc1.4d401f',
+                    codedWidth: 1_920,
+                    codedHeight: 1_080,
+                    displayWidth: 1_080,
+                    displayHeight: 1_920,
+                    rotation: 90,
+                },
+                target: { width: 360, height: 640, fit: 'fill', rotate: 0, alpha: 'discard' },
+                capabilities: { decode: true, avcEncode: true },
+                samplesProcessed: 627,
+                framesSubmitted: 627,
+                encodedChunks: 627,
+                encodedBytes: 400_000,
+                keyChunks: 5,
+                deltaChunks: 622,
+                maxQueueSize: 4,
+                throughput: 40,
+                timings: {
+                    inputTrackSetup: 12,
+                    sampleWaitIteration: 686,
+                    sourceVideoFrameAcquisition: 8,
+                    canvasDrawRotationResize: 500,
+                    outputVideoFrameCreation: 8,
+                    encodeSubmissionSync: 21,
+                    backpressureWait: 9,
+                    flushWait: 6,
+                    benchmarkTotalWall: 1_250,
+                },
+            });
+        };
+    })
+    : undefined;
+
 mount(MediaCompressionDebugPanel, {
     target,
     props: {
@@ -231,5 +277,6 @@ mount(MediaCompressionDebugPanel, {
         offscreenCanvasVideoEncoderBenchmarkRunner,
         videoDecodeBenchmarkRunner,
         realVideoPipelineBenchmarkRunner,
+        legacyLikeCanvasPipelineBenchmarkRunner,
     },
 });

--- a/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
+++ b/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
@@ -19,6 +19,7 @@ import type { VideoDecodeBenchmarkResult } from '../../lib/videoCompression/vide
 declare global {
     interface Window {
         completeRawVideoEncoderBenchmark?: () => void;
+        completeOffscreenCanvasVideoEncoderBenchmark?: () => void;
         completeVideoDecodeBenchmark?: () => void;
     }
 }
@@ -91,6 +92,38 @@ const rawVideoEncoderBenchmarkRunner = rawVideoEncoderBenchmark
             resolve({
                 status: 'completed',
                 source: RAW_VIDEO_ENCODER_BENCHMARK_SOURCE,
+                canvasSource: 'html-canvas',
+                config: { ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG },
+                frameCount: 3,
+                queueLimit: 2,
+                maxQueueSize: 2,
+                timings: {
+                    configSupportCheck: 1,
+                    encoderSetupConfigure: 2,
+                    benchmarkWall: 30,
+                    framePreparationSync: 3,
+                    encodeSubmissionSync: 4,
+                    backpressureWait: 5,
+                    flushWait: 6,
+                },
+                framesSubmitted: 3,
+                chunks: 3,
+                bytes: 240,
+                keyChunks: 1,
+                deltaChunks: 2,
+                throughput: 100,
+            });
+        };
+    })
+    : undefined;
+
+const offscreenCanvasVideoEncoderBenchmarkRunner = rawVideoEncoderBenchmark
+    ? () => new Promise<RawVideoEncoderBenchmarkResult>((resolve) => {
+        window.completeOffscreenCanvasVideoEncoderBenchmark = () => {
+            resolve({
+                status: 'completed',
+                source: RAW_VIDEO_ENCODER_BENCHMARK_SOURCE,
+                canvasSource: 'offscreen-canvas',
                 config: { ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG },
                 frameCount: 3,
                 queueLimit: 2,
@@ -146,4 +179,7 @@ const videoDecodeBenchmarkRunner = videoDecodeBenchmark
     })
     : undefined;
 
-mount(MediaCompressionDebugPanel, { target, props: { rawVideoEncoderBenchmarkRunner, videoDecodeBenchmarkRunner } });
+mount(MediaCompressionDebugPanel, {
+    target,
+    props: { rawVideoEncoderBenchmarkRunner, offscreenCanvasVideoEncoderBenchmarkRunner, videoDecodeBenchmarkRunner },
+});

--- a/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
+++ b/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
@@ -1,0 +1,44 @@
+import '../../app.css';
+import { mount } from 'svelte';
+import MediaCompressionDebugPanel from '../../components/MediaCompressionDebugPanel.svelte';
+import { startMediaCompressionDiagnostic } from '../../lib/videoCompression/mediaCompressionDiagnostics';
+
+const target = document.getElementById('app');
+
+if (!target) {
+    throw new Error('Media compression debug harness mount target was not found.');
+}
+
+const session = startMediaCompressionDiagnostic(new File(['diagnostic'], 'ignored.mp4', { type: 'video/mp4' }));
+session?.setTrackCounts(1, 1);
+session?.setVideo(0, {
+    codec: 'avc',
+    displayWidth: 1920,
+    displayHeight: 1080,
+    targetWidth: 640,
+    targetHeight: 360,
+    decode: true,
+    avcEncode: true,
+    compressionLevel: 'medium',
+    quality: 'medium',
+});
+session?.setAudio(0, {
+    codec: 'aac',
+    sourceSampleRate: 48000,
+    sourceChannels: 2,
+    targetSampleRate: 44100,
+    targetChannels: 2,
+    decode: true,
+    nativeCapabilityBeforeRegistration: true,
+    capabilityBeforeSelection: true,
+    customImport: 'no',
+    customRegistration: 'not-needed',
+    audioPath: 'native-aac',
+});
+session?.setConversion({ isValid: true, execute: 'success' });
+session?.finish({
+    file: new File(['output'], 'ignored-output.mp4', { type: 'video/mp4' }),
+    wasCompressed: true,
+});
+
+mount(MediaCompressionDebugPanel, { target });

--- a/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
+++ b/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
@@ -3,9 +3,21 @@ import { mount } from 'svelte';
 import MediaCompressionDebugPanel from '../../components/MediaCompressionDebugPanel.svelte';
 import {
     isMediaCompressionDebugAudioCopyEnabled,
+    isMediaCompressionDebugRawVideoEncoderEnabled,
     isMediaCompressionDebugVideoRealtimeEnabled,
     startMediaCompressionDiagnostic,
 } from '../../lib/videoCompression/mediaCompressionDiagnostics';
+import {
+    RAW_VIDEO_ENCODER_BENCHMARK_CONFIG,
+    RAW_VIDEO_ENCODER_BENCHMARK_SOURCE,
+    type RawVideoEncoderBenchmarkResult,
+} from '../../lib/videoCompression/rawVideoEncoderBenchmark';
+
+declare global {
+    interface Window {
+        completeRawVideoEncoderBenchmark?: () => void;
+    }
+}
 
 const target = document.getElementById('app');
 
@@ -16,6 +28,7 @@ if (!target) {
 const session = startMediaCompressionDiagnostic(new File(['diagnostic'], 'ignored.mp4', { type: 'video/mp4' }));
 const forceAudioPacketCopy = isMediaCompressionDebugAudioCopyEnabled();
 const realtimeVideoLatency = isMediaCompressionDebugVideoRealtimeEnabled();
+const rawVideoEncoderBenchmark = isMediaCompressionDebugRawVideoEncoderEnabled();
 session?.setTrackCounts(1, 1);
 session?.setVideo(0, {
     codec: 'avc',
@@ -65,4 +78,34 @@ session?.finish({
     wasCompressed: true,
 });
 
-mount(MediaCompressionDebugPanel, { target });
+const rawVideoEncoderBenchmarkRunner = rawVideoEncoderBenchmark
+    ? () => new Promise<RawVideoEncoderBenchmarkResult>((resolve) => {
+        window.completeRawVideoEncoderBenchmark = () => {
+            resolve({
+                status: 'completed',
+                source: RAW_VIDEO_ENCODER_BENCHMARK_SOURCE,
+                config: { ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG },
+                frameCount: 3,
+                queueLimit: 2,
+                maxQueueSize: 2,
+                timings: {
+                    configSupportCheck: 1,
+                    encoderSetupConfigure: 2,
+                    benchmarkWall: 30,
+                    framePreparationSync: 3,
+                    encodeSubmissionSync: 4,
+                    backpressureWait: 5,
+                    flushWait: 6,
+                },
+                framesSubmitted: 3,
+                chunks: 3,
+                bytes: 240,
+                keyChunks: 1,
+                deltaChunks: 2,
+                throughput: 100,
+            });
+        };
+    })
+    : undefined;
+
+mount(MediaCompressionDebugPanel, { target, props: { rawVideoEncoderBenchmarkRunner } });

--- a/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
+++ b/src/test/e2e/mediaCompressionDebugHarnessEntry.ts
@@ -6,6 +6,7 @@ import {
     isMediaCompressionDebugRawVideoEncoderEnabled,
     isMediaCompressionDebugVideoBitrateEnabled,
     isMediaCompressionDebugVideoDecodeBenchmarkEnabled,
+    isMediaCompressionDebugVideoPipelineBenchmarkEnabled,
     isMediaCompressionDebugVideoRealtimeEnabled,
     startMediaCompressionDiagnostic,
 } from '../../lib/videoCompression/mediaCompressionDiagnostics';
@@ -15,12 +16,14 @@ import {
     type RawVideoEncoderBenchmarkResult,
 } from '../../lib/videoCompression/rawVideoEncoderBenchmark';
 import type { VideoDecodeBenchmarkResult } from '../../lib/videoCompression/videoDecodeBenchmark';
+import type { RealVideoPipelineBenchmarkResult } from '../../lib/videoCompression/realVideoPipelineBenchmark';
 
 declare global {
     interface Window {
         completeRawVideoEncoderBenchmark?: () => void;
         completeOffscreenCanvasVideoEncoderBenchmark?: () => void;
         completeVideoDecodeBenchmark?: () => void;
+        completeRealVideoPipelineBenchmark?: () => void;
     }
 }
 
@@ -36,6 +39,7 @@ const realtimeVideoLatency = isMediaCompressionDebugVideoRealtimeEnabled();
 const rawVideoEncoderBenchmark = isMediaCompressionDebugRawVideoEncoderEnabled();
 const videoBitrateRateControl = isMediaCompressionDebugVideoBitrateEnabled();
 const videoDecodeBenchmark = isMediaCompressionDebugVideoDecodeBenchmarkEnabled();
+const realVideoPipelineBenchmark = isMediaCompressionDebugVideoPipelineBenchmarkEnabled();
 session?.setTrackCounts(1, 1);
 session?.setVideo(0, {
     codec: 'avc',
@@ -179,7 +183,53 @@ const videoDecodeBenchmarkRunner = videoDecodeBenchmark
     })
     : undefined;
 
+const realVideoPipelineBenchmarkRunner = realVideoPipelineBenchmark
+    ? () => new Promise<RealVideoPipelineBenchmarkResult>((resolve) => {
+        window.completeRealVideoPipelineBenchmark = () => {
+            resolve({
+                status: 'completed',
+                input: {
+                    mime: 'video/quicktime',
+                    size: 39_681_322,
+                    duration: 20.9,
+                    videoCodec: 'avc1.4d401f',
+                    codedWidth: 1_920,
+                    codedHeight: 1_080,
+                    displayWidth: 1_080,
+                    displayHeight: 1_920,
+                    rotation: 90,
+                },
+                target: { width: 360, height: 640, fit: 'fill', rotate: 0, alpha: 'discard' },
+                capabilities: { decode: true, avcEncode: true },
+                samplesProcessed: 627,
+                framesSubmitted: 627,
+                encodedChunks: 627,
+                encodedBytes: 395_052,
+                keyChunks: 1,
+                deltaChunks: 626,
+                maxQueueSize: 4,
+                throughput: 98.4,
+                timings: {
+                    inputTrackSetup: 12,
+                    sampleWaitIteration: 6_300,
+                    videoTransform: 5_200,
+                    videoFrameCreation: 1_800,
+                    encodeSubmissionSync: 30,
+                    backpressureWait: 8_400,
+                    flushWait: 1_200,
+                    benchmarkTotalWall: 16_600,
+                },
+            });
+        };
+    })
+    : undefined;
+
 mount(MediaCompressionDebugPanel, {
     target,
-    props: { rawVideoEncoderBenchmarkRunner, offscreenCanvasVideoEncoderBenchmarkRunner, videoDecodeBenchmarkRunner },
+    props: {
+        rawVideoEncoderBenchmarkRunner,
+        offscreenCanvasVideoEncoderBenchmarkRunner,
+        videoDecodeBenchmarkRunner,
+        realVideoPipelineBenchmarkRunner,
+    },
 });

--- a/src/test/unit/legacyLikeCanvasPipelineBenchmark.test.ts
+++ b/src/test/unit/legacyLikeCanvasPipelineBenchmark.test.ts
@@ -1,0 +1,386 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+    runLegacyLikeCanvasPipelineBenchmark,
+    type LegacyLikeCanvasPipelineBenchmarkFrameLike,
+    type LegacyLikeCanvasPipelineBenchmarkSampleLike,
+    type LegacyLikeCanvasPipelineBenchmarkSinkLike,
+} from '../../lib/videoCompression/legacyLikeCanvasPipelineBenchmark';
+import {
+    RAW_VIDEO_ENCODER_BENCHMARK_CONFIG,
+    RAW_VIDEO_ENCODER_BENCHMARK_QUEUE_LIMIT,
+} from '../../lib/videoCompression/rawVideoEncoderBenchmark';
+import type {
+    RealVideoPipelineBenchmarkEncoderConstructor,
+    RealVideoPipelineBenchmarkInputLike,
+    RealVideoPipelineBenchmarkTrackLike,
+} from '../../lib/videoCompression/realVideoPipelineBenchmark';
+
+class FakeFrame implements LegacyLikeCanvasPipelineBenchmarkFrameLike {
+    readonly displayWidth: number;
+    readonly displayHeight: number;
+    readonly close = vi.fn();
+
+    constructor(width = 1_920, height = 1_080) {
+        this.displayWidth = width;
+        this.displayHeight = height;
+    }
+}
+
+class FakeSample implements LegacyLikeCanvasPipelineBenchmarkSampleLike {
+    timestamp: number;
+    readonly duration = 1 / 30;
+    readonly close = vi.fn();
+    readonly setTimestamp = vi.fn((timestamp: number) => {
+        this.timestamp = timestamp;
+    });
+    readonly transform = vi.fn();
+    readonly toVideoFrame = vi.fn(() => {
+        if (FakeSample.sourceFrameError) throw new Error('source frame stopped');
+        const frame = new FakeFrame();
+        FakeSample.sourceFrames.push(frame);
+        return frame;
+    });
+
+    static sourceFrameError = false;
+    static sourceFrames: FakeFrame[] = [];
+
+    constructor(timestamp: number) {
+        this.timestamp = timestamp;
+    }
+
+    static reset(): void {
+        FakeSample.sourceFrameError = false;
+        FakeSample.sourceFrames = [];
+    }
+}
+
+class FakeEncoder extends EventTarget {
+    static supportConfigs: VideoEncoderConfig[] = [];
+    static configureConfigs: VideoEncoderConfig[] = [];
+    static encodeOptions: VideoEncoderEncodeOptions[] = [];
+    static mode: 'success' | 'encode-failure' | 'flush-failure' = 'success';
+    static instances: FakeEncoder[] = [];
+    static supported = true;
+
+    private queueSize = 0;
+    private readonly output: (chunk: { byteLength: number; type: EncodedVideoChunkType }) => void;
+    private readonly error: (error: unknown) => void;
+    readonly close = vi.fn();
+
+    constructor(init: {
+        output: (chunk: { byteLength: number; type: EncodedVideoChunkType }) => void;
+        error: (error: unknown) => void;
+    }) {
+        super();
+        this.output = init.output;
+        this.error = init.error;
+        FakeEncoder.instances.push(this);
+    }
+
+    get encodeQueueSize(): number {
+        return this.queueSize;
+    }
+
+    configure(config: VideoEncoderConfig): void {
+        FakeEncoder.configureConfigs.push(config);
+    }
+
+    encode(_frame: LegacyLikeCanvasPipelineBenchmarkFrameLike, options?: VideoEncoderEncodeOptions): void {
+        FakeEncoder.encodeOptions.push(options ?? {});
+        if (FakeEncoder.mode === 'encode-failure') {
+            const error = new Error('encode stopped');
+            this.error(error);
+            throw error;
+        }
+        this.queueSize += 1;
+        this.output({ byteLength: 100, type: options?.keyFrame === true ? 'key' : 'delta' });
+        queueMicrotask(() => {
+            this.queueSize = Math.max(0, this.queueSize - 1);
+            this.dispatchEvent(new Event('dequeue'));
+        });
+    }
+
+    async flush(): Promise<void> {
+        if (FakeEncoder.mode === 'flush-failure') {
+            const error = new Error('flush stopped');
+            this.error(error);
+            throw error;
+        }
+    }
+
+    static isConfigSupported = vi.fn(async (config: VideoEncoderConfig) => {
+        FakeEncoder.supportConfigs.push(config);
+        return { supported: FakeEncoder.supported, config };
+    });
+
+    static reset(): void {
+        FakeEncoder.supportConfigs = [];
+        FakeEncoder.configureConfigs = [];
+        FakeEncoder.encodeOptions = [];
+        FakeEncoder.mode = 'success';
+        FakeEncoder.instances = [];
+        FakeEncoder.supported = true;
+        FakeEncoder.isConfigSupported.mockClear();
+    }
+}
+
+function createTrack(canDecode = true): RealVideoPipelineBenchmarkTrackLike {
+    return {
+        canDecode: vi.fn(async () => canDecode),
+        getCodec: vi.fn(async () => 'avc1.4d401f'),
+        getCodedWidth: vi.fn(async () => 1_920),
+        getCodedHeight: vi.fn(async () => 1_080),
+        getDisplayWidth: vi.fn(async () => 1_080),
+        getDisplayHeight: vi.fn(async () => 1_920),
+        getRotation: vi.fn(async () => 90),
+        getFirstTimestamp: vi.fn(async () => 100),
+    };
+}
+
+function createInput(track: RealVideoPipelineBenchmarkTrackLike | undefined, dispose: (() => void) | undefined = vi.fn()): RealVideoPipelineBenchmarkInputLike {
+    return {
+        getVideoTracks: vi.fn(async () => track ? [track] : []),
+        getDurationFromMetadata: vi.fn(async () => 20.905),
+        dispose,
+    };
+}
+
+function createSink(samples: LegacyLikeCanvasPipelineBenchmarkSampleLike[]): LegacyLikeCanvasPipelineBenchmarkSinkLike {
+    return {
+        async *samples() {
+            yield* samples;
+        },
+    };
+}
+
+function createCanvas(context: Partial<CanvasRenderingContext2D> | null) {
+    const canvas = {
+        width: 0,
+        height: 0,
+        getContext: vi.fn(() => context),
+    };
+    return canvas as unknown as HTMLCanvasElement;
+}
+
+function createContext(throwOnDraw = false) {
+    return {
+        resetTransform: vi.fn(),
+        setTransform: vi.fn(),
+        clearRect: vi.fn(),
+        save: vi.fn(),
+        translate: vi.fn(),
+        rotate: vi.fn(),
+        scale: vi.fn(),
+        drawImage: vi.fn(() => {
+            if (throwOnDraw) throw new Error('canvas draw stopped');
+        }),
+        restore: vi.fn(),
+    } as unknown as CanvasRenderingContext2D;
+}
+
+function createOptions(
+    track: RealVideoPipelineBenchmarkTrackLike | undefined,
+    samples: LegacyLikeCanvasPipelineBenchmarkSampleLike[] = [],
+    options: {
+        dispose?: () => void;
+        canvas?: HTMLCanvasElement | null;
+        createOutputVideoFrame?: (canvas: HTMLCanvasElement, init: VideoFrameInit) => LegacyLikeCanvasPipelineBenchmarkFrameLike;
+    } = {},
+) {
+    const input = createInput(track, options.dispose);
+    return {
+        VideoEncoder: FakeEncoder as unknown as RealVideoPipelineBenchmarkEncoderConstructor,
+        createInput: () => input,
+        createVideoSampleSink: (sinkTrack: RealVideoPipelineBenchmarkTrackLike) => {
+            expect(sinkTrack).toBe(track);
+            return createSink(samples);
+        },
+        createCanvas: () => options.canvas === undefined ? createCanvas(createContext()) : options.canvas,
+        createOutputVideoFrame: options.createOutputVideoFrame,
+        now: () => 100,
+    };
+}
+
+describe('runLegacyLikeCanvasPipelineBenchmark', () => {
+    it('uses public source VideoFrames, one reused HTMLCanvasElement, and no VideoSample.transform()', async () => {
+        FakeEncoder.reset();
+        FakeSample.reset();
+        const context = createContext();
+        const canvas = createCanvas(context);
+        const samples = [new FakeSample(100), new FakeSample(100 + 1 / 30), new FakeSample(100 + 2 / 30)];
+        const outputFrames: FakeFrame[] = [];
+        const outputFrameInits: VideoFrameInit[] = [];
+        const dispose = vi.fn();
+        const result = await runLegacyLikeCanvasPipelineBenchmark(
+            new File(['video'], 'private.mov', { type: 'video/quicktime' }),
+            createOptions(createTrack(), samples, {
+                dispose,
+                canvas,
+                createOutputVideoFrame: (_canvas, init) => {
+                    outputFrameInits.push(init);
+                    const frame = new FakeFrame(360, 640);
+                    outputFrames.push(frame);
+                    return frame;
+                },
+            }),
+        );
+
+        expect(result).toMatchObject({
+            pipelineKind: 'legacy-like-html-canvas',
+            status: 'completed',
+            target: { width: 360, height: 640, fit: 'fill', rotate: 0, alpha: 'discard' },
+            capabilities: { decode: true, avcEncode: true },
+            samplesProcessed: 3,
+            framesSubmitted: 3,
+            encodedChunks: 3,
+            encodedBytes: 300,
+            keyChunks: 1,
+            deltaChunks: 2,
+        });
+        expect(FakeEncoder.supportConfigs).toEqual([{ ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG }]);
+        expect(FakeEncoder.configureConfigs).toEqual([{ ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG }]);
+        expect(FakeEncoder.encodeOptions).toEqual([{ keyFrame: true }, { keyFrame: false }, { keyFrame: false }]);
+        expect(canvas.width).toBe(360);
+        expect(canvas.height).toBe(640);
+        expect(canvas.getContext).toHaveBeenCalledTimes(1);
+        expect(samples.every((sample) => sample.transform.mock.calls.length === 0)).toBe(true);
+        expect(samples.every((sample) => sample.toVideoFrame.mock.calls.length === 1)).toBe(true);
+        expect(outputFrameInits).toEqual([
+            { timestamp: 0, duration: 33_333 },
+            { timestamp: 33_333, duration: 33_333 },
+            { timestamp: 66_667, duration: 33_333 },
+        ]);
+        expect(samples.every((sample) => sample.close.mock.calls.length === 1)).toBe(true);
+        expect(FakeSample.sourceFrames.every((frame) => frame.close.mock.calls.length === 1)).toBe(true);
+        expect(outputFrames.every((frame) => frame.close.mock.calls.length === 1)).toBe(true);
+        expect(dispose).toHaveBeenCalledTimes(1);
+        expect(JSON.stringify(result)).not.toContain('private.mov');
+    });
+
+    it('bakes the portrait MOV 90° rotation into an upright 360x640 Canvas draw geometry', async () => {
+        FakeEncoder.reset();
+        FakeSample.reset();
+        const context = createContext();
+        const canvas = createCanvas(context);
+        await runLegacyLikeCanvasPipelineBenchmark(
+            new File(['video'], 'ignored.mov', { type: 'video/quicktime' }),
+            createOptions(createTrack(), [new FakeSample(100)], { canvas, createOutputVideoFrame: () => new FakeFrame(360, 640) }),
+        );
+
+        expect(context.clearRect).toHaveBeenCalledWith(0, 0, 360, 640);
+        expect(context.translate).toHaveBeenNthCalledWith(1, 180, 320);
+        expect(context.rotate).toHaveBeenCalledWith(Math.PI / 2);
+        expect(context.scale).toHaveBeenCalledWith(640 / 360, 360 / 640);
+        expect(context.translate).toHaveBeenNthCalledWith(2, -180, -320);
+        expect(context.drawImage).toHaveBeenCalledWith(
+            expect.objectContaining({ displayWidth: 1_920, displayHeight: 1_080 }),
+            0,
+            0,
+            1_920,
+            1_080,
+            0,
+            0,
+            360,
+            640,
+        );
+    });
+
+    it('normalizes MediaBunny second timestamps and schedules five-second keyframes without microsecond assumptions', async () => {
+        FakeEncoder.reset();
+        FakeSample.reset();
+        const relativeTimestamps = [0, 4.999, 5, 9.999, 10];
+        const samples = relativeTimestamps.map((timestamp) => new FakeSample(100 + timestamp));
+        const outputFrameInits: VideoFrameInit[] = [];
+        const result = await runLegacyLikeCanvasPipelineBenchmark(
+            new File(['video'], 'ignored.mov', { type: 'video/quicktime' }),
+            createOptions(createTrack(), samples, {
+                createOutputVideoFrame: (_canvas, init) => {
+                    outputFrameInits.push(init);
+                    return new FakeFrame(360, 640);
+                },
+            }),
+        );
+
+        expect(result.status).toBe('completed');
+        samples.forEach((sample, index) => {
+            expect(sample.setTimestamp.mock.calls[0]?.[0]).toBeCloseTo(relativeTimestamps[index], 12);
+        });
+        expect(outputFrameInits.map((init) => init.timestamp)).toEqual([0, 4_999_000, 5_000_000, 9_999_000, 10_000_000]);
+        expect(outputFrameInits.every((init) => init.duration === 33_333)).toBe(true);
+        expect(FakeEncoder.encodeOptions).toEqual([
+            { keyFrame: true },
+            { keyFrame: false },
+            { keyFrame: true },
+            { keyFrame: false },
+            { keyFrame: true },
+        ]);
+    });
+
+    it.each([
+        ['canvas unavailable', { canvas: null }, 'canvas-unavailable'],
+        ['canvas context unavailable', { canvas: createCanvas(null) }, 'canvas-context-unavailable'],
+    ] as const)('reports %s with cleanup', async (_name, options, stage) => {
+        FakeEncoder.reset();
+        const dispose = vi.fn();
+        const result = await runLegacyLikeCanvasPipelineBenchmark(
+            new File(['x'], 'ignored.mov', { type: 'video/quicktime' }),
+            createOptions(createTrack(), [], { ...options, dispose }),
+        );
+
+        expect(result).toMatchObject({ status: 'failed', failure: { stage } });
+        expect(dispose).toHaveBeenCalledTimes(1);
+        expect(FakeEncoder.instances).toHaveLength(0);
+    });
+
+    it.each([
+        ['source frame', 'source-frame-failure'],
+        ['canvas draw', 'canvas-draw-failure'],
+        ['encode', 'encode-failure'],
+        ['flush', 'flush-failure'],
+    ] as const)('classifies %s failures and closes every acquired resource', async (mode, stage) => {
+        FakeEncoder.reset();
+        FakeSample.reset();
+        const sample = new FakeSample(100);
+        const dispose = vi.fn();
+        const context = createContext(mode === 'canvas draw');
+        if (mode === 'source frame') FakeSample.sourceFrameError = true;
+        if (mode === 'encode') FakeEncoder.mode = 'encode-failure';
+        if (mode === 'flush') FakeEncoder.mode = 'flush-failure';
+        const result = await runLegacyLikeCanvasPipelineBenchmark(
+            new File(['x'], 'ignored.mov', { type: 'video/quicktime' }),
+            createOptions(createTrack(), [sample], {
+                dispose,
+                canvas: createCanvas(context),
+                createOutputVideoFrame: () => new FakeFrame(360, 640),
+            }),
+        );
+
+        expect(result).toMatchObject({ status: 'failed', failure: { stage } });
+        expect(sample.close).toHaveBeenCalledTimes(1);
+        expect(dispose).toHaveBeenCalledTimes(1);
+        expect(FakeEncoder.instances[0]?.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns aborted without allocating Canvas or an encoder', async () => {
+        FakeEncoder.reset();
+        const controller = new AbortController();
+        controller.abort();
+        const createCanvasMock = vi.fn(() => createCanvas(createContext()));
+        const result = await runLegacyLikeCanvasPipelineBenchmark(
+            new File(['x'], 'ignored.mov', { type: 'video/quicktime' }),
+            { ...createOptions(createTrack()), signal: controller.signal, createCanvas: createCanvasMock },
+        );
+
+        expect(result).toMatchObject({ status: 'failed', failure: { stage: 'aborted' } });
+        expect(createCanvasMock).not.toHaveBeenCalled();
+        expect(FakeEncoder.instances).toHaveLength(0);
+    });
+
+    it('keeps the existing native encoder conditions', () => {
+        expect(RAW_VIDEO_ENCODER_BENCHMARK_CONFIG).toMatchObject({
+            codec: 'avc1.64001E', width: 360, height: 640, framerate: 30, bitrate: 400_000,
+        });
+        expect(RAW_VIDEO_ENCODER_BENCHMARK_QUEUE_LIMIT).toBe(4);
+    });
+});

--- a/src/test/unit/mediaCompressionDiagnostics.test.ts
+++ b/src/test/unit/mediaCompressionDiagnostics.test.ts
@@ -6,8 +6,10 @@ import {
     clearMediaCompressionDiagnosticRecords,
     formatMediaCompressionDiagnostics,
     getAacCustomEncoderState,
+    getMediaCompressionAudioDiagnosticMode,
     getMediaCompressionDiagnosticRecords,
     isMediaCompressionDebugEnabled,
+    isMediaCompressionDebugAudioCopyEnabled,
     startMediaCompressionDiagnostic,
 } from '../../lib/videoCompression/mediaCompressionDiagnostics';
 
@@ -30,6 +32,10 @@ describe('media compression diagnostics', () => {
         expect(isMediaCompressionDebugEnabled('')).toBe(false);
         expect(isMediaCompressionDebugEnabled('?media-debug=0')).toBe(false);
         expect(isMediaCompressionDebugEnabled('?media-debug=1')).toBe(true);
+        expect(isMediaCompressionDebugAudioCopyEnabled('?media-debug-audio=copy')).toBe(false);
+        expect(isMediaCompressionDebugAudioCopyEnabled('?media-debug=1&media-debug-audio=copy')).toBe(true);
+        expect(getMediaCompressionAudioDiagnosticMode('?media-debug=1')).toBe('normal');
+        expect(getMediaCompressionAudioDiagnosticMode('?media-debug=1&media-debug-audio=copy')).toBe('force-packet-copy');
         expect(startMediaCompressionDiagnostic(new File(['x'], 'clip.mp4', { type: 'video/mp4' }))).toBeNull();
         expect(getMediaCompressionDiagnosticRecords()).toHaveLength(0);
     });
@@ -59,6 +65,33 @@ describe('media compression diagnostics', () => {
         clearMediaCompressionDiagnosticRecords();
         expect(getMediaCompressionDiagnosticRecords()).toHaveLength(0);
         expect(getAacCustomEncoderState()).toBe('not-loaded');
+    });
+
+    it('records and formats the forced packet-copy mode only when both query parameters are present', () => {
+        setSearch('?media-debug-audio=copy');
+        expect(startMediaCompressionDiagnostic(new File(['x'], 'clip.mp4', { type: 'video/mp4' }))).toBeNull();
+
+        setSearch('?media-debug=1&media-debug-audio=copy');
+        const session = startMediaCompressionDiagnostic(new File(['x'], 'clip.mp4', { type: 'video/mp4' }));
+        session?.setAudio(0, {
+            sourceSampleRate: 48000,
+            sourceChannels: 2,
+            targetSampleRate: 44100,
+            targetChannels: 2,
+            effectiveEncodingMode: 'packet-copy',
+            audioPath: 'packet-copy',
+            reason: 'debug-forced-packet-copy',
+            outputCodec: 'aac',
+            outputSampleRate: 48000,
+            outputChannels: 2,
+        });
+
+        const text = formatMediaCompressionDiagnostics();
+        expect(text).toContain('Forced audio packet copy');
+        expect(text).toContain('audio diagnostic mode: force-packet-copy');
+        expect(text).toContain('normal target: 44100 Hz / 2ch');
+        expect(text).toContain('reason: debug-forced-packet-copy');
+        expect(text).toContain('output audio: 48000 Hz / 2ch');
     });
 
     it('classifies native, custom, packet-copy, and unknown paths from observed state', () => {

--- a/src/test/unit/mediaCompressionDiagnostics.test.ts
+++ b/src/test/unit/mediaCompressionDiagnostics.test.ts
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import MediaCompressionDebugPanel from '../../components/MediaCompressionDebugPanel.svelte';
 import {
     classifyMediaCompressionAudioPath,
+    addRealVideoPipelineBenchmarkRecord,
     addVideoDecodeBenchmarkRecord,
     clearMediaCompressionDiagnosticRecords,
     formatMediaCompressionDiagnostics,
@@ -15,6 +16,7 @@ import {
     isMediaCompressionDebugAudioCopyEnabled,
     isMediaCompressionDebugRawVideoEncoderEnabled,
     isMediaCompressionDebugVideoDecodeBenchmarkEnabled,
+    isMediaCompressionDebugVideoPipelineBenchmarkEnabled,
     isMediaCompressionDebugVideoBitrateEnabled,
     isMediaCompressionDebugVideoRealtimeEnabled,
     startMediaCompressionDiagnostic,
@@ -54,6 +56,9 @@ describe('media compression diagnostics', () => {
         expect(isMediaCompressionDebugVideoDecodeBenchmarkEnabled('?media-debug-video-decode-benchmark=1')).toBe(false);
         expect(isMediaCompressionDebugVideoDecodeBenchmarkEnabled('?media-debug=1')).toBe(false);
         expect(isMediaCompressionDebugVideoDecodeBenchmarkEnabled('?media-debug=1&media-debug-video-decode-benchmark=1')).toBe(true);
+        expect(isMediaCompressionDebugVideoPipelineBenchmarkEnabled('?media-debug-video-pipeline-benchmark=1')).toBe(false);
+        expect(isMediaCompressionDebugVideoPipelineBenchmarkEnabled('?media-debug=1')).toBe(false);
+        expect(isMediaCompressionDebugVideoPipelineBenchmarkEnabled('?media-debug=1&media-debug-video-pipeline-benchmark=1')).toBe(true);
         expect(getMediaCompressionAudioDiagnosticMode('?media-debug=1')).toBe('normal');
         expect(getMediaCompressionAudioDiagnosticMode('?media-debug=1&media-debug-audio=copy')).toBe('force-packet-copy');
         expect(getMediaCompressionVideoDiagnosticMode('?media-debug=1')).toBe('default-quality');
@@ -179,6 +184,55 @@ describe('media compression diagnostics', () => {
         expect(text).toContain('samples decoded: 627');
         expect(text).toContain('sample #627: +6800.0 ms');
         expect(text).toContain('No resize, video encode, audio, muxing, or file output is performed by this benchmark.');
+        expect(text).not.toContain('.mov');
+    });
+
+    it('formats real pipeline results with target, counts, timings, and no selected file name', () => {
+        setSearch('?media-debug=1&media-debug-video-pipeline-benchmark=1');
+        addRealVideoPipelineBenchmarkRecord({
+            status: 'completed',
+            input: {
+                mime: 'video/quicktime',
+                size: 39_681_322,
+                duration: 20.9,
+                videoCodec: 'avc1.4d401f',
+                codedWidth: 1920,
+                codedHeight: 1080,
+                displayWidth: 1080,
+                displayHeight: 1920,
+                rotation: 90,
+            },
+            target: { width: 360, height: 640, fit: 'fill', rotate: 0, alpha: 'discard' },
+            capabilities: { decode: true, avcEncode: true },
+            samplesProcessed: 627,
+            framesSubmitted: 627,
+            encodedChunks: 627,
+            encodedBytes: 395_052,
+            keyChunks: 1,
+            deltaChunks: 626,
+            maxQueueSize: 4,
+            throughput: 98.4,
+            timings: {
+                inputTrackSetup: 12,
+                sampleWaitIteration: 6300,
+                videoTransform: 5200,
+                videoFrameCreation: 1800,
+                encodeSubmissionSync: 30,
+                backpressureWait: 8400,
+                flushWait: 1200,
+                benchmarkTotalWall: 16600,
+            },
+        });
+
+        const text = formatMediaCompressionDiagnostics();
+        expect(text).toContain('Real video pipeline benchmark: enabled (manual run)');
+        expect(text).toContain('Real Video Pipeline Benchmark #1');
+        expect(text).toContain('source display: 1080x1920');
+        expect(text).toContain('target: 360x640');
+        expect(text).toContain('samples processed: 627');
+        expect(text).toContain('encoded chunks: 627');
+        expect(text).toContain('benchmark total wall: 16600.0 ms');
+        expect(text).toContain('Uses MediaBunny public Input/VideoSampleSink/VideoSample.transform only; no Conversion, audio, muxing, Blob, or file output.');
         expect(text).not.toContain('.mov');
     });
 
@@ -316,5 +370,42 @@ describe('media compression diagnostics', () => {
 
         expect(videoDecodeBenchmarkLoader).toHaveBeenCalledTimes(1);
         expect(screen.getByText('Video decode benchmark: failed').textContent).toBe('Video decode benchmark: failed');
+    });
+
+    it('wires the real pipeline file selection through a lazy runner and returns to failed on loader error', async () => {
+        setSearch('?media-debug=1&media-debug-video-pipeline-benchmark=1');
+        const runner = vi.fn().mockResolvedValue({
+            status: 'completed',
+            input: { mime: 'video/quicktime', size: 5, duration: 1, videoCodec: 'avc', codedWidth: 1920, codedHeight: 1080, displayWidth: 1080, displayHeight: 1920, rotation: 90 },
+            target: { width: 360, height: 640, fit: 'fill', rotate: 0, alpha: 'discard' },
+            capabilities: { decode: true, avcEncode: true },
+            samplesProcessed: 1,
+            framesSubmitted: 1,
+            encodedChunks: 1,
+            encodedBytes: 100,
+            keyChunks: 1,
+            deltaChunks: 0,
+            maxQueueSize: 1,
+            throughput: 1,
+            timings: { inputTrackSetup: 1, sampleWaitIteration: 1, videoTransform: 1, videoFrameCreation: 1, encodeSubmissionSync: 1, backpressureWait: 1, flushWait: 1, benchmarkTotalWall: 1 },
+        });
+        render(MediaCompressionDebugPanel, { realVideoPipelineBenchmarkRunner: runner });
+        await fireEvent.click(screen.getByRole('button', { name: /Media Compression Debug/ }));
+        await fireEvent.change(screen.getByLabelText('Select video for real pipeline benchmark'), {
+            target: { files: [new File(['video'], 'private.mov', { type: 'video/quicktime' })] },
+        });
+        expect(runner).toHaveBeenCalledTimes(1);
+        expect(screen.getByText('Real video pipeline benchmark: completed').textContent).toBe('Real video pipeline benchmark: completed');
+
+        clearMediaCompressionDiagnosticRecords();
+        setSearch('?media-debug=1&media-debug-video-pipeline-benchmark=1');
+        const loader = vi.fn().mockRejectedValue(new Error('benchmark chunk unavailable'));
+        render(MediaCompressionDebugPanel, { realVideoPipelineBenchmarkLoader: loader });
+        await fireEvent.click(screen.getAllByRole('button', { name: /Media Compression Debug/ })[1]);
+        await fireEvent.change(screen.getAllByLabelText('Select video for real pipeline benchmark')[1], {
+            target: { files: [new File(['video'], 'private.mov', { type: 'video/quicktime' })] },
+        });
+        expect(loader).toHaveBeenCalledTimes(1);
+        expect(screen.getAllByText('Real video pipeline benchmark: failed')[0].textContent).toBe('Real video pipeline benchmark: failed');
     });
 });

--- a/src/test/unit/mediaCompressionDiagnostics.test.ts
+++ b/src/test/unit/mediaCompressionDiagnostics.test.ts
@@ -10,10 +10,12 @@ import {
     getMediaCompressionAudioDiagnosticMode,
     getMediaCompressionDiagnosticRecords,
     getMediaCompressionVideoDiagnosticMode,
+    getMediaCompressionVideoRateControlMode,
     isMediaCompressionDebugEnabled,
     isMediaCompressionDebugAudioCopyEnabled,
     isMediaCompressionDebugRawVideoEncoderEnabled,
     isMediaCompressionDebugVideoDecodeBenchmarkEnabled,
+    isMediaCompressionDebugVideoBitrateEnabled,
     isMediaCompressionDebugVideoRealtimeEnabled,
     startMediaCompressionDiagnostic,
 } from '../../lib/videoCompression/mediaCompressionDiagnostics';
@@ -42,6 +44,10 @@ describe('media compression diagnostics', () => {
         expect(isMediaCompressionDebugVideoRealtimeEnabled('?media-debug-video-latency=realtime')).toBe(false);
         expect(isMediaCompressionDebugVideoRealtimeEnabled('?media-debug=1&media-debug-video-latency=realtime')).toBe(false);
         expect(isMediaCompressionDebugVideoRealtimeEnabled('?media-debug=1&media-debug-audio=copy&media-debug-video-latency=realtime')).toBe(true);
+        expect(isMediaCompressionDebugVideoBitrateEnabled('?media-debug-video-rate-control=bitrate')).toBe(false);
+        expect(isMediaCompressionDebugVideoBitrateEnabled('?media-debug=1&media-debug-video-rate-control=bitrate')).toBe(false);
+        expect(isMediaCompressionDebugVideoBitrateEnabled('?media-debug=1&media-debug-audio=copy')).toBe(false);
+        expect(isMediaCompressionDebugVideoBitrateEnabled('?media-debug=1&media-debug-audio=copy&media-debug-video-rate-control=bitrate')).toBe(true);
         expect(isMediaCompressionDebugRawVideoEncoderEnabled('?media-debug-raw-video-encoder=1')).toBe(false);
         expect(isMediaCompressionDebugRawVideoEncoderEnabled('?media-debug=1')).toBe(false);
         expect(isMediaCompressionDebugRawVideoEncoderEnabled('?media-debug=1&media-debug-raw-video-encoder=1')).toBe(true);
@@ -52,6 +58,8 @@ describe('media compression diagnostics', () => {
         expect(getMediaCompressionAudioDiagnosticMode('?media-debug=1&media-debug-audio=copy')).toBe('force-packet-copy');
         expect(getMediaCompressionVideoDiagnosticMode('?media-debug=1')).toBe('default-quality');
         expect(getMediaCompressionVideoDiagnosticMode('?media-debug=1&media-debug-audio=copy&media-debug-video-latency=realtime')).toBe('realtime');
+        expect(getMediaCompressionVideoRateControlMode('?media-debug=1&media-debug-audio=copy')).toBe('subjective-quality');
+        expect(getMediaCompressionVideoRateControlMode('?media-debug=1&media-debug-audio=copy&media-debug-video-rate-control=bitrate')).toBe('explicit-bitrate');
         expect(startMediaCompressionDiagnostic(new File(['x'], 'clip.mp4', { type: 'video/mp4' }))).toBeNull();
         expect(getMediaCompressionDiagnosticRecords()).toHaveLength(0);
     });

--- a/src/test/unit/mediaCompressionDiagnostics.test.ts
+++ b/src/test/unit/mediaCompressionDiagnostics.test.ts
@@ -11,6 +11,7 @@ import {
     getMediaCompressionVideoDiagnosticMode,
     isMediaCompressionDebugEnabled,
     isMediaCompressionDebugAudioCopyEnabled,
+    isMediaCompressionDebugRawVideoEncoderEnabled,
     isMediaCompressionDebugVideoRealtimeEnabled,
     startMediaCompressionDiagnostic,
 } from '../../lib/videoCompression/mediaCompressionDiagnostics';
@@ -39,6 +40,9 @@ describe('media compression diagnostics', () => {
         expect(isMediaCompressionDebugVideoRealtimeEnabled('?media-debug-video-latency=realtime')).toBe(false);
         expect(isMediaCompressionDebugVideoRealtimeEnabled('?media-debug=1&media-debug-video-latency=realtime')).toBe(false);
         expect(isMediaCompressionDebugVideoRealtimeEnabled('?media-debug=1&media-debug-audio=copy&media-debug-video-latency=realtime')).toBe(true);
+        expect(isMediaCompressionDebugRawVideoEncoderEnabled('?media-debug-raw-video-encoder=1')).toBe(false);
+        expect(isMediaCompressionDebugRawVideoEncoderEnabled('?media-debug=1')).toBe(false);
+        expect(isMediaCompressionDebugRawVideoEncoderEnabled('?media-debug=1&media-debug-raw-video-encoder=1')).toBe(true);
         expect(getMediaCompressionAudioDiagnosticMode('?media-debug=1')).toBe('normal');
         expect(getMediaCompressionAudioDiagnosticMode('?media-debug=1&media-debug-audio=copy')).toBe('force-packet-copy');
         expect(getMediaCompressionVideoDiagnosticMode('?media-debug=1')).toBe('default-quality');
@@ -206,5 +210,39 @@ describe('media compression diagnostics', () => {
         await fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
         expect(document.querySelector('pre')?.textContent).toContain('No conversions recorded.');
         expect(getAacCustomEncoderState()).toBe('not-loaded');
+    });
+
+    it('shows the manual raw encoder control only for its fully gated diagnostic query', async () => {
+        setSearch('?media-debug=1&media-debug-raw-video-encoder=1');
+        const rawRunner = vi.fn().mockResolvedValue({
+            status: 'failed',
+            source: 'canvas-2d synthetic pattern',
+            config: { codec: 'avc1.42001E', width: 360, height: 640, framerate: 30, bitrate: 400_000 },
+            frameCount: 627,
+            queueLimit: 4,
+            maxQueueSize: 0,
+            framesSubmitted: 0,
+            chunks: 0,
+            bytes: 0,
+            keyChunks: 0,
+            deltaChunks: 0,
+            timings: {
+                configSupportCheck: 1,
+                encoderSetupConfigure: 0,
+                benchmarkWall: 0,
+                framePreparationSync: 0,
+                encodeSubmissionSync: 0,
+                backpressureWait: 0,
+                flushWait: 0,
+            },
+            failure: { stage: 'api-unavailable', message: 'VideoEncoder or VideoFrame is unavailable.' },
+        });
+        render(MediaCompressionDebugPanel, { rawVideoEncoderBenchmarkRunner: rawRunner });
+
+        await fireEvent.click(screen.getByRole('button', { name: /Media Compression Debug/ }));
+        await fireEvent.click(screen.getByRole('button', { name: 'Run raw VideoEncoder benchmark' }));
+        expect(rawRunner).toHaveBeenCalledTimes(1);
+        expect(screen.getByText('Raw benchmark: failed').textContent).toBe('Raw benchmark: failed');
+        expect(document.querySelector('pre')?.textContent).toContain('failure: api-unavailable');
     });
 });

--- a/src/test/unit/mediaCompressionDiagnostics.test.ts
+++ b/src/test/unit/mediaCompressionDiagnostics.test.ts
@@ -294,4 +294,18 @@ describe('media compression diagnostics', () => {
         expect(document.querySelector('pre')?.textContent).toContain('Video Decode Benchmark #1');
         expect(document.querySelector('pre')?.textContent).not.toContain('private.mov');
     });
+
+    it('returns the decode control to failed when the lazy benchmark import fails', async () => {
+        setSearch('?media-debug=1&media-debug-video-decode-benchmark=1');
+        const videoDecodeBenchmarkLoader = vi.fn().mockRejectedValue(new Error('benchmark chunk unavailable'));
+        render(MediaCompressionDebugPanel, { videoDecodeBenchmarkLoader });
+
+        await fireEvent.click(screen.getByRole('button', { name: /Media Compression Debug/ }));
+        await fireEvent.change(screen.getByLabelText('Select video for decode benchmark'), {
+            target: { files: [new File(['video'], 'private.mov', { type: 'video/quicktime' })] },
+        });
+
+        expect(videoDecodeBenchmarkLoader).toHaveBeenCalledTimes(1);
+        expect(screen.getByText('Video decode benchmark: failed').textContent).toBe('Video decode benchmark: failed');
+    });
 });

--- a/src/test/unit/mediaCompressionDiagnostics.test.ts
+++ b/src/test/unit/mediaCompressionDiagnostics.test.ts
@@ -8,8 +8,10 @@ import {
     getAacCustomEncoderState,
     getMediaCompressionAudioDiagnosticMode,
     getMediaCompressionDiagnosticRecords,
+    getMediaCompressionVideoDiagnosticMode,
     isMediaCompressionDebugEnabled,
     isMediaCompressionDebugAudioCopyEnabled,
+    isMediaCompressionDebugVideoRealtimeEnabled,
     startMediaCompressionDiagnostic,
 } from '../../lib/videoCompression/mediaCompressionDiagnostics';
 
@@ -34,8 +36,13 @@ describe('media compression diagnostics', () => {
         expect(isMediaCompressionDebugEnabled('?media-debug=1')).toBe(true);
         expect(isMediaCompressionDebugAudioCopyEnabled('?media-debug-audio=copy')).toBe(false);
         expect(isMediaCompressionDebugAudioCopyEnabled('?media-debug=1&media-debug-audio=copy')).toBe(true);
+        expect(isMediaCompressionDebugVideoRealtimeEnabled('?media-debug-video-latency=realtime')).toBe(false);
+        expect(isMediaCompressionDebugVideoRealtimeEnabled('?media-debug=1&media-debug-video-latency=realtime')).toBe(false);
+        expect(isMediaCompressionDebugVideoRealtimeEnabled('?media-debug=1&media-debug-audio=copy&media-debug-video-latency=realtime')).toBe(true);
         expect(getMediaCompressionAudioDiagnosticMode('?media-debug=1')).toBe('normal');
         expect(getMediaCompressionAudioDiagnosticMode('?media-debug=1&media-debug-audio=copy')).toBe('force-packet-copy');
+        expect(getMediaCompressionVideoDiagnosticMode('?media-debug=1')).toBe('default-quality');
+        expect(getMediaCompressionVideoDiagnosticMode('?media-debug=1&media-debug-audio=copy&media-debug-video-latency=realtime')).toBe('realtime');
         expect(startMediaCompressionDiagnostic(new File(['x'], 'clip.mp4', { type: 'video/mp4' }))).toBeNull();
         expect(getMediaCompressionDiagnosticRecords()).toHaveLength(0);
     });
@@ -51,6 +58,20 @@ describe('media compression diagnostics', () => {
             sourceChannels: 2,
             audioPath: 'native-aac',
         });
+        session?.setVideo(0, {
+            inputPacketStats: {
+                packetCount: 627,
+                averagePacketRate: 30,
+                averageBitrate: 4_000_000,
+                duration: 20.9,
+            },
+            outputPacketStats: {
+                packetCount: 627,
+                averagePacketRate: 30,
+                averageBitrate: 3_900_000,
+                duration: 20.9,
+            },
+        });
         session?.finish({
             file: new File(['compressed'], 'output.mp4', { type: 'video/mp4' }),
             wasCompressed: true,
@@ -59,6 +80,8 @@ describe('media compression diagnostics', () => {
         const text = formatMediaCompressionDiagnostics();
         expect(text).toContain('Conversion #1');
         expect(text).toContain('audio path: native-aac');
+        expect(text).toContain('input frames: 627');
+        expect(text).toContain('output FPS: 30.00');
         expect(text).toContain('total compression:');
         expect(text).not.toContain('clip.mp4');
 
@@ -92,6 +115,31 @@ describe('media compression diagnostics', () => {
         expect(text).toContain('normal target: 44100 Hz / 2ch');
         expect(text).toContain('reason: debug-forced-packet-copy');
         expect(text).toContain('output audio: 48000 Hz / 2ch');
+    });
+
+    it('formats realtime video diagnostics and keeps packet scan timing separate', () => {
+        setSearch('?media-debug=1&media-debug-audio=copy&media-debug-video-latency=realtime');
+        const session = startMediaCompressionDiagnostic(new File(['x'], 'clip.mp4', { type: 'video/mp4' }));
+        session?.setVideo(0, {
+            inputPacketStats: { packetCount: 627, averagePacketRate: 30, averageBitrate: 4_000_000, duration: 20.9 },
+            outputPacketStats: { packetCount: 620, averagePacketRate: 29.7, averageBitrate: 3_900_000, duration: 20.9 },
+        });
+        session?.setTiming('input video stats scan', 25);
+        session?.setTiming('output video stats scan', 35);
+        session?.setTiming('conversion.execute', 16600);
+        session?.finish({
+            file: new File(['output'], 'output.mp4', { type: 'video/mp4' }),
+            wasCompressed: true,
+        });
+
+        const text = formatMediaCompressionDiagnostics();
+        expect(text).toContain('Video latency: realtime');
+        expect(text).toContain('video diagnostic mode: realtime');
+        expect(text).toContain('input frames: 627');
+        expect(text).toContain('output frames: 620');
+        expect(text).toContain('input video stats scan: 25.0 ms');
+        expect(text).toContain('output video stats scan: 35.0 ms');
+        expect(text).toContain('conversion.execute: 16600.0 ms');
     });
 
     it('classifies native, custom, packet-copy, and unknown paths from observed state', () => {

--- a/src/test/unit/mediaCompressionDiagnostics.test.ts
+++ b/src/test/unit/mediaCompressionDiagnostics.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import MediaCompressionDebugPanel from '../../components/MediaCompressionDebugPanel.svelte';
+import type { LegacyLikeCanvasPipelineBenchmarkOptions, LegacyLikeCanvasPipelineBenchmarkResult } from '../../lib/videoCompression/legacyLikeCanvasPipelineBenchmark';
+import type { RealVideoPipelineBenchmarkOptions, RealVideoPipelineBenchmarkResult } from '../../lib/videoCompression/realVideoPipelineBenchmark';
 import {
     classifyMediaCompressionAudioPath,
+    addLegacyLikeCanvasPipelineBenchmarkRecord,
     addRealVideoPipelineBenchmarkRecord,
     addVideoDecodeBenchmarkRecord,
     clearMediaCompressionDiagnosticRecords,
@@ -190,6 +193,7 @@ describe('media compression diagnostics', () => {
     it('formats real pipeline results with target, counts, timings, and no selected file name', () => {
         setSearch('?media-debug=1&media-debug-video-pipeline-benchmark=1');
         addRealVideoPipelineBenchmarkRecord({
+            pipelineKind: 'mediabunny-transform',
             status: 'completed',
             input: {
                 mime: 'video/quicktime',
@@ -227,6 +231,7 @@ describe('media compression diagnostics', () => {
         const text = formatMediaCompressionDiagnostics();
         expect(text).toContain('Real video pipeline benchmark: enabled (manual run)');
         expect(text).toContain('Real Video Pipeline Benchmark #1');
+        expect(text).toContain('pipeline kind: mediabunny-transform');
         expect(text).toContain('source display: 1080x1920');
         expect(text).toContain('target: 360x640');
         expect(text).toContain('samples processed: 627');
@@ -375,6 +380,7 @@ describe('media compression diagnostics', () => {
     it('wires the real pipeline file selection through a lazy runner and returns to failed on loader error', async () => {
         setSearch('?media-debug=1&media-debug-video-pipeline-benchmark=1');
         const runner = vi.fn().mockResolvedValue({
+            pipelineKind: 'mediabunny-transform' as const,
             status: 'completed',
             input: { mime: 'video/quicktime', size: 5, duration: 1, videoCodec: 'avc', codedWidth: 1920, codedHeight: 1080, displayWidth: 1080, displayHeight: 1920, rotation: 90 },
             target: { width: 360, height: 640, fit: 'fill', rotate: 0, alpha: 'discard' },
@@ -391,21 +397,94 @@ describe('media compression diagnostics', () => {
         });
         render(MediaCompressionDebugPanel, { realVideoPipelineBenchmarkRunner: runner });
         await fireEvent.click(screen.getByRole('button', { name: /Media Compression Debug/ }));
-        await fireEvent.change(screen.getByLabelText('Select video for real pipeline benchmark'), {
+        await fireEvent.change(screen.getByLabelText('Select video for MediaBunny transform pipeline benchmark'), {
             target: { files: [new File(['video'], 'private.mov', { type: 'video/quicktime' })] },
         });
         expect(runner).toHaveBeenCalledTimes(1);
-        expect(screen.getByText('Real video pipeline benchmark: completed').textContent).toBe('Real video pipeline benchmark: completed');
+        expect(screen.getByText('MediaBunny transform pipeline benchmark: completed').textContent).toBe('MediaBunny transform pipeline benchmark: completed');
 
         clearMediaCompressionDiagnosticRecords();
         setSearch('?media-debug=1&media-debug-video-pipeline-benchmark=1');
         const loader = vi.fn().mockRejectedValue(new Error('benchmark chunk unavailable'));
         render(MediaCompressionDebugPanel, { realVideoPipelineBenchmarkLoader: loader });
         await fireEvent.click(screen.getAllByRole('button', { name: /Media Compression Debug/ })[1]);
-        await fireEvent.change(screen.getAllByLabelText('Select video for real pipeline benchmark')[1], {
+        await fireEvent.change(screen.getAllByLabelText('Select video for MediaBunny transform pipeline benchmark')[1], {
             target: { files: [new File(['video'], 'private.mov', { type: 'video/quicktime' })] },
         });
         expect(loader).toHaveBeenCalledTimes(1);
-        expect(screen.getAllByText('Real video pipeline benchmark: failed')[0].textContent).toBe('Real video pipeline benchmark: failed');
+        expect(screen.getAllByText('MediaBunny transform pipeline benchmark: failed')[0].textContent).toBe('MediaBunny transform pipeline benchmark: failed');
+    });
+
+    it('records a distinct legacy-like Canvas result and keeps both pipeline controls mutually exclusive', async () => {
+        setSearch('?media-debug=1&media-debug-video-pipeline-benchmark=1');
+        let completeTransform: (() => void) | undefined;
+        const transformRunner = vi.fn((_file: File, _options?: RealVideoPipelineBenchmarkOptions) => new Promise<RealVideoPipelineBenchmarkResult>((resolve) => {
+            completeTransform = () => resolve({
+                pipelineKind: 'mediabunny-transform' as const,
+                status: 'completed' as const,
+                input: { mime: 'video/quicktime', size: 5, duration: 1, videoCodec: 'avc', codedWidth: 1920, codedHeight: 1080, displayWidth: 1080, displayHeight: 1920, rotation: 90 },
+                target: { width: 360, height: 640, fit: 'fill' as const, rotate: 0 as const, alpha: 'discard' as const },
+                capabilities: { decode: true, avcEncode: true },
+                samplesProcessed: 1, framesSubmitted: 1, encodedChunks: 1, encodedBytes: 100, keyChunks: 1, deltaChunks: 0, maxQueueSize: 1, throughput: 1,
+                timings: { inputTrackSetup: 1, sampleWaitIteration: 1, videoTransform: 1, videoFrameCreation: 1, encodeSubmissionSync: 1, backpressureWait: 1, flushWait: 1, benchmarkTotalWall: 1 },
+            });
+        }));
+        const canvasRunner = vi.fn((_file: File, _options?: LegacyLikeCanvasPipelineBenchmarkOptions): Promise<LegacyLikeCanvasPipelineBenchmarkResult> => Promise.resolve({
+            pipelineKind: 'legacy-like-html-canvas' as const,
+            status: 'completed' as const,
+            input: { mime: 'video/quicktime', size: 5, duration: 1, videoCodec: 'avc', codedWidth: 1920, codedHeight: 1080, displayWidth: 1080, displayHeight: 1920, rotation: 90 },
+            target: { width: 360, height: 640, fit: 'fill' as const, rotate: 0 as const, alpha: 'discard' as const },
+            capabilities: { decode: true, avcEncode: true },
+            samplesProcessed: 1, framesSubmitted: 1, encodedChunks: 1, encodedBytes: 100, keyChunks: 1, deltaChunks: 0, maxQueueSize: 1, throughput: 1,
+            timings: { inputTrackSetup: 1, sampleWaitIteration: 1, sourceVideoFrameAcquisition: 1, canvasDrawRotationResize: 1, outputVideoFrameCreation: 1, encodeSubmissionSync: 1, backpressureWait: 1, flushWait: 1, benchmarkTotalWall: 1 },
+        }));
+        render(MediaCompressionDebugPanel, {
+            realVideoPipelineBenchmarkRunner: transformRunner,
+            legacyLikeCanvasPipelineBenchmarkRunner: canvasRunner,
+        });
+
+        await fireEvent.click(screen.getByRole('button', { name: /Media Compression Debug/ }));
+        await fireEvent.change(screen.getByLabelText('Select video for MediaBunny transform pipeline benchmark'), {
+            target: { files: [new File(['video'], 'private.mov', { type: 'video/quicktime' })] },
+        });
+        expect((screen.getByRole('button', { name: /legacy-like Canvas pipeline benchmark/ }) as HTMLButtonElement).disabled).toBe(true);
+        expect(canvasRunner).not.toHaveBeenCalled();
+        completeTransform?.();
+        await vi.waitFor(() => expect(screen.getByText('MediaBunny transform pipeline benchmark: completed')).toBeDefined());
+
+        await fireEvent.change(screen.getByLabelText('Select video for legacy-like Canvas pipeline benchmark'), {
+            target: { files: [new File(['video'], 'private.mov', { type: 'video/quicktime' })] },
+        });
+        expect(canvasRunner).toHaveBeenCalledTimes(1);
+        expect(document.querySelector('pre')?.textContent).toContain('pipeline kind: legacy-like-html-canvas');
+        expect(document.querySelector('pre')?.textContent).not.toContain('private.mov');
+
+        addLegacyLikeCanvasPipelineBenchmarkRecord({
+            pipelineKind: 'legacy-like-html-canvas', status: 'failed',
+            input: { mime: 'video/quicktime', size: 5, duration: null, videoCodec: null, codedWidth: null, codedHeight: null, displayWidth: null, displayHeight: null, rotation: null },
+            target: { width: 360, height: 640, fit: 'fill', rotate: 0, alpha: 'discard' },
+            capabilities: { decode: true, avcEncode: true },
+            samplesProcessed: 0, framesSubmitted: 0, encodedChunks: 0, encodedBytes: 0, keyChunks: 0, deltaChunks: 0, maxQueueSize: 0, throughput: null,
+            timings: { inputTrackSetup: 1, sampleWaitIteration: 0, sourceVideoFrameAcquisition: 0, canvasDrawRotationResize: 0, outputVideoFrameCreation: 0, encodeSubmissionSync: 0, backpressureWait: 0, flushWait: 0, benchmarkTotalWall: 1 },
+            failure: { stage: 'canvas-draw-failure', message: 'draw stopped' },
+        });
+        await vi.waitFor(() => expect(document.querySelector('pre')?.textContent).toContain('failure: canvas-draw-failure: draw stopped'));
+    });
+
+    it('aborts an in-flight legacy-like Canvas benchmark when the debug panel unmounts', async () => {
+        setSearch('?media-debug=1&media-debug-video-pipeline-benchmark=1');
+        const abortSpy = vi.fn();
+        const runner = vi.fn((_file: File, options?: LegacyLikeCanvasPipelineBenchmarkOptions) => new Promise<LegacyLikeCanvasPipelineBenchmarkResult>(() => {
+            options?.signal?.addEventListener('abort', abortSpy, { once: true });
+        }));
+        const view = render(MediaCompressionDebugPanel, { legacyLikeCanvasPipelineBenchmarkRunner: runner });
+
+        await fireEvent.click(screen.getByRole('button', { name: /Media Compression Debug/ }));
+        await fireEvent.change(screen.getByLabelText('Select video for legacy-like Canvas pipeline benchmark'), {
+            target: { files: [new File(['video'], 'private.mov', { type: 'video/quicktime' })] },
+        });
+        view.unmount();
+
+        expect(abortSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/test/unit/mediaCompressionDiagnostics.test.ts
+++ b/src/test/unit/mediaCompressionDiagnostics.test.ts
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import MediaCompressionDebugPanel from '../../components/MediaCompressionDebugPanel.svelte';
 import {
     classifyMediaCompressionAudioPath,
+    addVideoDecodeBenchmarkRecord,
     clearMediaCompressionDiagnosticRecords,
     formatMediaCompressionDiagnostics,
     getAacCustomEncoderState,
@@ -12,6 +13,7 @@ import {
     isMediaCompressionDebugEnabled,
     isMediaCompressionDebugAudioCopyEnabled,
     isMediaCompressionDebugRawVideoEncoderEnabled,
+    isMediaCompressionDebugVideoDecodeBenchmarkEnabled,
     isMediaCompressionDebugVideoRealtimeEnabled,
     startMediaCompressionDiagnostic,
 } from '../../lib/videoCompression/mediaCompressionDiagnostics';
@@ -43,6 +45,9 @@ describe('media compression diagnostics', () => {
         expect(isMediaCompressionDebugRawVideoEncoderEnabled('?media-debug-raw-video-encoder=1')).toBe(false);
         expect(isMediaCompressionDebugRawVideoEncoderEnabled('?media-debug=1')).toBe(false);
         expect(isMediaCompressionDebugRawVideoEncoderEnabled('?media-debug=1&media-debug-raw-video-encoder=1')).toBe(true);
+        expect(isMediaCompressionDebugVideoDecodeBenchmarkEnabled('?media-debug-video-decode-benchmark=1')).toBe(false);
+        expect(isMediaCompressionDebugVideoDecodeBenchmarkEnabled('?media-debug=1')).toBe(false);
+        expect(isMediaCompressionDebugVideoDecodeBenchmarkEnabled('?media-debug=1&media-debug-video-decode-benchmark=1')).toBe(true);
         expect(getMediaCompressionAudioDiagnosticMode('?media-debug=1')).toBe('normal');
         expect(getMediaCompressionAudioDiagnosticMode('?media-debug=1&media-debug-audio=copy')).toBe('force-packet-copy');
         expect(getMediaCompressionVideoDiagnosticMode('?media-debug=1')).toBe('default-quality');
@@ -146,6 +151,29 @@ describe('media compression diagnostics', () => {
         expect(text).toContain('conversion.execute: 16600.0 ms');
     });
 
+    it('formats decode-only results without retaining a selected file name or samples', () => {
+        setSearch('?media-debug=1&media-debug-video-decode-benchmark=1');
+        addVideoDecodeBenchmarkRecord({
+            status: 'completed',
+            input: { mime: 'video/quicktime', size: 39_681_322, duration: 20.9, videoCodec: 'avc', displayWidth: 1080, displayHeight: 1920 },
+            decode: {
+                samplesDecoded: 627,
+                firstSample: { format: 'NV12', codedWidth: 1080, codedHeight: 1920, displayWidth: 1080, displayHeight: 1920 },
+                milestoneOffsets: { 1: 11, 100: 1200, 300: 3400, 500: 5400, 627: 6800 },
+                lastSampleOffset: 6800,
+            },
+            timing: { inputTrackSetup: 12, decodeWall: 6900, throughput: 90.87 },
+        });
+
+        const text = formatMediaCompressionDiagnostics();
+        expect(text).toContain('Video decode benchmark: enabled (manual run)');
+        expect(text).toContain('Video Decode Benchmark #1');
+        expect(text).toContain('samples decoded: 627');
+        expect(text).toContain('sample #627: +6800.0 ms');
+        expect(text).toContain('No resize, video encode, audio, muxing, or file output is performed by this benchmark.');
+        expect(text).not.toContain('.mov');
+    });
+
     it('classifies native, custom, packet-copy, and unknown paths from observed state', () => {
         expect(classifyMediaCompressionAudioPath({
             decodeAvailable: true,
@@ -217,7 +245,7 @@ describe('media compression diagnostics', () => {
         const rawRunner = vi.fn().mockResolvedValue({
             status: 'failed',
             source: 'canvas-2d synthetic pattern',
-            config: { codec: 'avc1.42001E', width: 360, height: 640, framerate: 30, bitrate: 400_000 },
+            config: { codec: 'avc1.64001E', width: 360, height: 640, framerate: 30, bitrate: 400_000 },
             frameCount: 627,
             queueLimit: 4,
             maxQueueSize: 0,
@@ -244,5 +272,26 @@ describe('media compression diagnostics', () => {
         expect(rawRunner).toHaveBeenCalledTimes(1);
         expect(screen.getByText('Raw benchmark: failed').textContent).toBe('Raw benchmark: failed');
         expect(document.querySelector('pre')?.textContent).toContain('failure: api-unavailable');
+    });
+
+    it('wires the manual decode file selection only for its fully gated diagnostic query', async () => {
+        setSearch('?media-debug=1&media-debug-video-decode-benchmark=1');
+        const decodeRunner = vi.fn().mockResolvedValue({
+            status: 'completed',
+            input: { mime: 'video/quicktime', size: 5, duration: 1, videoCodec: 'avc', displayWidth: 1080, displayHeight: 1920 },
+            decode: { samplesDecoded: 1, firstSample: null, milestoneOffsets: { 1: 2 }, lastSampleOffset: 2 },
+            timing: { inputTrackSetup: 1, decodeWall: 2, throughput: 500 },
+        });
+        render(MediaCompressionDebugPanel, { videoDecodeBenchmarkRunner: decodeRunner });
+
+        await fireEvent.click(screen.getByRole('button', { name: /Media Compression Debug/ }));
+        expect(screen.getByRole('button', { name: 'Run video decode benchmark' })).toBeDefined();
+        const input = screen.getByLabelText('Select video for decode benchmark');
+        await fireEvent.change(input, { target: { files: [new File(['video'], 'private.mov', { type: 'video/quicktime' })] } });
+        expect(decodeRunner).toHaveBeenCalledTimes(1);
+        expect(decodeRunner.mock.calls[0][0]).toBeInstanceOf(File);
+        expect(screen.getByText('Video decode benchmark: completed').textContent).toBe('Video decode benchmark: completed');
+        expect(document.querySelector('pre')?.textContent).toContain('Video Decode Benchmark #1');
+        expect(document.querySelector('pre')?.textContent).not.toContain('private.mov');
     });
 });

--- a/src/test/unit/mediaCompressionDiagnostics.test.ts
+++ b/src/test/unit/mediaCompressionDiagnostics.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import MediaCompressionDebugPanel from '../../components/MediaCompressionDebugPanel.svelte';
+import {
+    classifyMediaCompressionAudioPath,
+    clearMediaCompressionDiagnosticRecords,
+    formatMediaCompressionDiagnostics,
+    getAacCustomEncoderState,
+    getMediaCompressionDiagnosticRecords,
+    isMediaCompressionDebugEnabled,
+    startMediaCompressionDiagnostic,
+} from '../../lib/videoCompression/mediaCompressionDiagnostics';
+
+function setSearch(search: string): void {
+    window.history.replaceState({}, '', `${search || '/'}${search ? '' : ''}`);
+}
+
+describe('media compression diagnostics', () => {
+    beforeEach(() => {
+        setSearch('');
+        clearMediaCompressionDiagnosticRecords();
+    });
+
+    afterEach(() => {
+        setSearch('');
+        clearMediaCompressionDiagnosticRecords();
+    });
+
+    it('is disabled unless media-debug=1 is present', () => {
+        expect(isMediaCompressionDebugEnabled('')).toBe(false);
+        expect(isMediaCompressionDebugEnabled('?media-debug=0')).toBe(false);
+        expect(isMediaCompressionDebugEnabled('?media-debug=1')).toBe(true);
+        expect(startMediaCompressionDiagnostic(new File(['x'], 'clip.mp4', { type: 'video/mp4' }))).toBeNull();
+        expect(getMediaCompressionDiagnosticRecords()).toHaveLength(0);
+    });
+
+    it('creates a readable Conversion #1 record and Clear removes records only', () => {
+        setSearch('?media-debug=1');
+        const session = startMediaCompressionDiagnostic(new File(['x'], 'clip.mp4', { type: 'video/mp4' }));
+        expect(session?.conversionId).toBe(1);
+        session?.setTrackCounts(1, 1);
+        session?.setAudio(0, {
+            codec: 'aac',
+            sourceSampleRate: 48000,
+            sourceChannels: 2,
+            audioPath: 'native-aac',
+        });
+        session?.finish({
+            file: new File(['compressed'], 'output.mp4', { type: 'video/mp4' }),
+            wasCompressed: true,
+        });
+
+        const text = formatMediaCompressionDiagnostics();
+        expect(text).toContain('Conversion #1');
+        expect(text).toContain('audio path: native-aac');
+        expect(text).toContain('total compression:');
+        expect(text).not.toContain('clip.mp4');
+
+        clearMediaCompressionDiagnosticRecords();
+        expect(getMediaCompressionDiagnosticRecords()).toHaveLength(0);
+        expect(getAacCustomEncoderState()).toBe('not-loaded');
+    });
+
+    it('classifies native, custom, packet-copy, and unknown paths from observed state', () => {
+        expect(classifyMediaCompressionAudioPath({
+            decodeAvailable: true,
+            stateAtStart: 'not-loaded',
+            capabilityBeforeSelection: true,
+        })).toEqual({ path: 'native-aac' });
+        expect(classifyMediaCompressionAudioPath({
+            decodeAvailable: true,
+            stateAtStart: 'not-loaded',
+            capabilityBeforeSelection: false,
+            capabilityAfterRegistration: true,
+            registrationSucceeded: true,
+        })).toEqual({ path: 'custom-aac' });
+        expect(classifyMediaCompressionAudioPath({
+            decodeAvailable: true,
+            stateAtStart: 'not-loaded',
+            capabilityBeforeSelection: false,
+            capabilityAfterRegistration: false,
+        })).toEqual({ path: 'packet-copy', reason: 'aac-encode-unavailable' });
+        expect(classifyMediaCompressionAudioPath({
+            decodeAvailable: false,
+            stateAtStart: 'not-loaded',
+            capabilityBeforeSelection: false,
+        })).toEqual({ path: 'packet-copy', reason: 'decode-unavailable' });
+        expect(classifyMediaCompressionAudioPath({
+            decodeAvailable: true,
+            stateAtStart: 'registered',
+            capabilityBeforeSelection: true,
+        })).toEqual({ path: 'custom-aac' });
+        expect(classifyMediaCompressionAudioPath({
+            decodeAvailable: true,
+            stateAtStart: 'loading',
+            capabilityBeforeSelection: true,
+        })).toEqual({ path: 'unknown' });
+    });
+
+    it('shows only in diagnostic mode and wires expand, Copy, and Clear', async () => {
+        const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText: clipboardWriteText },
+        });
+
+        const withoutDebug = render(MediaCompressionDebugPanel);
+        expect(withoutDebug.container.querySelector('.media-debug-panel')).toBeNull();
+        withoutDebug.unmount();
+
+        setSearch('?media-debug=1');
+        const session = startMediaCompressionDiagnostic(new File(['x'], 'clip.mp4', { type: 'video/mp4' }));
+        const conversionId = session?.conversionId;
+        session?.finish({
+            file: new File(['y'], 'output.mp4', { type: 'video/mp4' }),
+            wasCompressed: true,
+        });
+        render(MediaCompressionDebugPanel);
+
+        expect(screen.getByRole('button', { name: /Media Compression Debug/ }).getAttribute('aria-expanded')).toBe('false');
+        await fireEvent.click(screen.getByRole('button', { name: /Media Compression Debug/ }));
+        expect(document.querySelector('pre')?.textContent).toContain(`Conversion #${conversionId}`);
+        await fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+        expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining(`Conversion #${conversionId}`));
+        await fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+        expect(document.querySelector('pre')?.textContent).toContain('No conversions recorded.');
+        expect(getAacCustomEncoderState()).toBe('not-loaded');
+    });
+});

--- a/src/test/unit/mediaCompressionDiagnostics.test.ts
+++ b/src/test/unit/mediaCompressionDiagnostics.test.ts
@@ -253,6 +253,7 @@ describe('media compression diagnostics', () => {
         const rawRunner = vi.fn().mockResolvedValue({
             status: 'failed',
             source: 'canvas-2d synthetic pattern',
+            canvasSource: 'html-canvas',
             config: { codec: 'avc1.64001E', width: 360, height: 640, framerate: 30, bitrate: 400_000 },
             frameCount: 627,
             queueLimit: 4,
@@ -276,7 +277,7 @@ describe('media compression diagnostics', () => {
         render(MediaCompressionDebugPanel, { rawVideoEncoderBenchmarkRunner: rawRunner });
 
         await fireEvent.click(screen.getByRole('button', { name: /Media Compression Debug/ }));
-        await fireEvent.click(screen.getByRole('button', { name: 'Run raw VideoEncoder benchmark' }));
+        await fireEvent.click(screen.getByRole('button', { name: 'Run HTMLCanvas VideoEncoder benchmark' }));
         expect(rawRunner).toHaveBeenCalledTimes(1);
         expect(screen.getByText('Raw benchmark: failed').textContent).toBe('Raw benchmark: failed');
         expect(document.querySelector('pre')?.textContent).toContain('failure: api-unavailable');

--- a/src/test/unit/mediabunnyCompression.test.ts
+++ b/src/test/unit/mediabunnyCompression.test.ts
@@ -112,6 +112,7 @@ import {
     clearMediaCompressionDiagnosticRecords,
     formatMediaCompressionDiagnostics,
     getMediaCompressionDiagnosticRecords,
+    getRawVideoEncoderBenchmarkRecords,
 } from '../../lib/videoCompression/mediaCompressionDiagnostics';
 
 function videoFile(): File {
@@ -214,6 +215,18 @@ describe('MediaBunnyCompression', () => {
         expect(getMediaCompressionDiagnosticRecords()).toHaveLength(0);
         expect(state.videoOptions[0]).not.toHaveProperty('latencyMode');
         expect(state.videoCapabilityOptions[0]).not.toHaveProperty('latencyMode');
+    });
+
+    it('keeps MediaBunny options and AAC loading unchanged when only the raw encoder benchmark is enabled', async () => {
+        window.history.replaceState({}, '', '/?media-debug=1&media-debug-raw-video-encoder=1');
+        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+
+        expect(result.wasCompressed).toBe(true);
+        expect(state.audioOptions).toEqual([expect.objectContaining({ codec: 'aac', forceTranscode: true })]);
+        expect(state.videoOptions[0]).not.toHaveProperty('latencyMode');
+        expect(state.videoCapabilityOptions[0]).not.toHaveProperty('latencyMode');
+        expect(state.registeredAacEncoder).toBe(0);
+        expect(getRawVideoEncoderBenchmarkRecords()).toHaveLength(0);
     });
 
     it('keeps realtime disabled when diagnostics do not use forced audio copy', async () => {

--- a/src/test/unit/mediabunnyCompression.test.ts
+++ b/src/test/unit/mediabunnyCompression.test.ts
@@ -22,6 +22,7 @@ vi.mock('mediabunny', () => {
         source: { blob: File };
         videoTrack = {
             canDecode: vi.fn(async () => state.videoTrackCanDecode),
+            getCodec: vi.fn(async () => 'avc'),
             getDisplayWidth: vi.fn(async () => state.videoWidth),
             getDisplayHeight: vi.fn(async () => state.videoHeight),
             isVideoTrack: () => true,
@@ -29,10 +30,20 @@ vi.mock('mediabunny', () => {
         constructor({ source }: any) { this.source = source; }
         async getVideoTracks() { return [this.videoTrack]; }
         async getAudioTracks() {
+            const track = {
+                codec: 'aac',
+                numberOfChannels: 2,
+                sampleRate: 44100,
+                getCodec: vi.fn(async () => 'aac'),
+                getNumberOfChannels: vi.fn(async () => 2),
+                getSampleRate: vi.fn(async () => 44100),
+                isAudioTrack: () => true,
+            };
             return this.source.blob.name.includes('_compressed')
-                ? (state.preserveAudio ? [{ codec: 'aac', numberOfChannels: 2, sampleRate: 44100 }] : [])
-                : [{ codec: 'aac', numberOfChannels: 2, sampleRate: 44100 }];
+                ? (state.preserveAudio ? [track] : [])
+                : [track];
         }
+        async getDurationFromMetadata() { return 1.5; }
         dispose() { }
     }
     class BlobSource { constructor(public blob: File) { } }
@@ -51,7 +62,15 @@ vi.mock('mediabunny', () => {
         Conversion: {
             init: vi.fn(async (options: any) => {
                 state.videoOptions.push(await options.video((await options.input.getVideoTracks())[0]));
-                state.audioOptions.push(await options.audio({ codec: 'aac', numberOfChannels: 2, sampleRate: 44100 }));
+                state.audioOptions.push(await options.audio({
+                    codec: 'aac',
+                    numberOfChannels: 2,
+                    sampleRate: 44100,
+                    getCodec: vi.fn(async () => 'aac'),
+                    getNumberOfChannels: vi.fn(async () => 2),
+                    getSampleRate: vi.fn(async () => 44100),
+                    isAudioTrack: () => true,
+                }));
                 const conversion: any = {
                     isValid: true,
                     discardedTracks: state.preserveAudio ? [] : [{ track: { isVideoTrack: () => false, isAudioTrack: () => true } }],
@@ -77,6 +96,10 @@ vi.mock('@mediabunny/aac-encoder', () => ({
 }));
 
 import { MediaBunnyCompression } from '../../lib/videoCompression/mediabunnyCompression';
+import {
+    clearMediaCompressionDiagnosticRecords,
+    getMediaCompressionDiagnosticRecords,
+} from '../../lib/videoCompression/mediaCompressionDiagnostics';
 
 function videoFile(): File {
     return new File([new Uint8Array(300 * 1024)], 'clip.mp4', { type: 'video/mp4' });
@@ -93,6 +116,8 @@ const options = {
 
 describe('MediaBunnyCompression', () => {
     beforeEach(() => {
+        window.history.replaceState({}, '', '/');
+        clearMediaCompressionDiagnosticRecords();
         Object.assign(state, {
             videoTrackCanDecode: true,
             videoWidth: 1280,
@@ -157,18 +182,65 @@ describe('MediaBunnyCompression', () => {
         expect(state.audioOptions).toEqual([expect.objectContaining({ codec: 'aac', forceTranscode: true })]);
     });
 
+    it('records the first native AAC decision in diagnostic mode without loading custom AAC', async () => {
+        window.history.replaceState({}, '', '/?media-debug=1');
+        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const record = getMediaCompressionDiagnosticRecords().at(-1);
+
+        expect(result.wasCompressed).toBe(true);
+        expect(record).toMatchObject({
+            conversionId: 1,
+            input: { mime: 'video/mp4' },
+            aac: { stateAtStart: 'not-loaded' },
+            audio: [{
+                nativeCapabilityBeforeRegistration: true,
+                customImport: 'no',
+                audioPath: 'native-aac',
+            }],
+        });
+        expect(record?.timing['total compression']).toBeGreaterThanOrEqual(0);
+        expect(state.registeredAacEncoder).toBe(0);
+    });
+
     it('registers the optional AAC encoder only when native AAC encoding is unavailable', async () => {
         state.nativeAac = false;
+        window.history.replaceState({}, '', '/?media-debug=1');
         const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const record = getMediaCompressionDiagnosticRecords().at(-1);
         expect(result.wasCompressed).toBe(true);
         expect(state.registeredAacEncoder).toBe(1);
+        expect(record?.audio[0]).toMatchObject({
+            nativeCapabilityBeforeRegistration: false,
+            customImport: 'yes',
+            customRegistration: 'success',
+            capabilityAfterRegistration: true,
+            audioPath: 'custom-aac',
+        });
+        expect(record?.aac.loadRegisterDuration).toBeGreaterThanOrEqual(0);
     });
 
     it('packet-copies audio when it cannot be decoded for AAC transcoding', async () => {
         state.canDecodeAudio = false;
+        window.history.replaceState({}, '', '/?media-debug=1');
         const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const record = getMediaCompressionDiagnosticRecords().at(-1);
         expect(result.wasCompressed).toBe(true);
         expect(state.audioOptions).toEqual([{}]);
+        expect(record?.audio[0]).toMatchObject({ audioPath: 'packet-copy', reason: 'decode-unavailable' });
+    });
+
+    it('labels a matching registered custom encoder as custom AAC on later conversions', async () => {
+        state.customAac = true;
+        window.history.replaceState({}, '', '/?media-debug=1');
+        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const record = getMediaCompressionDiagnosticRecords().at(-1);
+
+        expect(result.wasCompressed).toBe(true);
+        expect(record?.aac.stateAtStart).toBe('registered');
+        expect(record?.audio[0]).toMatchObject({
+            customImport: 'already registered',
+            audioPath: 'custom-aac',
+        });
     });
 
     it('keeps the original file when MediaBunny would discard input audio', async () => {

--- a/src/test/unit/mediabunnyCompression.test.ts
+++ b/src/test/unit/mediabunnyCompression.test.ts
@@ -10,6 +10,7 @@ const state = vi.hoisted(() => ({
     canDecodeAudio: true,
     nativeAac: true,
     customAac: false,
+    outputAudioSampleRate: 44100,
     preserveAudio: true,
     failConversion: false,
     videoOptions: [] as any[],
@@ -30,13 +31,14 @@ vi.mock('mediabunny', () => {
         constructor({ source }: any) { this.source = source; }
         async getVideoTracks() { return [this.videoTrack]; }
         async getAudioTracks() {
+            const isOutput = this.source.blob.name.includes('_compressed');
             const track = {
                 codec: 'aac',
                 numberOfChannels: 2,
-                sampleRate: 44100,
+                sampleRate: isOutput ? state.outputAudioSampleRate : 48000,
                 getCodec: vi.fn(async () => 'aac'),
                 getNumberOfChannels: vi.fn(async () => 2),
-                getSampleRate: vi.fn(async () => 44100),
+                getSampleRate: vi.fn(async () => isOutput ? state.outputAudioSampleRate : 48000),
                 isAudioTrack: () => true,
             };
             return this.source.blob.name.includes('_compressed')
@@ -128,6 +130,7 @@ describe('MediaBunnyCompression', () => {
             canDecodeAudio: true,
             nativeAac: true,
             customAac: false,
+            outputAudioSampleRate: 44100,
             preserveAudio: true,
             failConversion: false,
             videoOptions: [],
@@ -182,6 +185,15 @@ describe('MediaBunnyCompression', () => {
         expect(state.audioOptions).toEqual([expect.objectContaining({ codec: 'aac', forceTranscode: true })]);
     });
 
+    it('does not enable forced packet copy when media-debug-audio is used without media-debug', async () => {
+        window.history.replaceState({}, '', '/?media-debug-audio=copy');
+        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+
+        expect(result.wasCompressed).toBe(true);
+        expect(state.audioOptions).toEqual([expect.objectContaining({ codec: 'aac', forceTranscode: true })]);
+        expect(getMediaCompressionDiagnosticRecords()).toHaveLength(0);
+    });
+
     it('records the first native AAC decision in diagnostic mode without loading custom AAC', async () => {
         window.history.replaceState({}, '', '/?media-debug=1');
         const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
@@ -192,14 +204,63 @@ describe('MediaBunnyCompression', () => {
             conversionId: 1,
             input: { mime: 'video/mp4' },
             aac: { stateAtStart: 'not-loaded' },
+            audioDiagnosticMode: 'normal',
             audio: [{
                 nativeCapabilityBeforeRegistration: true,
                 customImport: 'no',
+                effectiveEncodingMode: 'quality',
+                configuredBitrate: 64_000,
                 audioPath: 'native-aac',
+                outputCodec: 'aac',
+                outputSampleRate: 44100,
+                outputChannels: 2,
             }],
         });
+        const text = (await import('../../lib/videoCompression/mediaCompressionDiagnostics')).formatMediaCompressionDiagnostics();
+        expect(text).toContain('effective audio encoding mode: quality');
+        expect(text).toContain('configured audio bitrate: 64000');
+        expect(text).not.toContain('target bitrate: 64000');
         expect(record?.timing['total compression']).toBeGreaterThanOrEqual(0);
         expect(state.registeredAacEncoder).toBe(0);
+    });
+
+    it('forces packet-copy audio in diagnostic A/B mode without loading custom AAC', async () => {
+        window.history.replaceState({}, '', '/?media-debug=1&media-debug-audio=copy');
+        state.outputAudioSampleRate = 48000;
+        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const record = getMediaCompressionDiagnosticRecords().at(-1);
+
+        expect(result.wasCompressed).toBe(true);
+        expect(state.registeredAacEncoder).toBe(0);
+        expect(state.audioOptions).toEqual([{}]);
+        expect(record).toMatchObject({
+            audioDiagnosticMode: 'force-packet-copy',
+            audio: [{
+                nativeCapabilityBeforeRegistration: true,
+                capabilityBeforeSelection: true,
+                effectiveEncodingMode: 'packet-copy',
+                audioPath: 'packet-copy',
+                reason: 'debug-forced-packet-copy',
+                outputCodec: 'aac',
+                outputSampleRate: 48000,
+                outputChannels: 2,
+            }],
+        });
+    });
+
+    it('does not load custom AAC when forced packet-copy mode observes unavailable native AAC', async () => {
+        state.nativeAac = false;
+        window.history.replaceState({}, '', '/?media-debug=1&media-debug-audio=copy');
+        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const record = getMediaCompressionDiagnosticRecords().at(-1);
+
+        expect(result.wasCompressed).toBe(true);
+        expect(state.registeredAacEncoder).toBe(0);
+        expect(state.audioOptions).toEqual([{}]);
+        expect(record?.audio[0]).toMatchObject({
+            audioPath: 'packet-copy',
+            reason: 'debug-forced-packet-copy',
+        });
     });
 
     it('registers the optional AAC encoder only when native AAC encoding is unavailable', async () => {

--- a/src/test/unit/mediabunnyCompression.test.ts
+++ b/src/test/unit/mediabunnyCompression.test.ts
@@ -11,6 +11,7 @@ const state = vi.hoisted(() => ({
     nativeAac: true,
     customAac: false,
     outputAudioSampleRate: 44100,
+    outputVideoPacketCount: 627,
     preserveAudio: true,
     failConversion: false,
     videoOptions: [] as any[],
@@ -21,15 +22,24 @@ const state = vi.hoisted(() => ({
 vi.mock('mediabunny', () => {
     class Input {
         source: { blob: File };
-        videoTrack = {
-            canDecode: vi.fn(async () => state.videoTrackCanDecode),
-            getCodec: vi.fn(async () => 'avc'),
-            getDisplayWidth: vi.fn(async () => state.videoWidth),
-            getDisplayHeight: vi.fn(async () => state.videoHeight),
-            isVideoTrack: () => true,
-        };
         constructor({ source }: any) { this.source = source; }
-        async getVideoTracks() { return [this.videoTrack]; }
+        async getVideoTracks() {
+            const isOutput = this.source.blob.name.includes('_compressed');
+            const track = {
+                canDecode: vi.fn(async () => state.videoTrackCanDecode),
+                getCodec: vi.fn(async () => 'avc'),
+                getDisplayWidth: vi.fn(async () => state.videoWidth),
+                getDisplayHeight: vi.fn(async () => state.videoHeight),
+                getDurationFromMetadata: vi.fn(async () => 1.5),
+                computePacketStats: vi.fn(async () => ({
+                    packetCount: isOutput ? state.outputVideoPacketCount : 627,
+                    averagePacketRate: isOutput ? 29.8 : 30,
+                    averageBitrate: isOutput ? 3_900_000 : 4_000_000,
+                })),
+                isVideoTrack: () => true,
+            };
+            return [track];
+        }
         async getAudioTracks() {
             const isOutput = this.source.blob.name.includes('_compressed');
             const track = {
@@ -100,6 +110,7 @@ vi.mock('@mediabunny/aac-encoder', () => ({
 import { MediaBunnyCompression } from '../../lib/videoCompression/mediabunnyCompression';
 import {
     clearMediaCompressionDiagnosticRecords,
+    formatMediaCompressionDiagnostics,
     getMediaCompressionDiagnosticRecords,
 } from '../../lib/videoCompression/mediaCompressionDiagnostics';
 
@@ -131,6 +142,7 @@ describe('MediaBunnyCompression', () => {
             nativeAac: true,
             customAac: false,
             outputAudioSampleRate: 44100,
+            outputVideoPacketCount: 627,
             preserveAudio: true,
             failConversion: false,
             videoOptions: [],
@@ -194,6 +206,28 @@ describe('MediaBunnyCompression', () => {
         expect(getMediaCompressionDiagnosticRecords()).toHaveLength(0);
     });
 
+    it('does not enable realtime video latency when the realtime query is not fully gated', async () => {
+        window.history.replaceState({}, '', '/?media-debug-video-latency=realtime');
+        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+
+        expect(result.wasCompressed).toBe(true);
+        expect(getMediaCompressionDiagnosticRecords()).toHaveLength(0);
+        expect(state.videoOptions[0]).not.toHaveProperty('latencyMode');
+        expect(state.videoCapabilityOptions[0]).not.toHaveProperty('latencyMode');
+    });
+
+    it('keeps realtime disabled when diagnostics do not use forced audio copy', async () => {
+        window.history.replaceState({}, '', '/?media-debug=1&media-debug-video-latency=realtime');
+        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const record = getMediaCompressionDiagnosticRecords().at(-1);
+
+        expect(result.wasCompressed).toBe(true);
+        expect(record?.videoDiagnosticMode).toBe('default-quality');
+        expect(state.videoOptions[0]).not.toHaveProperty('latencyMode');
+        expect(state.videoCapabilityOptions[0]).not.toHaveProperty('latencyMode');
+        expect(state.audioOptions).toEqual([expect.objectContaining({ codec: 'aac', forceTranscode: true })]);
+    });
+
     it('records the first native AAC decision in diagnostic mode without loading custom AAC', async () => {
         window.history.replaceState({}, '', '/?media-debug=1');
         const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
@@ -201,7 +235,7 @@ describe('MediaBunnyCompression', () => {
 
         expect(result.wasCompressed).toBe(true);
         expect(record).toMatchObject({
-            conversionId: 1,
+            conversionId: expect.any(Number),
             input: { mime: 'video/mp4' },
             aac: { stateAtStart: 'not-loaded' },
             audioDiagnosticMode: 'normal',
@@ -233,6 +267,8 @@ describe('MediaBunnyCompression', () => {
         expect(result.wasCompressed).toBe(true);
         expect(state.registeredAacEncoder).toBe(0);
         expect(state.audioOptions).toEqual([{}]);
+        expect(state.videoOptions[0]).not.toHaveProperty('latencyMode');
+        expect(state.videoCapabilityOptions[0]).not.toHaveProperty('latencyMode');
         expect(record).toMatchObject({
             audioDiagnosticMode: 'force-packet-copy',
             audio: [{
@@ -245,6 +281,69 @@ describe('MediaBunnyCompression', () => {
                 outputSampleRate: 48000,
                 outputChannels: 2,
             }],
+        });
+    });
+
+    it('adds realtime latency to the video option and matching capability check only for the experimental A/B mode', async () => {
+        window.history.replaceState({}, '', '/?media-debug=1&media-debug-audio=copy&media-debug-video-latency=realtime');
+        state.outputVideoPacketCount = 620;
+        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const record = getMediaCompressionDiagnosticRecords().at(-1);
+
+        expect(result.wasCompressed).toBe(true);
+        expect(state.registeredAacEncoder).toBe(0);
+        expect(state.audioOptions).toEqual([{}]);
+        expect(state.videoOptions[0]).toEqual(expect.objectContaining({
+            codec: 'avc',
+            forceTranscode: true,
+            latencyMode: 'realtime',
+        }));
+        expect(state.videoCapabilityOptions[0]).toEqual(expect.objectContaining({
+            latencyMode: 'realtime',
+        }));
+        expect(record).toMatchObject({
+            audioDiagnosticMode: 'force-packet-copy',
+            videoDiagnosticMode: 'realtime',
+        });
+        expect(record?.video[0]).toMatchObject({
+            inputPacketStats: {
+                packetCount: 627,
+                averagePacketRate: 30,
+                averageBitrate: 4_000_000,
+                duration: 1.5,
+            },
+            outputPacketStats: {
+                packetCount: 620,
+                averagePacketRate: 29.8,
+                averageBitrate: 3_900_000,
+                duration: 1.5,
+            },
+        });
+        expect(record?.timing['input video stats scan']).toBeGreaterThanOrEqual(0);
+        expect(record?.timing['output video stats scan']).toBeGreaterThanOrEqual(0);
+        expect(record?.timing['diagnostic total']).toBeGreaterThanOrEqual(record?.timing['total compression'] ?? 0);
+
+        const text = formatMediaCompressionDiagnostics();
+        expect(text).toContain('Video latency: realtime');
+        expect(text).toContain('input frames: 627');
+        expect(text).toContain('output frames: 620');
+        expect(text).toContain('input video stats scan:');
+        expect(text).toContain('output video stats scan:');
+    });
+
+    it('uses the existing video capability fallback when realtime latency is unsupported', async () => {
+        state.canEncodeVideo = false;
+        window.history.replaceState({}, '', '/?media-debug=1&media-debug-audio=copy&media-debug-video-latency=realtime');
+        const file = videoFile();
+        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(file, options);
+        const record = getMediaCompressionDiagnosticRecords().at(-1);
+
+        expect(result).toEqual({ file, wasCompressed: false, wasSkipped: true });
+        expect(state.videoCapabilityOptions[0]).toEqual(expect.objectContaining({ latencyMode: 'realtime' }));
+        expect(record).toMatchObject({
+            videoDiagnosticMode: 'realtime',
+            video: [{ avcEncode: false }],
+            conversion: { fallback: true, fallbackReason: 'video-capability-unavailable' },
         });
     });
 

--- a/src/test/unit/mediabunnyCompression.test.ts
+++ b/src/test/unit/mediabunnyCompression.test.ts
@@ -229,6 +229,18 @@ describe('MediaBunnyCompression', () => {
         expect(getRawVideoEncoderBenchmarkRecords()).toHaveLength(0);
     });
 
+    it('keeps MediaBunny options and AAC loading unchanged when the decode benchmark is enabled', async () => {
+        window.history.replaceState({}, '', '/?media-debug=1&media-debug-video-decode-benchmark=1');
+        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+
+        expect(result.wasCompressed).toBe(true);
+        expect(state.audioOptions).toEqual([expect.objectContaining({ codec: 'aac', forceTranscode: true })]);
+        expect(state.videoOptions[0]).not.toHaveProperty('latencyMode');
+        expect(state.videoCapabilityOptions[0]).not.toHaveProperty('latencyMode');
+        expect(state.registeredAacEncoder).toBe(0);
+        expect(getRawVideoEncoderBenchmarkRecords()).toHaveLength(0);
+    });
+
     it('keeps realtime disabled when diagnostics do not use forced audio copy', async () => {
         window.history.replaceState({}, '', '/?media-debug=1&media-debug-video-latency=realtime');
         const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);

--- a/src/test/unit/mediabunnyCompression.test.ts
+++ b/src/test/unit/mediabunnyCompression.test.ts
@@ -62,8 +62,12 @@ vi.mock('mediabunny', () => {
     class BufferTarget { buffer: ArrayBuffer | null = null; }
     class Output { constructor(public options: { target: BufferTarget }) { } }
     class Mp4OutputFormat { }
+    class Quality {
+        constructor(public options: any) { }
+    }
     return {
         ALL_FORMATS: [], BlobSource, BufferTarget, Input, Output, Mp4OutputFormat,
+        Quality,
         QUALITY_HIGH: { factor: 2 }, QUALITY_MEDIUM: { factor: 1 }, QUALITY_VERY_LOW: { factor: 0.3 },
         canEncodeVideo: vi.fn(async (_codec: string, options: any) => {
             state.videoCapabilityOptions.push(options);
@@ -239,6 +243,60 @@ describe('MediaBunnyCompression', () => {
         expect(state.videoCapabilityOptions[0]).not.toHaveProperty('latencyMode');
         expect(state.registeredAacEncoder).toBe(0);
         expect(getRawVideoEncoderBenchmarkRecords()).toHaveLength(0);
+    });
+
+    it('keeps subjective video Quality for every partial rate-control query', async () => {
+        const searches = [
+            '/',
+            '/?media-debug=1',
+            '/?media-debug-video-rate-control=bitrate',
+            '/?media-debug=1&media-debug-video-rate-control=bitrate',
+            '/?media-debug=1&media-debug-audio=copy',
+        ];
+
+        for (const search of searches) {
+            clearMediaCompressionDiagnosticRecords();
+            window.history.replaceState({}, '', search);
+            state.videoCapabilityOptions = [];
+            state.videoOptions = [];
+            const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+            const record = getMediaCompressionDiagnosticRecords().at(-1);
+
+            expect(result.wasCompressed).toBe(true);
+            expect(state.videoOptions[0].quality).toEqual({ factor: 1 });
+            expect(state.videoCapabilityOptions[0].quality).toBe(state.videoOptions[0].quality);
+            expect(record?.videoRateControlMode).toBe(search.includes('media-debug=1') ? 'subjective-quality' : undefined);
+        }
+    });
+
+    it('uses the same explicit variable-bitrate Quality for capability and Conversion only for the full A/B gate', async () => {
+        window.history.replaceState({}, '', '/?media-debug=1&media-debug-audio=copy&media-debug-video-rate-control=bitrate');
+        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const record = getMediaCompressionDiagnosticRecords().at(-1);
+        const capabilityQuality = state.videoCapabilityOptions[0].quality;
+        const conversionQuality = state.videoOptions[0].quality;
+
+        expect(result.wasCompressed).toBe(true);
+        expect(capabilityQuality).toBe(conversionQuality);
+        expect(capabilityQuality).toEqual({ options: { bitrate: 400_000, bitrateMode: 'variable' } });
+        expect(state.videoCapabilityOptions[0]).toEqual(expect.objectContaining({ width: 640, height: 360, quality: capabilityQuality }));
+        expect(state.videoOptions[0]).toEqual(expect.objectContaining({
+            codec: 'avc',
+            forceTranscode: true,
+            width: 640,
+            quality: conversionQuality,
+        }));
+        expect(state.audioOptions).toEqual([{}]);
+        expect(record?.audioDiagnosticMode).toBe('force-packet-copy');
+        expect(record?.videoRateControlMode).toBe('explicit-bitrate');
+        expect(record?.video[0]).toEqual(expect.objectContaining({
+            configuredBitrate: 400_000,
+            bitrateMode: 'variable',
+            quality: 'medium',
+        }));
+        expect(formatMediaCompressionDiagnostics()).toContain('video rate control: explicit-bitrate');
+        expect(formatMediaCompressionDiagnostics()).toContain('configured video bitrate: 400000 bps');
+        expect(formatMediaCompressionDiagnostics()).toContain('bitrate mode: variable');
     });
 
     it('keeps realtime disabled when diagnostics do not use forced audio copy', async () => {

--- a/src/test/unit/playwrightWorktreePort.test.ts
+++ b/src/test/unit/playwrightWorktreePort.test.ts
@@ -134,6 +134,7 @@ describe('Playwright config connection values', () => {
                 '**/webComponentEmbed.spec.ts',
                 '**/webComponentParentClientExample.spec.ts',
                 '**/postEditorSending.spec.ts',
+                '**/mediaCompressionDebug.spec.ts',
             ]);
         } finally {
             if (originalPortOverride === undefined) {

--- a/src/test/unit/rawVideoEncoderBenchmark.test.ts
+++ b/src/test/unit/rawVideoEncoderBenchmark.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import {
+    RAW_VIDEO_ENCODER_BENCHMARK_CONFIG,
+    rawVideoEncoderTimestampForFrame,
+    runRawVideoEncoderBenchmark,
+    type RawVideoEncoderConstructor,
+} from '../../lib/videoCompression/rawVideoEncoderBenchmark';
+
+class FakeEncoder extends EventTarget {
+    static supported = true;
+    static configureCalls = 0;
+    static closeCalls = 0;
+    static flushCalls = 0;
+    static mode: 'success' | 'encode-failure' | 'flush-failure' = 'success';
+    static frames: Array<{ timestamp: number; closed: boolean }> = [];
+    static maxQueueSize = 0;
+
+    encodeQueueSize = 0;
+    private readonly output: (chunk: { byteLength: number; type: 'key' | 'delta' }) => void;
+
+    constructor(init: { output: (chunk: { byteLength: number; type: 'key' | 'delta' }) => void }) {
+        super();
+        this.output = init.output;
+    }
+
+    static async isConfigSupported(config: VideoEncoderConfig): Promise<{ supported: boolean; config: VideoEncoderConfig }> {
+        return { supported: FakeEncoder.supported, config };
+    }
+
+    configure(): void {
+        FakeEncoder.configureCalls += 1;
+    }
+
+    encode(frame: { timestamp: number; closed: boolean; close(): void }): void {
+        if (FakeEncoder.mode === 'encode-failure') throw new Error('encode failed');
+        this.encodeQueueSize += 1;
+        FakeEncoder.maxQueueSize = Math.max(FakeEncoder.maxQueueSize, this.encodeQueueSize);
+        FakeEncoder.frames.push(frame);
+        this.output({ byteLength: 80, type: FakeEncoder.frames.length === 1 ? 'key' : 'delta' });
+        queueMicrotask(() => {
+            this.encodeQueueSize -= 1;
+            this.dispatchEvent(new Event('dequeue'));
+        });
+    }
+
+    async flush(): Promise<void> {
+        FakeEncoder.flushCalls += 1;
+        if (FakeEncoder.mode === 'flush-failure') throw new Error('flush failed');
+    }
+
+    close(): void {
+        FakeEncoder.closeCalls += 1;
+    }
+
+    static reset(): void {
+        FakeEncoder.supported = true;
+        FakeEncoder.configureCalls = 0;
+        FakeEncoder.closeCalls = 0;
+        FakeEncoder.flushCalls = 0;
+        FakeEncoder.mode = 'success';
+        FakeEncoder.frames = [];
+        FakeEncoder.maxQueueSize = 0;
+    }
+}
+
+function createFrame(_index: number, timestamp: number): { timestamp: number; closed: boolean; close(): void } {
+    return {
+        timestamp,
+        closed: false,
+        close() {
+            this.closed = true;
+        },
+    };
+}
+
+describe('raw VideoEncoder benchmark', () => {
+    it('uses fixed AVC configuration and one-at-a-time frames without retaining them', async () => {
+        FakeEncoder.reset();
+        const result = await runRawVideoEncoderBenchmark({
+            VideoEncoder: FakeEncoder as unknown as RawVideoEncoderConstructor,
+            createFrame,
+            frameCount: 5,
+            queueLimit: 2,
+        });
+
+        expect(result).toMatchObject({
+            status: 'completed',
+            config: RAW_VIDEO_ENCODER_BENCHMARK_CONFIG,
+            frameCount: 5,
+            queueLimit: 2,
+            framesSubmitted: 5,
+            chunks: 5,
+            bytes: 400,
+            keyChunks: 1,
+            deltaChunks: 4,
+        });
+        expect(result.throughput).toBeGreaterThan(0);
+        expect(FakeEncoder.configureCalls).toBe(1);
+        expect(FakeEncoder.flushCalls).toBe(1);
+        expect(FakeEncoder.closeCalls).toBe(1);
+        expect(FakeEncoder.maxQueueSize).toBeLessThanOrEqual(2);
+        expect(FakeEncoder.frames).toHaveLength(5);
+        expect(FakeEncoder.frames.every((frame) => frame.closed)).toBe(true);
+        expect(FakeEncoder.frames.map((frame) => frame.timestamp)).toEqual([0, 33333, 66667, 100000, 133333]);
+    });
+
+    it('creates monotonic microsecond timestamps at 30 fps', () => {
+        const timestamps = Array.from({ length: 627 }, (_, frameIndex) => rawVideoEncoderTimestampForFrame(frameIndex));
+        expect(timestamps[0]).toBe(0);
+        expect(timestamps.every((timestamp, index) => index === 0 || timestamp > timestamps[index - 1]!)).toBe(true);
+        expect(timestamps.at(-1)).toBe(20_866_667);
+    });
+
+    it('reports unavailable and unsupported APIs without configuring or encoding', async () => {
+        const unavailable = await runRawVideoEncoderBenchmark({
+            VideoEncoder: null,
+            VideoFrame: null,
+        });
+        expect(unavailable.failure?.stage).toBe('api-unavailable');
+
+        FakeEncoder.reset();
+        FakeEncoder.supported = false;
+        const unsupported = await runRawVideoEncoderBenchmark({
+            VideoEncoder: FakeEncoder as unknown as RawVideoEncoderConstructor,
+            createFrame,
+        });
+        expect(unsupported.failure?.stage).toBe('config-unsupported');
+        expect(FakeEncoder.configureCalls).toBe(0);
+        expect(FakeEncoder.frames).toHaveLength(0);
+    });
+
+    it.each([
+        ['encode-failure', 'encode-failure'],
+        ['flush-failure', 'flush-failure'],
+    ] as const)('closes frames and the encoder after %s', async (mode, expectedStage) => {
+        FakeEncoder.reset();
+        FakeEncoder.mode = mode;
+        const createdFrames: Array<{ timestamp: number; closed: boolean; close(): void }> = [];
+        const result = await runRawVideoEncoderBenchmark({
+            VideoEncoder: FakeEncoder as unknown as RawVideoEncoderConstructor,
+            createFrame: (index, timestamp) => {
+                const frame = createFrame(index, timestamp);
+                createdFrames.push(frame);
+                return frame;
+            },
+            frameCount: 3,
+        });
+
+        expect(result.status).toBe('failed');
+        expect(result.failure?.stage).toBe(expectedStage);
+        expect(FakeEncoder.closeCalls).toBe(1);
+        expect(createdFrames.every((frame) => frame.closed)).toBe(true);
+    });
+});

--- a/src/test/unit/rawVideoEncoderBenchmark.test.ts
+++ b/src/test/unit/rawVideoEncoderBenchmark.test.ts
@@ -9,6 +9,8 @@ import {
 class FakeEncoder extends EventTarget {
     static supported = true;
     static configureCalls = 0;
+    static supportConfigs: VideoEncoderConfig[] = [];
+    static configureConfigs: VideoEncoderConfig[] = [];
     static closeCalls = 0;
     static flushCalls = 0;
     static mode: 'success' | 'encode-failure' | 'flush-failure' = 'success';
@@ -24,11 +26,13 @@ class FakeEncoder extends EventTarget {
     }
 
     static async isConfigSupported(config: VideoEncoderConfig): Promise<{ supported: boolean; config: VideoEncoderConfig }> {
+        FakeEncoder.supportConfigs.push({ ...config });
         return { supported: FakeEncoder.supported, config };
     }
 
-    configure(): void {
+    configure(config: VideoEncoderConfig): void {
         FakeEncoder.configureCalls += 1;
+        FakeEncoder.configureConfigs.push({ ...config });
     }
 
     encode(frame: { timestamp: number; closed: boolean; close(): void }): void {
@@ -55,6 +59,8 @@ class FakeEncoder extends EventTarget {
     static reset(): void {
         FakeEncoder.supported = true;
         FakeEncoder.configureCalls = 0;
+        FakeEncoder.supportConfigs = [];
+        FakeEncoder.configureConfigs = [];
         FakeEncoder.closeCalls = 0;
         FakeEncoder.flushCalls = 0;
         FakeEncoder.mode = 'success';
@@ -94,6 +100,9 @@ describe('raw VideoEncoder benchmark', () => {
             keyChunks: 1,
             deltaChunks: 4,
         });
+        expect(RAW_VIDEO_ENCODER_BENCHMARK_CONFIG.codec).toBe('avc1.64001E');
+        expect(FakeEncoder.supportConfigs).toEqual([RAW_VIDEO_ENCODER_BENCHMARK_CONFIG]);
+        expect(FakeEncoder.configureConfigs).toEqual([RAW_VIDEO_ENCODER_BENCHMARK_CONFIG]);
         expect(result.throughput).toBeGreaterThan(0);
         expect(FakeEncoder.configureCalls).toBe(1);
         expect(FakeEncoder.flushCalls).toBe(1);

--- a/src/test/unit/rawVideoEncoderBenchmark.test.ts
+++ b/src/test/unit/rawVideoEncoderBenchmark.test.ts
@@ -69,6 +69,41 @@ class FakeEncoder extends EventTarget {
     }
 }
 
+class FakeOffscreenCanvas {
+    width: number;
+    height: number;
+    readonly context = {
+        fillStyle: '',
+        fillRect: (_x: number, _y: number, _width: number, _height: number) => undefined,
+    };
+
+    constructor(width: number, height: number) {
+        this.width = width;
+        this.height = height;
+    }
+
+    getContext(_contextId: '2d') {
+        return this.context;
+    }
+}
+
+class FakeVideoFrame {
+    static sources: unknown[] = [];
+    closed = false;
+
+    constructor(source: unknown, _init: VideoFrameInit) {
+        FakeVideoFrame.sources.push(source);
+    }
+
+    close(): void {
+        this.closed = true;
+    }
+
+    static reset(): void {
+        FakeVideoFrame.sources = [];
+    }
+}
+
 function createFrame(_index: number, timestamp: number): { timestamp: number; closed: boolean; close(): void } {
     return {
         timestamp,
@@ -92,6 +127,7 @@ describe('raw VideoEncoder benchmark', () => {
         expect(result).toMatchObject({
             status: 'completed',
             config: RAW_VIDEO_ENCODER_BENCHMARK_CONFIG,
+            canvasSource: 'html-canvas',
             frameCount: 5,
             queueLimit: 2,
             framesSubmitted: 5,
@@ -111,6 +147,33 @@ describe('raw VideoEncoder benchmark', () => {
         expect(FakeEncoder.frames).toHaveLength(5);
         expect(FakeEncoder.frames.every((frame) => frame.closed)).toBe(true);
         expect(FakeEncoder.frames.map((frame) => frame.timestamp)).toEqual([0, 33333, 66667, 100000, 133333]);
+    });
+
+    it('uses the same fixed benchmark conditions with an OffscreenCanvas source', async () => {
+        FakeEncoder.reset();
+        FakeVideoFrame.reset();
+        const result = await runRawVideoEncoderBenchmark({
+            VideoEncoder: FakeEncoder as unknown as RawVideoEncoderConstructor,
+            VideoFrame: FakeVideoFrame as unknown as { new(source: CanvasImageSource, init: VideoFrameInit): { close(): void } },
+            OffscreenCanvas: FakeOffscreenCanvas,
+            canvasSource: 'offscreen-canvas',
+            frameCount: 5,
+            queueLimit: 2,
+        });
+
+        expect(result).toMatchObject({
+            status: 'completed',
+            canvasSource: 'offscreen-canvas',
+            config: RAW_VIDEO_ENCODER_BENCHMARK_CONFIG,
+            frameCount: 5,
+            queueLimit: 2,
+            framesSubmitted: 5,
+        });
+        expect(FakeEncoder.supportConfigs).toEqual([RAW_VIDEO_ENCODER_BENCHMARK_CONFIG]);
+        expect(FakeEncoder.configureConfigs).toEqual([RAW_VIDEO_ENCODER_BENCHMARK_CONFIG]);
+        expect(FakeVideoFrame.sources).toHaveLength(5);
+        expect(FakeVideoFrame.sources.every((source) => source instanceof FakeOffscreenCanvas)).toBe(true);
+        expect(FakeEncoder.frames.every((frame) => frame.closed)).toBe(true);
     });
 
     it('creates monotonic microsecond timestamps at 30 fps', () => {
@@ -136,6 +199,34 @@ describe('raw VideoEncoder benchmark', () => {
         expect(unsupported.failure?.stage).toBe('config-unsupported');
         expect(FakeEncoder.configureCalls).toBe(0);
         expect(FakeEncoder.frames).toHaveLength(0);
+    });
+
+    it('reports OffscreenCanvas unavailability without affecting the HTMLCanvas path', async () => {
+        FakeEncoder.reset();
+        const result = await runRawVideoEncoderBenchmark({
+            VideoEncoder: FakeEncoder as unknown as RawVideoEncoderConstructor,
+            VideoFrame: FakeVideoFrame as unknown as { new(source: CanvasImageSource, init: VideoFrameInit): { close(): void } },
+            canvasSource: 'offscreen-canvas',
+            frameCount: 2,
+        });
+
+        expect(result).toMatchObject({
+            status: 'failed',
+            canvasSource: 'offscreen-canvas',
+            failure: { stage: 'setup-failure', message: 'OffscreenCanvas unavailable.' },
+        });
+        expect(FakeEncoder.configureCalls).toBe(1);
+        expect(FakeEncoder.frames).toHaveLength(0);
+
+        FakeEncoder.reset();
+        const htmlResult = await runRawVideoEncoderBenchmark({
+            VideoEncoder: FakeEncoder as unknown as RawVideoEncoderConstructor,
+            createFrame,
+            canvasSource: 'html-canvas',
+            frameCount: 2,
+        });
+        expect(htmlResult.status).toBe('completed');
+        expect(htmlResult.canvasSource).toBe('html-canvas');
     });
 
     it.each([

--- a/src/test/unit/realVideoPipelineBenchmark.test.ts
+++ b/src/test/unit/realVideoPipelineBenchmark.test.ts
@@ -20,7 +20,7 @@ class FakeFrame {
 
 class FakeSample implements RealVideoPipelineBenchmarkSampleLike {
     timestamp: number;
-    readonly duration = 33_333;
+    readonly duration = 1 / 30;
     readonly codedWidth = 1_920;
     readonly codedHeight = 1_080;
     readonly rotation = 90;
@@ -97,7 +97,7 @@ class FakeEncoder extends EventTarget {
             throw error;
         }
         this.queueSize += 1;
-        this.output({ byteLength: 100, type: FakeEncoder.encodeOptions.length === 1 ? 'key' : 'delta' });
+        this.output({ byteLength: 100, type: options?.keyFrame === true ? 'key' : 'delta' });
         queueMicrotask(() => {
             this.queueSize = Math.max(0, this.queueSize - 1);
             this.dispatchEvent(new Event('dequeue'));
@@ -137,7 +137,7 @@ function createTrack(canDecode = true): RealVideoPipelineBenchmarkTrackLike {
         getDisplayWidth: vi.fn(async () => 1_080),
         getDisplayHeight: vi.fn(async () => 1_920),
         getRotation: vi.fn(async () => 90),
-        getFirstTimestamp: vi.fn(async () => 100_000),
+        getFirstTimestamp: vi.fn(async () => 100),
     };
 }
 
@@ -182,7 +182,7 @@ describe('runRealVideoPipelineBenchmark', () => {
     it('uses the fixed High Profile AVC config and transforms every sample into native WebCodecs', async () => {
         FakeEncoder.reset();
         FakeSample.reset();
-        const samples = [new FakeSample(100_000), new FakeSample(133_333), new FakeSample(166_666)];
+        const samples = [new FakeSample(100), new FakeSample(100 + 1 / 30), new FakeSample(100 + 2 / 30)];
         const dispose = vi.fn();
         const result = await runRealVideoPipelineBenchmark(
             new File(['video'], 'private.mov', { type: 'video/quicktime' }),
@@ -221,6 +221,37 @@ describe('runRealVideoPipelineBenchmark', () => {
         expect(FakeSample.frames.every((frame) => frame.close.mock.calls.length === 1)).toBe(true);
         expect(dispose).toHaveBeenCalledTimes(1);
         expect(JSON.stringify(result)).not.toContain('private.mov');
+    });
+
+    it('schedules keyframes from normalized second timestamps at five-second boundaries', async () => {
+        FakeEncoder.reset();
+        FakeSample.reset();
+        const firstTimestamp = 100;
+        const relativeTimestamps = [0, 1, 4.999, 5, 9.999, 10];
+        const samples = relativeTimestamps.map((timestamp) => new FakeSample(firstTimestamp + timestamp));
+        const track = createTrack();
+        track.getFirstTimestamp = vi.fn(async () => firstTimestamp);
+
+        const result = await runRealVideoPipelineBenchmark(
+            new File(['video'], 'ignored.mov', { type: 'video/quicktime' }),
+            createOptions(track, samples),
+        );
+
+        expect(result.status).toBe('completed');
+        const normalizedTimestamps = samples.map((sample) => sample.setTimestamp.mock.calls[0]?.[0]);
+        normalizedTimestamps.forEach((timestamp, index) => {
+            expect(timestamp).toBeCloseTo(relativeTimestamps[index], 12);
+        });
+        expect(FakeEncoder.encodeOptions).toEqual([
+            { keyFrame: true },
+            { keyFrame: false },
+            { keyFrame: false },
+            { keyFrame: true },
+            { keyFrame: false },
+            { keyFrame: true },
+        ]);
+        expect(result.keyChunks).toBe(3);
+        expect(result.deltaChunks).toBe(3);
     });
 
     it('keeps the 360x640, 30fps, 400kbps raw encoder conditions as the native encode target', () => {
@@ -269,7 +300,7 @@ describe('runRealVideoPipelineBenchmark', () => {
             FakeSample.reset();
             FakeEncoder.mode = mode === 'transform' ? 'success' : mode;
             FakeSample.transformError = mode === 'transform';
-            const sample = new FakeSample(100_000);
+            const sample = new FakeSample(100);
             const dispose = vi.fn();
             const result = await runRealVideoPipelineBenchmark(
                 new File(['x'], 'ignored.mov', { type: 'video/quicktime' }),

--- a/src/test/unit/realVideoPipelineBenchmark.test.ts
+++ b/src/test/unit/realVideoPipelineBenchmark.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    RAW_VIDEO_ENCODER_BENCHMARK_CONFIG,
+    RAW_VIDEO_ENCODER_BENCHMARK_QUEUE_LIMIT,
+} from '../../lib/videoCompression/rawVideoEncoderBenchmark';
+import {
+    REAL_VIDEO_PIPELINE_BENCHMARK_TARGET,
+    runRealVideoPipelineBenchmark,
+    type RealVideoPipelineBenchmarkEncoderConstructor,
+    type RealVideoPipelineBenchmarkInputLike,
+    type RealVideoPipelineBenchmarkSampleLike,
+    type RealVideoPipelineBenchmarkSinkLike,
+    type RealVideoPipelineBenchmarkTrackLike,
+} from '../../lib/videoCompression/realVideoPipelineBenchmark';
+import type { VideoSampleTransformOptions } from 'mediabunny';
+
+class FakeFrame {
+    close = vi.fn();
+}
+
+class FakeSample implements RealVideoPipelineBenchmarkSampleLike {
+    timestamp: number;
+    readonly duration = 33_333;
+    readonly codedWidth = 1_920;
+    readonly codedHeight = 1_080;
+    readonly rotation = 90;
+    readonly close = vi.fn();
+    readonly setTimestamp = vi.fn((timestamp: number) => {
+        this.timestamp = timestamp;
+    });
+    readonly transform = vi.fn(async (options: VideoSampleTransformOptions) => {
+        FakeSample.lastTransformOptions = options;
+        if (FakeSample.transformError) throw new Error('transform stopped');
+        const transformed = new FakeSample(this.timestamp);
+        FakeSample.transformedSamples.push(transformed);
+        return transformed;
+    });
+    readonly toVideoFrame = vi.fn(() => {
+        const frame = new FakeFrame();
+        FakeSample.frames.push(frame);
+        return frame;
+    });
+
+    static lastTransformOptions: unknown;
+    static transformError = false;
+    static transformedSamples: FakeSample[] = [];
+    static frames: FakeFrame[] = [];
+
+    constructor(timestamp: number) {
+        this.timestamp = timestamp;
+    }
+
+    static reset(): void {
+        FakeSample.lastTransformOptions = undefined;
+        FakeSample.transformError = false;
+        FakeSample.transformedSamples = [];
+        FakeSample.frames = [];
+    }
+}
+
+class FakeEncoder extends EventTarget {
+    static supportConfigs: VideoEncoderConfig[] = [];
+    static configureConfigs: VideoEncoderConfig[] = [];
+    static encodeOptions: VideoEncoderEncodeOptions[] = [];
+    static mode: 'success' | 'encode-failure' | 'flush-failure' = 'success';
+    static instances: FakeEncoder[] = [];
+    static supported = true;
+
+    private queueSize = 0;
+    private readonly output: (chunk: { byteLength: number; type: EncodedVideoChunkType }) => void;
+    private readonly error: (error: unknown) => void;
+    readonly close = vi.fn();
+
+    constructor(init: {
+        output: (chunk: { byteLength: number; type: EncodedVideoChunkType }) => void;
+        error: (error: unknown) => void;
+    }) {
+        super();
+        this.output = init.output;
+        this.error = init.error;
+        FakeEncoder.instances.push(this);
+    }
+
+    get encodeQueueSize(): number {
+        return this.queueSize;
+    }
+
+    configure(config: VideoEncoderConfig): void {
+        FakeEncoder.configureConfigs.push(config);
+    }
+
+    encode(_frame: { close(): void }, options?: VideoEncoderEncodeOptions): void {
+        FakeEncoder.encodeOptions.push(options ?? {});
+        if (FakeEncoder.mode === 'encode-failure') {
+            const error = new Error('encode stopped');
+            this.error(error);
+            throw error;
+        }
+        this.queueSize += 1;
+        this.output({ byteLength: 100, type: FakeEncoder.encodeOptions.length === 1 ? 'key' : 'delta' });
+        queueMicrotask(() => {
+            this.queueSize = Math.max(0, this.queueSize - 1);
+            this.dispatchEvent(new Event('dequeue'));
+        });
+    }
+
+    async flush(): Promise<void> {
+        if (FakeEncoder.mode === 'flush-failure') {
+            const error = new Error('flush stopped');
+            this.error(error);
+            throw error;
+        }
+    }
+
+    static isConfigSupported = vi.fn(async (config: VideoEncoderConfig) => {
+        FakeEncoder.supportConfigs.push(config);
+        return { supported: FakeEncoder.supported, config };
+    });
+
+    static reset(): void {
+        FakeEncoder.supportConfigs = [];
+        FakeEncoder.configureConfigs = [];
+        FakeEncoder.encodeOptions = [];
+        FakeEncoder.mode = 'success';
+        FakeEncoder.instances = [];
+        FakeEncoder.supported = true;
+        FakeEncoder.isConfigSupported.mockClear();
+    }
+}
+
+function createTrack(canDecode = true): RealVideoPipelineBenchmarkTrackLike {
+    return {
+        canDecode: vi.fn(async () => canDecode),
+        getCodec: vi.fn(async () => 'avc1.4d401f'),
+        getCodedWidth: vi.fn(async () => 1_920),
+        getCodedHeight: vi.fn(async () => 1_080),
+        getDisplayWidth: vi.fn(async () => 1_080),
+        getDisplayHeight: vi.fn(async () => 1_920),
+        getRotation: vi.fn(async () => 90),
+        getFirstTimestamp: vi.fn(async () => 100_000),
+    };
+}
+
+function createInput(track: RealVideoPipelineBenchmarkTrackLike | undefined, dispose = vi.fn()): RealVideoPipelineBenchmarkInputLike {
+    return {
+        getVideoTracks: vi.fn(async () => track ? [track] : []),
+        getDurationFromMetadata: vi.fn(async () => 20.9),
+        dispose,
+    };
+}
+
+function createSink(samples: RealVideoPipelineBenchmarkSampleLike[]): RealVideoPipelineBenchmarkSinkLike {
+    return {
+        async *samples() {
+            yield* samples;
+        },
+    };
+}
+
+function encoderConstructor(): RealVideoPipelineBenchmarkEncoderConstructor {
+    return FakeEncoder as unknown as RealVideoPipelineBenchmarkEncoderConstructor;
+}
+
+function createOptions(
+    track: RealVideoPipelineBenchmarkTrackLike | undefined,
+    samples: RealVideoPipelineBenchmarkSampleLike[] = [],
+    dispose = vi.fn(),
+) {
+    const input = createInput(track, dispose);
+    return {
+        VideoEncoder: encoderConstructor(),
+        createInput: () => input,
+        createVideoSampleSink: (sinkTrack: RealVideoPipelineBenchmarkTrackLike) => {
+            expect(sinkTrack).toBe(track);
+            return createSink(samples);
+        },
+        now: () => 100,
+    };
+}
+
+describe('runRealVideoPipelineBenchmark', () => {
+    it('uses the fixed High Profile AVC config and transforms every sample into native WebCodecs', async () => {
+        FakeEncoder.reset();
+        FakeSample.reset();
+        const samples = [new FakeSample(100_000), new FakeSample(133_333), new FakeSample(166_666)];
+        const dispose = vi.fn();
+        const result = await runRealVideoPipelineBenchmark(
+            new File(['video'], 'private.mov', { type: 'video/quicktime' }),
+            createOptions(createTrack(), samples, dispose),
+        );
+
+        expect(result).toMatchObject({
+            status: 'completed',
+            input: {
+                mime: 'video/quicktime',
+                size: 5,
+                duration: 20.9,
+                videoCodec: 'avc1.4d401f',
+                codedWidth: 1920,
+                codedHeight: 1080,
+                displayWidth: 1080,
+                displayHeight: 1920,
+                rotation: 90,
+            },
+            target: REAL_VIDEO_PIPELINE_BENCHMARK_TARGET,
+            capabilities: { decode: true, avcEncode: true },
+            samplesProcessed: 3,
+            framesSubmitted: 3,
+            encodedChunks: 3,
+            encodedBytes: 300,
+            keyChunks: 1,
+            deltaChunks: 2,
+        });
+        expect(FakeEncoder.supportConfigs).toEqual([{ ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG }]);
+        expect(FakeEncoder.configureConfigs).toEqual([{ ...RAW_VIDEO_ENCODER_BENCHMARK_CONFIG }]);
+        expect(FakeEncoder.encodeOptions).toEqual([{ keyFrame: true }, { keyFrame: false }, { keyFrame: false }]);
+        expect(FakeSample.lastTransformOptions).toEqual(REAL_VIDEO_PIPELINE_BENCHMARK_TARGET);
+        expect(samples.every((sample) => sample.setTimestamp.mock.calls.length === 1)).toBe(true);
+        expect(samples.every((sample) => sample.close.mock.calls.length === 1)).toBe(true);
+        expect(FakeSample.transformedSamples.every((sample) => sample.close.mock.calls.length === 1)).toBe(true);
+        expect(FakeSample.frames.every((frame) => frame.close.mock.calls.length === 1)).toBe(true);
+        expect(dispose).toHaveBeenCalledTimes(1);
+        expect(JSON.stringify(result)).not.toContain('private.mov');
+    });
+
+    it('keeps the 360x640, 30fps, 400kbps raw encoder conditions as the native encode target', () => {
+        expect(RAW_VIDEO_ENCODER_BENCHMARK_CONFIG).toMatchObject({
+            codec: 'avc1.64001E', width: 360, height: 640, framerate: 30, bitrate: 400_000,
+        });
+        expect(RAW_VIDEO_ENCODER_BENCHMARK_QUEUE_LIMIT).toBe(4);
+    });
+
+    it.each([
+        ['no video track', undefined, 'no-video-track'],
+        ['decoder unavailable', createTrack(false), 'decode-unavailable'],
+    ] as const)('reports %s before sample iteration', async (_name, track, stage) => {
+        FakeEncoder.reset();
+        const dispose = vi.fn();
+        const result = await runRealVideoPipelineBenchmark(new File(['x'], 'ignored.mov', { type: 'video/quicktime' }), createOptions(track, [], dispose));
+
+        expect(result).toMatchObject({ status: 'failed', failure: { stage } });
+        expect(dispose).toHaveBeenCalledTimes(1);
+        expect(FakeEncoder.supportConfigs).toHaveLength(0);
+    });
+
+    it('does not silently fall back when the fixed AVC config is unsupported', async () => {
+        FakeEncoder.reset();
+        FakeEncoder.supported = false;
+        const result = await runRealVideoPipelineBenchmark(
+            new File(['x'], 'ignored.mov', { type: 'video/quicktime' }),
+            createOptions(createTrack()),
+        );
+
+        expect(result).toMatchObject({
+            status: 'failed',
+            capabilities: { decode: true, avcEncode: false },
+            failure: { stage: 'config-unsupported' },
+        });
+        expect(FakeEncoder.configureConfigs).toHaveLength(0);
+    });
+
+    it('classifies transform, encode, and flush failures and still cleans up resources', async () => {
+        for (const [mode, stage] of [
+            ['transform', 'transform-failure'],
+            ['encode-failure', 'encode-failure'],
+            ['flush-failure', 'flush-failure'],
+        ] as const) {
+            FakeEncoder.reset();
+            FakeSample.reset();
+            FakeEncoder.mode = mode === 'transform' ? 'success' : mode;
+            FakeSample.transformError = mode === 'transform';
+            const sample = new FakeSample(100_000);
+            const dispose = vi.fn();
+            const result = await runRealVideoPipelineBenchmark(
+                new File(['x'], 'ignored.mov', { type: 'video/quicktime' }),
+                createOptions(createTrack(), [sample], dispose),
+            );
+
+            expect(result).toMatchObject({ status: 'failed', failure: { stage } });
+            expect(sample.close).toHaveBeenCalledTimes(1);
+            expect(dispose).toHaveBeenCalledTimes(1);
+            expect(FakeEncoder.instances[0]?.close).toHaveBeenCalledTimes(1);
+        }
+    });
+
+    it('returns aborted and disposes input before any benchmark fallback can occur', async () => {
+        FakeEncoder.reset();
+        const controller = new AbortController();
+        controller.abort();
+        const dispose = vi.fn();
+        const result = await runRealVideoPipelineBenchmark(
+            new File(['x'], 'ignored.mov', { type: 'video/quicktime' }),
+            { ...createOptions(createTrack(), [], dispose), signal: controller.signal },
+        );
+
+        expect(result).toMatchObject({ status: 'failed', failure: { stage: 'aborted' } });
+        expect(dispose).not.toHaveBeenCalled();
+        expect(FakeEncoder.instances).toHaveLength(0);
+    });
+});

--- a/src/test/unit/videoDecodeBenchmark.test.ts
+++ b/src/test/unit/videoDecodeBenchmark.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    runVideoDecodeBenchmark,
+    type VideoDecodeBenchmarkInputLike,
+    type VideoDecodeBenchmarkSampleLike,
+    type VideoDecodeBenchmarkSinkLike,
+    type VideoDecodeBenchmarkTrackLike,
+} from '../../lib/videoCompression/videoDecodeBenchmark';
+
+function createTrack(canDecode = true): VideoDecodeBenchmarkTrackLike {
+    return {
+        canDecode: vi.fn(async () => canDecode),
+        getCodec: vi.fn(async () => 'avc'),
+        getDisplayWidth: vi.fn(async () => 1080),
+        getDisplayHeight: vi.fn(async () => 1920),
+    };
+}
+
+function createInput(track: VideoDecodeBenchmarkTrackLike | undefined, dispose = vi.fn()): VideoDecodeBenchmarkInputLike {
+    return {
+        getVideoTracks: vi.fn(async () => track ? [track] : []),
+        getDurationFromMetadata: vi.fn(async () => 20.9),
+        dispose,
+    };
+}
+
+function createSample() {
+    return {
+        format: 'NV12',
+        codedWidth: 1080,
+        codedHeight: 1920,
+        displayWidth: 1080,
+        displayHeight: 1920,
+        close: vi.fn(),
+    };
+}
+
+describe('runVideoDecodeBenchmark', () => {
+    it('iterates decoded samples once, records only lightweight milestones, and closes every sample', async () => {
+        const samples = Array.from({ length: 100 }, () => createSample());
+        const track = createTrack();
+        const dispose = vi.fn();
+        let time = 0;
+        const sink: VideoDecodeBenchmarkSinkLike = {
+            async *samples() {
+                for (const [index, sample] of samples.entries()) {
+                    time = index + 1;
+                    yield sample;
+                }
+                time = 101;
+            },
+        };
+
+        const result = await runVideoDecodeBenchmark(new File(['video'], 'ignored.mov', { type: 'video/quicktime' }), {
+            now: () => time,
+            createInput: () => createInput(track, dispose),
+            createVideoSampleSink: (sinkTrack) => {
+                expect(sinkTrack).toBe(track);
+                return sink;
+            },
+        });
+
+        expect(result).toMatchObject({
+            status: 'completed',
+            input: {
+                mime: 'video/quicktime', size: 5, duration: 20.9, videoCodec: 'avc', displayWidth: 1080, displayHeight: 1920,
+            },
+            decode: {
+                samplesDecoded: 100,
+                firstSample: { format: 'NV12', codedWidth: 1080, codedHeight: 1920, displayWidth: 1080, displayHeight: 1920 },
+                milestoneOffsets: { 1: 1, 100: 100 },
+                lastSampleOffset: 100,
+            },
+            timing: { decodeWall: 101, throughput: 100 / 0.101 },
+        });
+        expect(result.decode.milestoneOffsets[300]).toBeUndefined();
+        expect(samples.every((sample) => sample.close.mock.calls.length === 1)).toBe(true);
+        expect(result.decode).not.toHaveProperty('samples');
+        expect(dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns a clear failure without creating a sample sink when there is no video track', async () => {
+        const createVideoSampleSink = vi.fn();
+        const result = await runVideoDecodeBenchmark(new File(['x'], 'ignored.mov', { type: 'video/quicktime' }), {
+            createInput: () => createInput(undefined),
+            createVideoSampleSink,
+        });
+
+        expect(result).toMatchObject({ status: 'failed', failure: { stage: 'no-video-track' } });
+        expect(createVideoSampleSink).not.toHaveBeenCalled();
+    });
+
+    it('distinguishes an unavailable decoder before sample iteration', async () => {
+        const createVideoSampleSink = vi.fn();
+        const result = await runVideoDecodeBenchmark(new File(['x'], 'ignored.mov', { type: 'video/quicktime' }), {
+            createInput: () => createInput(createTrack(false)),
+            createVideoSampleSink,
+        });
+
+        expect(result).toMatchObject({ status: 'failed', failure: { stage: 'decoder-unavailable' } });
+        expect(createVideoSampleSink).not.toHaveBeenCalled();
+    });
+
+    it('closes samples already received when decoding fails', async () => {
+        const sample = createSample();
+        const dispose = vi.fn();
+        const result = await runVideoDecodeBenchmark(new File(['x'], 'ignored.mov', { type: 'video/quicktime' }), {
+            createInput: () => createInput(createTrack(), dispose),
+            createVideoSampleSink: () => ({
+                async *samples() {
+                    yield sample;
+                    throw new Error('decode stopped');
+                },
+            }),
+        });
+
+        expect(result).toMatchObject({ status: 'failed', decode: { samplesDecoded: 1 }, failure: { stage: 'decode-failure' } });
+        expect(sample.close).toHaveBeenCalledTimes(1);
+        expect(dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it('aborts safely, disposes the input, and closes the sample delivered before cancellation', async () => {
+        const controller = new AbortController();
+        const sample = createSample();
+        const dispose = vi.fn();
+        const result = await runVideoDecodeBenchmark(new File(['x'], 'ignored.mov', { type: 'video/quicktime' }), {
+            signal: controller.signal,
+            createInput: () => createInput(createTrack(), dispose),
+            createVideoSampleSink: () => ({
+                async *samples() {
+                    yield sample;
+                    controller.abort();
+                },
+            }),
+        });
+
+        expect(result).toMatchObject({ status: 'failed', failure: { stage: 'aborted' } });
+        expect(sample.close).toHaveBeenCalledTimes(1);
+        expect(dispose).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Purpose

Add opt-in, on-device diagnostics for investigating slow MediaBunny video compression on iPhone. Diagnostics stay on the device and do not alter normal compression unless an existing explicit diagnostic A/B query is selected.

## Real-device observations

The user measured the same approximately 20.9-second MOV (AVC 1080x1920, AAC audio, 627 frames at 30 fps, 39,681,322 bytes) on iOS 26.6:

- Forced audio packet-copy: `Conversion.execute` 16,567 ms; total compression 16,637 ms; output 360x640, 627 frames at 30 fps.
- `latencyMode: 'realtime'` A/B: `Conversion.execute` 16,574 ms; total compression 16,686 ms; output still 627 frames at 30 fps.
- Audio packet-copy had previously reduced time by only about 0.6 seconds, so audio is not the main explanation.

### Physical iPhone raw native VideoEncoder benchmark

The iOS 26.6 physical-device raw benchmark has a measurement:

- `avc1.64001E` ? H.264 High Profile / Level 3.0
- 360x640, 30 fps, 627 synthetic Canvas 2D frames, 400,000 bps, queue limit 4
- benchmark wall: 1,128 ms; throughput: 555.85 fps
- encoded chunks: 627; encoded bytes: 395,000; key: 1; delta: 626

Synthetic content is not identical to a real MOV encode, but this result does not support the explanation that native WebCodecs `VideoEncoder` itself always needs about 16 seconds.

### Physical iPhone video decode-only benchmark

The same MOV was also measured with the manual MediaBunny public-API decode-only benchmark on iOS 26.6:

- decoded samples: 627
- first sample: +33 ms
- sample 100: +224 ms
- sample 300: +601 ms
- sample 500: +934 ms
- sample 627 / decode wall: 1,136 ms
- throughput: 551.94 fps

This fast decode result does not support video decode as the main cause of the approximately 16.6-second compression time. The investigation continues with the real decode/transform/encode path below; no production speed-up claim is made.

An older pre-#179 GitHub Pages observation on the same iPhone/input felt approximately 2?3 seconds, but the old path was not instrumented sufficiently to identify its video implementation. The old lockfile's FFmpeg-related context does not prove that FFmpeg performed the video compression, so this is retained only as an unconfirmed historical observation.

## Rate-control A/B

MediaBunny v1.52 introduced quantizer support, allowing subjective `Quality` settings to use quantizer-based control in supported environments. The current dependency remains MediaBunny 1.55.1.

This PR adds one exact, debug-only A/B gate:

- Baseline and partial query forms retain the existing subjective `QUALITY_MEDIUM` setting.
- Full A/B query: `?media-debug=1&media-debug-audio=copy&media-debug-video-rate-control=bitrate`
- Only under that full gate, video uses the public API `new Quality({ bitrate: 400_000, bitrateMode: 'variable' })`.
- The same `Quality` object is passed to both `canEncodeVideo()` and `ConversionVideoOptions.quality`.
- Diagnostics identify `subjective-quality` versus `explicit-bitrate`, and the A/B record includes `configured video bitrate: 400000 bps` and `bitrate mode: variable`.
- The full A/B gate continues to force audio packet-copy, so the comparison isolates video rate control.
- Physical iPhone rate-control A/B measurements on iOS 26.6 are now available: subjective quality took 16,586 ms execute / 16,634 ms total, averaged 370,376.97 bps and produced 1,290,127 bytes; explicit 400,000 bps variable bitrate took 16,623 ms execute / 16,678 ms total, averaged 369,108.17 bps and produced 1,286,812 bytes. The difference is not a meaningful performance improvement, so rate control alone is unlikely to explain the slow path.

This does not change normal MediaBunny compression or partial-gate behavior.

## Stopped public callback probe

MediaBunny 1.55.1 exposes encode callbacks on `VideoEncodingConfig`, but `Conversion.init({ video: ... })` accepts `ConversionVideoOptions`, which does not expose or forward those callbacks. `Conversion` creates its own internal encoding config. Without private APIs, a MediaBunny patch, or a global `VideoEncoder` monkey patch, that pipeline-timeline probe cannot be implemented; no code change was made for it.

## Manual video decode-only benchmark

This change keeps the manual benchmark for measuring decode separately with MediaBunny 1.55.1 public APIs only.

- Available only at `?media-debug=1&media-debug-video-decode-benchmark=1`; partial query forms show neither the diagnostic panel nor this control.
- The benchmark implementation and its MediaBunny dependency are loaded through a runtime dynamic import only after a video file is selected; normal app startup and the existing compression lazy-loading path do not load them eagerly.
- The existing small panel exposes **Run video decode benchmark**. It opens a local `video/*` file picker, never starts automatically, prevents double runs, permits re-runs after completion/failure, and aborts on unmount.
- It creates `Input({ source: new BlobSource(file), formats: ALL_FORMATS })`, chooses the first public `InputVideoTrack`, creates `VideoSampleSink`, and iterates `for await (const sample of sink.samples())`.
- The decode timer starts immediately before sample iteration and ends only after the final sample was counted and closed. The record reports input/track setup, decode wall time, decoded sample count, throughput, first-sample scalar metadata, and offsets for samples 1/100/300/500/627 plus the last sample.
- Every `VideoSample` is closed in the loop's `finally`; `Input.dispose()` runs in helper cleanup and also on abort. No decoded frame list, filename, or media binary is retained in diagnostics.
- It deliberately performs no packet-stat pre-scan or full packet/sample warm-up, resize, pixel copy, video encode, audio decode/encode, muxing, output, Blob/File creation, upload, network logging, IndexedDB, or localStorage work.
- No `AudioSampleSink` or AAC encoder path is touched.

The physical iPhone decode result is now available and is fast; further investigation is focused on rate-control behavior and the remaining uninstrumented stages.

## Existing raw native VideoEncoder benchmark retained

The existing manual raw benchmark retains its fixed encoder conditions:

- Exact gate: `?media-debug=1&media-debug-raw-video-encoder=1`.
- Fixed `avc1.64001E` (H.264 High Profile / Level 3.0), matching medium output observed on iOS 26.6 and iOS 18.7.10.
- 360x640, 30 fps, 627 Canvas 2D synthetic frames, 400,000 bps, queue limit 4, default/omitted latency/hardware/bitrate modes.
- It still calls `VideoEncoder.isConfigSupported()` before configure and does not silently fall back to another codec.

## Normal compression and lazy-loading behavior retained

Normal MediaBunny compression behavior remains unchanged outside the exact debug A/B gate. Existing normal/medium `QUALITY_MEDIUM`, audio native/custom/packet-copy paths, realtime A/B, progress, abort, production fallback, output verification, and packet-stat diagnostics are preserved.

The debug decode benchmark has no runtime static import from `MediaCompressionDebugPanel.svelte`; its implementation and MediaBunny dependency are loaded only through the file-selection execution path. The existing `VideoCompressionService` compression dynamic path remains lazy. AAC custom registration remains a separate lazy chunk, and neither the raw benchmark nor the decode benchmark loads the AAC encoder.

## Verification

- Targeted unit tests (`legacyLikeCanvasPipelineBenchmark`, real video pipeline, diagnostics, and MediaBunny compression): 56 passed.
- `npm run check`: 0 errors, 0 warnings.
- `npm test`: 345 files passed, 1 skipped; 3,986 passed, 1 skipped.
- `npm run build`: passed, including fixed legacy bridge verification, Web Component build, and site assembly. Existing unrelated Web Component prop-inference and Blurhash chunking warnings remain.
- `npx playwright test src/test/e2e/mediaCompressionDebug.spec.ts`: 21 passed across desktop Chromium, mobile Chromium, and mobile WebKit. Covers exact query gating, separate manual file selection/run wiring, mutual exclusion while either pipeline is running, harness injection, Copy/Clear, and 360px overflow geometry. Browser emulation is not physical-iPhone performance evidence.
- `git diff --check`: passed.
- Build inspection: `legacyLikeCanvasPipelineBenchmark` and `realVideoPipelineBenchmark` are runtime dynamic-import chunks only; neither is listed by `dist/index.html` modulepreload. The existing compression `mediabunnyCompression` remains dynamically imported by `VideoCompressionService`. The MediaBunny AAC encoder remains a separate lazy chunk. There is no `dist/ffmpeg-core`, no `ffmpeg-core.wasm`, and no current `@ffmpeg/*` runtime dependency.
## Not performed

- The new legacy-like Canvas pipeline benchmark has not yet been measured on a physical iPhone.
- iOS 18.7.10 and Android comparisons have not been collected.
- No production speed-up work is included; both real video pipeline benchmarks are diagnostic-only.
## Raw HTMLCanvas vs OffscreenCanvas A/B

The existing raw native VideoEncoder diagnostic now supports two independently runnable source paths under the existing `?media-debug=1&media-debug-raw-video-encoder=1` gate:

- **HTMLCanvas baseline**: `HTMLCanvasElement` ? `VideoFrame` ? `VideoEncoder`.
- **OffscreenCanvas A/B**: `OffscreenCanvas` ? `VideoFrame` ? `VideoEncoder`.

Both paths retain the same `avc1.64001E` configuration, 360x640, 30 fps, 400,000 bps, 627 frames, queue limit 4, Canvas 2D synthetic pattern, timestamp generation, backpressure, timing fields, immediate `VideoFrame.close()`, and encoder cleanup. The only intended difference is the canvas/source kind. Results are retained separately in Copy diagnostics with `canvas/source kind: html-canvas` or `canvas/source kind: offscreen-canvas`.

The OffscreenCanvas path reports `OffscreenCanvas unavailable.` as a failed diagnostic result when unsupported; it does not prevent the HTMLCanvas baseline from running. The benchmark remains WebCodecs-only and does not import MediaBunny or affect production compression. Physical iPhone Canvas-source A/B measurements on iOS 26.6 are now available. HTMLCanvas runs measured 1,126 ms / 556.84 fps and 1,132 ms / 553.89 fps; OffscreenCanvas measured 1,144 ms / 548.08 fps and 1,115 ms / 562.33 fps. Each run submitted 627 frames and produced 395,052 encoded bytes with 1 key and 626 delta chunks, so no meaningful source-path difference was observed.

## Physical iPhone A/B procedure

On the same iPhone and with the same MOV, open the PR preview with `?media-debug=1&media-debug-raw-video-encoder=1`, expand **Media Compression Debug**, and run **HTMLCanvas VideoEncoder benchmark** and **OffscreenCanvas VideoEncoder benchmark** as separate runs. Record the copied diagnostics for each source, preferably in both orders across fresh loads if thermal/order effects are a concern. Playwright WebKit results are UI/regression evidence only, not physical-iPhone performance evidence.



## Real video pipeline benchmarks

This PR provides two independently runnable, diagnostic-only paths behind `?media-debug=1&media-debug-video-pipeline-benchmark=1`. Both open a local `video/*` picker only when chosen, load their implementation through runtime `import()` after file selection, and keep the normal app entry, `?media-debug=1` alone, and normal compression lazy-loading free of this benchmark implementation and MediaBunny dependency.

### MediaBunny transform baseline

The baseline uses only MediaBunny 1.55.1 public APIs: `Input` with `BlobSource` and `ALL_FORMATS`, the first video track, `VideoSampleSink`, decoded `VideoSample`, and `VideoSample.transform({ width: 360, height: 640, fit: 'fill', rotate: 0, alpha: 'discard' })`. The transformed sample is converted with `toVideoFrame()` and submitted to native WebCodecs `VideoEncoder` using fixed `avc1.64001E` H.264 High Profile / Level 3.0, 360x640, 30 fps, 400,000 bps, queue limit 4, and a 5-second keyframe interval. It deliberately omits Conversion, output/muxing, audio/AAC, FFmpeg, upload, Blob/File output, and packet pre-scans.

The same 20.905-second, 627-frame portrait MOV (39,681,321 bytes; AVC coded 1920x1080, display 1080x1920, rotation 90 degrees) was measured on a physical iPhone:

- 627 samples processed / 627 frames submitted / 627 encoded chunks; 943,513 encoded bytes; 5 key and 622 delta chunks; 39.73 fps.
- total wall: 15,782 ms; sample wait / iteration: 686 ms; `VideoSample.transform()` await wall: 14,997 ms; transformed `VideoFrame` creation: 8 ms; `encode()` submission: 21 ms; native encoder backpressure: 9 ms; flush: 6 ms.

Within this measurement only, removing Conversion still leaves about 15.8 seconds, while about 15.0 seconds is in the public `VideoSample.transform()` await wall and native encoder backpressure is 9 ms. The current evidence therefore concentrates the delay in that transform path rather than Conversion orchestration or native H.264 encoding. This is an instrumentation result, not a production speed-up claim.

### Legacy-like HTMLCanvas A/B

The second control, **Run legacy-like Canvas pipeline benchmark**, never calls `VideoSample.transform()`. It obtains each decoded source through the current public `sample.toVideoFrame()`, draws it immediately to one reused `HTMLCanvasElement` 2D context, then creates a native `VideoFrame(canvas, { timestamp, duration })` for the same encoder configuration and queue/backpressure policy. Source/output frames, decoded samples, encoder, and Input are closed/disposed on success, failure, abort, and panel unmount.

This is intentionally a small target-case recreation, not a reintroduction of old MediaBunny code. MediaBunny v1.44.2 Conversion configured rerender `CanvasSink` with `poolSize: 1`; in DOM it preferred and reused `HTMLCanvasElement`, cleared/reset the 2D context, applied rotation while drawing, and baked output rotation to zero. The benchmark follows those relevant properties for the measured MOV: it reuses one HTML canvas, uses browser-default image smoothing, applies the source 90-degree metadata rotation before the target 360x640 draw, and produces an upright 9:16 frame from the 1920x1080 coded / 1080x1920 display input. It does not copy CanvasSink, call private APIs, add old MediaBunny, implement generic crop/fit compatibility, or import current transform's high-quality smoothing/mipmapping path.

Copy diagnostics retain separate `pipeline kind: mediabunny-transform` and `pipeline kind: legacy-like-html-canvas` records, input/target/capability/count data, key/delta chunks, failure stage, and overlapping timing categories. The Canvas path adds source VideoFrame acquisition, Canvas draw/rotation/resize, and output VideoFrame creation timings. Both controls are disabled while either is running so they cannot contend for the same encoder/GPU resources.

The legacy-like Canvas A/B has not yet been physically measured on an iPhone. It does not change production `MediaBunnyCompression`, normal `VideoSample.transform()` use, media options, audio/AAC, FFmpeg policy, mux/output, fallback, upload, or Web Component/iframe behavior.
