### PR TITLE
Add configurable relay to iframe sample timeline

### DIFF
--- a/public/embed-parent-client-example.html
+++ b/public/embed-parent-client-example.html
@@ -565,9 +565,16 @@
             <section class="panel timeline-panel">
                 <div class="timeline-header">
                     <h2>簡易タイムライン</h2>
-                    <p class="small">wss://nos.lol の最新 kind 1 を表示します。reply / quote と本文は iframe ready 後に postMessage
-                        で同期し、未接続時だけ URL
-                        クエリ付きで再読み込みします。</p>
+                    <p class="small">指定したrelayの最新 kind 1 を表示します。現在の接続先はステータスに表示されます。reply / quote と本文は iframe ready 後に
+                        postMessage で同期し、未接続時だけ URL クエリ付きで再読み込みします。</p>
+                </div>
+
+                <div class="field">
+                    <label for="timeline-relay">タイムライン relay URL</label>
+                    <input id="timeline-relay" type="text" inputmode="url" list="timeline-relay-suggestions"
+                        spellcheck="false" autocomplete="off" value="wss://nos.lol">
+                    <datalist id="timeline-relay-suggestions"></datalist>
+                    <p class="small">ws:// または wss:// のrelayを入力して「タイムライン更新」を押してください。適用したrelayは次回入力時の候補に保存されます。</p>
                 </div>
 
                 <div class="timeline-toolbar">

--- a/public/embed-parent-client-example.js
+++ b/public/embed-parent-client-example.js
@@ -9,7 +9,9 @@ const PARENT_EMBED_STORAGE_PREFIX = "ehagaki.embed.storage.v1:";
 const PARENT_EMBED_INDEXEDDB_NAME = "ehagaki-parent-embed-storage-v1";
 const PARENT_EMBED_INDEXEDDB_VERSION = 1;
 const PARENT_EMBED_INDEXEDDB_SNAPSHOT_STORE = "snapshots";
-const TIMELINE_RELAYS = ["wss://nos.lol"];
+const DEFAULT_TIMELINE_RELAY = "wss://nos.lol";
+const TIMELINE_RELAY_HISTORY_KEY = "ehagaki.parent-client-sample.timeline-relays";
+const TIMELINE_RELAY_HISTORY_LIMIT = 10;
 const TIMELINE_EVENT_LIMIT = 24;
 const TIMELINE_QUERY_MAX_WAIT_MS = 4000;
 
@@ -54,6 +56,8 @@ const parentAuthStatus = document.getElementById("parent-auth-status");
 const authFeedback = document.getElementById("auth-feedback");
 const handshakeStatus = document.getElementById("handshake-status");
 const timelineStatus = document.getElementById("timeline-status");
+const timelineRelayInput = document.getElementById("timeline-relay");
+const timelineRelaySuggestions = document.getElementById("timeline-relay-suggestions");
 const timelineSelection = document.getElementById("timeline-selection");
 const timelineList = document.getElementById("timeline-list");
 const channelReferenceInput = document.getElementById("channel-reference");
@@ -129,6 +133,8 @@ const urlContextOverrides = {
     settings: false,
 };
 let timelineSubscription = null;
+let activeTimelineRelay = DEFAULT_TIMELINE_RELAY;
+let timelineLoadGeneration = 0;
 let composerRequestSequence = 0;
 let settingsRequestSequence = 0;
 
