### PR TITLE
Document eHagaki embedding options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ eHagaki（えはがき）は、画像・動画圧縮機能付きの投稿専用N
 - **ドラフト機能**: 投稿内容を下書きとして保存し、後から編集・投稿が可能
 - **リプライ・引用・チャンネル投稿**: 各種URLクエリや`nostr:` URIを通じたリプライ・引用投稿（NIP-10, NIP-18）に対応。パブリックチャット（NIP-28）のチャンネルへの投稿もサポート
 - **Content Warning (CW)**: センシティブなコンテンツ（NIP-36）に対する警告の設定が可能
-- **iframe埋め込み**: 他アプリの投稿フォームとして組み込んで利用するためのAPIを提供
-- **Web Component埋め込み**: 同一Window realmで利用できる `ehagaki-composer` と公開method/event/style APIを提供
+- **埋め込み**: iframe、Full Web Component、Host-owned Composer Lite Web Componentの3方式を提供
 - **多言語対応**: 日本語・英語に対応（ブラウザ設定から自動判定）
 
 ## URLクエリ
@@ -58,27 +57,17 @@ https://lokuyow.github.io/ehagaki/?quote=note1...
 - 本文中の `nostr:` URI からの引用ではプレビューは表示されません
 - ×ボタンでリプライ/引用をキャンセルし、通常投稿に戻れます
 
-## iframe埋め込み
+## 埋め込み
 
-eHagaki の iframe 埋め込み方法、親クライアント連携ログイン、`postMessage` 仕様は公開ガイドに分離しました。
+iframe、Full Web Component、Host-owned Composer Lite Web Componentの方式選択と最小例は、公式入口の [docs/EMBEDDING.md](docs/EMBEDDING.md) を参照してください。
 
