### PR TITLE
Pin MediaBunny 1.44.2 to restore iOS compression performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@jsquash/webp": "^1.5.0",
-        "@mediabunny/aac-encoder": "^1.55.1",
+        "@mediabunny/aac-encoder": "1.44.2",
         "@rx-nostr/crypto": "^3.1.6",
         "@tiptap/core": "^3.22.4",
         "@tiptap/extension-image": "^3.22.4",
@@ -23,7 +23,7 @@
         "dexie": "^4.4.2",
         "dompurify": "^3.4.13",
         "ipaddr.js": "^2.3.0",
-        "mediabunny": "^1.55.1",
+        "mediabunny": "1.44.2",
         "nip07-awaiter": "^1.1.0",
         "nostr-tools": "^2.23.3",
         "nostr-zap": "^1.3.0",
@@ -2329,9 +2329,9 @@
       }
     },
     "node_modules/@mediabunny/aac-encoder": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/@mediabunny/aac-encoder/-/aac-encoder-1.55.1.tgz",
-      "integrity": "sha512-NkLRZzfZoCmMZpMosj+O9gpl1tgHgKR85G8QrtUSUGJO1HaI/NqZznwSEdGWZKT4rSiRRaYtYXecLCAIdKWDFQ==",
+      "version": "1.44.2",
+      "resolved": "https://registry.npmjs.org/@mediabunny/aac-encoder/-/aac-encoder-1.44.2.tgz",
+      "integrity": "sha512-nE8cUzi+TQxj2LABYYZ0+FDE1dbZS2gF/ndtLkincFLUhgvcVBubrz2GqJQ8qG83JUdPBg2QwmgcgVXsNEB1mw==",
       "license": "MPL-2.0",
       "funding": {
         "type": "individual",
@@ -6696,13 +6696,12 @@
       }
     },
     "node_modules/mediabunny": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.55.1.tgz",
-      "integrity": "sha512-JDdTEUOw9g6Ey8eWc2Ei63GmRGtGTJoE56SE7CHikwzS8i9xpsWcve4bEiUw47d4j49L3r7MXDFsH/5oZIhjBw==",
+      "version": "1.44.2",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.44.2.tgz",
+      "integrity": "sha512-3ou3LB3ln31TYn/YZnRhRIVqwfgNy85gFvD3j34mEDq59Bc5PiNSV5ECavshm/+F2etC8UsJ/XdOrSoW3rB6lg==",
       "license": "MPL-2.0",
       "peer": true,
       "workspaces": [
-        ".",
         "packages/*"
       ],
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@jsquash/webp": "^1.5.0",
-    "@mediabunny/aac-encoder": "^1.55.1",
+    "@mediabunny/aac-encoder": "1.44.2",
     "@rx-nostr/crypto": "^3.1.6",
     "@tiptap/core": "^3.22.4",
     "@tiptap/extension-image": "^3.22.4",
@@ -62,7 +62,7 @@
     "dexie": "^4.4.2",
     "dompurify": "^3.4.13",
     "ipaddr.js": "^2.3.0",
-    "mediabunny": "^1.55.1",
+    "mediabunny": "1.44.2",
     "nip07-awaiter": "^1.1.0",
     "nostr-tools": "^2.23.3",
     "nostr-zap": "^1.3.0",

--- a/src/test/integration/video-compression.integration.test.ts
+++ b/src/test/integration/video-compression.integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { File as NodeFile } from 'node:buffer';
 import { VideoCompressionService } from '../../lib/videoCompression/videoCompressionService';
 import { VIDEO_COMPRESSION_OPTIONS_MAP } from '../../lib/constants';
 
@@ -60,7 +61,9 @@ function createTestVideoFile(size: number = 300 * 1024, name: string = 'test.mp4
         ...new Uint8Array(size - 32),
     ]);
 
-    return new File([header], name, { type: 'video/mp4' });
+    // MediaBunny 1.44.2 reads BlobSource through arrayBuffer() in jsdom. Node's
+    // File implementation provides the same Blob methods as a browser File.
+    return new NodeFile([header], name, { type: 'video/mp4' }) as unknown as File;
 }
 
 describe('Video Compression Integration Tests', () => {
@@ -227,7 +230,7 @@ describe('Video Compression Integration Tests', () => {
             storage.setItem('videoQualityLevel', 'medium');
 
             // 不正なファイルを作成
-            const invalidVideo = new File(['invalid'], 'invalid.mp4', { type: 'video/mp4' });
+            const invalidVideo = new NodeFile(['invalid'], 'invalid.mp4', { type: 'video/mp4' }) as unknown as File;
 
             const result = await service.compress(invalidVideo);
 


### PR DESCRIPTION
## Summary

- iPhone Safari medium compression of the same approximately 20.9-second MOV took about 16 seconds with MediaBunny 1.53/1.55 in the current production path.
- The earlier MediaBunny 1.44.2 experiment took about 3 seconds on iPhone.
- Pin both MediaBunny packages exactly to 1.44.2:
  - `mediabunny: 1.44.2`
  - `@mediabunny/aac-encoder: 1.44.2`
- The mixed `mediabunny@1.44.2` + `@mediabunny/aac-encoder@1.55.1` combination is intentionally not used because it fails the Vercel build due to the `Logging` API mismatch.

## Behavior preserved

- Existing video compression levels, resize/maxSize, AVC/MP4 output, portrait/landscape handling, audio preservation checks, native/custom AAC selection, lazy loading, fallback-to-original behavior, abort, progress, cleanup, filename/MIME, upload, standalone, iframe, and Web Component paths remain unchanged.
- No production compression implementation change was required for the 1.44.2 public API. The only code change outside dependency files makes the jsdom integration fixture use a Blob implementation with `arrayBuffer()`, which MediaBunny 1.44.2 uses when reading BlobSource.

## Validation

- `npm ci --ignore-scripts`: passed
- `npm run test -- src/test/unit/mediabunnyCompression.test.ts`: 10/10 passed
- `npm run test -- src/test/integration/video-compression.integration.test.ts`: 27/27 passed, no unhandled errors
- `npm test`: 340 files passed, 1 skipped; 3928 tests passed, 1 skipped
- `npm run check`: passed with 0 errors and 0 warnings
- `npm run build`: passed, including legacy bridge verification and Web Component build
- Playwright: existing Host-owned media preprocessing/upload test passed in desktop Chromium, mobile Chromium, and mobile WebKit (3/3)
- `git diff --check`: passed
- `npm ls mediabunny @mediabunny/aac-encoder --all`: both resolve to 1.44.2
- `npm ls '@ffmpeg/*' --all`: empty
- Build output has no `ffmpeg-core` directory or FFmpeg WASM runtime asset. AAC is a separate lazy chunk and is absent from initial modulepreload.

## Device validation

Please perform final physical-device validation on the Vercel Preview with the existing approximately 20.9-second MOV:

- iPhone SE2 / iOS 26.6.1: medium compression is substantially faster than the previous approximately 16 seconds, output is actually compressed, playable, correctly oriented, retains and plays audio, preserves duration approximately, and has a reasonable size.
- Android: compression, playback, audio, orientation, and duration remain correct.

Playwright WebKit is not treated as evidence of physical iPhone performance.

PR #181 is a separate diagnostic investigation and is not included in this production fix.