### PR TITLE
Exclude iframe sample from PWA precache

### DIFF
--- a/scripts/verifyPrecacheBuild.mjs
+++ b/scripts/verifyPrecacheBuild.mjs
@@ -6,6 +6,8 @@ const excludedSamplePaths = [
     "host-owned-composer-lite-example.html",
     "web-component-parent-client-example.html",
     "web-component-parent-client-example.js",
+    "embed-parent-client-example.html",
+    "embed-parent-client-example.js",
 ];
 const requiredPrecachePaths = ["index.html", "manifest.webmanifest"];
 
@@ -28,7 +30,7 @@ if (precacheUrls.length === 0) {
 
 const excludedUrls = excludedSamplePaths.filter((path) => precacheUrls.includes(path));
 if (excludedUrls.length > 0) {
-    fail(`Web Component sample paths must not be precached: ${excludedUrls.join(", ")}`);
+    fail(`excluded sample paths must not be precached: ${excludedUrls.join(", ")}`);
 }
 
 const missingRequiredUrls = requiredPrecachePaths.filter((path) => !precacheUrls.includes(path));
@@ -37,5 +39,5 @@ if (missingRequiredUrls.length > 0) {
 }
 
 console.log(
-    `[precache-build] verified ${precacheUrls.length} precache entries; excluded Web Component samples and retained ${requiredPrecachePaths.join(", ")}`,
+    `[precache-build] verified ${precacheUrls.length} precache entries; excluded ${excludedSamplePaths.length} samples and retained ${requiredPrecachePaths.join(", ")}`,
 );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -188,6 +188,8 @@ export default defineConfig({
           'host-owned-composer-lite-example.html',
           'web-component-parent-client-example.html',
           'web-component-parent-client-example.js',
+          'embed-parent-client-example.html',
+          'embed-parent-client-example.js',
           ...fixedLegacyBridgePaths
         ],
         additionalManifestEntries: fixedLegacyBridgePaths.map(url => ({


### PR DESCRIPTION
## Summary

Follow-up to #202.

- Exclude the two iframe manual sample host assets that were missing from the existing precache exclusion list:
  - mbed-parent-client-example.html
  - mbed-parent-client-example.js
- Preserve the three Web Component sample exclusions introduced by #202.
- Keep public/sw.js, runtime routing, Service Worker scope, registerType, and sample APIs unchanged.

## Verification

- 
pm run check — passed (0 errors, 0 warnings)
- 
pm test — passed (3952 passed, 1 skipped; thread-graph gate passed)
- 
pm run build — passed, including legacy bridge, Web Component Full/Lite build, assembly, and precache verification
- 
px playwright test src/test/e2e/embedParentClientExample.spec.ts --project=desktop-chromium --project=mobile-chromium — 16 passed
- Generated dist/sw.js — 190 precache entries; all five sample paths are absent from the precache manifest, while index.html and manifest.webmanifest remain present