-[docs/IFRAME_EMBEDDING.md](docs/IFRAME_EMBEDDING.md) を参照してください。
+- iframeの詳細仕様: [docs/IFRAME_EMBEDDING.md](docs/IFRAME_EMBEDDING.md)
+- Web Component API詳細: [docs/WEB_COMPONENT.md](docs/WEB_COMPONENT.md)
+- iframe live sample: [embed-parent-client-example.html](https://lokuyow.github.io/ehagaki/embed-parent-client-example.html)
+- Full Web Component live sample: [web-component-parent-client-example.html](https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html)
+- Host-owned Lite live sample: [host-owned-composer-lite-example.html](https://lokuyow.github.io/ehagaki/host-owned-composer-lite-example.html)
 
-親ページ連携の動作確認用サンプルは [https://lokuyow.github.io/ehagaki/embed-parent-client-example.html](https://lokuyow.github.io/ehagaki/embed-parent-client-example.html) からも直接アクセスできます。
-
-このガイドには次の内容をまとめています。
-
-- 基本の iframe 埋め込み
-- リプライ / 複数引用状態での起動
-- 親クライアント連携ログイン
-- `ehagaki.embed` envelope と `post.success` / `post.error` の受信方法
-- `auth.login` / `auth.request` / `auth.result` / `auth.error` / `rpc.request` の流れ
-
-## Web Component埋め込み
-
-Web Component版の公開API、lifecycle、context/settings、CustomEvent、CSS Custom Properties、storageとtrust boundaryは [docs/WEB_COMPONENT.md](docs/WEB_COMPONENT.md) にまとめています。
-
-実際に `Create / Mount`、`Destroy / Unmount`、再生成、設定・context更新、2個目instanceの拒否、event log、host側styleを操作するlive sampleは [https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html](https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html) から確認できます。
+既存のNostrクライアントがaccount、signer、event構築、publishを所有している場合はHost-owned Lite、eHagakiにself-publishまで所有させる場合はFull、origin境界やparent-client連携が必要な場合はiframeが候補です。iframe/Web Componentともhost側からAccent/Base themeを指定できます。優先順位とAPIの詳細は各ガイドを参照してください。
 
 Web Componentではiframeのparent-client auth/RPCや `postMessage` を使いません。ホストと同じWindow realm / originで動作するためローカルnsec認証には対応せず、NIP-07はhostの `window.nostr` を直接利用し、NIP-46は埋め込まれたeHagakiのUIから利用します。通常版/PWAとiframe版では従来どおりnsec認証を利用できます。
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -1,0 +1,119 @@
+# eHagaki 埋め込み・統合ガイド
+
+eHagaki の Composer は、次の3方式で外部ページへ統合できます。
+
+1. [iframe](./IFRAME_EMBEDDING.md)
+2. Full Web Component
+3. Host-owned Composer Lite Web Component
+
+iframe の parent-client、storage delegation、`postMessage` API は [iframe詳細ガイド](./IFRAME_EMBEDDING.md) を、Web Component の公開 API は [Web Component APIリファレンス](./WEB_COMPONENT.md) を参照してください。
+
+## どれを選ぶか
+
+既存の Nostr クライアントが account、signer、event 構築、publish をすでに所有しているなら、まず **Host-owned Composer Lite** を選んでください。eHagaki の Composer UI と編集・メディア処理だけを同じ document に組み込み、最終 event の作成・署名・publish はホストへ戻せます。
+
+eHagaki 自身に account/auth、relay、upload、sign、publish まで所有させ、同じ document に直接組み込みたい場合は **Full Web Component** を選びます。Full は eHagaki が self-publish します。
+
+ホスト JavaScript との origin / 実行環境の隔離が必要な場合、または iframe の parent-client auth/RPC や storage / IndexedDB delegation を利用したい場合は **iframe** を選びます。
+
+Host-owned Lite は既存 Nostr クライアントへ eHagaki の Composer UI / 編集処理を組み込む方式です。Lite 側は auth/account/session、Relay、target fetch、profile/history、draft、sign/send を所有せず、認証・署名・publish へ fallback しません。`submit` に渡る output は unsigned Nostr event ではなく、ホストが event を構築するための `{ content, tags, context }` です。
+
+## 3方式比較
+
+| 項目 | iframe | Full Web Component | Host-owned Composer Lite |
+| --- | --- | --- | --- |
+| DOM / Window境界 | 別 document、別 Window realm | 同じ document / Window realm、Shadow DOM | 同じ document / Window realm、Shadow DOM |
+| trust boundary | origin境界を設計可能 | ホストと共有、隔離なし | ホストと共有、隔離なし |
+| account / auth | eHagaki または parent-client | eHagaki が所有。NIP-07 は host の `window.nostr`、NIP-46 も利用可能 | ホストが所有。Lite は auth/account/session を持たない |
+| event構築・署名・publish | eHagaki または parent signer 連携 | eHagaki が所有し self-publish | ホストが kind、reference tag、pubkey、timestamp、署名、publish を所有 |
+| Relay | eHagaki または parent-client 境界 | eHagaki が所有 | ホストが所有。Lite は relay 接続しない |
+| storage | iframe内、parent storage / IndexedDB delegation | ホスト origin の localStorage / IndexedDB | Composer固有の内部認証・履歴等は持たず、投稿処理はホスト所有 |
+| styling / theme | iframe内設定、query、runtime `settings.set`、delegation | Shadow DOM と公開 CSS Custom Properties | Shadow DOM と公開 CSS Custom Properties。内部 SettingsDialog なし |
+| contextの渡し方 | `postMessage` の embed protocol | `setContext()` と CustomEvent | `setContext()` と Host-owned output の `context` |
+| 主な用途 | 隔離、parent-client連携、storage委譲 | eHagaki完結の直接組み込み | 既存Nostrクライアントへの Composer組み込み |
+
+iframe だけが host JavaScript との origin 境界を持ちます。Web Component は host と同じ Window realm で動くため、host JavaScript から秘密情報を隔離する用途には使わないでください。Web Component distribution は compiled ES module なので、host framework は Svelte に限定されません。plain JavaScript、Svelte、React、Vue などから Custom Element として利用できます。
+
+## Quick Start
+
+### iframe
+
+```html
+<iframe
+  src="https://lokuyow.github.io/ehagaki/"
+  width="600"
+  height="400"
+  title="eHagaki Composer"
+></iframe>
+```
+
+parent-client auth、`parentOrigin`、`postMessage`、storage delegation が必要な場合は [iframe詳細ガイド](./IFRAME_EMBEDDING.md) を参照してください。
+
+### Full Web Component
+
+```html
+<script type="module" src="https://lokuyow.github.io/ehagaki/web-component/ehagaki-composer.js"></script>
+<div style="height: 580px">
+  <ehagaki-composer
+    asset-base="https://lokuyow.github.io/ehagaki/web-component/"
+  ></ehagaki-composer>
+</div>
+
+<script type="module">
+  const composer = document.querySelector('ehagaki-composer');
+  await composer.whenReady();
+</script>
+```
+
+Full は eHagaki の UI から認証・署名・publish を行います。local nsec は Web Component では利用できません。NIP-07 は host の `window.nostr` を直接利用でき、NIP-46 も利用できます。
+
+### Host-owned Composer Lite
+
+Lite は Full と別 distribution です。1 document で Full と Lite の両方を import しないでください。`configureHostOwned()` は最初の connection より前に実行します。
+
+```html
+<div id="composer-mount" style="height: 580px"></div>
+<script type="module">
+  await import('https://lokuyow.github.io/ehagaki/web-component/host-owned/ehagaki-composer.js');
+
+  const composer = document.createElement('ehagaki-composer');
+  composer.assetBase = 'https://lokuyow.github.io/ehagaki/web-component/host-owned/';
+  composer.configureHostOwned({
+    async submit(output, { signal }) {
+      // ここをhost自身の投稿処理へ接続する。
+      // outputを使ってhostがeventを構築し、署名・publishする。
+      void output;
+      void signal;
+      return undefined;
+    },
+  });
+  document.querySelector('#composer-mount').append(composer);
+  await composer.whenReady();
+</script>
+```
+
+Lite の `submit(output, { signal })` に渡る `output` は unsigned Nostr event ではありません。host が event の kind、reference を表す構造 tag、pubkey、timestamp、署名、publish を所有します。Lite は eHagaki 側で認証・Relay・sign/send を開始しません。メディアをホストへ渡す場合は `uploadMedia` も `configureHostOwned()` に指定します。詳しい型と optional capability は [Web Component APIリファレンス](./WEB_COMPONENT.md) を参照してください。
+
+## Web Component共通の重要事項
+
+- Full と Lite はどちらも同じ `<ehagaki-composer>` tag を登録するため、1 document で両 distribution を import しないでください。接続可能なのは1 documentにつき1 instanceです。
+- host は definite height を指定してください。`asset-base` / `assetBase` は connection 前に、import した distribution のディレクトリへ設定します。
+- Shadow DOM 内のテーマ変更には公開 CSS Custom Properties を使用します。通常の host selector で内部 DOM を直接 style する契約ではありません。
+- `ehagaki-ready.detail.apiVersion` は現在 `1` です。
+- self-host する場合は entry だけでなく、その distribution の関連 assets、chunks、icons をディレクトリ構成ごと配信します。
+
+### Theme
+
+standalone / iframe / Full / Lite は Accent / Base から surface を生成する共通 generator と mix率を使用します。
+
+Full Web Component の Accent / Base の優先順位は、`--ehagaki-accent-color` / `--ehagaki-base-color`（外部強制） > 内部ユーザー設定 > `--ehagaki-default-accent-color` / `--ehagaki-default-base-color`（外部 default） > eHagaki 標準です。Full の SettingsDialog では内部ユーザー Accent / Base を設定・保存できます。
+
+Host-owned Lite には SettingsDialog を追加せず、host が公開 CSS Custom Properties で theme を指定します。`--ehagaki-background` などの詳細 CSS override は、Accent / Base 生成後の対象 token を直接上書きする既存契約です。
+
+iframe の優先順位は、外部 forced（`embedAccentColor` / `embedBaseColor`、runtime `settings.set`） > iframe 内部ユーザー設定 > external default（`defaultAccentColor` / `defaultBaseColor`） > eHagaki 標準です。`settings.set` の `accentColor` / `baseColor` は `null` で runtime 強制を解除できます。詳細は [iframe詳細ガイド](./IFRAME_EMBEDDING.md) と [Web Component APIリファレンス](./WEB_COMPONENT.md) を参照してください。
+
+## 公開サンプル
+
+- iframe: [embed-parent-client-example.html](https://lokuyow.github.io/ehagaki/embed-parent-client-example.html)
+- Full Web Component: [web-component-parent-client-example.html](https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html)
+- Host-owned Lite: [host-owned-composer-lite-example.html](https://lokuyow.github.io/ehagaki/host-owned-composer-lite-example.html)

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -25,14 +25,14 @@ Host-owned Lite は既存 Nostr クライアントへ eHagaki の Composer UI / 
 | DOM / Window境界 | 別 document、別 Window realm | 同じ document / Window realm、Shadow DOM | 同じ document / Window realm、Shadow DOM |
 | trust boundary | origin境界を設計可能 | ホストと共有、隔離なし | ホストと共有、隔離なし |
 | account / auth | eHagaki または parent-client | eHagaki が所有。NIP-07 は host の `window.nostr`、NIP-46 も利用可能 | ホストが所有。Lite は auth/account/session を持たない |
-| event構築・署名・publish | eHagaki または parent signer 連携 | eHagaki が所有し self-publish | ホストが kind、reference tag、pubkey、timestamp、署名、publish を所有 |
-| Relay | eHagaki または parent-client 境界 | eHagaki が所有 | ホストが所有。Lite は relay 接続しない |
+| event構築・署名・publish | eHagaki が event構築・publish。通常認証で署名し、parent-client利用時は署名を親へ委譲 | eHagaki が所有し self-publish | ホストが kind、reference tag、pubkey、timestamp、署名、publish を所有 |
+| Relay | eHagaki が Relay接続・publish | eHagaki が所有 | ホストが所有。Lite は relay 接続しない |
 | storage | iframe内、parent storage / IndexedDB delegation | ホスト origin の localStorage / IndexedDB | Composer固有の内部認証・履歴等は持たず、投稿処理はホスト所有 |
 | styling / theme | iframe内設定、query、runtime `settings.set`、delegation | Shadow DOM と公開 CSS Custom Properties | Shadow DOM と公開 CSS Custom Properties。内部 SettingsDialog なし |
 | contextの渡し方 | `postMessage` の embed protocol | `setContext()` と CustomEvent | `setContext()` と Host-owned output の `context` |
 | 主な用途 | 隔離、parent-client連携、storage委譲 | eHagaki完結の直接組み込み | 既存Nostrクライアントへの Composer組み込み |
 
-iframe だけが host JavaScript との origin 境界を持ちます。Web Component は host と同じ Window realm で動くため、host JavaScript から秘密情報を隔離する用途には使わないでください。Web Component distribution は compiled ES module なので、host framework は Svelte に限定されません。plain JavaScript、Svelte、React、Vue などから Custom Element として利用できます。
+3方式のうち iframe だけが、別 origin で配信することで host JavaScript との origin 境界を設計できます。同一 origin で self-host する iframe にはこの隔離は成立しません。Web Component は host と同じ Window realm で動くため、host JavaScript から秘密情報を隔離する用途には使わないでください。Web Component distribution は compiled ES module なので、host framework は Svelte に限定されません。plain JavaScript、Svelte、React、Vue などから Custom Element として利用できます。
 
 ## Quick Start
 

--- a/docs/IFRAME_EMBEDDING.md
+++ b/docs/IFRAME_EMBEDDING.md
@@ -1,5 +1,7 @@
 # eHagaki iframe埋め込みガイド
 
+iframe / Full Web Component / Host-owned Composer Lite の方式選択から始める場合は、先に [eHagaki 埋め込み・統合ガイド](./EMBEDDING.md) を参照してください。この文書は iframe 固有のAPIリファレンスです。
+
 このドキュメントは、eHagaki を自分の Web サイトや Web アプリに iframe で埋め込みたい開発者向けの公開ガイドです。
 
 > まずは動作確認用サンプルを直接開くには、以下の URL をブラウザで開いてください。

--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -1,6 +1,8 @@
 # eHagaki Composer Web Component ガイド
 
-Web Component 版では、`<ehagaki-composer>` を一般の Web ページへ直接配置できます。
+Web Component 版には、eHagaki が account/auth、Relay、署名、publish を所有する **Full self-publish** と、既存クライアントが投稿処理を所有する **Host-owned Composer Lite** の2 distributionがあります。方式選択から始める場合は先に [eHagaki 埋め込み・統合ガイド](./EMBEDDING.md) を参照してください。Lite はこの文書の [Full self-publish と Lite Host-owned](#full-self-publish-と-lite-host-owned) 節から利用します。
+
+どちらも `<ehagaki-composer>` を一般の Web ページへ直接配置できます。
 iframe 版のように別 document と `postMessage` で通信するのではなく、ホストページと同じ
 Window realm で動作し、ホストの JavaScript からは通常の要素・メソッド・CustomEvent として
 扱います。iframe の parent-client auth/RPC や `postMessage` は使用しません。
@@ -16,9 +18,12 @@ DOM へ直接組み込みたい場合に適しています。
 作成・破棄・再作成、設定、投稿コンテキスト、各種イベント、2 個目のインスタンスの拒否、
 CSS Custom Properties を確認できます。
 
-## 最小構成で埋め込む
+## 最小構成で埋め込む（Full self-publish）
 
-最初に Web Component のモジュールを読み込み、`asset-base` を指定した
+以下は Full self-publish distribution の最小例です。Host-owned Lite の最小例と責務は
+[Full self-publish と Lite Host-owned](#full-self-publish-と-lite-host-owned) を参照してください。
+
+最初に Full Web Component のモジュールを読み込み、`asset-base` を指定した
 `<ehagaki-composer>` をページへ追加します。その後、要素を取得して `whenReady()` を待ちます。
 以下は GitHub Pages で公開されている実際の配布物を使う最小例です。
 
@@ -89,9 +94,11 @@ Web Component の配布物には、PWA の manifest、共有ターゲット、eH
 iframe 連携は含まれません。
 
 - `npm run build:web-component` は、単独配布物を
-  `dist-web-component/ehagaki-composer.js` とその関連アセットとして生成します。
+  `dist-web-component/ehagaki-composer.js` とその関連アセットとして生成します。Host-owned Lite は
+  `dist-web-component/host-owned/ehagaki-composer.js` と `host-owned/` 配下の関連アセットとして生成します。
 - `npm run build` は通常の PWA build に加えて Web Component build を実行し、
-  `dist-web-component/` の内容を `dist/web-component/` に組み立てます。
+  Full の `dist-web-component/` を `dist/web-component/` に、Lite の
+  `dist-web-component/host-owned/` を `dist/web-component/host-owned/` に組み立てます。
 - eHagaki サイトと一緒に配信する場合は、`dist/web-component/` のディレクトリ構成を保ったまま
   サイトの出力として配信し、上記の GitHub Pages 例のように `/web-component/` を
   `asset-base` に指定します。
@@ -676,7 +683,7 @@ Base Colorは指定色でsurfaceを直接塗りつぶさず、light/darkそれ�
 個別overrideのtokenだけが上書きされます。
 
 | CSS Custom Property | 用途 |
-| --- | --- |
+| --- | --- | --- | --- |
 | `--ehagaki-background` | メイン背景 |
 | `--ehagaki-text` | 文字色 |
 | `--ehagaki-border` | 境界線 |
@@ -744,18 +751,19 @@ console.log('NIP-07 available:', nip07Available);
 
 ## iframe 版との使い分け
 
-| 項目 | iframe | Web Component |
-| --- | --- | --- |
-| DOM 統合 | 別 document。`postMessage` で連携 | 同じ document の要素として配置 |
-| スタイル | iframe 内 document の CSS 境界 | ShadowRoot。CSS Custom Properties を公開 |
-| Window realm | ホストとは分離 | ホストと共有 |
-| NIP-07 | iframe の認証経路または parent-client 連携 | ホストの `window.nostr` を直接利用 |
-| ローカル nsec | 利用可能 | 利用不可 |
-| parent-client auth/RPC | 利用可能 | 使用しない |
-| `postMessage` | 使用する | 使用しない |
-| 保存 | 親側の storage / IndexedDB 委譲を構成可能 | ホストオリジンに保存。専用 localStorage namespace を使用 |
-| 秘密情報の隔離 | origin 境界を設計可能 | 隔離されない。信頼できるホスト向け |
-| ライフサイクル | iframe の生成・再読み込みなど | DOM の追加・削除・再作成 |
+| 項目 | iframe | Full Web Component | Host-owned Composer Lite |
+| --- | --- | --- | --- |
+| DOM 統合 | 別 document。`postMessage` で連携 | 同じ document の要素として配置 | 同じ document の要素として配置 |
+| スタイル | iframe 内 document の CSS 境界 | ShadowRoot。CSS Custom Properties を公開 | ShadowRoot。CSS Custom Properties を公開 |
+| Window realm | ホストとは分離 | ホストと共有 | ホストと共有 |
+| NIP-07 | iframe の認証経路または parent-client 連携 | ホストの `window.nostr` を直接利用 | Lite は認証しない |
+| ローカル nsec | 利用可能 | 利用不可 | 利用しない |
+| parent-client auth/RPC | 利用可能 | 使用しない | 使用しない |
+| `postMessage` | 使用する | 使用しない | 使用しない |
+| 保存 | 親側の storage / IndexedDB 委譲を構成可能 | ホストオリジンに保存。専用 localStorage namespace を使用 | auth/account/session、Relay、履歴、draftを持たない |
+| 投稿所有者 | eHagaki または parent signer | eHagaki が self-publish | host が event構築・署名・publish |
+| 秘密情報の隔離 | origin 境界を設計可能 | 隔離されない。信頼できるホスト向け | 隔離されない。信頼できるホスト向け |
+| ライフサイクル | iframe の生成・再読み込みなど | DOM の追加・削除・再作成 | DOM の追加・削除・再作成 |
 
 iframe の通信、parent storage、parent-client auth/RPC が必要な場合は、[iframe 埋め込みガイド](./IFRAME_EMBEDDING.md)
 を参照してください。
@@ -785,16 +793,11 @@ Web Component 自身は eHagaki Service Worker を登録せず、Service Worker 
 ホストページに別の Service Worker が登録されている場合、その Service Worker は通常の HTTP fetch、
 画像、アップロードなどを観測できます。
 
-ただし、Service Worker の `fetch` イベントだけでは Nostr WebSocket のリレー通信の傍受を
-証明できません。Web Component はホストの Window realm を共有し、現在の
-`initializeNostrSession()` 経路は `websocketCtor` なしで rx-nostr を生成します。そのため、
-rx-nostr は relay を開くとき `globalThis.WebSocket` を使います。モジュールの import 前にホストが
-`globalThis.WebSocket` の wrapper を導入した場合、その wrapper が適用される境界になります。
-
-このリリースはブラウザレベルの relay-interceptor 保証をうたいません。通常のアプリのリレー経路
-には認証済みセッションが必要で、既存アプリケーションには認証情報不要で決定的な
-ローカルリレー経路が見つかっていません。専用の relay-interceptor API は提供せず、Issue #89 の
-relay-interceptor proof も未完了です。
+Service Worker の `fetch` イベントだけでは WebSocket を傍受しません。Web Component はホストの
+Window realm を共有するため、ホストが Web Component module import 前に
+`globalThis.WebSocket` の wrapper / interceptor を設置した場合は、その境界を実際の relay connection
+が通ります。これは NIP-07 の復元、relay 初期化、rx-nostr、browser WebSocket 経路を通る E2E で確認済みです。
+専用の relay-interceptor API 自体を公開しているわけではありません。
 
 ## CORS / CSP / 動的chunk / Worker
 
@@ -819,7 +822,7 @@ CSP の `worker-src` では、動画圧縮が遅延ロードするworkerがあ�
 
 ## 実動サンプル
 
-公開サンプルは [https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html](https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html)
+Full の公開サンプルは [https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html](https://lokuyow.github.io/ehagaki/web-component-parent-client-example.html)
 です。通常モードではページを開くと、既定の同梱モジュールとコンポーネントが自動的に接続されます。
 任意のモジュールを試す場合は URL に `?manual=1` を付けて manual mode に入り、module URL を編集してから
 `Create / Mount` を押してください。manual mode では明示的な操作までモジュールを読み込みません。
@@ -838,5 +841,5 @@ CSP の `worker-src` では、動画圧縮が遅延ロードするworkerがあ�
 だけを記録します。外部モジュールはホストページと同じ JavaScript 権限で実行されるため、
 module URL と `asset-base` には信頼できる URL だけを指定してください。
 
-Lite の Host-owned sample では text-only / media-enabled の切替、catalog、context、host submit/upload
+Host-owned Lite の公開サンプルは [https://lokuyow.github.io/ehagaki/host-owned-composer-lite-example.html](https://lokuyow.github.io/ehagaki/host-owned-composer-lite-example.html) です。Lite の sample では text-only / media-enabled の切替、catalog、context、host submit/upload
 の成功・失敗を、既存の Parent Client sample とは独立して確認できます。

--- a/docs/WEB_COMPONENT.md
+++ b/docs/WEB_COMPONENT.md
@@ -683,7 +683,7 @@ Base Colorは指定色でsurfaceを直接塗りつぶさず、light/darkそれ�
 個別overrideのtokenだけが上書きされます。
 
 | CSS Custom Property | 用途 |
-| --- | --- | --- | --- |
+| --- | --- |
 | `--ehagaki-background` | メイン背景 |
 | `--ehagaki-text` | 文字色 |
 | `--ehagaki-border` | 境界線 |
@@ -761,7 +761,7 @@ console.log('NIP-07 available:', nip07Available);
 | parent-client auth/RPC | 利用可能 | 使用しない | 使用しない |
 | `postMessage` | 使用する | 使用しない | 使用しない |
 | 保存 | 親側の storage / IndexedDB 委譲を構成可能 | ホストオリジンに保存。専用 localStorage namespace を使用 | auth/account/session、Relay、履歴、draftを持たない |
-| 投稿所有者 | eHagaki または parent signer | eHagaki が self-publish | host が event構築・署名・publish |
+| 投稿所有者 | eHagaki が event構築・publish。parent-client利用時は署名を親へ委譲 | eHagaki が self-publish | host が event構築・署名・publish |
 | 秘密情報の隔離 | origin 境界を設計可能 | 隔離されない。信頼できるホスト向け | 隔離されない。信頼できるホスト向け |
 | ライフサイクル | iframe の生成・再読み込みなど | DOM の追加・削除・再作成 | DOM の追加・削除・再作成 |
 


### PR DESCRIPTION
## Summary
- Add `docs/EMBEDDING.md` as the official iframe / Full Web Component / Host-owned Composer Lite entry guide.
- Link the new guide from README and the detailed iframe/Web Component references.
- Align Web Component documentation with the current Full/Lite distributions, PR #204 theme precedence, and merged WebSocket E2E contract.

## Verification
- Documentation-only change confirmed.
- Verified guide/detail/sample paths and Full/Lite entry and asset-base paths.
- Verified PR #204 theme tokens and precedence remain documented.
- Verified stale relay-interceptor proof wording is removed.
- `git diff --check`
- Vitest / Playwright / build not run because this is docs-only.