### PR TITLE
Fix iOS Low AAC corruption with 44.1 kHz audio

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -66,7 +66,7 @@ export const VIDEO_COMPRESSION_OPTIONS_MAP = {
         preset: 'medium',
         maxSize: 320,
         audioBitrate: '32k',
-        audioSampleRate: 16000,
+        audioSampleRate: 44100,
         audioChannels: 1,
         // Mediabunny用の品質ファクター（Quality(factor)に変換して使用）
         mediabunnyVideoQualityFactor: 0.3, // QUALITY_VERY_LOW

--- a/src/test/integration/video-compression.integration.test.ts
+++ b/src/test/integration/video-compression.integration.test.ts
@@ -107,7 +107,7 @@ describe('Video Compression Integration Tests', () => {
                 preset: 'medium',
                 maxSize: 320,
                 audioBitrate: '32k',
-                audioSampleRate: 16000,
+                audioSampleRate: 44100,
                 audioChannels: 1,
             });
         });

--- a/src/test/unit/videoCompressionService.test.ts
+++ b/src/test/unit/videoCompressionService.test.ts
@@ -66,11 +66,12 @@ describe('VIDEO_COMPRESSION_OPTIONS_MAP', () => {
             expect(mediumBitrate).toBeGreaterThan(lowBitrate);
         });
 
-        it('音声サンプルレートがmedium→lowで小さくなる', () => {
+        it('Lowの音声サンプルレートがAAC互換の44100Hzである', () => {
             const mediumSampleRate = VIDEO_COMPRESSION_OPTIONS_MAP.medium.audioSampleRate!;
             const lowSampleRate = VIDEO_COMPRESSION_OPTIONS_MAP.low.audioSampleRate!;
 
-            expect(mediumSampleRate).toBeGreaterThan(lowSampleRate);
+            expect(mediumSampleRate).toBe(44100);
+            expect(lowSampleRate).toBe(44100);
         });
     });
 


### PR DESCRIPTION
## Summary
- Change only Low audioSampleRate from 16000 Hz to 44100 Hz to avoid the WebKit HE-AAC v1 workaround path implicated in AAC AudioSpecificConfig corruption.
- Preserve Low mono, audioBitrate 32k, mediabunnyAudioQualityFactor 0.3, native-first/custom-on-capability-failure selection, and MediaBunny/@mediabunny/aac-encoder exact 1.44.2 pins.
- Update existing Low sample-rate expectations only; no rate-control or mediabunnyCompression.ts changes.

## Automated validation
- Targeted compression tests: 3 files, 48 passed
- npm test: 340 files passed, 3928 tests passed, 1 skipped
- npm run check: 0 errors, 0 warnings
- npm run build: passed; AAC encoder remains a separate lazy chunk for standalone and Web Component builds

## Acceptance
- Physical iPhone and Android acceptance are not completed by Codex and remain pending after PR creation. The user should test the same MOV on iPhone Low compression and verify playback, duration, orientation, output size/time, AAC profile/sample rate/channels, decoder open, and disappearance of SBR+0 / 96 kHz / 0-channel metadata.
- The Low 32k/Quality rate-control inconsistency is recorded but intentionally not changed in this PR.