@@ -264,6 +270,71 @@ function parseRelayListInput(value) {
         .split(/[\n,]+/)
         .map((entry) => entry.trim())
         .filter((entry) => entry.length > 0);
+}
+
+function normalizeTimelineRelay(value) {
+    const relay = trimToNull(value);
+    if (!relay) {
+        throw new Error("relay URLを入力してください");
+    }
+
+    let parsed;
+    try {
+        parsed = new URL(relay);
+    } catch {
+        throw new Error("relay URLの形式が不正です");
+    }
+
+    if ((parsed.protocol !== "wss:" && parsed.protocol !== "ws:") || !parsed.hostname) {
+        throw new Error("relay URLは ws:// または wss:// のWebSocket URLを指定してください");
+    }
+
+    return relay;
+}
+
+function readTimelineRelayHistory() {
+    try {
+        const stored = JSON.parse(window.localStorage.getItem(TIMELINE_RELAY_HISTORY_KEY) ?? "null");
+        if (!Array.isArray(stored)) {
+            return [];
+        }
+
+        const relays = [];
+        for (const value of stored) {
+            try {
+                const relay = normalizeTimelineRelay(value);
+                if (!relays.includes(relay)) {
+                    relays.push(relay);
+                }
+            } catch {
+                // Ignore malformed entries without affecting the timeline defaults.
+            }
+        }
+        return relays.slice(0, TIMELINE_RELAY_HISTORY_LIMIT);
+    } catch {
+        return [];
+    }
+}
+
+function saveTimelineRelayToHistory(relay) {
+    const history = [relay, ...readTimelineRelayHistory().filter((item) => item !== relay)]
+        .slice(0, TIMELINE_RELAY_HISTORY_LIMIT);
+    try {
+        window.localStorage.setItem(TIMELINE_RELAY_HISTORY_KEY, JSON.stringify(history));
+    } catch {
+        // History is an optional convenience; the timeline remains usable without it.
+    }
+    renderTimelineRelaySuggestions(history);
+}
+
+function renderTimelineRelaySuggestions(history = readTimelineRelayHistory()) {
+    timelineRelaySuggestions.textContent = "";
+    const suggestions = [DEFAULT_TIMELINE_RELAY, ...history.filter((relay) => relay !== DEFAULT_TIMELINE_RELAY)];
+    suggestions.forEach((relay) => {
+        const option = document.createElement("option");
+        option.value = relay;
+        timelineRelaySuggestions.append(option);
+    });
 }
 
 function formatRelayListInput(relays) {
@@ -608,7 +679,7 @@ function createTimelineReference(event) {
         eventId: event.id,
         queryValue: neventEncode({
             id: event.id,
-            relays: TIMELINE_RELAYS,
+            relays: [activeTimelineRelay],
             author: event.pubkey,
             kind: event.kind,
         }),
@@ -1150,13 +1221,13 @@ function clearComposerContent() {
     });
 }
 
