### PR TITLE
Fix post history search reset on close

### DIFF
--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -551,7 +551,7 @@
         const shouldClearAllSessionScrollState = history.prepareForClose();
         if (shouldClearAllSessionScrollState) {
             historyViewport.clearAllSessionScrollAnchorsForCurrentPubkey();
-        } else {
+        } else if (!wasSearchMode) {
             historyViewport.saveCurrentSessionScrollAnchor();
         }
         channelDisplay.cancelCurrentChannelResolution();

--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -543,6 +543,11 @@
     }
 
     function handleClose() {
+        const wasSearchMode = history.isSearchMode;
+        if (wasSearchMode) {
+            historyViewport.clearCurrentSessionScrollAnchor();
+        }
+        history.resetSearchState();
         const shouldClearAllSessionScrollState = history.prepareForClose();
         if (shouldClearAllSessionScrollState) {
             historyViewport.clearAllSessionScrollAnchorsForCurrentPubkey();

--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -988,6 +988,8 @@ export function usePostHistoryListing({
         state.searchTotalCount = 0;
         state.searchHasNext = false;
         appliedSearchQuery = "";
+        persistCurrentViewState();
+        persistCurrentListingSnapshot();
     }
 
     function clearCurrentListingState(): void {
@@ -1014,6 +1016,43 @@ export function usePostHistoryListing({
     function canPersistStateForCurrentPubkey(): boolean {
         const currentPubkeyKey = resolveListingSnapshotKey(getPubkeyHex());
         return !!currentPubkeyKey && currentPubkeyKey === stateOwnerPubkeyKey;
+    }
+
+    function persistCurrentViewState(): void {
+        if (!canPersistStateForCurrentPubkey()) {
+            return;
+        }
+
+        writePersistedPostHistoryViewState(getPubkeyHex(), {
+            searchInput: state.searchInput,
+            searchQuery: state.searchQuery,
+            currentPage: state.currentPage,
+            searchPage: state.searchPage,
+        });
+    }
+
+    function persistCurrentListingSnapshot(): void {
+        if (!canPersistStateForCurrentPubkey()) {
+            return;
+        }
+
+        writePersistedListingSnapshot(getPubkeyHex(), {
+            loadedPosts: state.loadedPosts,
+            searchPosts: state.searchPosts,
+            searchQuery: state.searchQuery,
+            totalCount: state.totalCount,
+            totalCountKnown: state.totalCountKnown,
+            totalCountFailed: state.totalCountStatus === "failed",
+            searchTotalCount: state.searchTotalCount,
+            searchHasNext: state.searchHasNext,
+            hasMoreRemote: state.hasMoreRemote,
+            nextUntil: state.nextUntil,
+            lastDialogOpenRefreshAt: state.lastDialogOpenRefreshAt,
+            visibleUntil: state.visibleUntil,
+            hasJumpCacheAnchors: state.hasJumpCacheAnchors,
+            hasOlderLocal: state.hasOlderLocal,
+            hasNewerLocal: state.hasNewerLocal,
+        });
     }
 
     function markStateOwner(pubkeyHex: string | null | undefined): void {
@@ -4293,40 +4332,11 @@ export function usePostHistoryListing({
     });
 
     $effect(() => {
-        if (!canPersistStateForCurrentPubkey()) {
-            return;
-        }
-
-        writePersistedPostHistoryViewState(getPubkeyHex(), {
-            searchInput: state.searchInput,
-            searchQuery: state.searchQuery,
-            currentPage: state.currentPage,
-            searchPage: state.searchPage,
-        });
+        persistCurrentViewState();
     });
 
     $effect(() => {
-        if (!canPersistStateForCurrentPubkey()) {
-            return;
-        }
-
-        writePersistedListingSnapshot(getPubkeyHex(), {
-            loadedPosts: state.loadedPosts,
-            searchPosts: state.searchPosts,
-            searchQuery: state.searchQuery,
-            totalCount: state.totalCount,
-            totalCountKnown: state.totalCountKnown,
-            totalCountFailed: state.totalCountStatus === "failed",
-            searchTotalCount: state.searchTotalCount,
-            searchHasNext: state.searchHasNext,
-            hasMoreRemote: state.hasMoreRemote,
-            nextUntil: state.nextUntil,
-            lastDialogOpenRefreshAt: state.lastDialogOpenRefreshAt,
-            visibleUntil: state.visibleUntil,
-            hasJumpCacheAnchors: state.hasJumpCacheAnchors,
-            hasOlderLocal: state.hasOlderLocal,
-            hasNewerLocal: state.hasNewerLocal,
-        });
+        persistCurrentListingSnapshot();
     });
 
     $effect(() => {

--- a/src/test/e2e/PostHistoryDialogHarness.svelte
+++ b/src/test/e2e/PostHistoryDialogHarness.svelte
@@ -35,6 +35,7 @@
     }, HARNESS_SECRET_KEY));
 
     let ready = $state(false);
+    let showDialog = $state(true);
 
     type HarnessState = {
         ready: boolean;
@@ -418,7 +419,7 @@
 <div class="post-history-playwright-harness">
     {#if ready}
         <PostHistoryDialog
-            show={true}
+            bind:show={showDialog}
             onClose={() => undefined}
             pubkeyHex={HARNESS_PUBKEY}
             rxNostr={{
@@ -428,6 +429,15 @@
             } as unknown as RxNostr}
             onQuotePost={() => undefined}
         />
+    {/if}
+    {#if ready && !showDialog}
+        <button
+            type="button"
+            data-testid="post-history-reopen"
+            onclick={() => (showDialog = true)}
+        >
+            reopen post history
+        </button>
     {/if}
 </div>
 

--- a/src/test/e2e/PostHistoryDialogHarness.svelte
+++ b/src/test/e2e/PostHistoryDialogHarness.svelte
@@ -417,18 +417,20 @@
 </svelte:head>
 
 <div class="post-history-playwright-harness">
-    {#if ready}
-        <PostHistoryDialog
-            bind:show={showDialog}
-            onClose={() => undefined}
-            pubkeyHex={HARNESS_PUBKEY}
-            rxNostr={{
-                use: () => ({
-                    subscribe: () => ({ unsubscribe: () => undefined }),
-                }),
-            } as unknown as RxNostr}
-            onQuotePost={() => undefined}
-        />
+    {#if ready && showDialog}
+        <div data-testid="post-history-mounted">
+            <PostHistoryDialog
+                show={showDialog}
+                onClose={() => (showDialog = false)}
+                pubkeyHex={HARNESS_PUBKEY}
+                rxNostr={{
+                    use: () => ({
+                        subscribe: () => ({ unsubscribe: () => undefined }),
+                    }),
+                } as unknown as RxNostr}
+                onQuotePost={() => undefined}
+            />
+        </div>
     {/if}
     {#if ready && !showDialog}
         <button

--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -494,10 +494,13 @@ test.describe('PostHistoryDialog Playwright', () => {
         await expectSummary(page, harness.matchingPosts);
         await expectVisiblePostCount(page, harness.matchingPosts);
 
+        await expect(page.getByTestId('post-history-mounted')).toHaveCount(1);
         await page.getByRole('button', { name: '閉じる', exact: true }).click();
         await expect(page.locator('.post-history-dialog')).toHaveCount(0);
+        await expect(page.getByTestId('post-history-mounted')).toHaveCount(0);
 
         await page.getByTestId('post-history-reopen').click();
+        await expect(page.getByTestId('post-history-mounted')).toHaveCount(1);
         await expect(page.locator('.post-history-dialog')).toBeVisible();
         await expect(page.getByRole('searchbox', { name: '検索' })).toHaveCount(0);
         await expectSummary(page, harness.totalPosts);

--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -478,6 +478,34 @@ test.describe('PostHistoryDialog Playwright', () => {
         await expect(page.getByRole('button', { name: '新しい検索結果を表示' })).toHaveCount(0);
     });
 
+    test('closing and reopening the dialog resets post history search state', async ({ page }) => {
+        const harness = await gotoHarness(page);
+
+        await expectSummary(page, harness.totalPosts);
+        await expectVisiblePostCount(page, 50);
+
+        await page.getByRole('button', { name: '投稿履歴メニューを開く' }).click();
+        await page.getByRole('menuitem', { name: '検索' }).click();
+        await page.getByRole('searchbox', { name: '検索' }).fill('alpha');
+        await expectSummary(page, harness.matchingPosts);
+        await expectVisiblePostCount(page, 50);
+
+        await page.getByRole('button', { name: 'さらに古い検索結果を表示' }).click();
+        await expectSummary(page, harness.matchingPosts);
+        await expectVisiblePostCount(page, harness.matchingPosts);
+
+        await page.getByRole('button', { name: '閉じる', exact: true }).click();
+        await expect(page.locator('.post-history-dialog')).toHaveCount(0);
+
+        await page.getByTestId('post-history-reopen').click();
+        await expect(page.locator('.post-history-dialog')).toBeVisible();
+        await expect(page.getByRole('searchbox', { name: '検索' })).toHaveCount(0);
+        await expectSummary(page, harness.totalPosts);
+        await expectVisiblePostCount(page, 50);
+        await expect(page.getByRole('button', { name: 'さらに古い投稿を表示' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'さらに古い検索結果を表示' })).toHaveCount(0);
+    });
+
     test('desktop newer prepend keeps the current post anchored', async ({ page, isMobile }) => {
         test.skip(isMobile, 'desktop only');
 

--- a/src/test/unit/postHistoryDialogTimelineSearch.test.ts
+++ b/src/test/unit/postHistoryDialogTimelineSearch.test.ts
@@ -18,6 +18,11 @@ import {
     waitForSearchDebounce,
 } from './postHistoryDialogTestHarness';
 import { readPersistedPostHistoryViewState } from '../../lib/postHistoryDialogViewState';
+import { readPersistedPostHistoryListingSnapshotForPubkey } from '../../lib/hooks/usePostHistoryListing.svelte';
+import {
+    readPostHistoryDialogScrollState,
+    writePostHistoryDialogScrollState,
+} from '../../lib/postHistoryDialogScrollState';
 
 function controlAnimationFrames() {
     let nextId = 1;
@@ -1039,16 +1044,21 @@ describe('PostHistoryDialog timeline search', () => {
             searchInput: '',
             searchQuery: '',
         });
-
-        await view.rerender({
-            show: false,
-            onClose,
-            pubkeyHex: PUBKEY_HEX,
+        expect(readPersistedPostHistoryListingSnapshotForPubkey(PUBKEY_HEX)).toMatchObject({
+            loadedPosts: [expect.objectContaining({ eventId: 'search-reopen-normal' })],
+            searchPosts: [],
+            searchQuery: '',
+            searchTotalCount: 0,
+            searchHasNext: false,
         });
-        await view.rerender({
-            show: true,
-            onClose,
-            pubkeyHex: PUBKEY_HEX,
+
+        view.unmount();
+        const reopenedView = render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose,
+                pubkeyHex: PUBKEY_HEX,
+            },
         });
 
         await waitFor(() => {
@@ -1057,6 +1067,74 @@ describe('PostHistoryDialog timeline search', () => {
             expect(screen.queryByText('reopen 検索結果 2')).toBeNull();
             expect(screen.queryByRole('searchbox', { name: '検索' })).toBeNull();
         });
+
+        reopenedView.unmount();
+    });
+
+    it('検索中に閉じても検索結果の scroll anchor を通常履歴へ保存しない', async () => {
+        const normalPost = createRecord({
+            eventId: 'search-close-normal-anchor',
+            content: '通常履歴 anchor',
+        });
+        const searchPost = createRecord({
+            eventId: 'search-close-search-anchor',
+            content: '検索結果 anchor',
+        });
+        repositoryMock.countForPubkey.mockResolvedValue(1);
+        repositoryMock.getLatestVisibleChunk.mockResolvedValueOnce([normalPost]);
+        repositoryMock.getNewerVisibleChunk.mockResolvedValueOnce([]);
+        repositoryMock.getOlderVisibleChunk.mockResolvedValueOnce([]);
+        localSearchServiceMock.searchLocalPosts.mockResolvedValue({
+            items: [searchPost],
+            total: 1,
+            hasNext: false,
+        });
+
+        const view = render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: PUBKEY_HEX,
+            },
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('通常履歴 anchor')).toBeTruthy();
+        });
+        writePostHistoryDialogScrollState({
+            pubkeyHex: PUBKEY_HEX,
+            mode: 'normal',
+            anchor: { eventId: normalPost.eventId, offsetTop: 64 },
+            savedAt: 100,
+        });
+
+        const searchInput = await openSearchBar();
+        await fireEvent.input(searchInput, { target: { value: 'alpha' } });
+        await waitForSearchDebounce();
+        await waitFor(() => {
+            expect(screen.getByText('検索結果 anchor')).toBeTruthy();
+        });
+        writePostHistoryDialogScrollState({
+            pubkeyHex: PUBKEY_HEX,
+            mode: 'search',
+            searchQuery: 'alpha',
+            anchor: { eventId: searchPost.eventId, offsetTop: 24 },
+            savedAt: 101,
+        });
+
+        await fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
+
+        expect(readPostHistoryDialogScrollState({
+            pubkeyHex: PUBKEY_HEX,
+            mode: 'normal',
+        })).toMatchObject({
+            anchor: { eventId: normalPost.eventId, offsetTop: 64 },
+        });
+        expect(readPostHistoryDialogScrollState({
+            pubkeyHex: PUBKEY_HEX,
+            mode: 'search',
+            searchQuery: 'alpha',
+        })).toBeNull();
 
         view.unmount();
     });

--- a/src/test/unit/postHistoryDialogTimelineSearch.test.ts
+++ b/src/test/unit/postHistoryDialogTimelineSearch.test.ts
@@ -66,7 +66,6 @@ async function persistSearchSnapshot(
     await waitFor(() => {
         expect(screen.getByText(String(post.content))).toBeTruthy();
     });
-    await fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
     view.unmount();
 }
 
@@ -665,7 +664,6 @@ describe('PostHistoryDialog timeline search', () => {
         await waitFor(() => {
             expect(screen.getByText('保存済み検索結果')).toBeTruthy();
         });
-        await fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
         firstView.unmount();
 
         postMediaCacheServiceMock.prefetchCachedMediaDescriptors.mockClear();
@@ -988,8 +986,7 @@ describe('PostHistoryDialog timeline search', () => {
         view.unmount();
     });
 
-    it('contiguous 表示中の検索を閉じて reopen した場合は既存の検索復元を維持する', async () => {
-        let searchDataRevision = 0;
+    it('ダイアログを閉じて reopen した場合は検索を解除して通常履歴を表示する', async () => {
         repositoryMock.countForPubkey.mockResolvedValue(1);
         repositoryMock.getLatestVisibleChunk.mockResolvedValueOnce([
             createRecord({ eventId: 'search-reopen-normal', content: '検索復元前の通常一覧' }),
@@ -998,26 +995,10 @@ describe('PostHistoryDialog timeline search', () => {
         repositoryMock.getOlderVisibleChunk.mockResolvedValueOnce([]);
         localSearchServiceMock.searchLocalPosts.mockImplementation(
             async ({ page }: { page: number }) => ({
-                items: searchDataRevision === 0
-                    ? [createRecord({
-                        eventId: `search-reopen-hit-${page}`,
-                        content: `reopen 検索結果 ${page}`,
-                    })]
-                    : page === 1
-                        ? [
-                            createRecord({
-                                eventId: 'search-reopen-newest-hit',
-                                content: 'reopen 新しい先頭結果',
-                            }),
-                            createRecord({
-                                eventId: 'search-reopen-hit-1',
-                                content: 'reopen 検索結果 1',
-                            }),
-                        ]
-                        : [createRecord({
-                            eventId: 'search-reopen-hit-2',
-                            content: 'reopen 検索結果 2',
-                        })],
+                items: [createRecord({
+                    eventId: `search-reopen-hit-${page}`,
+                    content: `reopen 検索結果 ${page}`,
+                })],
                 total: 100,
                 hasNext: page === 1,
             }),
@@ -1045,20 +1026,18 @@ describe('PostHistoryDialog timeline search', () => {
             expect(screen.getByText('reopen 検索結果 2')).toBeTruthy();
         });
 
-        repositoryMock.getLatestVisibleChunk.mockClear();
-        localSearchServiceMock.searchLocalPosts.mockClear();
-
         await fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
         await waitFor(() => {
             expect(onClose).toHaveBeenCalledTimes(1);
         });
-        searchDataRevision = 1;
-
+        await waitFor(() => {
+            expect(screen.queryByRole('searchbox', { name: '検索' })).toBeNull();
+        });
         expect(readPersistedPostHistoryViewState(PUBKEY_HEX)).toEqual({
             currentPage: 1,
-            searchPage: 2,
-            searchInput: 'alpha',
-            searchQuery: 'alpha',
+            searchPage: 1,
+            searchInput: '',
+            searchQuery: '',
         });
 
         await view.rerender({
@@ -1073,23 +1052,11 @@ describe('PostHistoryDialog timeline search', () => {
         });
 
         await waitFor(() => {
-            expect(screen.getByText('reopen 新しい先頭結果')).toBeTruthy();
-            expect(screen.getByText('reopen 検索結果 1')).toBeTruthy();
-            expect(screen.getByText('reopen 検索結果 2')).toBeTruthy();
+            expect(screen.getByText('検索復元前の通常一覧')).toBeTruthy();
+            expect(screen.queryByText('reopen 検索結果 1')).toBeNull();
+            expect(screen.queryByText('reopen 検索結果 2')).toBeNull();
+            expect(screen.queryByRole('searchbox', { name: '検索' })).toBeNull();
         });
-
-        expect(repositoryMock.getLatestVisibleChunk).not.toHaveBeenCalled();
-        expect(localSearchServiceMock.searchLocalPosts.mock.calls.map(([args]) => args.page))
-            .toEqual([1, 2]);
-        expect(screen.queryByText('reopen 検索結果 3')).toBeNull();
-        expect(
-            [...document.querySelectorAll<HTMLElement>('.post-history-item')]
-                .map((element) => element.dataset.postHistoryEventId),
-        ).toEqual([
-            'search-reopen-newest-hit',
-            'search-reopen-hit-1',
-            'search-reopen-hit-2',
-        ]);
 
         view.unmount();
     });


### PR DESCRIPTION
## Summary
- Reset post history search state through the existing listing API on every dialog close path.
- Clear the search scroll anchor before the existing close cleanup.
- Add unit and desktop/mobile Chromium regression coverage for close and reopen.

## Verification
- npm run check
- npm test
- npm run build
- npx playwright test src/test/e2e/postHistoryDialog.spec.ts --project=desktop-chromium --project=mobile-chromium
