### PR TITLE
Fix MediaBunny audio Quality configuration

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -43,29 +43,20 @@ export const COMPRESSION_OPTIONS_MAP = {
 export const VIDEO_COMPRESSION_OPTIONS_MAP = {
     none: { skip: true },
     high: {
-        crf: 20,
-        preset: 'superfast',
         maxSize: 1280,
-        audioBitrate: '128k',
         // Mediabunny用の品質ファクター（Quality(factor)に変換して使用）
         mediabunnyVideoQualityFactor: 2,   // QUALITY_HIGH
         mediabunnyAudioQualityFactor: 2,   // QUALITY_HIGH
     },
     medium: {
-        crf: 26,
-        preset: 'superfast',
         maxSize: 640,
-        audioBitrate: '64k',
         audioSampleRate: 44100,
         // Mediabunny用の品質ファクター（Quality(factor)に変換して使用）
         mediabunnyVideoQualityFactor: 1,   // QUALITY_MEDIUM
         mediabunnyAudioQualityFactor: 1,   // QUALITY_MEDIUM
     },
     low: {
-        crf: 28,
-        preset: 'medium',
         maxSize: 320,
-        audioBitrate: '32k',
         audioSampleRate: 44100,
         audioChannels: 1,
         // Mediabunny用の品質ファクター（Quality(factor)に変換して使用）

--- a/src/lib/videoCompression/mediabunnyCompression.ts
+++ b/src/lib/videoCompression/mediabunnyCompression.ts
@@ -50,7 +50,6 @@ export class MediaBunnyCompression extends BaseCompression {
     private abortRequested = false;
 
     constructor(
-        private parseAudioBitrate: (audioBitrate: unknown) => number | null,
         isUploadAborted: UploadAbortChecker = isDefaultUploadAborted,
     ) {
         super('MediaBunnyCompression', isUploadAborted);
@@ -90,11 +89,10 @@ export class MediaBunnyCompression extends BaseCompression {
 
         const numberOfChannels = options.audioChannels ?? track.numberOfChannels;
         const sampleRate = options.audioSampleRate ?? track.sampleRate;
-        const bitrate = this.parseAudioBitrate(options.audioBitrate);
         const encoderOptions = {
             numberOfChannels,
             sampleRate,
-            ...(quality ? { quality } : bitrate ? { bitrate } : {}),
+            ...(quality ? { bitrate: quality } : {}),
         };
 
         if (!await canEncodeAudio('aac', encoderOptions)) {

--- a/src/lib/videoCompression/videoCompressionService.ts
+++ b/src/lib/videoCompression/videoCompressionService.ts
@@ -20,7 +20,7 @@ export class VideoCompressionService {
         if (this.mediabunnyCompression) return;
         if (!this.initPromise) {
             this.initPromise = import('./mediabunnyCompression').then(({ MediaBunnyCompression }) => {
-                this.mediabunnyCompression = new MediaBunnyCompression(this.parseAudioBitrate.bind(this), this.isUploadAborted);
+                this.mediabunnyCompression = new MediaBunnyCompression(this.isUploadAborted);
                 this.mediabunnyCompression.setProgressCallback(this.onProgress);
             });
         }
@@ -46,15 +46,6 @@ export class VideoCompressionService {
 
     public hasCompressionSettings(): boolean {
         return this.getCompressionOptions() !== null;
-    }
-
-    private parseAudioBitrate(audioBitrate: unknown): number | null {
-        if (typeof audioBitrate === 'number' && Number.isFinite(audioBitrate)) return audioBitrate;
-        if (typeof audioBitrate === 'string') {
-            const numeric = Number.parseInt(audioBitrate, 10);
-            return Number.isFinite(numeric) && numeric > 0 ? numeric * 1000 : null;
-        }
-        return null;
     }
 
     public async compress(file: File): Promise<VideoCompressionResult> {

--- a/src/test/integration/video-compression.integration.test.ts
+++ b/src/test/integration/video-compression.integration.test.ts
@@ -86,30 +86,34 @@ describe('Video Compression Integration Tests', () => {
         it('各圧縮レベルに必要なプロパティが存在する', () => {
             // high
             expect(VIDEO_COMPRESSION_OPTIONS_MAP.high).toMatchObject({
-                crf: 20,
-                preset: 'superfast',
                 maxSize: 1280,
-                audioBitrate: '128k',
+                mediabunnyVideoQualityFactor: 2,
+                mediabunnyAudioQualityFactor: 2,
             });
 
             // medium
             expect(VIDEO_COMPRESSION_OPTIONS_MAP.medium).toMatchObject({
-                crf: 26,
-                preset: 'superfast',
                 maxSize: 640,
-                audioBitrate: '64k',
                 audioSampleRate: 44100,
+                mediabunnyVideoQualityFactor: 1,
+                mediabunnyAudioQualityFactor: 1,
             });
 
             // low
             expect(VIDEO_COMPRESSION_OPTIONS_MAP.low).toMatchObject({
-                crf: 28,
-                preset: 'medium',
                 maxSize: 320,
-                audioBitrate: '32k',
                 audioSampleRate: 44100,
                 audioChannels: 1,
+                mediabunnyVideoQualityFactor: 0.3,
+                mediabunnyAudioQualityFactor: 0.3,
             });
+
+            for (const level of ['high', 'medium', 'low'] as const) {
+                const config = VIDEO_COMPRESSION_OPTIONS_MAP[level];
+                expect(config).not.toHaveProperty('audioBitrate');
+                expect(config).not.toHaveProperty('crf');
+                expect(config).not.toHaveProperty('preset');
+            }
         });
 
         it('maxSizeが適切に設定されている（高→中→低の順で小さくなる）', () => {

--- a/src/test/unit/mediabunnyCompression.test.ts
+++ b/src/test/unit/mediabunnyCompression.test.ts
@@ -7,6 +7,7 @@ const state = vi.hoisted(() => ({
     canEncodeVideo: true,
     canEncodeVideoPredicate: null as ((options: any) => boolean) | null,
     videoCapabilityOptions: [] as any[],
+    audioCapabilityOptions: [] as any[],
     canDecodeAudio: true,
     nativeAac: true,
     customAac: false,
@@ -47,7 +48,10 @@ vi.mock('mediabunny', () => {
             return state.canEncodeVideoPredicate?.(options) ?? state.canEncodeVideo;
         }),
         canDecodeAudio: vi.fn(async () => state.canDecodeAudio),
-        canEncodeAudio: vi.fn(async () => state.nativeAac || state.customAac),
+        canEncodeAudio: vi.fn(async (_codec: string, options: any) => {
+            state.audioCapabilityOptions.push(options);
+            return state.nativeAac || state.customAac;
+        }),
         Conversion: {
             init: vi.fn(async (options: any) => {
                 state.videoOptions.push(await options.video((await options.input.getVideoTracks())[0]));
@@ -77,19 +81,14 @@ vi.mock('@mediabunny/aac-encoder', () => ({
 }));
 
 import { MediaBunnyCompression } from '../../lib/videoCompression/mediabunnyCompression';
+import { VIDEO_COMPRESSION_OPTIONS_MAP } from '../../lib/constants';
+import { QUALITY_HIGH, QUALITY_MEDIUM, QUALITY_VERY_LOW } from 'mediabunny';
 
 function videoFile(): File {
     return new File([new Uint8Array(300 * 1024)], 'clip.mp4', { type: 'video/mp4' });
 }
 
-const options = {
-    maxSize: 640,
-    audioBitrate: '64k',
-    audioSampleRate: 44100,
-    audioChannels: 2,
-    mediabunnyVideoQualityFactor: 1,
-    mediabunnyAudioQualityFactor: 1,
-};
+const options = VIDEO_COMPRESSION_OPTIONS_MAP.medium;
 
 describe('MediaBunnyCompression', () => {
     beforeEach(() => {
@@ -100,6 +99,7 @@ describe('MediaBunnyCompression', () => {
             canEncodeVideo: true,
             canEncodeVideoPredicate: null,
             videoCapabilityOptions: [],
+            audioCapabilityOptions: [],
             canDecodeAudio: true,
             nativeAac: true,
             customAac: false,
@@ -113,7 +113,7 @@ describe('MediaBunnyCompression', () => {
 
     it('skips compression when video decode or AVC encode is unavailable', async () => {
         state.videoTrackCanDecode = false;
-        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const result = await new MediaBunnyCompression().compressWithMediabunny(videoFile(), options);
         expect(result).toMatchObject({ wasCompressed: false, wasSkipped: true });
         expect(state.videoCapabilityOptions).toEqual([]);
         expect(state.videoOptions).toEqual([]);
@@ -123,7 +123,7 @@ describe('MediaBunnyCompression', () => {
         state.videoWidth = 3840;
         state.videoHeight = 2160;
         state.canEncodeVideoPredicate = ({ width, height }) => width <= 640 && height <= 360;
-        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const result = await new MediaBunnyCompression().compressWithMediabunny(videoFile(), options);
 
         expect(result.wasCompressed).toBe(true);
         expect(state.videoCapabilityOptions).toEqual([expect.objectContaining({ width: 640, height: 360 })]);
@@ -133,7 +133,7 @@ describe('MediaBunnyCompression', () => {
     it('uses the resized portrait dimensions for AVC capability checks', async () => {
         state.videoWidth = 2160;
         state.videoHeight = 3840;
-        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const result = await new MediaBunnyCompression().compressWithMediabunny(videoFile(), options);
 
         expect(result.wasCompressed).toBe(true);
         expect(state.videoCapabilityOptions).toEqual([expect.objectContaining({ width: 360, height: 640 })]);
@@ -143,7 +143,7 @@ describe('MediaBunnyCompression', () => {
     it('keeps the original dimensions when maxSize does not require resizing', async () => {
         state.videoWidth = 320;
         state.videoHeight = 240;
-        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const result = await new MediaBunnyCompression().compressWithMediabunny(videoFile(), options);
 
         expect(result.wasCompressed).toBe(true);
         expect(state.videoCapabilityOptions).toEqual([expect.objectContaining({ width: 320, height: 240 })]);
@@ -151,22 +151,66 @@ describe('MediaBunnyCompression', () => {
     });
 
     it('uses native AAC encoding without loading the optional encoder', async () => {
-        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const result = await new MediaBunnyCompression().compressWithMediabunny(videoFile(), options);
         expect(result.wasCompressed).toBe(true);
         expect(state.registeredAacEncoder).toBe(0);
         expect(state.audioOptions).toEqual([expect.objectContaining({ codec: 'aac', forceTranscode: true })]);
     });
 
+    it.each([
+        ['high', VIDEO_COMPRESSION_OPTIONS_MAP.high, QUALITY_HIGH, 44100, 2],
+        ['medium', VIDEO_COMPRESSION_OPTIONS_MAP.medium, QUALITY_MEDIUM, 44100, 2],
+        ['low', VIDEO_COMPRESSION_OPTIONS_MAP.low, QUALITY_VERY_LOW, 44100, 1],
+    ] as const)('passes %s audio Quality through the capability check and Conversion', async (
+        _level,
+        levelOptions,
+        bitrate,
+        sampleRate,
+        numberOfChannels,
+    ) => {
+        const result = await new MediaBunnyCompression().compressWithMediabunny(videoFile(), levelOptions);
+        const expectedOptions = { numberOfChannels, sampleRate, bitrate };
+
+        expect(result.wasCompressed).toBe(true);
+        expect(state.audioCapabilityOptions).toEqual([expectedOptions, expectedOptions]);
+        expect(state.audioOptions).toEqual([{
+            codec: 'aac',
+            forceTranscode: true,
+            ...expectedOptions,
+        }]);
+        expect(state.audioOptions[0]).not.toHaveProperty('quality');
+    });
+
+    it('keeps the existing video Quality option unchanged', async () => {
+        const result = await new MediaBunnyCompression().compressWithMediabunny(videoFile(), options);
+
+        expect(result.wasCompressed).toBe(true);
+        expect(state.videoOptions).toEqual([expect.objectContaining({ quality: QUALITY_MEDIUM })]);
+        expect(state.videoOptions[0]).not.toHaveProperty('bitrate');
+    });
+
     it('registers the optional AAC encoder only when native AAC encoding is unavailable', async () => {
         state.nativeAac = false;
-        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const result = await new MediaBunnyCompression().compressWithMediabunny(videoFile(), options);
         expect(result.wasCompressed).toBe(true);
         expect(state.registeredAacEncoder).toBe(1);
+        expect(state.audioCapabilityOptions).toEqual([
+            { numberOfChannels: 2, sampleRate: 44100, bitrate: QUALITY_MEDIUM },
+            { numberOfChannels: 2, sampleRate: 44100, bitrate: QUALITY_MEDIUM },
+        ]);
+    });
+
+    it('packet-copies audio when custom AAC encoding remains unavailable', async () => {
+        state.nativeAac = false;
+        const result = await new MediaBunnyCompression().compressWithMediabunny(videoFile(), options);
+
+        expect(result.wasCompressed).toBe(true);
+        expect(state.audioOptions).toEqual([{}]);
     });
 
     it('packet-copies audio when it cannot be decoded for AAC transcoding', async () => {
         state.canDecodeAudio = false;
-        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(videoFile(), options);
+        const result = await new MediaBunnyCompression().compressWithMediabunny(videoFile(), options);
         expect(result.wasCompressed).toBe(true);
         expect(state.audioOptions).toEqual([{}]);
     });
@@ -174,20 +218,20 @@ describe('MediaBunnyCompression', () => {
     it('keeps the original file when MediaBunny would discard input audio', async () => {
         state.preserveAudio = false;
         const file = videoFile();
-        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(file, options);
+        const result = await new MediaBunnyCompression().compressWithMediabunny(file, options);
         expect(result).toEqual({ file, wasCompressed: false, wasSkipped: true });
     });
 
     it('keeps the original file when conversion fails', async () => {
         state.failConversion = true;
         const file = videoFile();
-        const result = await new MediaBunnyCompression(() => 64_000).compressWithMediabunny(file, options);
+        const result = await new MediaBunnyCompression().compressWithMediabunny(file, options);
         expect(result).toEqual({ file, wasCompressed: false, wasSkipped: true });
     });
 
     it('keeps the aborted result contract', async () => {
         const file = videoFile();
-        const result = await new MediaBunnyCompression(() => 64_000, () => true).compressWithMediabunny(file, options);
+        const result = await new MediaBunnyCompression(() => true).compressWithMediabunny(file, options);
         expect(result).toEqual({ file, wasCompressed: false, wasSkipped: true, aborted: true });
     });
 });

--- a/src/test/unit/videoCompressionService.test.ts
+++ b/src/test/unit/videoCompressionService.test.ts
@@ -26,25 +26,17 @@ describe('VIDEO_COMPRESSION_OPTIONS_MAP', () => {
             const levels = ['low', 'medium', 'high'] as const;
             levels.forEach(level => {
                 const config = VIDEO_COMPRESSION_OPTIONS_MAP[level];
-                expect(config).toHaveProperty('crf');
                 expect(config).toHaveProperty('maxSize');
-                expect(config).toHaveProperty('audioBitrate');
                 expect(config).toHaveProperty('mediabunnyVideoQualityFactor');
                 expect(config).toHaveProperty('mediabunnyAudioQualityFactor');
+                expect(config).not.toHaveProperty('crf');
+                expect(config).not.toHaveProperty('preset');
+                expect(config).not.toHaveProperty('audioBitrate');
             });
         });
     });
 
     describe('設定値の相対関係', () => {
-        it('CRF値が高→中→低の順で大きくなる（品質が低くなる）', () => {
-            const lowCrf = VIDEO_COMPRESSION_OPTIONS_MAP.low.crf!;
-            const mediumCrf = VIDEO_COMPRESSION_OPTIONS_MAP.medium.crf!;
-            const highCrf = VIDEO_COMPRESSION_OPTIONS_MAP.high.crf!;
-
-            expect(highCrf).toBeLessThan(mediumCrf);
-            expect(mediumCrf).toBeLessThan(lowCrf);
-        });
-
         it('maxSizeが高→中→低の順で小さくなる', () => {
             const lowSize = VIDEO_COMPRESSION_OPTIONS_MAP.low.maxSize!;
             const mediumSize = VIDEO_COMPRESSION_OPTIONS_MAP.medium.maxSize!;
@@ -54,16 +46,14 @@ describe('VIDEO_COMPRESSION_OPTIONS_MAP', () => {
             expect(mediumSize).toBeGreaterThan(lowSize);
         });
 
-        it('音声ビットレートが高→中→低の順で小さくなる', () => {
-            // ビットレートは文字列なので数値に変換して比較
-            const parseBitrate = (br: string) => parseInt(br.replace('k', ''), 10);
+        it('MediaBunny Quality factorがHigh→Medium→Lowの順で下がる', () => {
+            const { high, medium, low } = VIDEO_COMPRESSION_OPTIONS_MAP;
 
-            const lowBitrate = parseBitrate(VIDEO_COMPRESSION_OPTIONS_MAP.low.audioBitrate!);
-            const mediumBitrate = parseBitrate(VIDEO_COMPRESSION_OPTIONS_MAP.medium.audioBitrate!);
-            const highBitrate = parseBitrate(VIDEO_COMPRESSION_OPTIONS_MAP.high.audioBitrate!);
-
-            expect(highBitrate).toBeGreaterThan(mediumBitrate);
-            expect(mediumBitrate).toBeGreaterThan(lowBitrate);
+            expect(high.mediabunnyAudioQualityFactor).toBeGreaterThan(medium.mediabunnyAudioQualityFactor);
+            expect(medium.mediabunnyAudioQualityFactor).toBeGreaterThan(low.mediabunnyAudioQualityFactor);
+            expect(high.mediabunnyVideoQualityFactor).toBe(high.mediabunnyAudioQualityFactor);
+            expect(medium.mediabunnyVideoQualityFactor).toBe(medium.mediabunnyAudioQualityFactor);
+            expect(low.mediabunnyVideoQualityFactor).toBe(low.mediabunnyAudioQualityFactor);
         });
 
         it('Lowの音声サンプルレートがAAC互換の44100Hzである', () => {
@@ -76,16 +66,6 @@ describe('VIDEO_COMPRESSION_OPTIONS_MAP', () => {
     });
 
     describe('設定値の妥当性', () => {
-        it('CRF値が有効範囲内（0-51）である', () => {
-            const levels = ['low', 'medium', 'high'] as const;
-
-            levels.forEach(level => {
-                const crf = VIDEO_COMPRESSION_OPTIONS_MAP[level].crf!;
-                expect(crf).toBeGreaterThanOrEqual(0);
-                expect(crf).toBeLessThanOrEqual(51);
-            });
-        });
-
         it('maxSizeが正の整数である', () => {
             const levels = ['low', 'medium', 'high'] as const;
 


### PR DESCRIPTION
## Summary

- Pass MediaBunny 1.44.2 audio Quality through the supported `bitrate: Quality` option for both AAC capability checks and Conversion.
- Remove obsolete canonical `audioBitrate`, `crf`, `preset`, and `parseAudioBitrate` plumbing.
- Preserve the existing video path, lazy native-first AAC selection, packet-copy/original-file fallbacks, and fixed legacy bridge assets.

## Behavior

High, Medium, and Low now pass `QUALITY_HIGH`, `QUALITY_MEDIUM`, and `QUALITY_VERY_LOW` respectively as the audio bitrate control. This is an intentional audio rate-control behavior correction for the pinned MediaBunny 1.44.2 API; it does not assert a fixed resulting AAC stream bitrate.

PR #185 is already merged and Low remains 44.1 kHz mono. The similar video Quality API finding is deliberately out of scope for this PR.

## Validation

- Targeted video-compression tests: 51 passed
- Host-owned upload regression: 2 passed
- `npm run check`: 0 errors, 0 warnings
- `npm test`: 3,931 passed, 1 skipped
- `npm run build`: passed; verified 56 fixed legacy assets in dist and sw.js; AAC encoder remains a dynamic chunk
- iframe/Web Component Playwright regression: 96 passed, 2 skipped

## Physical-device acceptance required (user confirmation pending)

Please use the Vercel Preview or equivalent with the same representative MOV:

- iPhone: High, Medium, Low
- Android: Low; Medium smoke test if possible

Record compression success, video/audio playback, duration, orientation, output size, compression time, AAC profile/sample rate/channels/average bitrate, decoder-open result, and any `SBR+0`, 96 kHz, or 0-channel output. Low on iPhone must remain AAC-LC, 44.1 kHz, mono and must not regress the PR #185 AAC corruption fix.

If physical acceptance finds audio loss, decoder failure, Low AAC corruption, or another material regression, do not merge this PR. Do not add video Quality changes, FFmpeg fallback, validators, or a state machine here; handle those in a separate investigation.