### PR TITLE
Align settings update button to the right

### DIFF
--- a/src/components/SettingsDialog.svelte
+++ b/src/components/SettingsDialog.svelte
@@ -392,7 +392,7 @@
         <!-- SW更新セクション -->
         {#if $swNeedRefresh || isStaleAssetReloadRequired}
             <div class="setting-section">
-                <div class="setting-row">
+                <div class="setting-row sw-update-row">
                     <div class="setting-control">
                         <Button
                             variant="primary"
@@ -1175,6 +1175,10 @@
         width: auto;
         padding: 12px 10px 12px 8px;
         flex-shrink: 0;
+    }
+
+    .sw-update-row {
+        justify-content: flex-end;
     }
 
     :global(.sw-update-btn:disabled) {


### PR DESCRIPTION
## Summary
- Restore the app update button to the right side of its settings row
- Keep the update UI simplified to the button only

## Verification
- npm run test -- src/test/unit/settingsDialogAccessibility.test.ts
- npm run check
- npm run build
- Playwright CLI DOM check: update row uses flex-end, button aligns with row right edge, no status label, transparent background