### PR TITLE
Fix transient profile fetch failures during startup

### DIFF
--- a/src/lib/profileMetadataCache.svelte.ts
+++ b/src/lib/profileMetadataCache.svelte.ts
@@ -1,4 +1,8 @@
-import { createRxBackwardReq, type RxNostr } from "rx-nostr";
+import {
+    createRxBackwardReq,
+    type ConnectionStatePacket,
+    type RxNostr,
+} from "rx-nostr";
 import { filter } from "rxjs";
 import { addProfilePictureMarker } from "./profilePictureUrlUtils";
 import {
@@ -552,6 +556,7 @@ async function fetchBatchFromNetwork(
         const rxReq = createRxBackwardReq();
         let settled = false;
         let subscription: { unsubscribe: () => void } | null = null;
+        let connectionStateSubscription: { unsubscribe: () => void } | null = null;
 
         const done = () => {
             if (settled) {
@@ -559,6 +564,7 @@ async function fetchBatchFromNetwork(
             }
             settled = true;
             subscription?.unsubscribe();
+            connectionStateSubscription?.unsubscribe();
             resolve();
         };
 
@@ -581,6 +587,27 @@ async function fetchBatchFromNetwork(
             }
         };
 
+        const targetRelays = new Set(relayHints);
+        const handleConnectionState = (packet: ConnectionStatePacket) => {
+            if (
+                targetRelays.has(packet.from)
+                && (packet.state === "error" || packet.state === "rejected" || packet.state === "terminated")
+            ) {
+                markNetworkError();
+            }
+        };
+
+        for (const relay of targetRelays) {
+            const status = rxNostr.getRelayStatus?.(relay);
+            if (
+                status?.connection === "error"
+                || status?.connection === "rejected"
+                || status?.connection === "terminated"
+            ) {
+                markNetworkError();
+            }
+        }
+
         const isValidTimestampPacket = (packet: { event?: { created_at?: number; pubkey?: string } }): boolean => {
             const createdAt = packet.event?.created_at;
             if (typeof createdAt !== "number") {
@@ -602,6 +629,10 @@ async function fetchBatchFromNetwork(
         };
 
         try {
+            connectionStateSubscription = rxNostr.createConnectionStateObservable?.().subscribe({
+                next: handleConnectionState,
+            }) ?? null;
+
             const source = rxNostr.use(
                 rxReq,
                 { on: { relays: relayHints } },

--- a/src/lib/profileMetadataCache.svelte.ts
+++ b/src/lib/profileMetadataCache.svelte.ts
@@ -96,6 +96,7 @@ interface BatchNetworkResult {
     rejectedFutureTimestamp: boolean;
     parseError: boolean;
     networkError: boolean;
+    timedOut: boolean;
 }
 
 let entriesByPubkey = $state.raw<Record<string, ProfileMetadataCacheEntry>>({});
@@ -539,6 +540,7 @@ async function fetchBatchFromNetwork(
             rejectedFutureTimestamp: false,
             parseError: false,
             networkError: false,
+            timedOut: false,
         };
     }
 
@@ -561,6 +563,12 @@ async function fetchBatchFromNetwork(
         };
 
         const timeoutId = setTimeout(() => {
+            for (const pubkey of authors) {
+                results[pubkey] = {
+                    ...results[pubkey],
+                    timedOut: true,
+                };
+            }
             done();
         }, Math.max(1, timeoutMs));
 
@@ -674,6 +682,7 @@ async function fetchBatchFromNetwork(
                         rejectedFutureTimestamp: false,
                         parseError: false,
                         networkError: false,
+                        timedOut: existing.timedOut,
                     };
                 },
                 complete: () => {
@@ -716,6 +725,7 @@ export interface ProfileTierResolution {
     parseError: boolean;
     rejectedFutureTimestamp: boolean;
     networkError: boolean;
+    transientFailure: boolean;
 }
 
 async function applyTierNetworkResult(
@@ -746,6 +756,7 @@ async function applyTierNetworkResult(
                 parseError: false,
                 rejectedFutureTimestamp: false,
                 networkError: false,
+                transientFailure: result.networkError || result.timedOut,
             };
         } catch {
             const snapshot = resolveExistingSnapshot(pubkey, requests);
@@ -757,6 +768,7 @@ async function applyTierNetworkResult(
                 parseError: false,
                 rejectedFutureTimestamp: false,
                 networkError: false,
+                transientFailure: result.networkError || result.timedOut,
             };
         }
     }
@@ -767,6 +779,7 @@ async function applyTierNetworkResult(
         parseError: result.parseError,
         rejectedFutureTimestamp: result.rejectedFutureTimestamp,
         networkError: result.networkError,
+        transientFailure: result.networkError || result.timedOut,
     };
 }
 
@@ -830,6 +843,7 @@ async function flushPendingBatch(): Promise<void> {
         const resolvedProfiles: Record<string, ProfileData | null> = {};
         const parseErrors = new Set<string>();
         const rejectedFutureTimestamps = new Set<string>();
+        const transientFailures = new Set<string>();
         const queriedPubkeys = new Set<string>();
         const tierNames = ["bootstrap", "contextual", "fallback"] as const;
 
@@ -897,6 +911,9 @@ async function flushPendingBatch(): Promise<void> {
                         if (resolution.rejectedFutureTimestamp) {
                             rejectedFutureTimestamps.add(pubkey);
                         }
+                        if (resolution.transientFailure) {
+                            transientFailures.add(pubkey);
+                        }
                         if (resolution.stopReason !== null) {
                             unresolvedPubkeys.delete(pubkey);
                         }
@@ -911,7 +928,11 @@ async function flushPendingBatch(): Promise<void> {
                     markEntryStatus(pubkey, "parse-error");
                 } else if (rejectedFutureTimestamps.has(pubkey)) {
                     markEntryStatus(pubkey, "invalid-future-ts");
-                } else if (!snapshot && queriedPubkeys.has(pubkey)) {
+                } else if (
+                    !snapshot
+                    && queriedPubkeys.has(pubkey)
+                    && !transientFailures.has(pubkey)
+                ) {
                     setNegativeEntry(pubkey);
                 }
                 resolvedProfiles[pubkey] = snapshot

--- a/src/lib/relayManager.ts
+++ b/src/lib/relayManager.ts
@@ -135,8 +135,13 @@ export class RelayNetworkFetcher {
             let found = false;
             let resolved = false;
             let subscription: any = undefined;
+            let timeoutId: any = undefined;
 
             const cleanup = () => {
+                if (timeoutId !== undefined) {
+                    this.clearTimeoutFn(timeoutId);
+                    timeoutId = undefined;
+                }
                 if (subscription && typeof subscription.unsubscribe === "function") {
                     subscription.unsubscribe();
                     subscription = undefined;
@@ -152,6 +157,10 @@ export class RelayNetworkFetcher {
             };
 
             try {
+                timeoutId = this.setTimeoutFn(() => {
+                    safeResolve({ success: false, error: 'timeout' });
+                }, Math.max(1, timeoutMs));
+
                 subscription = this.rxNostr.use(rxReq, { on: { relays } }).subscribe({
                     next: (packet: any) => {
                         if (resolved) return;
@@ -192,7 +201,13 @@ export class RelayNetworkFetcher {
                     }
                 });
 
+                if (resolved) {
+                    cleanup();
+                    return;
+                }
+
                 // リクエスト送信（untilパラメータで未来のイベントをキャプチャしない）
+                if (resolved) return;
                 rxReq.emit({
                     authors: [pubkeyHex],
                     kinds: [10002],
@@ -220,8 +235,13 @@ export class RelayNetworkFetcher {
             let found = false;
             let resolved = false;
             let subscription: any = undefined;
+            let timeoutId: any = undefined;
 
             const cleanup = () => {
+                if (timeoutId !== undefined) {
+                    this.clearTimeoutFn(timeoutId);
+                    timeoutId = undefined;
+                }
                 if (subscription && typeof subscription.unsubscribe === "function") {
                     subscription.unsubscribe();
                     subscription = undefined;
@@ -237,6 +257,10 @@ export class RelayNetworkFetcher {
             };
 
             try {
+                timeoutId = this.setTimeoutFn(() => {
+                    safeResolve({ success: false, error: 'timeout' });
+                }, Math.max(1, timeoutMs));
+
                 subscription = this.rxNostr.use(rxReq, { on: { relays } }).subscribe({
                     next: (packet: any) => {
                         if (resolved) return;
@@ -274,7 +298,13 @@ export class RelayNetworkFetcher {
                     }
                 });
 
+                if (resolved) {
+                    cleanup();
+                    return;
+                }
+
                 // リクエスト送信（untilパラメータで未来のイベントをキャプチャしない）
+                if (resolved) return;
                 rxReq.emit({
                     authors: [pubkeyHex],
                     kinds: [3],

--- a/src/lib/replyQuoteProfileSync.ts
+++ b/src/lib/replyQuoteProfileSync.ts
@@ -30,6 +30,7 @@ interface ActiveProfileSync extends DesiredProfileSync {
     lastProfile: ProfileData | null;
     disposed: boolean;
     requestRevision: number;
+    nullRetryUsed: boolean;
 }
 
 export interface ReplyQuoteProfileSyncDependencies {
@@ -190,11 +191,19 @@ export function createReplyQuoteProfileSyncController(
             additionalRelays: active.relayHints,
         }).then((profile) => {
             if (
-                activeByPubkey.get(active.pubkey) === active
-                && active.requestRevision === requestRevision
+                activeByPubkey.get(active.pubkey) !== active
+                || active.requestRevision !== requestRevision
             ) {
-                applyProfile(active, profile);
+                return;
             }
+
+            if (profile === null && !active.nullRetryUsed) {
+                active.nullRetryUsed = true;
+                requestProfile(active);
+                return;
+            }
+
+            applyProfile(active, profile);
         }).catch((error) => {
             logger.error("返信・引用プロフィールの取得に失敗:", error);
         });
@@ -244,6 +253,7 @@ export function createReplyQuoteProfileSyncController(
                 lastProfile: null,
                 disposed: false,
                 requestRevision: 0,
+                nullRetryUsed: false,
             };
             activeByPubkey.set(pubkey, active);
             active.unsubscribe = deps.relayProfileService.subscribeProfile(

--- a/src/test/unit/profileMetadataCache.test.ts
+++ b/src/test/unit/profileMetadataCache.test.ts
@@ -309,6 +309,41 @@ function createErroringRxNostr() {
     return { use, calls };
 }
 
+function createConnectionStateFailureRxNostr(state: "error" | "rejected") {
+    const calls: Array<{ relays: string[]; authors: string[] }> = [];
+    let emitted = false;
+    const createConnectionStateObservable = vi.fn(() => ({
+        subscribe: (observer: { next?: (packet: unknown) => void }) => {
+            if (!emitted) {
+                emitted = true;
+                observer.next?.({ from: BOOTSTRAP_RELAYS[0], state });
+            }
+            return { unsubscribe: vi.fn() };
+        },
+    }));
+    const use = vi.fn((rxReq: { emit: (filter: { authors?: string[] }) => void }, options: {
+        on: { relays: string[] };
+    }) => {
+        const call = {
+            relays: [...options.on.relays],
+            authors: [] as string[],
+        };
+        calls.push(call);
+        const originalEmit = rxReq.emit.bind(rxReq);
+        rxReq.emit = (filter) => {
+            call.authors = [...(filter.authors ?? [])];
+            originalEmit(filter);
+        };
+        return {
+            subscribe: (observer: { complete?: () => void }) => {
+                observer.complete?.();
+                return { unsubscribe: vi.fn() };
+            },
+        };
+    });
+    return { use, calls, createConnectionStateObservable };
+}
+
 function createUpsertResult(
     candidate: ProfileEventCandidate,
     decision: ProfileUpsertDecision = "replaced",
@@ -1580,6 +1615,29 @@ describe("profileMetadataCache", () => {
         await expect(retry).resolves.toBeNull();
         expect(rxNostr.calls.length).toBeGreaterThan(3);
     });
+
+    it.each(["error", "rejected"] as const)(
+        "does not negative-cache when a queried relay reaches %s while use completes",
+        async (state) => {
+            const rxNostr = createConnectionStateFailureRxNostr(state);
+            const pending = profileMetadataCache.getProfile(pubkey, {
+                rxNostr: rxNostr as never,
+                forceRefresh: true,
+            });
+            await flushProfileBatch();
+
+            await expect(pending).resolves.toBeNull();
+            expect(profileMetadataCache.getReactiveEntry(pubkey)).toBeNull();
+
+            const retry = profileMetadataCache.getProfile(pubkey, {
+                rxNostr: rxNostr as never,
+            });
+            await flushProfileBatch();
+            await expect(retry).resolves.toBeNull();
+            expect(rxNostr.use).toHaveBeenCalledTimes(4);
+            expect(rxNostr.createConnectionStateObservable).toHaveBeenCalled();
+        },
+    );
 
     it("does not negative-cache a pubkey when no REQ could be started", async () => {
         const rxNostr = {

--- a/src/test/unit/profileMetadataCache.test.ts
+++ b/src/test/unit/profileMetadataCache.test.ts
@@ -1492,6 +1492,7 @@ describe("profileMetadataCache", () => {
             rejectedFutureTimestamp: false,
             parseError: false,
             networkError: false,
+            timedOut: false,
         }, []);
 
         expect(resolution.stopReason).toBe("persistence-unavailable");
@@ -1535,6 +1536,23 @@ describe("profileMetadataCache", () => {
             [pubkey],
             [pubkey],
         ]);
+        expect(profileMetadataCache.getReactiveEntry(pubkey)).toBeNull();
+
+        const retry = profileMetadataCache.getProfile(pubkey, {
+            rxNostr: rxNostr as never,
+        });
+        await flushProfileBatch();
+        await vi.advanceTimersByTimeAsync(
+            profileMetadataCacheInternals.PROFILE_CACHE_BATCH_TIMEOUT_MS,
+        );
+        await vi.advanceTimersByTimeAsync(
+            profileMetadataCacheInternals.PROFILE_CACHE_BATCH_TIMEOUT_MS,
+        );
+        await vi.advanceTimersByTimeAsync(
+            profileMetadataCacheInternals.PROFILE_CACHE_BATCH_TIMEOUT_MS,
+        );
+        await expect(retry).resolves.toBeNull();
+        expect(rxNostr.calls.length).toBeGreaterThan(3);
     });
 
     it("fails soft after network errors in every tier", async () => {
@@ -1553,10 +1571,14 @@ describe("profileMetadataCache", () => {
             [contextRelay],
             FALLBACK_RELAYS,
         ]);
-        expect(profileMetadataCache.getReactiveEntry(pubkey)).toMatchObject({
-            status: "negative",
-            profile: null,
+        expect(profileMetadataCache.getReactiveEntry(pubkey)).toBeNull();
+
+        const retry = profileMetadataCache.getProfile(pubkey, {
+            rxNostr: rxNostr as never,
         });
+        await flushProfileBatch();
+        await expect(retry).resolves.toBeNull();
+        expect(rxNostr.calls.length).toBeGreaterThan(3);
     });
 
     it("does not negative-cache a pubkey when no REQ could be started", async () => {

--- a/src/test/unit/relayManager.test.ts
+++ b/src/test/unit/relayManager.test.ts
@@ -381,20 +381,45 @@ describe('RelayNetworkFetcher', () => {
             expect(mockSubscription.unsubscribe).toHaveBeenCalled();
         });
 
-        it('タイムアウト時に適切に処理する', async () => {
-            // Backward Strategy: イベントなしでcompleteを呼ぶ
-            subscribeFn.mockImplementation((observer: any) => {
-                queueMicrotask(() => {
-                    observer.complete();
-                });
+        it('イベント終端がない場合は注入timerでtimeoutする', async () => {
+            let timeoutCallback: (() => void) | undefined;
+            mockSetTimeout.mockImplementation((callback: () => void) => {
+                timeoutCallback = callback;
+                return 'timeout-id';
+            });
+            subscribeFn.mockImplementation(() => mockSubscription);
+
+            const pending = fetcher.fetchKind10002('testpubkey', ['wss://bootstrap.example.com'], 1);
+            timeoutCallback?.();
+            const result = await pending;
+
+            expect(result.success).toBe(false);
+            expect(result.error).toBe('timeout');
+            expect(mockSubscription.unsubscribe).toHaveBeenCalled();
+            expect(mockClearTimeout).toHaveBeenCalledWith('timeout-id');
+        });
+
+        it('timeout後の遅延packetは結果とcleanupを変更しない', async () => {
+            let observer: any;
+            let timeoutCallback: (() => void) | undefined;
+            mockSetTimeout.mockImplementation((callback: () => void) => {
+                timeoutCallback = callback;
+                return 'timeout-id';
+            });
+            subscribeFn.mockImplementation((nextObserver: any) => {
+                observer = nextObserver;
                 return mockSubscription;
             });
 
-            const result = await fetcher.fetchKind10002('testpubkey', ['wss://bootstrap.example.com'], 1);
+            const pending = fetcher.fetchKind10002('testpubkey', ['wss://bootstrap.example.com']);
+            timeoutCallback?.();
+            await expect(pending).resolves.toMatchObject({ success: false, error: 'timeout' });
+            observer.next({ event: { kind: 10002, pubkey: 'testpubkey', tags: [['r', 'wss://late.example.com']] } });
+            observer.complete();
+            observer.error(new Error('late'));
 
-            expect(result.success).toBe(false);
-            expect(result.error).toBe('not_found');
-            expect(mockSubscription.unsubscribe).toHaveBeenCalled();
+            expect(mockSubscription.unsubscribe).toHaveBeenCalledOnce();
+            expect(mockClearTimeout).toHaveBeenCalledOnce();
         });
 
         it('終了済み relay だけの Kind 10002 を未取得として扱う', async () => {
@@ -432,6 +457,22 @@ describe('RelayNetworkFetcher', () => {
                 'Kind 10002取得エラー:',
                 expect.any(Error)
             );
+        });
+
+        it('正常終了時はtimeout timerをclearする', async () => {
+            let timeoutId: any;
+            mockSetTimeout.mockImplementation((callback: () => void) => {
+                timeoutId = 'timeout-id';
+                return timeoutId;
+            });
+            subscribeFn.mockImplementation((observer: any) => {
+                queueMicrotask(() => observer.complete());
+                return mockSubscription;
+            });
+
+            await expect(fetcher.fetchKind10002('testpubkey', ['wss://bootstrap.example.com']))
+                .resolves.toMatchObject({ success: false, error: 'not_found' });
+            expect(mockClearTimeout).toHaveBeenCalledWith(timeoutId);
         });
     });
 
@@ -482,6 +523,29 @@ describe('RelayNetworkFetcher', () => {
 
             expect(result.success).toBe(false);
             expect(result.error).toBe('not_found');
+        });
+
+        it('イベント終端がない場合は注入timerでtimeoutし、遅延packetを無視する', async () => {
+            let observer: any;
+            let timeoutCallback: (() => void) | undefined;
+            mockSetTimeout.mockImplementation((callback: () => void) => {
+                timeoutCallback = callback;
+                return 'timeout-id';
+            });
+            subscribeFn.mockImplementation((nextObserver: any) => {
+                observer = nextObserver;
+                return mockSubscription;
+            });
+
+            const pending = fetcher.fetchKind3('testpubkey', ['wss://bootstrap.example.com']);
+            timeoutCallback?.();
+            await expect(pending).resolves.toMatchObject({ success: false, error: 'timeout' });
+            observer.next({ event: { kind: 3, pubkey: 'testpubkey', content: '{}' } });
+            observer.complete();
+            observer.error(new Error('late'));
+
+            expect(mockSubscription.unsubscribe).toHaveBeenCalledOnce();
+            expect(mockClearTimeout).toHaveBeenCalledOnce();
         });
 
         it('終了済み relay だけの Kind 3 を未取得として扱う', async () => {
@@ -704,6 +768,48 @@ describe('RelayManager統合テスト', () => {
             expect((mockDeps.console?.log as any).mock.calls.some(
                 (call: any[]) => call[0] && typeof call[0] === 'string' && call[0].includes('リモート取得失敗、フォールバックリレーを使用')
             )).toBe(true);
+        });
+
+        it('Kind 10002とKind 3のtimeout後にフォールバックへ進み、pendingにならない', async () => {
+            const timers: Array<() => void> = [];
+            const observers: any[] = [];
+            mockSetTimeout = vi.fn((callback: () => void) => {
+                timers.push(callback);
+                return timers.length;
+            });
+            mockClearTimeout = vi.fn();
+            mockRxNostr.use = vi.fn(() => ({
+                subscribe: (observer: any) => {
+                    observers.push(observer);
+                    return { unsubscribe: vi.fn() };
+                },
+            })) as any;
+            manager = new RelayManager(mockRxNostr, {
+                ...mockDeps,
+                setTimeoutFn: mockSetTimeout,
+                clearTimeoutFn: mockClearTimeout,
+            });
+
+            const pending = manager.fetchUserRelays('timeout-fallback-pubkey', {
+                forceRemote: true,
+                timeoutMs: 1,
+            });
+            await Promise.resolve();
+            expect(timers).toHaveLength(1);
+            timers[0]();
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(timers).toHaveLength(2);
+            timers[1]();
+
+            await expect(pending).resolves.toMatchObject({
+                success: false,
+                source: 'fallback',
+                relayConfig: FALLBACK_RELAYS,
+            });
+            expect(mockRxNostr.use).toHaveBeenCalledTimes(2);
+            expect(observers).toHaveLength(2);
+            expect(mockRxNostr.setDefaultRelays).toHaveBeenCalledWith(FALLBACK_RELAYS);
         });
 
         it('終了済み relay だけの保存済み設定をキャッシュとして復元せず既存フォールバックへ進む', async () => {

--- a/src/test/unit/replyQuoteProfileSync.test.ts
+++ b/src/test/unit/replyQuoteProfileSync.test.ts
@@ -270,6 +270,107 @@ describe("replyQuoteProfileSync", () => {
         });
     });
 
+    it("retries one null profile result once and applies the recovered profile", async () => {
+        const fetchProfileRealtime = vi.fn()
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(createProfile("Recovered"))
+            .mockResolvedValueOnce(createProfile("Unexpected third result"));
+        const updateAuthorProfile = vi.fn();
+        const controller = createReplyQuoteProfileSyncController({
+            relayProfileService: {
+                fetchProfileRealtime,
+                subscribeProfile: vi.fn(() => vi.fn()),
+            },
+            updateAuthorProfile,
+            updateReplyNotificationRecipientProfile: vi.fn(),
+        });
+
+        controller.sync({
+            reply: createReference("reply", "retry-event", { authorPubkey: "retry-author" }),
+            quotes: [],
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(fetchProfileRealtime).toHaveBeenCalledTimes(2);
+        expect(updateAuthorProfile).toHaveBeenCalledWith(
+            ownedTarget("retry-event", "reply"),
+            "retry-author",
+            {
+                displayName: "Recovered",
+                picture: "https://example.com/Recovered.png",
+            },
+        );
+    });
+
+    it("stops after at most two null profile results", async () => {
+        const fetchProfileRealtime = vi.fn()
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null);
+        const controller = createReplyQuoteProfileSyncController({
+            relayProfileService: {
+                fetchProfileRealtime,
+                subscribeProfile: vi.fn(() => vi.fn()),
+            },
+            updateAuthorProfile: vi.fn(),
+            updateReplyNotificationRecipientProfile: vi.fn(),
+        });
+
+        controller.sync({
+            reply: createReference("reply", "null-event", { authorPubkey: "null-author" }),
+            quotes: [],
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(fetchProfileRealtime).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not retry a null result from an obsolete owner request", async () => {
+        let resolveOld!: (profile: ProfileData | null) => void;
+        const fetchProfileRealtime = vi.fn()
+            .mockReturnValueOnce(new Promise<ProfileData | null>((resolve) => {
+                resolveOld = resolve;
+            }))
+            .mockReturnValueOnce(Promise.resolve(createProfile("New")));
+        const controller = createReplyQuoteProfileSyncController({
+            relayProfileService: {
+                fetchProfileRealtime,
+                subscribeProfile: vi.fn(() => vi.fn()),
+            },
+            updateAuthorProfile: vi.fn(),
+            updateReplyNotificationRecipientProfile: vi.fn(),
+        });
+
+        controller.sync({
+            reply: createReference("reply", "obsolete-event", {
+                ownerToken: Symbol("old"),
+                authorPubkey: "obsolete-author",
+            }),
+            quotes: [],
+        });
+        controller.sync({
+            reply: createReference("reply", "obsolete-event", {
+                ownerToken: Symbol("new"),
+                authorPubkey: "obsolete-author",
+            }),
+            quotes: [],
+        });
+
+        resolveOld(null);
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(fetchProfileRealtime).toHaveBeenCalledTimes(2);
+
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(fetchProfileRealtime).toHaveBeenCalledTimes(2);
+    });
+
     it("applies later subscription updates and stops UI updates after dispose", async () => {
         let callback: (profile: ProfileData | null) => void = () => undefined;
         const unsubscribe = vi.fn();


### PR DESCRIPTION
## Summary

Fix transient profile fetch failures during startup without changing relay discovery or application/session ordering.

## Root-cause fixes

- RelayNetworkFetcher metadata requests are bounded by their existing timeout contract, preventing kind:10002/kind:3 fetches from blocking authentication bootstrap forever.
- Profile metadata now observes rx-nostr connection state for the relays used by each batch. `error`, `rejected`, and `terminated` states are treated as transient network failures even when `use()` completes without emitting an Observable error, so these failures do not create a negative profile cache entry.
- Profile batch timeouts and network errors remain transient and do not create negative cache entries.
- ReplyQuoteProfileSync retries a null profile result at most once, preserving request revision, owner-token, deduplication, and disposal guards.

Clean completion with no kind:0 across all tiers still uses the existing negative-cache behavior.

## Validation

- `src/test/unit/profileMetadataCache.test.ts`: passed (43 tests)
- `npm run check`: passed
- `npm test`: passed (3951 passed, 1 skipped)
- `npm run build`: passed
- Playwright/E2E not run because this change does not modify UI structure or embed protocol.

Build output retained only existing warnings about chunk sizes, Svelte rest props, and blurhash import mode.