### PR TITLE
Fix Portal Button E2E CSS value comparison

### DIFF
--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -1879,7 +1879,7 @@ test("keeps the normal app Portal Button scope", async ({ page }) => {
         )!;
         return {
             inBody: document.body.contains(primary),
-            buttonBackground: getComputedStyle(primary).getPropertyValue("--btn-bg"),
+            buttonBackground: getComputedStyle(primary).getPropertyValue("--btn-bg").trim(),
             background: getComputedStyle(primary).backgroundColor,
         };
     });


### PR DESCRIPTION
Trim the Portal Button CSS custom property before comparison. Preserve the expected HSL token and backgroundColor assertion. Verified with the mobile-chromium target test, the full webComponentEmbed E2E file, npm run check, and npm test.