### PR TITLE
fix: defer embed relay hydration until runtime is ready

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -538,6 +538,7 @@
   let customEmojiPickerHeight = $derived(
     composerLayoutMetrics.customEmojiPickerHeight,
   );
+  let parentClientTransitionCount = 0;
   const parentClientAuthCoordinator = createParentClientAuthCoordinator({
     authenticateWithParentClient: (options) =>
       authService.authenticateWithParentClient(options),
@@ -1076,6 +1077,7 @@
       onSession: (session) => {
         rxNostr = session.rxNostr;
         relayProfileService = session.relayProfileService;
+        void flushPendingReplyQuoteHydrationWhenRuntimeReady();
       },
     });
   }
@@ -1108,6 +1110,7 @@
 
     rxNostr = session.rxNostr;
     relayProfileService = session.relayProfileService;
+    void flushPendingReplyQuoteHydrationWhenRuntimeReady();
   }
 
   /** アカウントリストストアを保存済みプロフィールキャッシュから同期 */
@@ -1134,7 +1137,9 @@
       timeoutMs?: number;
     } = {},
   ): Promise<string | undefined> {
-    return appAuthLoginController.activateParentClientAuth(options);
+    return runParentClientTransition(() =>
+      appAuthLoginController.activateParentClientAuth(options),
+    );
   }
 
   function getReplyQuoteApplyParams() {
@@ -1270,8 +1275,7 @@
     },
     runtime: {
       isBootstrappingApp: () => isBootstrappingApp,
-      hasPendingParentAuth: () =>
-        parentClientAuthCoordinator.hasPendingRequest(),
+      isParentClientTransitioning: () => parentClientTransitionCount > 0,
       getReplyQuoteState: () => replyQuoteState.value,
       getChannelContextState: () => channelContextState.value,
       getChannelContextProvenance: () => channelContextProvenanceState.value,
@@ -1304,6 +1308,26 @@
       },
     },
   });
+
+  async function flushPendingReplyQuoteHydrationWhenRuntimeReady(): Promise<void> {
+    if (!rxNostr || parentClientTransitionCount > 0) {
+      return;
+    }
+
+    await appEmbedController.flushPendingReplyQuoteHydration();
+  }
+
+  async function runParentClientTransition<T>(
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    parentClientTransitionCount += 1;
+    try {
+      return await operation();
+    } finally {
+      parentClientTransitionCount -= 1;
+      void flushPendingReplyQuoteHydrationWhenRuntimeReady();
+    }
+  }
   const appParentClientSyncController = createAppParentClientSyncController({
     isBootstrappingApp: () => isBootstrappingApp,
     hasPendingParentAuth: () => parentClientAuthCoordinator.hasPendingRequest(),
@@ -1412,7 +1436,9 @@
   }
 
   async function handleParentClientLogin(): Promise<string | undefined> {
-    return appAuthLoginController.handleParentClientLogin();
+    return runParentClientTransition(() =>
+      appAuthLoginController.handleParentClientLogin(),
+    );
   }
 
   async function handleNip46Login(
@@ -1574,6 +1600,7 @@
         startupAuthenticationSettled = true;
       }
       void flushPendingRemoteParentClientAndEmbedActions().finally(() => {
+        void flushPendingReplyQuoteHydrationWhenRuntimeReady();
         appEmbedController.notifyComposerContextUpdatedIfChanged();
       });
     });

--- a/src/lib/appEmbedController.ts
+++ b/src/lib/appEmbedController.ts
@@ -113,7 +113,7 @@ export interface AppEmbedRuntimeSnapshot {
 
 export interface AppEmbedRuntimeStateGetters {
     isBootstrappingApp(): boolean;
-    hasPendingParentAuth(): boolean;
+    isParentClientTransitioning(): boolean;
     getReplyQuoteState(): ReplyQuoteComposerState;
     getChannelContextState(): ChannelContextState | null;
     getChannelContextProvenance(): ChannelContextProvenance | null;
@@ -163,6 +163,9 @@ export type AppEmbedPendingComposerAction = Readonly<{
 
 interface AppEmbedControllerState {
     pendingComposerAction?: AppEmbedPendingComposerAction;
+    pendingReplyQuoteHydration?: Readonly<{
+        references: ReplyQuoteHydrationTarget[];
+    }>;
     lastNotifiedComposerContextSignature: string | null;
     applyingComposerContext: boolean;
 }
@@ -187,13 +190,14 @@ export interface AppEmbedController {
         requestId: string,
     ): void;
     flushPendingComposerAction(): Promise<void>;
+    flushPendingReplyQuoteHydration(): Promise<void>;
     notifyComposerContextUpdatedIfChanged(): void;
     initializeEmbedStorageSync(): Promise<void>;
     resetNotifiedComposerContextSignature(): void;
 }
 
 function shouldQueueAction(getters: AppEmbedRuntimeStateGetters): boolean {
-    return getters.isBootstrappingApp() || getters.hasPendingParentAuth();
+    return getters.isBootstrappingApp();
 }
 
 export function createAppEmbedController(
@@ -207,6 +211,7 @@ export function createAppEmbedController(
         })();
     const state: AppEmbedControllerState = {
         pendingComposerAction: undefined,
+        pendingReplyQuoteHydration: undefined,
         lastNotifiedComposerContextSignature: null,
         applyingComposerContext: false,
     };
@@ -263,6 +268,7 @@ export function createAppEmbedController(
         }
 
         if (replyQuoteQuery === null) {
+            state.pendingReplyQuoteHydration = undefined;
             deps.composerContextApply.clearReplyQuote();
             return [];
         }
@@ -274,13 +280,86 @@ export function createAppEmbedController(
             payload.preloadedEvents,
             references,
         );
-        return references.length > 0
-            ? [() => deps.composerContextApply.hydrateReplyQuoteReferences(
-                references,
-                runtimeSnapshot,
+        const preloadedReferences = references.filter((reference) =>
+            Object.prototype.hasOwnProperty.call(
                 selectedPreloadedEvents,
-            )]
-            : [];
+                reference.eventId,
+            ),
+        );
+        const relayReferences = references.filter((reference) =>
+            !Object.prototype.hasOwnProperty.call(
+                selectedPreloadedEvents,
+                reference.eventId,
+            ),
+        );
+
+        state.pendingReplyQuoteHydration = relayReferences.length > 0
+            ? { references: [...relayReferences] }
+            : undefined;
+
+        const tasks: Array<() => Promise<void>> = [];
+        if (preloadedReferences.length > 0) {
+            tasks.push(() => deps.composerContextApply.hydrateReplyQuoteReferences(
+                preloadedReferences,
+                {
+                    rxNostr: undefined,
+                    relayConfig: runtimeSnapshot.relayConfig,
+                },
+                selectedPreloadedEvents,
+            ));
+        }
+        if (relayReferences.length > 0) {
+            tasks.push(flushPendingReplyQuoteHydration);
+        }
+        return tasks;
+    }
+
+    function isCurrentReplyQuoteHydrationTarget(
+        target: ReplyQuoteHydrationTarget,
+    ): boolean {
+        const current = deps.runtime.getReplyQuoteState();
+        if (target.mode === "reply") {
+            return current.reply?.eventId === target.eventId
+                && current.reply.ownerToken === target.ownerToken;
+        }
+
+        return current.quotes.some((quote) =>
+            quote.eventId === target.eventId
+            && quote.ownerToken === target.ownerToken,
+        );
+    }
+
+    async function flushPendingReplyQuoteHydration(): Promise<void> {
+        if (deps.runtime.isParentClientTransitioning()) {
+            return;
+        }
+
+        const runtimeSnapshot = deps.runtime.getRuntimeSnapshot();
+        if (!runtimeSnapshot.rxNostr) {
+            return;
+        }
+
+        const pending = state.pendingReplyQuoteHydration;
+        if (!pending) {
+            return;
+        }
+
+        const currentReferences = pending.references.filter(
+            isCurrentReplyQuoteHydrationTarget,
+        );
+        state.pendingReplyQuoteHydration = undefined;
+        if (currentReferences.length === 0) {
+            return;
+        }
+
+        try {
+            await deps.composerContextApply.hydrateReplyQuoteReferences(
+                currentReferences,
+                runtimeSnapshot,
+            );
+        } catch (error) {
+            deps.logger.warn("composer context の非同期補完をスキップ:", error);
+        }
     }
 
     function runBackgroundComposerTasks(tasks: Array<() => Promise<void>>): void {
@@ -417,6 +496,8 @@ export function createAppEmbedController(
                 );
             }
         },