-function startTimelineSubscription() {
+function startTimelineSubscription(relay, generation) {
     const since = timelineEvents[0]?.created_at
         ? timelineEvents[0].created_at + 1
         : Math.floor(Date.now() / 1000) - 300;
 
     timelineSubscription = timelinePool.subscribeMany(
-        TIMELINE_RELAYS,
+        [relay],
         {
             kinds: [1],
             since,
@@ -1164,11 +1235,14 @@ function startTimelineSubscription() {
         {
             label: "embed sample timeline",
             onevent(event) {
+                if (generation !== timelineLoadGeneration || relay !== activeTimelineRelay) {
+                    return;
+                }
                 mergeTimelineEvents([event]);
                 renderTimeline();
                 updateStatus(
                     timelineStatus,
-                    `${TIMELINE_RELAYS[0]} 接続中 (${timelineEvents.length} 件)`,
+                    `${relay} 接続中 (${timelineEvents.length} 件)`,
                     "ok",
                 );
             },
@@ -1177,17 +1251,49 @@ function startTimelineSubscription() {
 }
 
 async function loadTimeline() {
+    let relay;
+    try {
+        relay = normalizeTimelineRelay(timelineRelayInput.value);
+    } catch (error) {
+        updateStatus(timelineStatus, error instanceof Error ? error.message : "relay URLが不正です", "error");
+        return;
+    }
+
+    const generation = ++timelineLoadGeneration;
+    activeTimelineRelay = relay;
+    timelineRelayInput.value = relay;
+    saveTimelineRelayToHistory(relay);
     refreshTimelineButton.disabled = true;
-    updateStatus(timelineStatus, "タイムライン読み込み中", "warn");
+    updateStatus(timelineStatus, `${relay} を読み込み中`, "warn");
 
     if (timelineSubscription) {
         timelineSubscription.close("timeline-refresh");
         timelineSubscription = null;
     }
+    const hadReplyQuoteSelection = selectedReplyReference !== null || selectedQuoteReferences.length > 0;
+    timelineEvents = [];
+    selectedReplyReference = null;
+    selectedQuoteReferences = [];
+    if (hadReplyQuoteSelection) {
+        urlContextOverrides.replyQuote = true;
+    }
+    renderTimeline();
+    if (hadReplyQuoteSelection) {
+        sendRuntimeComposerMessage(
+            "composer.setContext",
+            buildComposerContextPayload({ includeReplyQuote: true }),
+            {
+                actionLabel: "relay変更時の reply / quote 解除",
+                infoMessage: "relay変更に合わせて reply / quote 選択を解除しました",
+                detail: { relay },
+                failureMessage: "relay変更時の reply / quote 解除に失敗しました",
+            },
+        );
+    }
 
     try {
         const events = await timelinePool.querySync(
-            TIMELINE_RELAYS,
+            [relay],
             {
                 kinds: [1],
                 limit: TIMELINE_EVENT_LIMIT,
@@ -1198,20 +1304,26 @@ async function loadTimeline() {
             },
         );
 
+        if (generation !== timelineLoadGeneration || relay !== activeTimelineRelay) {
+            return;
+        }
         mergeTimelineEvents(events);
         renderTimeline();
-        startTimelineSubscription();
+        startTimelineSubscription(relay, generation);
         updateStatus(
             timelineStatus,
-            `${TIMELINE_RELAYS[0]} 接続中 (${timelineEvents.length} 件)`,
+            `${relay} 接続中 (${timelineEvents.length} 件)`,
             "ok",
         );
         appendLog("info", "簡易タイムラインを更新しました", {
-            relay: TIMELINE_RELAYS[0],
+            relay,
             count: timelineEvents.length,
         });
     } catch (error) {
-        updateStatus(timelineStatus, "タイムライン取得失敗", "error");
+        if (generation !== timelineLoadGeneration || relay !== activeTimelineRelay) {
+            return;
+        }
+        updateStatus(timelineStatus, `${relay} タイムライン取得失敗`, "error");
         renderTimeline();
         appendLog("error", "簡易タイムラインの取得に失敗しました", error instanceof Error ? error.message : String(error));
     } finally {
@@ -2336,6 +2448,8 @@ if (storedParentSession) {
 }
 
 renderTimeline();
+timelineRelayInput.value = DEFAULT_TIMELINE_RELAY;
+renderTimelineRelaySuggestions();
 syncChannelInputsFromSelection();
 updateDisplayedEmbedUrl();
 reloadIframeButton.addEventListener("click", loadIframe);
@@ -2385,6 +2499,12 @@ announceLogoutButton.addEventListener("click", () => {
 refreshTimelineButton.addEventListener("click", () => {
     void loadTimeline();
 });
+timelineRelayInput.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+        event.preventDefault();
+        void loadTimeline();
+    }
+});
 clearReplyQuoteButton.addEventListener("click", clearReplyQuoteSelection);
 syncComposerContentButton.addEventListener("click", syncComposerContent);
 clearComposerContentButton.addEventListener("click", clearComposerContent);
@@ -2402,8 +2522,9 @@ window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () 
 });
 window.addEventListener("focus", refreshSignerStatus);
 window.addEventListener("beforeunload", () => {
+    timelineLoadGeneration += 1;
     timelineSubscription?.close("page-unload");
-    timelinePool.close(TIMELINE_RELAYS);
+    timelinePool.close([activeTimelineRelay]);
     timelinePool.destroy();
 });
 

--- a/public/embed-parent-client-example.js
+++ b/public/embed-parent-client-example.js
@@ -1259,6 +1259,7 @@ async function loadTimeline() {
         return;
     }
 
+    const relayChanged = relay !== activeTimelineRelay;
     const generation = ++timelineLoadGeneration;
     activeTimelineRelay = relay;
     timelineRelayInput.value = relay;
@@ -1270,25 +1271,27 @@ async function loadTimeline() {
         timelineSubscription.close("timeline-refresh");
         timelineSubscription = null;
     }
-    const hadReplyQuoteSelection = selectedReplyReference !== null || selectedQuoteReferences.length > 0;
-    timelineEvents = [];
-    selectedReplyReference = null;
-    selectedQuoteReferences = [];
-    if (hadReplyQuoteSelection) {
-        urlContextOverrides.replyQuote = true;
-    }
-    renderTimeline();
-    if (hadReplyQuoteSelection) {
-        sendRuntimeComposerMessage(
-            "composer.setContext",
-            buildComposerContextPayload({ includeReplyQuote: true }),
-            {
-                actionLabel: "relay変更時の reply / quote 解除",
-                infoMessage: "relay変更に合わせて reply / quote 選択を解除しました",
-                detail: { relay },
-                failureMessage: "relay変更時の reply / quote 解除に失敗しました",
-            },
-        );
+    if (relayChanged) {
+        const hadReplyQuoteSelection = selectedReplyReference !== null || selectedQuoteReferences.length > 0;
+        timelineEvents = [];
+        selectedReplyReference = null;
+        selectedQuoteReferences = [];
+        if (hadReplyQuoteSelection) {
+            urlContextOverrides.replyQuote = true;
+        }
+        renderTimeline();
+        if (hadReplyQuoteSelection) {
+            sendRuntimeComposerMessage(
+                "composer.setContext",
+                buildComposerContextPayload({ includeReplyQuote: true }),
+                {
+                    actionLabel: "relay変更時の reply / quote 解除",
+                    infoMessage: "relay変更に合わせて reply / quote 選択を解除しました",
+                    detail: { relay },
+                    failureMessage: "relay変更時の reply / quote 解除に失敗しました",
+                },
+            );
+        }
     }
 
     try {

--- a/src/test/e2e/embedParentClientExample.spec.ts
+++ b/src/test/e2e/embedParentClientExample.spec.ts
@@ -3,9 +3,24 @@ import { finalizeEvent, generateSecretKey, nip19 } from "nostr-tools";
 import { WebSocketServer, type WebSocket } from "ws";
 
 let relayServer: WebSocketServer;
+let secondRelayServer: WebSocketServer;
 let relayOrigin = "";
+let secondRelayOrigin = "";
 let relayTargetEvent: ReturnType<typeof finalizeEvent> | null = null;
 let targetRequestCount = 0;
+let timelineRequestCounts = [0, 0];
+const firstTimelineEvent = finalizeEvent({
+    kind: 1,
+    content: "timeline from first test relay",
+    tags: [],
+    created_at: 100,
+}, generateSecretKey());
+const secondTimelineEvent = finalizeEvent({
+    kind: 1,
+    content: "timeline from second test relay",
+    tags: [],
+    created_at: 200,
+}, generateSecretKey());
 
 function listenWebSocketServer(server: WebSocketServer): Promise<number> {
     return new Promise((resolve, reject) => {
@@ -32,9 +47,8 @@ function closeWebSocketServer(server: WebSocketServer): Promise<void> {
     });
 }
 
-test.beforeAll(async () => {
-    relayServer = new WebSocketServer({ host: "127.0.0.1", port: 0 });
-    relayServer.on("connection", (socket: WebSocket) => {
+function attachRelayHandler(server: WebSocketServer, timelineEvent: ReturnType<typeof finalizeEvent>, relayIndex: number) {
+    server.on("connection", (socket: WebSocket) => {
         socket.on("message", (rawMessage) => {
             try {
                 const message = JSON.parse(rawMessage.toString()) as unknown[];
@@ -43,7 +57,7 @@ test.beforeAll(async () => {
                 }
 
                 const subscriptionId = message[1];
-                const filters = message.slice(2) as Array<{ ids?: unknown }>;
+                const filters = message.slice(2) as Array<{ ids?: unknown; kinds?: unknown }>;
                 const requestsTarget = !!relayTargetEvent && filters.some((filter) =>
                     Array.isArray(filter?.ids) && filter.ids.includes(relayTargetEvent?.id),
                 );
@@ -55,25 +69,112 @@ test.beforeAll(async () => {
                         relayTargetEvent,
                     ]));
                 }
+                if (!requestsTarget && filters.some((filter) => Array.isArray(filter?.kinds) && filter.kinds.includes(1))) {
+                    timelineRequestCounts[relayIndex] += 1;
+                    socket.send(JSON.stringify(["EVENT", subscriptionId, timelineEvent]));
+                }
                 socket.send(JSON.stringify(["EOSE", subscriptionId]));
             } catch {
                 // This deterministic relay only needs REQ/EOSE for the fixture.
             }
         });
     });
+}
+
+test.beforeAll(async () => {
+    relayServer = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    attachRelayHandler(relayServer, firstTimelineEvent, 0);
     const relayPort = await listenWebSocketServer(relayServer);
     relayOrigin = `ws://127.0.0.1:${relayPort}`;
+    secondRelayServer = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    attachRelayHandler(secondRelayServer, secondTimelineEvent, 1);
+    const secondRelayPort = await listenWebSocketServer(secondRelayServer);
+    secondRelayOrigin = `ws://127.0.0.1:${secondRelayPort}`;
 });
 
 test.beforeEach(() => {
     relayTargetEvent = null;
     targetRequestCount = 0;
+    timelineRequestCounts = [0, 0];
 });
 
 test.afterAll(async () => {
     if (relayServer) {
         await closeWebSocketServer(relayServer);
     }
+    if (secondRelayServer) {
+        await closeWebSocketServer(secondRelayServer);
+    }
+});
+
+test("loads and switches the configurable timeline relay without mixing events", async ({ page }) => {
+    await page.goto("/ehagaki/public/embed-parent-client-example.html");
+    const relayInput = page.getByLabel("タイムライン relay URL");
+
+    await relayInput.fill(relayOrigin);
+    await page.getByRole("button", { name: "タイムライン更新" }).click();
+    await expect(page.locator(".timeline-content")).toContainText(firstTimelineEvent.content);
+    await expect.poll(() => timelineRequestCounts[0]).toBeGreaterThanOrEqual(2);
+    await expect(page.locator("#timeline-status")).toContainText(relayOrigin);
+
+    await relayInput.fill(secondRelayOrigin);
+    await page.getByRole("button", { name: "タイムライン更新" }).click();
+    await expect(page.locator(".timeline-content")).toContainText(secondTimelineEvent.content);
+    await expect(page.locator(".timeline-content")).not.toContainText(firstTimelineEvent.content);
+    await expect.poll(() => timelineRequestCounts[1]).toBeGreaterThanOrEqual(2);
+    await expect(page.locator("#timeline-status")).toContainText(secondRelayOrigin);
+});
+
+test("uses the active timeline relay in nevent hints and stores unique relay suggestions", async ({ page }) => {
+    await page.goto("/ehagaki/public/embed-parent-client-example.html");
+    const relayInput = page.getByLabel("タイムライン relay URL");
+    await relayInput.fill(secondRelayOrigin);
+    await page.getByRole("button", { name: "タイムライン更新" }).click();
+    await expect(page.locator(".timeline-content")).toContainText(secondTimelineEvent.content);
+
+    await page.getByRole("button", { name: "reply テスト" }).click();
+    const log = await page.locator("#event-log").inputValue();
+    const encodedReference = log.match(/nevent1[0-9a-z]+/)?.[0];
+    expect(encodedReference).toBeTruthy();
+    expect(nip19.decode(encodedReference as string)).toMatchObject({
+        type: "nevent",
+        data: { relays: [secondRelayOrigin] },
+    });
+
+    await relayInput.fill(relayOrigin);
+    await page.getByRole("button", { name: "タイムライン更新" }).click();
+    await expect(page.locator(".timeline-content")).toContainText(firstTimelineEvent.content);
+    await relayInput.fill(relayOrigin);
+    await page.getByRole("button", { name: "タイムライン更新" }).click();
+
+    const savedHistory = await page.evaluate(() =>
+        JSON.parse(localStorage.getItem("ehagaki.parent-client-sample.timeline-relays") ?? "null"),
+    );
+    expect(savedHistory).toEqual([relayOrigin, secondRelayOrigin, "wss://nos.lol"]);
+
+    await page.reload();
+    await expect(page.locator("#timeline-relay-suggestions option")).toHaveCount(3);
+    expect(await page.locator("#timeline-relay-suggestions option").evaluateAll((options) =>
+        options.map((option) => option.getAttribute("value")),
+    )).toEqual(["wss://nos.lol", relayOrigin, secondRelayOrigin]);
+});
+
+test("rejects invalid timeline relay URLs without falling back to nos.lol", async ({ page }) => {
+    await page.addInitScript(() => {
+        localStorage.setItem("ehagaki.parent-client-sample.timeline-relays", "not-json");
+    });
+    await page.goto("/ehagaki/public/embed-parent-client-example.html");
+    const relayInput = page.getByLabel("タイムライン relay URL");
+    await expect(relayInput).toHaveValue("wss://nos.lol");
+    expect(await page.locator("#timeline-relay-suggestions option").evaluateAll((options) =>
+        options.map((option) => option.getAttribute("value")),
+    )).toEqual(["wss://nos.lol"]);
+    await relayInput.fill("https://example.com/relay");
+    await page.getByRole("button", { name: "タイムライン更新" }).click();
+
+    await expect(page.locator("#timeline-status")).toContainText("ws:// または wss://");
+    expect(await page.locator("#timeline-relay").inputValue()).toBe("https://example.com/relay");
+    expect(timelineRequestCounts).toEqual([0, 0]);
 });
 
 test("uses an edited URL as the source of truth after an iframe context update", async ({ page }) => {

--- a/src/test/e2e/embedParentClientExample.spec.ts
+++ b/src/test/e2e/embedParentClientExample.spec.ts
@@ -125,6 +125,27 @@ test("loads and switches the configurable timeline relay without mixing events",
     await expect(page.locator("#timeline-status")).toContainText(secondRelayOrigin);
 });
 
+test("preserves reply selection and iframe preview when refreshing the same relay", async ({ page }) => {
+    await page.goto("/ehagaki/public/embed-parent-client-example.html");
+    const frame = page.frameLocator("#ehagaki-iframe");
+    await expect(frame.locator(".tiptap-editor")).toBeVisible();
+
+    const relayInput = page.getByLabel("タイムライン relay URL");
+    await relayInput.fill(relayOrigin);
+    await page.getByRole("button", { name: "タイムライン更新" }).click();
+    await expect(page.locator(".timeline-content")).toContainText(firstTimelineEvent.content);
+
+    await page.getByRole("button", { name: "reply テスト" }).click();
+    await expect(page.locator("#timeline-selection")).not.toContainText("reply: なし");
+    await expect(frame.locator(".reply-quote-preview")).toHaveCount(1);
+
+    await relayInput.fill(relayOrigin);
+    await page.getByRole("button", { name: "タイムライン更新" }).click();
+    await expect(page.locator(".timeline-content")).toContainText(firstTimelineEvent.content);
+    await expect(page.locator("#timeline-selection")).not.toContainText("reply: なし");
+    await expect(frame.locator(".reply-quote-preview")).toHaveCount(1);
+});
+
 test("uses the active timeline relay in nevent hints and stores unique relay suggestions", async ({ page }) => {
     await page.goto("/ehagaki/public/embed-parent-client-example.html");
     const relayInput = page.getByLabel("タイムライン relay URL");


### PR DESCRIPTION
## Summary
- Add configurable ws:// or wss:// relay input with Enter/apply support to the iframe Parent Client Sample timeline.
- Keep the default at wss://nos.lol and show the active relay in status text.
- Close/restart timeline subscriptions on relay changes, clear stale events, guard stale async results, and use the active relay as nevent hints.
- Persist up to 10 deduplicated recent valid relay URLs in parent localStorage with datalist suggestions; malformed history is ignored.

## Validation
- 
px playwright test src/test/e2e/embedParentClientExample.spec.ts --project=desktop-chromium (7 passed)
- 
pm run check (0 errors, 0 warnings)
- 
pm test (3942 passed, 1 skipped)
- 
pm run build (passed)
- git diff --check (passed)

## Not run
- Real physical-device validation was not available; desktop Chromium Playwright covered the real-browser interaction flow.