### PR TITLE
Fix stale profile avatar for accounts without kind 0

### DIFF
--- a/src/lib/bootstrap/authBootstrap.ts
+++ b/src/lib/bootstrap/authBootstrap.ts
@@ -1,6 +1,6 @@
 import { createRxNostr } from "rx-nostr";
 import { verifier } from "@rx-nostr/crypto";
-import { ProfileUrlUtils } from "../profileManager";
+import { ProfileDataFactory, ProfileUrlUtils } from "../profileManager";
 import { RelayManager } from "../relayManager";
 import { RelayProfileService } from "../relayProfileService";
 import type { AccountManager } from "../accountManager";
@@ -166,6 +166,10 @@ export function applyProfileToStores({
     });
 }
 
+function createDefaultProfileForAccount(pubkeyHex: string): ProfileData {
+    return new ProfileDataFactory().createProfileData({}, pubkeyHex);
+}
+
 export async function refreshRelaysAndProfileForAccount({
     pubkeyHex,
     relayProfileService,
@@ -173,10 +177,8 @@ export async function refreshRelaysAndProfileForAccount({
     profileLoadedStore,
     accountProfileCacheStore,
 }: RefreshRelaysAndProfileForAccountParams): Promise<ProfileData | null> {
-    const profile = await relayProfileService.refreshRelaysAndProfile(pubkeyHex);
-    if (!profile) {
-        return null;
-    }
+    const fetchedProfile = await relayProfileService.refreshRelaysAndProfile(pubkeyHex);
+    const profile = fetchedProfile ?? createDefaultProfileForAccount(pubkeyHex);
 
     applyProfileToStores({
         pubkeyHex,
@@ -212,17 +214,16 @@ export async function completePostAuthBootstrap({
             setRelayManager,
             onRelayConfigSaved,
         });
-        const profile = await session.relayProfileService.initializeForLogin(pubkeyHex);
+        const fetchedProfile = await session.relayProfileService.initializeForLogin(pubkeyHex);
+        const profile = fetchedProfile ?? createDefaultProfileForAccount(pubkeyHex);
 
-        if (profile) {
-            applyProfileToStores({
-                pubkeyHex,
-                profile,
-                profileDataStore,
-                profileLoadedStore,
-                accountProfileCacheStore,
-            });
-        }
+        applyProfileToStores({
+            pubkeyHex,
+            profile,
+            profileDataStore,
+            profileLoadedStore,
+            accountProfileCacheStore,
+        });
 
         return session;
     } finally {

--- a/src/test/unit/authBootstrap.test.ts
+++ b/src/test/unit/authBootstrap.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
     applyProfileToStores,
+    completePostAuthBootstrap,
     runInitializeNostrSession,
     refreshRelaysAndProfileForAccount,
 } from '../../lib/bootstrap/authBootstrap';
+import { RelayProfileService } from '../../lib/relayProfileService';
 
 function createProfile() {
     return {
@@ -70,7 +72,8 @@ describe('refreshRelaysAndProfileForAccount', () => {
         });
     });
 
-    it('プロフィールが取得できない場合はストア更新を行わない', async () => {
+    it('プロフィールがないアカウントには対象pubkeyのデフォルトプロフィールを反映する', async () => {
+        const accountA = createProfile();
         const relayProfileService = {
             refreshRelaysAndProfile: vi.fn().mockResolvedValue(null),
         };
@@ -78,18 +81,79 @@ describe('refreshRelaysAndProfileForAccount', () => {
         const profileLoadedStore = { set: vi.fn() };
         const accountProfileCacheStore = { setProfile: vi.fn() };
 
+        profileDataStore.set(accountA);
+
         const result = await refreshRelaysAndProfileForAccount({
-            pubkeyHex: 'pubkey-1',
+            pubkeyHex: '02'.repeat(32),
             relayProfileService,
             profileDataStore,
             profileLoadedStore,
             accountProfileCacheStore,
         });
 
-        expect(result).toBeNull();
-        expect(profileDataStore.set).not.toHaveBeenCalled();
-        expect(profileLoadedStore.set).not.toHaveBeenCalled();
-        expect(accountProfileCacheStore.setProfile).not.toHaveBeenCalled();
+        expect(result).toMatchObject({
+            name: '',
+            displayName: '',
+            picture: '',
+        });
+        expect(result?.npub).toMatch(/^npub1/);
+        expect(result?.nprofile).toMatch(/^nprofile1/);
+        expect(profileDataStore.set).toHaveBeenLastCalledWith(result);
+        expect(profileLoadedStore.set).toHaveBeenLastCalledWith(true);
+        expect(accountProfileCacheStore.setProfile).toHaveBeenLastCalledWith('02'.repeat(32), {
+            name: '',
+            displayName: '',
+            picture: '',
+        });
+        expect(result?.picture).not.toBe(accountA.picture);
+    });
+});
+
+describe('completePostAuthBootstrap', () => {
+    it('認証後にkind:0がない場合も前アカウントのプロフィールを残さない', async () => {
+        const pubkeyHex = '03'.repeat(32);
+        const accountA = createProfile();
+        const currentProfile = { value: accountA };
+        const profileDataStore = {
+            set: vi.fn((profile) => {
+                currentProfile.value = profile;
+            }),
+        };
+        const profileLoadedStore = { set: vi.fn() };
+        const accountProfileCacheStore = { setProfile: vi.fn() };
+
+        vi.spyOn(RelayProfileService.prototype, 'initializeRelays').mockResolvedValue(undefined);
+        vi.spyOn(RelayProfileService.prototype, 'initializeForLogin').mockResolvedValue(null);
+
+        await completePostAuthBootstrap({
+            pubkeyHex,
+            closeAuthDialogs: vi.fn(),
+            relayListUpdatedStore: { value: 0, set: vi.fn() },
+            setRelayManager: vi.fn(),
+            profileDataStore,
+            profileLoadedStore,
+            isLoadingProfileStore: { set: vi.fn() },
+            accountManager: { getAccounts: () => [] },
+            accountListStore: { set: vi.fn() },
+            accountProfileCacheStore,
+        });
+
+        expect(currentProfile.value).toMatchObject({
+            name: '',
+            displayName: '',
+            picture: '',
+        });
+        expect(currentProfile.value.npub).toMatch(/^npub1/);
+        expect(currentProfile.value.nprofile).toMatch(/^nprofile1/);
+        expect(currentProfile.value).not.toEqual(accountA);
+        expect(profileLoadedStore.set).toHaveBeenCalledWith(true);
+        expect(accountProfileCacheStore.setProfile).toHaveBeenCalledWith(pubkeyHex, {
+            name: '',
+            displayName: '',
+            picture: '',
+        });
+
+        vi.restoreAllMocks();
     });
 });
 


### PR DESCRIPTION
## Summary
- Apply a pubkey-specific default profile when post-auth kind:0 lookup returns null.
- Mark the profile as loaded and update the per-account profile cache so the existing ProfileAvatar fallback renders.
- Preserve normal kind:0 profile handling and the profileMetadataCache null/negative-cache contract.

## Root cause
When profile lookup returned null after authentication, the current profile store was not updated. The previous account's profileData/profileLoaded state could therefore remain visible.

## Tests
- 
pm run test -- src/test/unit/authBootstrap.test.ts
- 
pm run check
- 
pm test (342 files, 3933 passed, 1 skipped)
- 
pm run build

## Verification not run
- No real-network or device verification; the regression tests use mocked profile results and the requested scope is covered by deterministic unit tests.