### PR TITLE
Fix mobile keyboard layout regression

### DIFF
--- a/src/lib/hooks/useComposerLayoutMetrics.svelte.ts
+++ b/src/lib/hooks/useComposerLayoutMetrics.svelte.ts
@@ -1,3 +1,4 @@
+import { untrack } from "svelte";
 import { resolveComposerAvailableHeight, resolveComposerSiblingHeight } from "../utils/composerLayoutUtils";
 import type { ReplyQuoteComposerState } from "../types";
 
@@ -24,7 +25,7 @@ export function useComposerLayoutMetrics({
     let customEmojiPickerHeight = $state(0);
 
     $effect(() => {
-        const cleanup = setupViewportListener();
+        const cleanup = untrack(() => setupViewportListener());
         return cleanup;
     });
 

--- a/src/test/unit/fixtures/ComposerLayoutMetricsHook.svelte
+++ b/src/test/unit/fixtures/ComposerLayoutMetricsHook.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+    import { useComposerLayoutMetrics } from "../../../lib/hooks/useComposerLayoutMetrics.svelte";
+
+    interface Props {
+        setupViewportListener: () => (() => void) | undefined;
+        keyboardLayoutState: number;
+    }
+
+    let { setupViewportListener, keyboardLayoutState }: Props = $props();
+
+    useComposerLayoutMetrics({
+        setupViewportListener: () => {
+            // Mirror the reactive keyboard layout read made during real setup.
+            void keyboardLayoutState;
+            return setupViewportListener();
+        },
+        getComposerScrollRegionEl: () => null,
+        getComposerScrollContentEl: () => null,
+        getCustomEmojiPickerRegionEl: () => null,
+        getCustomEmojiPickerOpen: () => false,
+        getReplyQuoteState: () => ({ reply: null, quotes: [] }),
+        minHeight: 100,
+    });
+</script>
+
+<div data-testid="composer-layout-metrics-hook"></div>

--- a/src/test/unit/uiStore.test.ts
+++ b/src/test/unit/uiStore.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'svelte';
+import { render } from '@testing-library/svelte';
+
+import ComposerLayoutMetricsHook from './fixtures/ComposerLayoutMetricsHook.svelte';
 
 type ViewportListener = () => void;
 
@@ -277,6 +281,56 @@ describe('uiStore', () => {
 
         requestAnimationFrameSpy.mockRestore();
         cancelAnimationFrameSpy.mockRestore();
+    });
+
+    it('composer layout metricsのeffectはkeyboard geometry変更でviewport listenerを再登録しない', async () => {
+        setUserAgent('Mozilla/5.0 (Linux; Android 15; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36');
+
+        vi
+            .spyOn(window, 'requestAnimationFrame')
+            .mockImplementation((callback: FrameRequestCallback) => {
+                callback(0);
+                return 1;
+            });
+        vi
+            .spyOn(window, 'cancelAnimationFrame')
+            .mockImplementation(() => { });
+
+        const { visualViewport } = createVisualViewportMock(800);
+        const virtualKeyboard = createVirtualKeyboardMock();
+        const { keyboardHeightStore, setupViewportListener } = await import('../../stores/uiStore.svelte');
+        const setupViewportListenerSpy = vi.fn(() => setupViewportListener());
+        const { rerender, unmount } = render(ComposerLayoutMetricsHook, {
+            setupViewportListener: setupViewportListenerSpy,
+            keyboardLayoutState: keyboardHeightStore.value,
+        });
+
+        flushSync();
+        expect(setupViewportListenerSpy).toHaveBeenCalledOnce();
+        expect(visualViewport.addEventListener).toHaveBeenCalledTimes(2);
+        expect(virtualKeyboard.virtualKeyboard.addEventListener).toHaveBeenCalledOnce();
+
+        virtualKeyboard.setHeight(300);
+        virtualKeyboard.emitGeometryChange();
+        flushSync();
+        await rerender({
+            setupViewportListener: setupViewportListenerSpy,
+            keyboardLayoutState: keyboardHeightStore.value,
+        });
+
+        expect(setupViewportListenerSpy).toHaveBeenCalledOnce();
+        expect(visualViewport.removeEventListener).not.toHaveBeenCalled();
+        expect(visualViewport.addEventListener).toHaveBeenCalledTimes(2);
+        expect(virtualKeyboard.virtualKeyboard.removeEventListener).not.toHaveBeenCalled();
+        expect(virtualKeyboard.virtualKeyboard.addEventListener).toHaveBeenCalledOnce();
+        expect(virtualKeyboard.virtualKeyboard.overlaysContent).toBe(true);
+        expect(document.documentElement.style.getPropertyValue('--keyboard-button-bar-bottom')).toBe('300px');
+
+        unmount();
+
+        expect(visualViewport.removeEventListener).toHaveBeenCalledTimes(2);
+        expect(virtualKeyboard.virtualKeyboard.removeEventListener).toHaveBeenCalledOnce();
+        expect(virtualKeyboard.virtualKeyboard.overlaysContent).toBe(false);
     });
 
     it('「宛先を指定」ダイアログの入力欄では投稿エディター向けレイアウトを有効にしない', async () => {


### PR DESCRIPTION
## Summary

- Prevent `useComposerLayoutMetrics` from tracking reactive keyboard layout state while registering the viewport listener.
- Preserve the existing `$effect` cleanup lifecycle and all viewport/VirtualKeyboard geometry calculations.
- Add a regression test that mounts the real hook through a Svelte component lifecycle, drives the Android Chrome VirtualKeyboard geometry mock, and verifies no listener re-registration during keyboard-open state changes.

## Root cause

PR #177 added synchronous capability initialization and `syncLayoutCssVariables(false)` to `setupViewportListener()`. Because the setup was called directly from a Svelte `$effect`, those synchronous reactive reads became effect dependencies. Keyboard geometry updates then cleaned up and recreated the viewport listener, temporarily restoring closed-layout values and hiding the KeyboardButtonBar behind the IME while keyboard height adjustment remained active.

## Fix

The listener setup call is wrapped with Svelte `untrack()`. The listener remains registered once for the component lifecycle and is cleaned up on teardown. Header/footer capabilities and Host-owned Lite spacing/geometry behavior remain unchanged.

## Verification on latest main

This branch was rebased onto `main` at `909bfe4d4e788be433b3615224c6f84500c05512` (PR #206 included).

- Portal Button regression: `keeps the normal app Portal Button scope` passed 2/2 on mobile Chromium and mobile WebKit
- Full/Lite Playwright: 116 passed, 4 skipped, 0 failed across desktop Chromium, mobile Chromium, and mobile WebKit
- Host-owned Web Component dev-server sample: 1 passed
- Targeted keyboard/layout unit tests: 4 files, 29 passed
- `npm run check`: 0 errors, 0 warnings
- `npm test`: 3955 passed, 1 skipped
- `npm run build`: passed, including PWA, Full Web Component, and Host-owned Lite outputs

The earlier Portal Button trailing-space failures were caused by testing before PR #206 was included in `main`; they are resolved on this final branch and no unrelated test or production change was made here.

## Physical device verification

ユーザー実機確認待ち:

- Android Chrome non-PWA / PWA
- iPhone Safari non-PWA / PWA
- Keyboard open/close editor geometry, KeyboardButtonBar position, editor double-shrink, gaps/overlap, and closed footer/button-bar restoration

Playwright mobile emulation is not treated as physical IME proof.