### PR TITLE
Exclude Web Component samples from PWA precache

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:web-component": "node scripts/devWebComponentSample.mjs",
     "dev:web-component:lan": "node scripts/devWebComponentSample.mjs --lan",
     "prebuild": "npx rimraf dist",
-    "build": "vite build && node scripts/verifyLegacyBridgeBuild.mjs && npm run build:web-component && npm run assemble:web-component-site",
+    "build": "vite build && node scripts/verifyPrecacheBuild.mjs && node scripts/verifyLegacyBridgeBuild.mjs && npm run build:web-component && npm run assemble:web-component-site",
     "build:web-component": "node scripts/runWebComponentBuild.mjs",
     "assemble:web-component-site": "node scripts/assembleWebComponentSite.mjs",
     "verify:legacy-bridge-remote": "node scripts/verifyLegacyBridgeRemote.mjs",

--- a/scripts/verifyPrecacheBuild.mjs
+++ b/scripts/verifyPrecacheBuild.mjs
@@ -1,0 +1,41 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const swPath = resolve("dist", "sw.js");
+const excludedSamplePaths = [
+    "host-owned-composer-lite-example.html",
+    "web-component-parent-client-example.html",
+    "web-component-parent-client-example.js",
+];
+const requiredPrecachePaths = ["index.html", "manifest.webmanifest"];
+
+function fail(message) {
+    throw new Error(`[precache-build] ${message}`);
+}
+
+const swText = await readFile(swPath, "utf8").catch(() => {
+    fail(`generated service worker is missing: ${swPath}`);
+});
+
+const precacheUrls = Array.from(
+    swText.matchAll(/\{"revision":(?:null|"[^"]*"),"url":"([^"]+)"\}/g),
+    (match) => match[1],
+);
+
+if (precacheUrls.length === 0) {
+    fail("generated service worker does not contain an injected precache manifest");
+}
+
+const excludedUrls = excludedSamplePaths.filter((path) => precacheUrls.includes(path));
+if (excludedUrls.length > 0) {
+    fail(`Web Component sample paths must not be precached: ${excludedUrls.join(", ")}`);
+}
+
+const missingRequiredUrls = requiredPrecachePaths.filter((path) => !precacheUrls.includes(path));
+if (missingRequiredUrls.length > 0) {
+    fail(`expected PWA precache paths are missing: ${missingRequiredUrls.join(", ")}`);
+}
+
+console.log(
+    `[precache-build] verified ${precacheUrls.length} precache entries; excluded Web Component samples and retained ${requiredPrecachePaths.join(", ")}`,
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -185,6 +185,9 @@ export default defineConfig({
           '**/node_modules/**/*',
           'sw.js',
           'workbox-*.js',
+          'host-owned-composer-lite-example.html',
+          'web-component-parent-client-example.html',
+          'web-component-parent-client-example.js',
           ...fixedLegacyBridgePaths
         ],
         additionalManifestEntries: fixedLegacyBridgePaths.map(url => ({


### PR DESCRIPTION
## Summary

- Exclude the three Web Component manual sample host assets from the PWA Workbox precache manifest.
- Keep public/sw.js runtime routing and Web Component distributions unchanged.
- Add a production build-time verification for the generated precache manifest.

## Root cause

ite-plugin-pwa uses injectManifest with JavaScript, CSS, and HTML glob patterns. Because the Web Component manual samples live under public/, the PWA build included their host assets in the same-origin precache. This allowed an old sample host code to remain available even though Full/Lite Web Components do not register or update a Service Worker themselves.

## Verification

- 
pm run check — passed (0 errors, 0 warnings)
- 
pm test — passed (3952 passed, 1 skipped; thread-graph gate passed)
- 
pm run build — passed, including legacy bridge, Full/Lite Web Component build, assembly, and the new precache verification
- Web Component E2E — 170 passed, 4 skipped across desktop Chromium, mobile Chromium, mobile WebKit, and desktop Firefox for Full/Lite and the production parent-client sample
- webComponentDevServer.spec.ts — passed (1 passed)
- Generated dist/sw.js — 192 precache entries; host-owned-composer-lite-example.html, web-component-parent-client-example.html, and web-component-parent-client-example.js are absent; index.html and manifest.webmanifest remain present