+
+        flushPendingReplyQuoteHydration,
 
         notifyComposerContextUpdatedIfChanged(): void {
             if (deps.runtime.isBootstrappingApp() || state.applyingComposerContext) {

--- a/src/test/e2e/embedParentClientExample.spec.ts
+++ b/src/test/e2e/embedParentClientExample.spec.ts
@@ -1,5 +1,80 @@
 import { test, expect } from "@playwright/test";
 import { finalizeEvent, generateSecretKey, nip19 } from "nostr-tools";
+import { WebSocketServer, type WebSocket } from "ws";
+
+let relayServer: WebSocketServer;
+let relayOrigin = "";
+let relayTargetEvent: ReturnType<typeof finalizeEvent> | null = null;
+let targetRequestCount = 0;
+
+function listenWebSocketServer(server: WebSocketServer): Promise<number> {
+    return new Promise((resolve, reject) => {
+        const onError = (error: Error) => {
+            server.off("listening", onListening);
+            reject(error);
+        };
+        const onListening = () => {
+            server.off("error", onError);
+            const address = server.address();
+            resolve(typeof address === "object" && address ? address.port : 0);
+        };
+        server.once("error", onError);
+        server.once("listening", onListening);
+    });
+}
+
+function closeWebSocketServer(server: WebSocketServer): Promise<void> {
+    for (const client of server.clients) {
+        client.terminate();
+    }
+    return new Promise((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+    });
+}
+
+test.beforeAll(async () => {
+    relayServer = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    relayServer.on("connection", (socket: WebSocket) => {
+        socket.on("message", (rawMessage) => {
+            try {
+                const message = JSON.parse(rawMessage.toString()) as unknown[];
+                if (message[0] !== "REQ" || typeof message[1] !== "string") {
+                    return;
+                }
+
+                const subscriptionId = message[1];
+                const filters = message.slice(2) as Array<{ ids?: unknown }>;
+                const requestsTarget = !!relayTargetEvent && filters.some((filter) =>
+                    Array.isArray(filter?.ids) && filter.ids.includes(relayTargetEvent?.id),
+                );
+                if (requestsTarget && relayTargetEvent) {
+                    targetRequestCount += 1;
+                    socket.send(JSON.stringify([
+                        "EVENT",
+                        subscriptionId,
+                        relayTargetEvent,
+                    ]));
+                }
+                socket.send(JSON.stringify(["EOSE", subscriptionId]));
+            } catch {
+                // This deterministic relay only needs REQ/EOSE for the fixture.
+            }
+        });
+    });
+    const relayPort = await listenWebSocketServer(relayServer);
+    relayOrigin = `ws://127.0.0.1:${relayPort}`;
+});
+
+test.beforeEach(() => {
+    relayTargetEvent = null;
+    targetRequestCount = 0;
+});
+
+test.afterAll(async () => {
+    if (relayServer) {
+        await closeWebSocketServer(relayServer);
+    }
+});
 
 test("uses an edited URL as the source of truth after an iframe context update", async ({ page }) => {
     const previousQuote = nip19.noteEncode("1".repeat(64));
@@ -128,6 +203,144 @@ test("applies a signed preloaded event through the iframe composer context proto
     await expect(preview).toHaveCount(1);
     await preview.locator(".preview-label").click();
     await expect(preview).toContainText("iframe preloaded reply");
+});
+
+test("hydrates a preload-free reply sent once with auth.login on the first ready", async ({ page }) => {
+    const event = finalizeEvent({
+        kind: 1,
+        content: "ready race relay event",
+        tags: [],
+        created_at: 5,
+    }, generateSecretKey());
+    relayTargetEvent = event;
+    const parentPubkeyHex = "12".repeat(32);
+    const reply = nip19.neventEncode({
+        id: event.id,
+        author: event.pubkey,
+        relays: [relayOrigin],
+    });
+
+    await page.addInitScript(({ relayOrigin }) => {
+        const NativeWebSocket = window.WebSocket;
+        class RoutedWebSocket extends NativeWebSocket {
+            constructor(url: string | URL, protocols?: string | string[]) {
+                super(relayOrigin, protocols as string | string[]);
+            }
+        }
+        window.WebSocket = RoutedWebSocket as typeof window.WebSocket;
+    }, { relayOrigin });
+
+    await page.route("**/e2e-embed-ready-parent.html", async (route) => {
+        const childUrl = new URL("/ehagaki/", route.request().url());
+        childUrl.searchParams.set("parentOrigin", childUrl.origin);
+        await route.fulfill({
+            contentType: "text/html",
+            body: `<!doctype html>
+<html lang="ja"><head><style>
+html, body { margin: 0; height: 100%; }
+#child { display: block; width: 100%; height: 100vh; border: 0; }
+</style></head><body>
+<iframe id="child" src="${childUrl.toString()}"></iframe>
+<script>
+localStorage.setItem("firstVisit", "1");
+const iframe = document.querySelector("#child");
+const state = window.__readyRaceState = {
+  readyCount: 0,
+  setContextSendCount: 0,
+  appliedRequestIds: [],
+  authRequestCount: 0,
+};
+const post = (type, payload, requestId) => iframe.contentWindow.postMessage({
+  namespace: "ehagaki.embed",
+  version: 1,
+  type,
+  ...(requestId ? { requestId } : {}),
+  ...(payload === undefined ? {} : { payload }),
+}, location.origin);
+window.addEventListener("message", (event) => {
+  if (event.source !== iframe.contentWindow || event.origin !== location.origin) return;
+  const message = event.data;
+  if (message?.namespace !== "ehagaki.embed" || message?.version !== 1) return;
+  if (message.type === "ready") {
+    state.readyCount += 1;
+    if (state.setContextSendCount === 0) {
+      post("auth.login", { pubkeyHex: ${JSON.stringify(parentPubkeyHex)} });
+      state.setContextSendCount += 1;
+      post("composer.setContext", { reply: ${JSON.stringify(reply)} }, "ready-race-context");
+    }
+    return;
+  }
+  if (message.type === "auth.request") {
+    state.authRequestCount += 1;
+    post("auth.result", {
+      pubkeyHex: ${JSON.stringify(parentPubkeyHex)},
+      capabilities: message.payload.capabilities,
+    }, message.requestId);
+    return;
+  }
+  if (message.type === "storage.get") {
+    const values = Object.fromEntries(message.payload.keys.map((key) => [key, null]));
+    post("storage.result", { timestamp: Date.now(), values }, message.requestId);
+    return;
+  }
+  if (message.type === "storage.set") {
+    post("storage.result", {
+      timestamp: Date.now(),
+      applied: Object.keys(message.payload.values),
+    }, message.requestId);
+    return;
+  }
+  if (message.type === "storage.remove") {
+    post("storage.result", {
+      timestamp: Date.now(),
+      removed: message.payload.keys,
+    }, message.requestId);
+    return;
+  }
+  if (message.type === "idb.getSnapshot") {
+    post("idb.result", {
+      timestamp: Date.now(),
+      store: message.payload.store,
+      scopeKey: message.payload.scopeKey,
+      records: [],
+    }, message.requestId);
+    return;
+  }
+  if (message.type === "composer.contextApplied") {
+    state.appliedRequestIds.push(message.requestId);
+  }
+});
+</script>
+</body></html>`,
+        });
+    });
+
+    await page.goto("/ehagaki/e2e-embed-ready-parent.html");
+    const frame = page.frameLocator("#child");
+    await expect(frame.locator(".tiptap-editor")).toBeVisible();
+
+    await expect.poll(() => page.evaluate(() => ({
+        readyCount: (window as any).__readyRaceState.readyCount,
+        setContextSendCount: (window as any).__readyRaceState.setContextSendCount,
+        authRequestCount: (window as any).__readyRaceState.authRequestCount,
+        appliedRequestIds: (window as any).__readyRaceState.appliedRequestIds,
+    }))).toMatchObject({
+        readyCount: expect.any(Number),
+        setContextSendCount: 1,
+        authRequestCount: 1,
+        appliedRequestIds: ["ready-race-context"],
+    });
+    await expect.poll(() => page.evaluate(() =>
+        (window as any).__readyRaceState.readyCount,
+    )).toBeGreaterThanOrEqual(2);
+    await expect.poll(() => targetRequestCount).toBeGreaterThanOrEqual(1);
+
+    const preview = frame.locator(".reply-quote-preview");
+    await expect(preview).toHaveCount(1);
+    await preview.locator(".preview-label").click();
+    await expect(preview).toContainText("ready race relay event");
+    await expect(preview).not.toContainText("イベントの取得に失敗しました");
+    expect(await page.evaluate(() => (window as any).__readyRaceState.setContextSendCount)).toBe(1);
 });
 
 test("only replaces initial settings queries after the settings UI changes", async ({ page }) => {

--- a/src/test/integration/app-parent-client.integration.test.ts
+++ b/src/test/integration/app-parent-client.integration.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
-import { nip19 } from 'nostr-tools';
+import { finalizeEvent, generateSecretKey, nip19 } from 'nostr-tools';
 import {
     mockAuthStoreModule,
     mockProfileStoreModule,
@@ -82,11 +82,7 @@ const mockState = vi.hoisted(() => {
     const setNsec = vi.fn();
     const logoutAccount = vi.fn(() => null);
     const applyReplyQuoteQuery = vi.fn(({ replyQuoteQuery, setReplyQuote }: any) => {
-        setReplyQuote(replyQuoteQuery);
-        return [
-            ...(replyQuoteQuery.reply ? [replyQuoteQuery.reply] : []),
-            ...replyQuoteQuery.quotes,
-        ];
+        return setReplyQuote(replyQuoteQuery);
     });
     const authenticateWithParentClient = vi.fn(async () => ({
         success: true,
@@ -109,7 +105,7 @@ const mockState = vi.hoisted(() => {
             }),
         },
     }));
-    const runInitializeNostrSession = vi.fn(async () => ({
+    const runInitializeNostrSession = vi.fn(async (_params?: any): Promise<any> => ({
         rxNostr: undefined,
         relayProfileService: {
             getRelayManager: () => ({
@@ -117,7 +113,7 @@ const mockState = vi.hoisted(() => {
             }),
         },
     }));
-    const completePostAuthBootstrap = vi.fn(async () => ({
+    const completePostAuthBootstrap = vi.fn(async (): Promise<any> => ({
         rxNostr: undefined,
         relayProfileService: {
             getRelayManager: () => ({
@@ -128,6 +124,7 @@ const mockState = vi.hoisted(() => {
     const runAppInitializationBootstrap = vi.fn((params: {
         markLocaleInitialized: () => void;
         handleAuthenticated: (pubkeyHex: string) => Promise<void>;
+        initializeGuestSession: () => Promise<void>;
         getExternalInputBootstrapParams: () => {
             rxNostr?: unknown;
             relayProfileService?: unknown;
@@ -199,6 +196,7 @@ const mockState = vi.hoisted(() => {
         accountManager,
         bootstrapParams: null as {
             handleAuthenticated: (pubkeyHex: string) => Promise<void>;
+            initializeGuestSession: () => Promise<void>;
             getExternalInputBootstrapParams: () => {
                 rxNostr?: unknown;
                 relayProfileService?: unknown;
@@ -433,7 +431,27 @@ describe('App parentClient integration', () => {
         mockSharedContentStoreModule.updateUrlQueryContentStore.mockClear();
         mockSharedContentStoreModule.clearUrlQueryContentStore.mockClear();
         mockState.initializeNostrSession.mockClear();
+        mockState.runInitializeNostrSession.mockResolvedValue({
+            rxNostr: undefined,
+            relayProfileService: {
+                getRelayManager: () => ({
+                    loadRelayConfigForUI: vi.fn(),
+                }),
+                subscribeProfile: vi.fn(() => () => undefined),
+                fetchProfileRealtime: vi.fn().mockResolvedValue(null),
+            },
+        } as any);
         mockState.completePostAuthBootstrap.mockClear();
+        mockState.completePostAuthBootstrap.mockResolvedValue({
+            rxNostr: undefined,
+            relayProfileService: {
+                getRelayManager: () => ({
+                    loadRelayConfigForUI: vi.fn(),
+                }),
+                subscribeProfile: vi.fn(() => () => undefined),
+                fetchProfileRealtime: vi.fn().mockResolvedValue(null),
+            },
+        } as any);
         mockState.applyReplyQuoteQuery.mockClear();
         mockState.getReplyQuoteFromEmbedPayload.mockClear();
         mockState.getChannelFromEmbedPayload.mockClear();
@@ -443,6 +461,8 @@ describe('App parentClient integration', () => {
         mockState.notifySettingsApplied.mockClear();
         mockState.notifySettingsError.mockClear();
         mockState.applyUploadEndpointPreference.mockClear();
+        mockState.hydrateReplyQuoteReferences.mockReset();
+        mockState.hydrateReplyQuoteReferences.mockResolvedValue(undefined);
         mockState.settingsRemoteSetListener = null;
         mockState.syncAccountStores.mockClear();
     });
@@ -538,6 +558,326 @@ describe('App parentClient integration', () => {
                 }),
             );
         });
+    });
+
+    it('bootstrap中のauth.result後はstable parent-client session確立までrelay hydrationを保留する', async () => {
+        const stableSession = {
+            rxNostr: { tag: 'stable-parent-client-rxnostr' },
+            relayProfileService: {
+                getRelayManager: () => ({
+                    loadRelayConfigForUI: vi.fn(),
+                }),
+                subscribeProfile: vi.fn(() => () => undefined),
+                fetchProfileRealtime: vi.fn().mockResolvedValue(null),
+            },
+        };
+        const replyQuoteQuery = {
+            reply: {
+                eventId: QUEUED_REPLY_EVENT_ID,
+                relayHints: ['wss://hint-relay.example.com'],
+                authorPubkey: null,
+            },
+            quotes: [],
+        };
+        let resolveBootstrap!: () => void;
+        let resolvePostAuth!: (session: typeof stableSession) => void;
+        mockState.runAppInitializationBootstrap.mockImplementationOnce((params: any) => {
+            mockState.bootstrapParams = params;
+            params.markLocaleInitialized();
+            return new Promise<void>((resolve) => {
+                resolveBootstrap = resolve;
+            });
+        });
+        mockState.completePostAuthBootstrap.mockImplementationOnce(() =>
+            new Promise((resolve) => {
+                resolvePostAuth = resolve;
+            }),
+        );
+        mockState.getReplyQuoteFromEmbedPayload.mockReturnValue(replyQuoteQuery);
+
+        render(App);
+
+        await waitFor(() => {
+            expect(mockState.parentRemoteLoginListener).toBeTruthy();
+            expect(mockState.composerRemoteSetContextListener).toBeTruthy();
+        });
+
+        mockState.parentRemoteLoginListener?.(PARENT_CLIENT_PUBKEY);
+        mockState.composerRemoteSetContextListener?.({
+            reply: nip19.noteEncode(QUEUED_REPLY_EVENT_ID),
+        }, 'composer-ready-race');
+        resolveBootstrap();
+
+        await waitFor(() => {
+            expect(mockState.completePostAuthBootstrap).toHaveBeenCalled();
+            expect(mockState.notifyComposerContextApplied).toHaveBeenCalledWith(
+                'composer-ready-race',
+            );
+        });
+        expect(mockState.hydrateReplyQuoteReferences).not.toHaveBeenCalled();
+
+        resolvePostAuth(stableSession);
+
+        await waitFor(() => {
+            expect(mockState.hydrateReplyQuoteReferences).toHaveBeenCalledTimes(1);
+        });
+        expect(mockState.hydrateReplyQuoteReferences).toHaveBeenCalledWith(
+            expect.objectContaining({
+                rxNostr: stableSession.rxNostr,
+                references: [expect.objectContaining({
+                    eventId: QUEUED_REPLY_EVENT_ID,
+                    mode: 'reply',
+                    ownerToken: expect.any(Symbol),
+                })],
+            }),
+        );
+    });
+
+    it('transition終了時にruntimeがなければpendingを維持し、後続guest session確立時にflushする', async () => {
+        const noRuntimeSession = {
+            rxNostr: undefined,
+            relayProfileService: {
+                getRelayManager: () => ({
+                    loadRelayConfigForUI: vi.fn(),
+                }),
+                subscribeProfile: vi.fn(() => () => undefined),
+                fetchProfileRealtime: vi.fn().mockResolvedValue(null),
+            },
+        };
+        const guestSession = {
+            rxNostr: { tag: 'later-guest-rxnostr' },
+            relayProfileService: noRuntimeSession.relayProfileService,
+        };
+        let resolvePostAuth!: (session: typeof noRuntimeSession) => void;
+        const postAuthPromise = new Promise<typeof noRuntimeSession>((resolve) => {
+            resolvePostAuth = resolve;
+        });
+        mockState.completePostAuthBootstrap.mockReturnValueOnce(postAuthPromise as any);
+        mockState.getReplyQuoteFromEmbedPayload.mockReturnValue({
+            reply: {
+                eventId: DEFAULT_REPLY_EVENT_ID,
+                relayHints: [],
+                authorPubkey: null,
+            },
+            quotes: [],
+        });
+
+        render(App);
+
+        await waitFor(() => {
+            expect(mockState.parentRemoteLoginListener).toBeTruthy();
+            expect(mockState.composerRemoteSetContextListener).toBeTruthy();
+            expect(mockState.bootstrapParams).toBeTruthy();
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        mockState.parentRemoteLoginListener?.(PARENT_CLIENT_PUBKEY);
+        await waitFor(() => {
+            expect(mockState.completePostAuthBootstrap).toHaveBeenCalled();
+        });
+        mockState.composerRemoteSetContextListener?.({
+            reply: nip19.noteEncode(DEFAULT_REPLY_EVENT_ID),
+        }, 'composer-pending-without-runtime');
+
+        await waitFor(() => {
+            expect(mockState.notifyComposerContextApplied).toHaveBeenCalledWith(
+                'composer-pending-without-runtime',
+            );
+        });
+        resolvePostAuth(noRuntimeSession);
+        await postAuthPromise;
+        await Promise.resolve();
+        expect(mockState.hydrateReplyQuoteReferences).not.toHaveBeenCalled();
+
+        mockState.runInitializeNostrSession.mockImplementationOnce(async (params: any) => {
+            params.onSession(guestSession);
+            return guestSession;
+        });
+        await mockState.bootstrapParams?.initializeGuestSession();
+
+        await waitFor(() => {
+            expect(mockState.hydrateReplyQuoteReferences).toHaveBeenCalledTimes(1);
+        });
+        expect(mockState.hydrateReplyQuoteReferences).toHaveBeenCalledWith(
+            expect.objectContaining({
+                rxNostr: guestSession.rxNostr,
+                references: [expect.objectContaining({
+                    eventId: DEFAULT_REPLY_EVENT_ID,
+                    ownerToken: expect.any(Symbol),
+                })],
+            }),
+        );
+    });
+
+    it('並行parent-client transitionは最後のsession確立までstable扱いにしない', async () => {
+        const firstSession = {
+            rxNostr: { tag: 'first-parent-client-rxnostr' },
+            relayProfileService: {
+                getRelayManager: () => ({ loadRelayConfigForUI: vi.fn() }),
+                subscribeProfile: vi.fn(() => () => undefined),
+                fetchProfileRealtime: vi.fn().mockResolvedValue(null),
+            },
+        };
+        const secondSession = {
+            ...firstSession,
+            rxNostr: { tag: 'second-parent-client-rxnostr' },
+        };
+        let resolveAuth!: (result: { success: true; pubkeyHex: string }) => void;
+        const authPromise = new Promise<{ success: true; pubkeyHex: string }>((resolve) => {
+            resolveAuth = resolve;
+        });
+        let resolveFirstSession!: (session: typeof firstSession) => void;
+        let resolveSecondSession!: (session: typeof secondSession) => void;
+        const firstSessionPromise = new Promise<typeof firstSession>((resolve) => {
+            resolveFirstSession = resolve;
+        });
+        const secondSessionPromise = new Promise<typeof secondSession>((resolve) => {
+            resolveSecondSession = resolve;
+        });
+        mockState.authenticateWithParentClient.mockReturnValue(authPromise as any);
+        mockState.completePostAuthBootstrap
+            .mockReturnValueOnce(firstSessionPromise as any)
+            .mockReturnValueOnce(secondSessionPromise as any);
+        mockState.getReplyQuoteFromEmbedPayload.mockReturnValue({
+            reply: {
+                eventId: DEFAULT_REPLY_EVENT_ID,
+                relayHints: [],
+                authorPubkey: null,
+            },
+            quotes: [],
+        });
+
+        render(App);
+        await waitFor(() => {
+            expect(mockState.parentRemoteLoginListener).toBeTruthy();
+            expect(mockState.composerRemoteSetContextListener).toBeTruthy();
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        mockState.parentRemoteLoginListener?.(PARENT_CLIENT_PUBKEY);
+        mockState.parentRemoteLoginListener?.(PARENT_CLIENT_PUBKEY);
+        await waitFor(() => {
+            expect(mockState.authenticateWithParentClient).toHaveBeenCalledTimes(1);
+        });
+        resolveAuth({ success: true, pubkeyHex: PARENT_CLIENT_PUBKEY });
+        await waitFor(() => {
+            expect(mockState.completePostAuthBootstrap).toHaveBeenCalledTimes(2);
+        });
+
+        mockState.composerRemoteSetContextListener?.({
+            reply: nip19.noteEncode(DEFAULT_REPLY_EVENT_ID),
+        }, 'composer-concurrent-transition');
+        await waitFor(() => {
+            expect(mockState.notifyComposerContextApplied).toHaveBeenCalledWith(
+                'composer-concurrent-transition',
+            );
+        });
+
+        resolveFirstSession(firstSession);
+        await firstSessionPromise;
+        await Promise.resolve();
+        expect(mockState.hydrateReplyQuoteReferences).not.toHaveBeenCalled();
+
+        resolveSecondSession(secondSession);
+        await secondSessionPromise;
+        await waitFor(() => {
+            expect(mockState.hydrateReplyQuoteReferences).toHaveBeenCalledTimes(1);
+        });
+        expect(mockState.hydrateReplyQuoteReferences).toHaveBeenCalledWith(
+            expect.objectContaining({
+                rxNostr: secondSession.rxNostr,
+            }),
+        );
+    });
+
+    it('transition中もcontent-only、channel-only、valid preloadを即時適用する', async () => {
+        const preloadedEvent = finalizeEvent({
+            kind: 1,
+            content: 'integration preload',
+            tags: [],
+            created_at: 4,
+        }, generateSecretKey());
+        const noRuntimeSession = {
+            rxNostr: undefined,
+            relayProfileService: {
+                getRelayManager: () => ({
+                    loadRelayConfigForUI: vi.fn(),
+                }),
+                subscribeProfile: vi.fn(() => () => undefined),
+                fetchProfileRealtime: vi.fn().mockResolvedValue(null),
+            },
+        };
+        let resolvePostAuth!: (session: typeof noRuntimeSession) => void;
+        const postAuthPromise = new Promise<typeof noRuntimeSession>((resolve) => {
+            resolvePostAuth = resolve;
+        });
+        mockState.completePostAuthBootstrap.mockReturnValueOnce(postAuthPromise as any);
+        mockState.getChannelFromEmbedPayload.mockReturnValue({
+            eventId: CHANNEL_EVENT_ID,
+            relayHints: [],
+        } as any);
+        mockState.getReplyQuoteFromEmbedPayload.mockReturnValue({
+            reply: {
+                eventId: preloadedEvent.id,
+                relayHints: [],
+                authorPubkey: preloadedEvent.pubkey,
+            },
+            quotes: [],
+        });
+
+        render(App);
+        await waitFor(() => {
+            expect(mockState.parentRemoteLoginListener).toBeTruthy();
+            expect(mockState.composerRemoteSetContextListener).toBeTruthy();
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        mockState.parentRemoteLoginListener?.(PARENT_CLIENT_PUBKEY);
+        await waitFor(() => {
+            expect(mockState.completePostAuthBootstrap).toHaveBeenCalled();
+        });
+
+        mockState.composerRemoteSetContextListener?.({
+            content: 'during transition',
+        }, 'composer-transition-content');
+        mockState.composerRemoteSetContextListener?.({
+            channel: { reference: nip19.noteEncode(CHANNEL_EVENT_ID) },
+        } as any, 'composer-transition-channel');
+        mockState.composerRemoteSetContextListener?.({
+            reply: nip19.neventEncode({
+                id: preloadedEvent.id,
+                author: preloadedEvent.pubkey,
+            }),
+            preloadedEvents: { [preloadedEvent.id]: preloadedEvent },
+        } as any, 'composer-transition-preload');
+
+        await waitFor(() => {
+            expect(mockState.notifyComposerContextApplied).toHaveBeenCalledWith(
+                'composer-transition-content',
+            );
+            expect(mockState.notifyComposerContextApplied).toHaveBeenCalledWith(
+                'composer-transition-channel',
+            );
+            expect(mockState.notifyComposerContextApplied).toHaveBeenCalledWith(
+                'composer-transition-preload',
+            );
+            expect(mockState.hydrateReplyQuoteReferences).toHaveBeenCalledTimes(1);
+        });
+        expect(mockSharedContentStoreModule.clearUrlQueryContentStore).toHaveBeenCalled();
+        expect(mockState.hydrateReplyQuoteReferences).toHaveBeenCalledWith(
+            expect.objectContaining({
+                rxNostr: undefined,
+                preloadedEvents: {
+                    [preloadedEvent.id]: expect.objectContaining({ id: preloadedEvent.id }),
+                },
+            }),
+        );
+
+        resolvePostAuth(noRuntimeSession);
+        await postAuthPromise;
     });
 
     it('remote logout を受け取ると parentClient アカウントを notify なしでログアウトする', async () => {
@@ -709,6 +1049,7 @@ describe('App parentClient integration', () => {
         mockState.runAppInitializationBootstrap.mockImplementationOnce((params: {
             markLocaleInitialized: () => void;
             handleAuthenticated: (pubkeyHex: string) => Promise<void>;
+            initializeGuestSession: () => Promise<void>;
             getExternalInputBootstrapParams: () => {
                 rxNostr?: unknown;
                 relayProfileService?: unknown;

--- a/src/test/unit/appEmbedController.test.ts
+++ b/src/test/unit/appEmbedController.test.ts
@@ -1,11 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { finalizeEvent, generateSecretKey, nip19 } from 'nostr-tools';
 
-import { createAppEmbedController } from '../../lib/appEmbedController';
-import type { ReplyQuoteComposerState } from '../../lib/types';
+import {
+    createAppEmbedController,
+    type AppEmbedRuntimeSnapshot,
+} from '../../lib/appEmbedController';
+import type {
+    ReplyQuoteComposerState,
+    ReplyQuoteHydrationTarget,
+    ReplyQuoteState,
+} from '../../lib/types';
 import { createPlainNostrEventSnapshot } from '../../lib/postHistoryEventUtils';
 
-function createRuntimeSnapshot() {
+function createRuntimeSnapshot(): AppEmbedRuntimeSnapshot {
     return {
         rxNostr: undefined,
         relayConfig: null,
@@ -21,6 +28,33 @@ function createReplyQuoteState() {
 
 function createChannelContextState() {
     return null;
+}
+
+function createSelectedReplyQuoteState(
+    references: ReplyQuoteHydrationTarget[],
+): ReplyQuoteComposerState {
+    const toState = (reference: ReplyQuoteHydrationTarget): ReplyQuoteState => ({
+        ...reference,
+        quoteNotificationEnabled: false,
+        replyNotificationRecipients: [],
+        authorDisplayName: null,
+        authorPicture: null,
+        referencedEvent: null,
+        rootEventId: null,
+        rootRelayHint: null,
+        rootPubkey: null,
+        loading: true,
+        error: null,
+    });
+
+    return {
+        reply: references.find((reference) => reference.mode === 'reply')
+            ? toState(references.find((reference) => reference.mode === 'reply')!)
+            : null,
+        quotes: references
+            .filter((reference) => reference.mode === 'quote')
+            .map(toState),
+    };
 }
 
 function createController(overrides: Record<string, unknown> = {}) {
@@ -60,15 +94,17 @@ function createController(overrides: Record<string, unknown> = {}) {
         error: vi.fn(),
     };
     let bootstrappingApp = false;
-    let pendingParentAuth = false;
+    let parentClientTransitioning = false;
+    let replyQuoteState: ReplyQuoteComposerState = createReplyQuoteState();
+    let runtimeSnapshot = createRuntimeSnapshot();
 
     const runtime = {
         isBootstrappingApp: vi.fn(() => bootstrappingApp),
-        hasPendingParentAuth: vi.fn(() => pendingParentAuth),
-        getReplyQuoteState: vi.fn(createReplyQuoteState),
+        isParentClientTransitioning: vi.fn(() => parentClientTransitioning),
+        getReplyQuoteState: vi.fn(() => replyQuoteState),
         getChannelContextState: vi.fn(createChannelContextState),
         getChannelContextProvenance: vi.fn(() => null),
-        getRuntimeSnapshot: vi.fn(createRuntimeSnapshot),
+        getRuntimeSnapshot: vi.fn(() => runtimeSnapshot),
     };
 
     const controller = createAppEmbedController({
@@ -98,8 +134,14 @@ function createController(overrides: Record<string, unknown> = {}) {
         setBootstrappingApp(value: boolean) {
             bootstrappingApp = value;
         },
-        setPendingParentAuth(value: boolean) {
-            pendingParentAuth = value;
+        setParentClientTransitioning(value: boolean) {
+            parentClientTransitioning = value;
+        },
+        setReplyQuoteState(value: ReplyQuoteComposerState) {
+            replyQuoteState = value;
+        },
+        setRuntimeSnapshot(value: ReturnType<typeof createRuntimeSnapshot>) {
+            runtimeSnapshot = value;
         },
     };
 }
@@ -139,7 +181,7 @@ describe('createAppEmbedController', () => {
             composerInput: { get: vi.fn(() => composerInput) },
             runtime: {
                 isBootstrappingApp: vi.fn(() => false),
-                hasPendingParentAuth: vi.fn(() => false),
+                isParentClientTransitioning: vi.fn(() => false),
                 getReplyQuoteState: vi.fn(createReplyQuoteState),
                 getChannelContextState: vi.fn(createChannelContextState),
                 getChannelContextProvenance: vi.fn(() => null),
@@ -193,7 +235,7 @@ describe('createAppEmbedController', () => {
         expect(parentFrame.notifyComposerContextUpdated).not.toHaveBeenCalled();
     });
 
-    it('reply選択を同期適用してhydrate完了前にackし、hydrateはack後に開始する', async () => {
+    it('runtime未準備では選択とackだけを適用し、stable runtime後に1回だけhydrateする', async () => {
         let resolveHydration!: () => void;
         const hydration = new Promise<void>((resolve) => {
             resolveHydration = resolve;
@@ -207,7 +249,13 @@ describe('createAppEmbedController', () => {
         };
         const applyReplyQuoteSelection = vi.fn(() => [reply]);
         const hydrateReplyQuoteReferences = vi.fn(() => hydration);
-        const { controller, parentFrame } = createController({
+        const {
+            controller,
+            parentFrame,
+            setParentClientTransitioning,
+            setReplyQuoteState,
+            setRuntimeSnapshot,
+        } = createController({
             composerContextApply: {
                 applyReplyQuoteSelection,
                 hydrateReplyQuoteReferences,
@@ -216,6 +264,8 @@ describe('createAppEmbedController', () => {
                 clearChannelContext: vi.fn(),
             },
         });
+        setParentClientTransitioning(true);
+        setReplyQuoteState(createSelectedReplyQuoteState([reply]));
 
         await controller.handleRemoteComposerSetContext({
             reply: nip19.noteEncode(reply.eventId),
@@ -223,14 +273,30 @@ describe('createAppEmbedController', () => {
 
         expect(applyReplyQuoteSelection).toHaveBeenCalledOnce();
         expect(parentFrame.notifyComposerContextApplied).toHaveBeenCalledWith('req-reply-fast-ack');
+        expect(hydrateReplyQuoteReferences).not.toHaveBeenCalled();
+
+        const stableRxNostr = {} as NonNullable<AppEmbedRuntimeSnapshot['rxNostr']>;
+        setRuntimeSnapshot({ rxNostr: stableRxNostr, relayConfig: null });
+        await controller.flushPendingReplyQuoteHydration();
+        expect(hydrateReplyQuoteReferences).not.toHaveBeenCalled();
+
+        setParentClientTransitioning(false);
+        const hydrationFlush = controller.flushPendingReplyQuoteHydration();
+
         expect(hydrateReplyQuoteReferences).toHaveBeenCalledOnce();
+        expect(hydrateReplyQuoteReferences).toHaveBeenCalledWith(
+            [reply],
+            { rxNostr: stableRxNostr, relayConfig: null },
+        );
         expect(parentFrame.notifyComposerContextApplied.mock.invocationCallOrder[0])
             .toBeLessThan(hydrateReplyQuoteReferences.mock.invocationCallOrder[0]);
+        await controller.flushPendingReplyQuoteHydration();
+        expect(hydrateReplyQuoteReferences).toHaveBeenCalledOnce();
         resolveHydration();
-        await hydration;
+        await hydrationFlush;
     });
 
-    it('quoteだけのpayloadも選択設定直後にackしてからhydrateする', async () => {
+    it('reply/quotesを変更しないpatchはtransition中も即時適用し、pending hydrationを維持する', async () => {
         const quote = {
             eventId: '5'.repeat(64),
             mode: 'quote' as const,
@@ -240,23 +306,59 @@ describe('createAppEmbedController', () => {
         };
         const applyReplyQuoteSelection = vi.fn(() => [quote]);
         const hydrateReplyQuoteReferences = vi.fn().mockResolvedValue(undefined);
-        const { controller, parentFrame } = createController({
+        const applyChannelContextQuery = vi.fn();
+        const {
+            controller,
+            composerInput,
+            parentFrame,
+            setParentClientTransitioning,
+            setReplyQuoteState,
+            setRuntimeSnapshot,
+        } = createController({
             composerContextApply: {
                 applyReplyQuoteSelection,
                 hydrateReplyQuoteReferences,
                 clearReplyQuote: vi.fn(),
-                applyChannelContextQuery: vi.fn(),
+                applyChannelContextQuery,
                 clearChannelContext: vi.fn(),
             },
         });
+        setParentClientTransitioning(true);
+        setReplyQuoteState(createSelectedReplyQuoteState([quote]));
 
         await controller.handleRemoteComposerSetContext({
             quotes: [nip19.noteEncode(quote.eventId)],
-        }, 'req-quote-fast-ack');
+        }, 'req-quote-pending');
+        await controller.handleRemoteComposerSetContext({
+            content: 'content patch',
+        }, 'req-content-patch');
+        await controller.handleRemoteComposerSetContext({
+            channel: { reference: nip19.noteEncode('6'.repeat(64)) },
+        }, 'req-channel-patch');
+        await controller.handleRemoteComposerSetContext({
+            content: 'combined patch',
+            channel: null,
+        }, 'req-combined-patch');
+        await controller.handleRemoteComposerSetContext({
+            preloadedEvents: {},
+        }, 'req-preload-only-patch');
 
-        expect(parentFrame.notifyComposerContextApplied).toHaveBeenCalledWith('req-quote-fast-ack');
-        expect(parentFrame.notifyComposerContextApplied.mock.invocationCallOrder[0])
-            .toBeLessThan(hydrateReplyQuoteReferences.mock.invocationCallOrder[0]);
+        expect(composerInput.insertText).toHaveBeenCalledWith('content patch');
+        expect(composerInput.insertText).toHaveBeenCalledWith('combined patch');
+        expect(applyChannelContextQuery).toHaveBeenCalledOnce();
+        expect(parentFrame.notifyComposerContextApplied).toHaveBeenCalledTimes(5);
+        expect(hydrateReplyQuoteReferences).not.toHaveBeenCalled();
+
+        const stableRxNostr = {} as NonNullable<AppEmbedRuntimeSnapshot['rxNostr']>;
+        setRuntimeSnapshot({ rxNostr: stableRxNostr, relayConfig: null });
+        setParentClientTransitioning(false);
+        await controller.flushPendingReplyQuoteHydration();
+
+        expect(hydrateReplyQuoteReferences).toHaveBeenCalledOnce();
+        expect(hydrateReplyQuoteReferences).toHaveBeenCalledWith(
+            [quote],
+            { rxNostr: stableRxNostr, relayConfig: null },
+        );
     });
 
     it('valid preloaded event は detached plain snapshot として hydration port へ渡す', async () => {
@@ -275,7 +377,11 @@ describe('createAppEmbedController', () => {
         };
         const applyReplyQuoteSelection = vi.fn(() => [reply]);
         const hydrateReplyQuoteReferences = vi.fn().mockResolvedValue(undefined);
-        const { controller } = createController({
+        const {
+            controller,
+            setParentClientTransitioning,
+            setRuntimeSnapshot,
+        } = createController({
             composerContextApply: {
                 applyReplyQuoteSelection,
                 hydrateReplyQuoteReferences,
@@ -284,6 +390,7 @@ describe('createAppEmbedController', () => {
                 clearChannelContext: vi.fn(),
             },
         });
+        setParentClientTransitioning(true);
         const externalEvent = {
             ...event,
             libraryMetadata: { shouldNotBeForwarded: true },
@@ -300,6 +407,243 @@ describe('createAppEmbedController', () => {
         expect(selected[event.id]).not.toBe(externalEvent);
         expect(selected[event.id].content).toBe('preloaded');
         expect(selected[event.id].libraryMetadata).toBeUndefined();
+        expect(hydrateReplyQuoteReferences.mock.calls[0]?.[1].rxNostr).toBeUndefined();
+
+        setRuntimeSnapshot({
+            rxNostr: {} as NonNullable<AppEmbedRuntimeSnapshot['rxNostr']>,
+            relayConfig: null,
+        });
+        setParentClientTransitioning(false);
+        await controller.flushPendingReplyQuoteHydration();
+        expect(hydrateReplyQuoteReferences).toHaveBeenCalledOnce();
+    });
+
+    it('valid preloadとmissing referenceの混在時はvalidだけを即時、missingだけを後でhydrateする', async () => {
+        const event = finalizeEvent({
+            kind: 1,
+            content: 'mixed preload',
+            tags: [],
+            created_at: 2,
+        }, generateSecretKey());
+        const preloadedQuote: ReplyQuoteHydrationTarget = {
+            eventId: event.id,
+            mode: 'quote',
+            ownerToken: Symbol('preloaded-quote-owner'),
+            relayHints: [],
+            authorPubkey: event.pubkey,
+        };
+        const relayQuote: ReplyQuoteHydrationTarget = {
+            eventId: '7'.repeat(64),
+            mode: 'quote',
+            ownerToken: Symbol('relay-quote-owner'),
+            relayHints: ['wss://relay.example.com'],
+            authorPubkey: null,
+        };
+        const hydrateReplyQuoteReferences = vi.fn().mockResolvedValue(undefined);
+        const {
+            controller,
+            setParentClientTransitioning,
+            setReplyQuoteState,
+            setRuntimeSnapshot,
+        } = createController({
+            composerContextApply: {
+                applyReplyQuoteSelection: vi.fn(() => [preloadedQuote, relayQuote]),
+                hydrateReplyQuoteReferences,
+                clearReplyQuote: vi.fn(),
+                applyChannelContextQuery: vi.fn(),
+                clearChannelContext: vi.fn(),
+            },
+        });
+        setParentClientTransitioning(true);
+        setReplyQuoteState(createSelectedReplyQuoteState([preloadedQuote, relayQuote]));
+
+        await controller.handleRemoteComposerSetContext({
+            quotes: [
+                nip19.neventEncode({ id: event.id, author: event.pubkey }),
+                nip19.noteEncode(relayQuote.eventId),
+            ],
+            preloadedEvents: { [event.id]: event },
+        }, 'req-mixed-preload');
+
+        expect(hydrateReplyQuoteReferences).toHaveBeenCalledTimes(1);
+        expect(hydrateReplyQuoteReferences.mock.calls[0]?.[0]).toEqual([preloadedQuote]);
+        expect(hydrateReplyQuoteReferences.mock.calls[0]?.[1].rxNostr).toBeUndefined();
+        expect(hydrateReplyQuoteReferences.mock.calls[0]?.[2]).toHaveProperty(event.id);
+
+        const stableRxNostr = {} as NonNullable<AppEmbedRuntimeSnapshot['rxNostr']>;
+        setRuntimeSnapshot({ rxNostr: stableRxNostr, relayConfig: null });
+        setParentClientTransitioning(false);
+        await controller.flushPendingReplyQuoteHydration();
+
+        expect(hydrateReplyQuoteReferences).toHaveBeenCalledTimes(2);
+        expect(hydrateReplyQuoteReferences.mock.calls[1]).toEqual([
+            [relayQuote],
+            { rxNostr: stableRxNostr, relayConfig: null },
+        ]);
+    });
+
+    it('invalidまたはmismatch preloadはpendingに残してstable runtimeでrelay fallbackする', async () => {
+        const signedEvent = finalizeEvent({
+            kind: 1,
+            content: 'signed',
+            tags: [],
+            created_at: 3,
+        }, generateSecretKey());
+        const invalidTarget: ReplyQuoteHydrationTarget = {
+            eventId: signedEvent.id,
+            mode: 'quote',
+            ownerToken: Symbol('invalid-preload-owner'),
+            relayHints: [],
+            authorPubkey: signedEvent.pubkey,
+        };
+        const mismatchTarget: ReplyQuoteHydrationTarget = {
+            eventId: '8'.repeat(64),
+            mode: 'quote',
+            ownerToken: Symbol('mismatch-preload-owner'),
+            relayHints: [],
+            authorPubkey: null,
+        };
+        const hydrateReplyQuoteReferences = vi.fn().mockResolvedValue(undefined);
+        const {
+            controller,
+            setParentClientTransitioning,
+            setReplyQuoteState,
+            setRuntimeSnapshot,
+        } = createController({
+            composerContextApply: {
+                applyReplyQuoteSelection: vi.fn(() => [invalidTarget, mismatchTarget]),
+                hydrateReplyQuoteReferences,
+                clearReplyQuote: vi.fn(),
+                applyChannelContextQuery: vi.fn(),
+                clearChannelContext: vi.fn(),
+            },
+        });
+        setParentClientTransitioning(true);
+        setReplyQuoteState(createSelectedReplyQuoteState([invalidTarget, mismatchTarget]));
+
+        await controller.handleRemoteComposerSetContext({
+            quotes: [
+                nip19.neventEncode({ id: signedEvent.id, author: signedEvent.pubkey }),
+                nip19.noteEncode(mismatchTarget.eventId),
+            ],
+            preloadedEvents: {
+                [signedEvent.id]: { ...signedEvent, content: 'tampered' },
+                [mismatchTarget.eventId]: signedEvent,
+            },
+        }, 'req-invalid-preloads');
+
+        expect(hydrateReplyQuoteReferences).not.toHaveBeenCalled();
+        const stableRxNostr = {} as NonNullable<AppEmbedRuntimeSnapshot['rxNostr']>;
+        setRuntimeSnapshot({ rxNostr: stableRxNostr, relayConfig: null });
+        setParentClientTransitioning(false);
+        await controller.flushPendingReplyQuoteHydration();
+
+        expect(hydrateReplyQuoteReferences).toHaveBeenCalledWith(
+            [invalidTarget, mismatchTarget],
+            { rxNostr: stableRxNostr, relayConfig: null },
+        );
+    });
+
+    it('新しいselectionはpendingを置換し、旧ownerはrelay fetchしない', async () => {
+        const oldTarget: ReplyQuoteHydrationTarget = {
+            eventId: '9'.repeat(64),
+            mode: 'reply',
+            ownerToken: Symbol('old-owner'),
+            relayHints: [],
+            authorPubkey: null,
+        };
+        const newTarget: ReplyQuoteHydrationTarget = {
+            eventId: 'a'.repeat(64),
+            mode: 'reply',
+            ownerToken: Symbol('new-owner'),
+            relayHints: [],
+            authorPubkey: null,
+        };
+        const hydrateReplyQuoteReferences = vi.fn().mockResolvedValue(undefined);
+        const applyReplyQuoteSelection = vi.fn()
+            .mockReturnValueOnce([oldTarget])
+            .mockReturnValueOnce([newTarget]);
+        const {
+            controller,
+            setParentClientTransitioning,
+            setReplyQuoteState,
+            setRuntimeSnapshot,
+        } = createController({
+            composerContextApply: {
+                applyReplyQuoteSelection,
+                hydrateReplyQuoteReferences,
+                clearReplyQuote: vi.fn(),
+                applyChannelContextQuery: vi.fn(),
+                clearChannelContext: vi.fn(),
+            },
+        });
+        setParentClientTransitioning(true);
+        setReplyQuoteState(createSelectedReplyQuoteState([oldTarget]));
+        await controller.handleRemoteComposerSetContext({
+            reply: nip19.noteEncode(oldTarget.eventId),
+        }, 'req-old-owner');
+
+        setReplyQuoteState(createSelectedReplyQuoteState([newTarget]));
+        await controller.handleRemoteComposerSetContext({
+            reply: nip19.noteEncode(newTarget.eventId),
+        }, 'req-new-owner');
+
+        const stableRxNostr = {} as NonNullable<AppEmbedRuntimeSnapshot['rxNostr']>;
+        setRuntimeSnapshot({ rxNostr: stableRxNostr, relayConfig: null });
+        setParentClientTransitioning(false);
+        await controller.flushPendingReplyQuoteHydration();
+
+        expect(hydrateReplyQuoteReferences).toHaveBeenCalledOnce();
+        expect(hydrateReplyQuoteReferences).toHaveBeenCalledWith(
+            [newTarget],
+            { rxNostr: stableRxNostr, relayConfig: null },
+        );
+    });
+
+    it('reply/quotes clearはpending hydrationも破棄する', async () => {
+        const reply: ReplyQuoteHydrationTarget = {
+            eventId: 'b'.repeat(64),
+            mode: 'reply',
+            ownerToken: Symbol('clear-owner'),
+            relayHints: [],
+            authorPubkey: null,
+        };
+        const hydrateReplyQuoteReferences = vi.fn().mockResolvedValue(undefined);
+        const clearReplyQuote = vi.fn();
+        const {
+            controller,
+            setParentClientTransitioning,
+            setReplyQuoteState,
+            setRuntimeSnapshot,
+        } = createController({
+            composerContextApply: {
+                applyReplyQuoteSelection: vi.fn(() => [reply]),
+                hydrateReplyQuoteReferences,
+                clearReplyQuote,
+                applyChannelContextQuery: vi.fn(),
+                clearChannelContext: vi.fn(),
+            },
+        });
+        setParentClientTransitioning(true);
+        setReplyQuoteState(createSelectedReplyQuoteState([reply]));
+        await controller.handleRemoteComposerSetContext({
+            reply: nip19.noteEncode(reply.eventId),
+        }, 'req-before-clear');
+
+        await controller.handleRemoteComposerSetContext({
+            reply: null,
+            quotes: null,
+        }, 'req-clear');
+        setReplyQuoteState(createReplyQuoteState());
+        setRuntimeSnapshot({
+            rxNostr: {} as NonNullable<AppEmbedRuntimeSnapshot['rxNostr']>,
+            relayConfig: null,
+        });
+        setParentClientTransitioning(false);
+        await controller.flushPendingReplyQuoteHydration();
+
+        expect(clearReplyQuote).toHaveBeenCalledOnce();
+        expect(hydrateReplyQuoteReferences).not.toHaveBeenCalled();
     });
 
     it('channel・reply・quotes同時指定でも初期状態だけでackし、hydrate失敗は非致命的に扱う', async () => {
@@ -321,7 +665,13 @@ describe('createAppEmbedController', () => {
         const applyReplyQuoteSelection = vi.fn(() => [reply, quote]);
         const hydrateError = new Error('hydrate failed');
         const hydrateReplyQuoteReferences = vi.fn().mockRejectedValue(hydrateError);
-        const { controller, parentFrame, logger } = createController({
+        const {
+            controller,
+            parentFrame,
+            logger,
+            setReplyQuoteState,
+            setRuntimeSnapshot,
+        } = createController({
             composerContextApply: {
                 applyReplyQuoteSelection,
                 hydrateReplyQuoteReferences,
@@ -329,6 +679,11 @@ describe('createAppEmbedController', () => {
                 applyChannelContextQuery,
                 clearChannelContext: vi.fn(),
             },
+        });
+        setReplyQuoteState(createSelectedReplyQuoteState([reply, quote]));
+        setRuntimeSnapshot({
+            rxNostr: {} as NonNullable<AppEmbedRuntimeSnapshot['rxNostr']>,
+            relayConfig: null,
         });
 
         await controller.handleRemoteComposerSetContext({
@@ -532,17 +887,16 @@ describe('createAppEmbedController', () => {
         );
     });
 
-    it('pending parent auth 中の composer.setContext も保留し、解除後 flush で適用する', async () => {
-        const { controller, composerInput, parentFrame, setPendingParentAuth } = createController();
-        setPendingParentAuth(true);
+    it('parent-client transition中もcontent patchとackは保留しない', async () => {
+        const {
+            controller,
+            composerInput,
+            parentFrame,
+            setParentClientTransitioning,
+        } = createController();
+        setParentClientTransitioning(true);
 
         await controller.handleRemoteComposerSetContext({ content: 'pending auth message' }, 'req-pa-1');
-
-        expect(composerInput.insertText).not.toHaveBeenCalled();
-        expect(parentFrame.notifyComposerContextApplied).not.toHaveBeenCalled();
-
-        setPendingParentAuth(false);
-        await controller.flushPendingComposerAction();
 
         expect(composerInput.insertText).toHaveBeenCalledWith('pending auth message');
         expect(parentFrame.notifyComposerContextApplied).toHaveBeenCalledWith('req-pa-1');
@@ -592,7 +946,7 @@ describe('createAppEmbedController', () => {
         const { controller, parentFrame } = createController({
             runtime: {
                 isBootstrappingApp: vi.fn(() => bootstrapping),
-                hasPendingParentAuth: vi.fn(() => false),
+                isParentClientTransitioning: vi.fn(() => false),
                 getReplyQuoteState: vi.fn(() => replyState),
                 getChannelContextState: vi.fn(() => null),
                 getChannelContextProvenance: vi.fn(() => null),
@@ -658,7 +1012,7 @@ describe('createAppEmbedController', () => {
         const { controller, parentFrame } = createController({
             runtime: {
                 isBootstrappingApp: vi.fn(() => false),
-                hasPendingParentAuth: vi.fn(() => false),
+                isParentClientTransitioning: vi.fn(() => false),
                 getReplyQuoteState: vi.fn(createReplyQuoteState),
                 getChannelContextState: vi.fn(() => channelContext),
                 getChannelContextProvenance: vi.fn(() => provenance),


### PR DESCRIPTION
## 変更概要

- iframe Parent Client transition中も composer selection と `composer.contextApplied` は即時に適用し、relayが必要なreply / quote hydrationだけをstable Nostr runtime確立まで保留します。
- App側に共通のstable-runtime flush境界を追加し、guest session確立、post-auth session確立、parent-client transition終了、bootstrap pending action flush後から再評価します。
- content-only / channel-only / content+channel / preloadedEvents-only patchは既存pending reply / quote hydrationを維持します。
- owner tokenをflush前にも照合し、置換・clear済みの旧referenceをrelay fetchしません。

## Raceの直接原因

`auth.result`でparent auth requestがsettledした時点は、旧guest `rxNostr`の破棄と`handlePostAuth()`による最終parent-client session確立より前でした。その間にbootstrap中の`composer.setContext`がflushされると、preloadなしreferenceのhydrationが未確立または破棄予定のruntime snapshotで一度だけ消費されます。`rxNostr`もvalid preloadもない場合はhydration対象0件のままloading状態が残り、旧runtimeを掴んだ場合はtarget REQがrelayへ到達しない経路がありました。

## 修正方式

- bootstrap中だけ`composer.setContext`全体をqueueします。
- valid preloadがあるreferenceはruntimeを待たず、detached verified snapshotで即時hydrateします。
- missing / invalid / mismatch preloadのreferenceはcontroller内の最新pendingとして保持します。
- Appのparent-client transition counterが0で、最新snapshotに`rxNostr`がある場合だけpendingを1回flushします。
- transition終了時にruntimeがなければpendingを残し、後続のguestまたは認証済みsession確立で同じ境界からflushします。
- timer、retry、parent再送、新protocol message、汎用状態機械は追加していません。

## Preloadあり / なしのデータフロー

- valid preloadあり: selection → `composer.contextApplied` → preload hydration。relay runtimeは不要です。
- preloadなしまたは無効: selection → `composer.contextApplied` → pending保持 → stable runtime確立 → 最新runtimeでrelay hydration。
- valid / missing混在: valid分だけ即時、missing分だけ後続flushです。

## 検証結果

- Targeted Vitest: 3 files / 68 tests passed
  - `src/test/unit/appEmbedController.test.ts`
  - `src/test/integration/app-parent-client.integration.test.ts`
  - `src/test/unit/externalInputBootstrap.test.ts`
- Playwright desktop Chromium: `embedParentClientExample.spec.ts` 4/4 passed
- Playwright mobile Chromium (iPhone 13 descriptor): 4/4 passed
- 新E2Eで最初の`ready`にauth + preloadなしsetContextを各1回だけ送信し、2回目以降の`ready`で再送せず、`contextApplied`、target REQ、fixture本文展開、取得失敗なしを確認
- `npm test`: 342 files passed / 1 skipped、3942 tests passed / 1 skipped
- `npm run check`: 0 errors / 0 warnings
- `npm run build`: passed
- `git diff --check`: passed

## Build warning

編集前baselineと同じ既存warningのみです。

- minified chunk sizeが680 kBを超えるwarning
- `Button.svelte`と`PostPreviewFooterActionButton.svelte`のCustom Element buildで、`$props()` rest propsを使うため公開propsを推論できないwarning
- `blurhash`がstatic importとdynamic importの両方で参照され、別chunkへ移動しないwarning

新規warningやbuild失敗はありません。

## 未実行確認

- 物理端末での確認は実施していません。このraceはOS固有UIやIMEではなくiframe message / session lifecycleの問題であり、決定論的なローカルWebSocket relayを使ったdesktop Chromiumとmobile Chromiumで公開フローを確認しました。
- mobile WebKitとdesktop Firefoxは今回の指定検証対象外のため未実行です。公開wire protocol、origin validation、Web Component、Host-owned Liteには変更していません。