### PR TITLE
Jump from post history search to exact post

### DIFF
--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -1333,7 +1333,7 @@
         history.resetSearchState();
     }
 
-    async function handleJumpToPost(
+    async function handleShowSurroundingPosts(
         post: PostHistoryRecord,
     ): Promise<void> {
         const changed = await history.jumpToEventId(post.eventId);
@@ -2142,7 +2142,7 @@
                                                                     <DropdownMenu.Item
                                                                         class="menu-action-button"
                                                                         onSelect={() =>
-                                                                            void handleJumpToPost(
+                                                                            void handleShowSurroundingPosts(
                                                                                 post,
                                                                             )}
                                                                     >
@@ -2152,7 +2152,7 @@
                                                                         ></div>
                                                                         <span>
                                                                             {$_(
-                                                                                "postHistory.jumpToPost",
+                                                                                "postHistory.showSurroundingPosts",
                                                                             )}
                                                                         </span>
                                                                     </DropdownMenu.Item>
@@ -2617,7 +2617,7 @@
                                                             <DropdownMenu.Item
                                                                 class="menu-action-button"
                                                                 onSelect={() =>
-                                                                    void handleJumpToPost(
+                                                                    void handleShowSurroundingPosts(
                                                                         post,
                                                                     )}
                                                             >
@@ -2627,7 +2627,7 @@
                                                                 ></div>
                                                                 <span>
                                                                     {$_(
-                                                                        "postHistory.jumpToPost",
+                                                                        "postHistory.showSurroundingPosts",
                                                                     )}
                                                                 </span>
                                                             </DropdownMenu.Item>

--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -1333,17 +1333,18 @@
         history.resetSearchState();
     }
 
-    async function handleJumpToPostDate(
+    async function handleJumpToPost(
         post: PostHistoryRecord,
     ): Promise<void> {
+        const changed = await history.jumpToEventId(post.eventId);
+        if (!changed) {
+            return;
+        }
+
         historyViewport.clearAllSessionScrollAnchorsForCurrentPubkey();
         activeUtilityPanel = "none";
         history.resetSearchState();
-
-        const changed = await history.jumpToCreatedAt(post.createdAt);
-        if (changed) {
-            historyViewport.resetHistoryScrollSoon();
-        }
+        historyViewport.scrollHistoryEventToTopSoon(post.eventId);
     }
 
     function toggleJumpDate(): void {
@@ -2141,7 +2142,7 @@
                                                                     <DropdownMenu.Item
                                                                         class="menu-action-button"
                                                                         onSelect={() =>
-                                                                            void handleJumpToPostDate(
+                                                                            void handleJumpToPost(
                                                                                 post,
                                                                             )}
                                                                     >
@@ -2151,7 +2152,7 @@
                                                                         ></div>
                                                                         <span>
                                                                             {$_(
-                                                                                "postHistory.jumpToPostDate",
+                                                                                "postHistory.jumpToPost",
                                                                             )}
                                                                         </span>
                                                                     </DropdownMenu.Item>
@@ -2616,7 +2617,7 @@
                                                             <DropdownMenu.Item
                                                                 class="menu-action-button"
                                                                 onSelect={() =>
-                                                                    void handleJumpToPostDate(
+                                                                    void handleJumpToPost(
                                                                         post,
                                                                     )}
                                                             >
@@ -2626,7 +2627,7 @@
                                                                 ></div>
                                                                 <span>
                                                                     {$_(
-                                                                        "postHistory.jumpToPostDate",
+                                                                        "postHistory.jumpToPost",
                                                                     )}
                                                                 </span>
                                                             </DropdownMenu.Item>

--- a/src/lib/hooks/usePostHistoryDialogViewport.svelte.ts
+++ b/src/lib/hooks/usePostHistoryDialogViewport.svelte.ts
@@ -271,6 +271,19 @@ export function usePostHistoryDialogViewport({
         });
     }
 
+    function scrollHistoryEventToTopSoon(eventId: string): void {
+        void tick().then(() => {
+            if (!getShow()) {
+                return;
+            }
+
+            restoreHistoryScrollAnchor({
+                eventId,
+                offsetTop: 0,
+            });
+        });
+    }
+
     function captureHistoryScrollAnchor(): PostHistoryDialogScrollAnchor | null {
         const container = getContainer();
         if (!container) {
@@ -508,6 +521,7 @@ export function usePostHistoryDialogViewport({
         handleHistoryScroll,
         resetHistoryScrollSoon,
         resetHistoryScrollToBottomSoon,
+        scrollHistoryEventToTopSoon,
         captureHistoryScrollAnchor,
         restoreHistoryScrollAnchor,
         preserveThreadParentToggleScroll,

--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -2935,6 +2935,54 @@ export function usePostHistoryListing({
         return true;
     }
 
+    async function jumpToEventId(eventId: string): Promise<boolean> {
+        clearContiguousProgress();
+        const pubkeyHex = getPubkeyHex();
+        if (!pubkeyHex || !eventId) {
+            return false;
+        }
+
+        const requestId = ++loadRequestId;
+        const visibleUntil = await refreshVisibleUntil(pubkeyHex, requestId);
+        const getPostsAroundEvent = (range: number | null) =>
+            postHistoryRepository.getVisibleChunkAroundEventId({
+                pubkeyHex,
+                visibleUntil: range,
+                eventId,
+                limit: maxVisiblePosts,
+                keepAbove: pageSize,
+            });
+
+        let targetPosts = await getPostsAroundEvent(visibleUntil);
+        if (!getShow() || requestId !== loadRequestId) {
+            return false;
+        }
+
+        const targetWasInVisibleRange = targetPosts.some(
+            (post) => post.eventId === eventId,
+        );
+        let isSparseJump = false;
+        if (!targetWasInVisibleRange && typeof visibleUntil === "number") {
+            targetPosts = await getPostsAroundEvent(null);
+            isSparseJump = true;
+            if (!getShow() || requestId !== loadRequestId) {
+                return false;
+            }
+        }
+
+        if (!targetPosts.some((post) => post.eventId === eventId)) {
+            return false;
+        }
+
+        refreshTotalCountFromRepository();
+        state.listingMode = isSparseJump ? "sparse" : "contiguous";
+        state.sparseSource = isSparseJump ? "jump" : null;
+        state.loadedPosts = targetPosts;
+        resetOlderBackfillSearchState();
+        await refreshTimelineAvailability(pubkeyHex, targetPosts, requestId);
+        return true;
+    }
+
     function mergeSearchPageResults(
         currentPosts: PostHistoryRecord[],
         nextPosts: PostHistoryRecord[],
@@ -4690,6 +4738,7 @@ export function usePostHistoryListing({
         showSavedOlderPosts,
         jumpToOldest,
         jumpToCreatedAt,
+        jumpToEventId,
         fetchOlderFromRelays,
         goFirstPage,
         goPreviousPage,

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -148,7 +148,7 @@
     "returnToLatest": "Back to latest",
     "jumpToOldest": "Jump to oldest",
     "jumpToDate": "Jump to date",
-    "jumpToPostDate": "Jump to post date",
+    "jumpToPost": "Jump to this post",
     "jumpToDateLabel": "Date",
     "jumpToDateSubmit": "Show near this date",
     "hideJumpToDate": "Close jump to date",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -148,7 +148,7 @@
     "returnToLatest": "Back to latest",
     "jumpToOldest": "Jump to oldest",
     "jumpToDate": "Jump to date",
-    "jumpToPost": "Jump to this post",
+    "showSurroundingPosts": "Show surrounding posts",
     "jumpToDateLabel": "Date",
     "jumpToDateSubmit": "Show near this date",
     "hideJumpToDate": "Close jump to date",

--- a/src/lib/i18n/ja.json
+++ b/src/lib/i18n/ja.json
@@ -148,7 +148,7 @@
     "returnToLatest": "最新へ戻る",
     "jumpToOldest": "最古へ移動",
     "jumpToDate": "日付へ移動",
-    "jumpToPost": "この投稿へ移動",
+    "showSurroundingPosts": "前後の投稿を表示",
     "jumpToDateLabel": "日付",
     "jumpToDateSubmit": "この日付付近を表示",
     "hideJumpToDate": "日付へ移動を閉じる",

--- a/src/lib/i18n/ja.json
+++ b/src/lib/i18n/ja.json
@@ -148,7 +148,7 @@
     "returnToLatest": "最新へ戻る",
     "jumpToOldest": "最古へ移動",
     "jumpToDate": "日付へ移動",
-    "jumpToPostDate": "投稿の日付へ飛ぶ",
+    "jumpToPost": "この投稿へ移動",
     "jumpToDateLabel": "日付",
     "jumpToDateSubmit": "この日付付近を表示",
     "hideJumpToDate": "日付へ移動を閉じる",

--- a/src/test/e2e/PostHistoryDialogHarness.svelte
+++ b/src/test/e2e/PostHistoryDialogHarness.svelte
@@ -61,6 +61,7 @@
         importEventJsonl: string;
         sparseVisiblePostContent: string;
         sparseStoredPostContent: string;
+        sparseStoredPostEventId: string;
         absoluteOldestPostContent: string;
     };
 
@@ -80,10 +81,11 @@
         const timestampMs = STARTED_AT_MS - index * 24 * 60 * 60 * 1000;
         const timestampSeconds = Math.floor(timestampMs / 1000);
         const label = index < SEARCH_MATCHING_POSTS ? "alpha" : "beta";
+        const eventId = buildHexId(index, "aa");
 
         return {
-            id: `playwright-post-${index}`,
-            eventId: buildHexId(index, "aa"),
+            id: eventId,
+            eventId,
             pubkeyHex: HARNESS_PUBKEY,
             kind: 1,
             content: `${label} post ${index + 1}`,
@@ -339,6 +341,7 @@
         importEventJsonl: IMPORT_EVENT_JSONL,
         sparseVisiblePostContent: sparseVisiblePost.content,
         sparseStoredPostContent: sparseStoredPost.content,
+        sparseStoredPostEventId: sparseStoredPost.eventId,
         absoluteOldestPostContent: absoluteOldestPost.content,
     };
 
@@ -407,6 +410,7 @@
             importEventJsonl: IMPORT_EVENT_JSONL,
             sparseVisiblePostContent: sparseVisiblePost.content,
             sparseStoredPostContent: sparseStoredPost.content,
+            sparseStoredPostEventId: sparseStoredPost.eventId,
             absoluteOldestPostContent: absoluteOldestPost.content,
         };
     });

--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -427,7 +427,7 @@ test.describe('PostHistoryDialog Playwright', () => {
         );
         await expect(targetItem).toBeVisible();
         await targetItem.getByRole('button', { name: 'アクションを表示' }).click();
-        await page.getByRole('menuitem', { name: 'この投稿へ移動' }).click();
+        await page.getByRole('menuitem', { name: '前後の投稿を表示' }).click();
 
         await expect(page.getByRole('searchbox', { name: '検索' })).toHaveCount(0);
         await expect(targetItem).toBeVisible();

--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -23,6 +23,7 @@ type HarnessState = {
     importEventJsonl: string;
     sparseVisiblePostContent: string;
     sparseStoredPostContent: string;
+    sparseStoredPostEventId: string;
     absoluteOldestPostContent: string;
 };
 
@@ -412,6 +413,32 @@ test.describe('PostHistoryDialog Playwright', () => {
         await expect(page.getByText(harness.sparseStoredPostContent, { exact: true })).toBeVisible();
         await page.getByRole('button', { name: '最新へ戻る' }).click();
         await expect(page.getByText(harness.sparseVisiblePostContent, { exact: true })).toBeVisible();
+    });
+
+    test('search result jumps to the exact saved post and aligns it to the viewport top', async ({ page }) => {
+        const harness = await gotoSparseHarness(page);
+
+        await page.getByRole('button', { name: '投稿履歴メニューを開く' }).click();
+        await page.getByRole('menuitem', { name: '検索' }).click();
+        await page.getByRole('searchbox', { name: '検索' }).fill('alpha');
+
+        const targetItem = page.locator(
+            `.post-history-item[data-post-history-event-id="${harness.sparseStoredPostEventId}"]`,
+        );
+        await expect(targetItem).toBeVisible();
+        await targetItem.getByRole('button', { name: 'アクションを表示' }).click();
+        await page.getByRole('menuitem', { name: 'この投稿へ移動' }).click();
+
+        await expect(page.getByRole('searchbox', { name: '検索' })).toHaveCount(0);
+        await expect(targetItem).toBeVisible();
+        await expect.poll(async () => {
+            const snapshot = await getPostSnapshotByEventId(
+                page,
+                harness.sparseStoredPostEventId,
+            );
+            return snapshot?.offsetTop ?? Number.POSITIVE_INFINITY;
+        }).toBeLessThanOrEqual(1);
+        await expect(page.getByRole('button', { name: '最新へ戻る' })).toBeVisible();
     });
 
     test('saved sparse pages can jump to the absolute local oldest and scroll to the bottom', async ({

--- a/src/test/unit/postHistoryDialogTestHarness.ts
+++ b/src/test/unit/postHistoryDialogTestHarness.ts
@@ -42,7 +42,7 @@ const hoisted = vi.hoisted(() => {
             'postHistory.returnToLatest': '最新へ戻る',
             'postHistory.jumpToOldest': '最古へ移動',
             'postHistory.jumpToDate': '日付へ移動',
-            'postHistory.jumpToPost': 'この投稿へ移動',
+            'postHistory.showSurroundingPosts': '前後の投稿を表示',
             'postHistory.jumpToDateLabel': '日付',
             'postHistory.jumpToDateSubmit': 'この日付付近を表示',
             'postHistory.fetchOlderFromRelays': 'リレーから続きを取得',

--- a/src/test/unit/postHistoryDialogTestHarness.ts
+++ b/src/test/unit/postHistoryDialogTestHarness.ts
@@ -42,7 +42,7 @@ const hoisted = vi.hoisted(() => {
             'postHistory.returnToLatest': '最新へ戻る',
             'postHistory.jumpToOldest': '最古へ移動',
             'postHistory.jumpToDate': '日付へ移動',
-            'postHistory.jumpToPostDate': '投稿の日付へ飛ぶ',
+            'postHistory.jumpToPost': 'この投稿へ移動',
             'postHistory.jumpToDateLabel': '日付',
             'postHistory.jumpToDateSubmit': 'この日付付近を表示',
             'postHistory.fetchOlderFromRelays': 'リレーから続きを取得',

--- a/src/test/unit/postHistoryDialogTimelineSearch.test.ts
+++ b/src/test/unit/postHistoryDialogTimelineSearch.test.ts
@@ -15,6 +15,7 @@ import {
     repositoryMock,
     replyRepairServiceMock,
     resetPostHistoryDialogHarness,
+    visibleRangeRepositoryMock,
     waitForSearchDebounce,
 } from './postHistoryDialogTestHarness';
 import { readPersistedPostHistoryViewState } from '../../lib/postHistoryDialogViewState';
@@ -929,9 +930,15 @@ describe('PostHistoryDialog timeline search', () => {
         view.unmount();
     });
 
-    it('検索結果投稿のメニューから投稿の日付へ飛ぶと検索を閉じて通常履歴へ移動する', async () => {
+    it('検索結果投稿のメニューからこの投稿へ移動すると対象eventIdの履歴へ移動する', async () => {
         const jumpCreatedAt = 1_690_100_000;
 
+        visibleRangeRepositoryMock.get.mockResolvedValue({
+            pubkeyHex: PUBKEY_HEX,
+            kindsKey: '1,42',
+            visibleUntil: 1_690_000_000,
+            updatedAt: 1,
+        });
         repositoryMock.countForPubkey.mockResolvedValue(2);
         repositoryMock.getLatestVisibleChunk.mockResolvedValueOnce([
             createRecord({ eventId: 'normal-timeline', content: '通常履歴' }),
@@ -949,11 +956,21 @@ describe('PostHistoryDialog timeline search', () => {
             total: 1,
             hasNext: false,
         });
-        repositoryMock.getVisibleChunkFromCreatedAt.mockResolvedValueOnce([
+        repositoryMock.getVisibleChunkAroundEventId.mockResolvedValueOnce([
             createRecord({
-                eventId: 'jumped-timeline',
-                content: '日付ジャンプ後',
+                eventId: 'jumped-timeline-newer',
+                content: '対象より新しい投稿',
                 createdAt: jumpCreatedAt,
+            }),
+            createRecord({
+                eventId: 'search-hit',
+                content: '検索ヒット',
+                createdAt: jumpCreatedAt,
+            }),
+            createRecord({
+                eventId: 'jumped-timeline-older',
+                content: '対象より古い投稿',
+                createdAt: jumpCreatedAt - 1,
             }),
         ]);
 
@@ -975,18 +992,126 @@ describe('PostHistoryDialog timeline search', () => {
 
         const actionTrigger = screen.getAllByRole('button', { name: 'アクションを表示' })[0];
         await fireEvent.click(actionTrigger);
-        await fireEvent.click(await screen.findByRole('menuitem', { name: '投稿の日付へ飛ぶ' }));
+        await fireEvent.click(await screen.findByRole('menuitem', { name: 'この投稿へ移動' }));
 
         await waitFor(() => {
-            expect(repositoryMock.getVisibleChunkFromCreatedAt).toHaveBeenCalledWith({
+            expect(repositoryMock.getVisibleChunkAroundEventId).toHaveBeenCalledWith({
+                pubkeyHex: PUBKEY_HEX,
+                visibleUntil: 1_690_000_000,
+                eventId: 'search-hit',
+                limit: 150,
+                keepAbove: 50,
+            });
+            expect(repositoryMock.getVisibleChunkAroundEventId).toHaveBeenCalledTimes(1);
+            expect(repositoryMock.getVisibleChunkFromCreatedAt).not.toHaveBeenCalled();
+            expect(screen.queryByRole('searchbox', { name: '検索' })).toBeNull();
+            expect(screen.getByText('対象より新しい投稿')).toBeTruthy();
+            expect(screen.getByText('対象より古い投稿')).toBeTruthy();
+        });
+
+        view.unmount();
+    });
+
+    it('検索結果が現在のvisible range外でもeventId周辺のsparse jumpへ移動する', async () => {
+        const target = createRecord({
+            eventId: 'saved-outside-range-target',
+            content: '表示範囲外の検索対象',
+            createdAt: 1_690_100_000,
+        });
+        visibleRangeRepositoryMock.get.mockResolvedValue({
+            pubkeyHex: PUBKEY_HEX,
+            kindsKey: '1,42',
+            visibleUntil: target.createdAt + 1,
+            updatedAt: 1,
+        });
+        repositoryMock.countForPubkey.mockResolvedValue(3);
+        repositoryMock.getLatestVisibleChunk.mockResolvedValueOnce([
+            createRecord({ eventId: 'range-newest', content: '現在の履歴' }),
+        ]);
+        repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
+        repositoryMock.getOlderVisibleChunk.mockResolvedValue([]);
+        localSearchServiceMock.searchLocalPosts.mockResolvedValue({
+            items: [target],
+            total: 1,
+            hasNext: false,
+        });
+        repositoryMock.getVisibleChunkAroundEventId
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([
+                createRecord({ eventId: 'outside-newer', content: '周辺の新しい投稿' }),
+                target,
+                createRecord({ eventId: 'outside-older', content: '周辺の古い投稿' }),
+            ]);
+
+        const view = render(PostHistoryDialog, {
+            props: { show: true, onClose: vi.fn(), pubkeyHex: PUBKEY_HEX },
+        });
+        const searchInput = await openSearchBar();
+        await fireEvent.input(searchInput, { target: { value: 'target' } });
+        await waitForSearchDebounce();
+        await waitFor(() => expect(screen.getByText(target.content)).toBeTruthy());
+
+        await fireEvent.click(screen.getByRole('button', { name: 'アクションを表示' }));
+        await fireEvent.click(await screen.findByRole('menuitem', { name: 'この投稿へ移動' }));
+
+        await waitFor(() => {
+            expect(repositoryMock.getVisibleChunkAroundEventId).toHaveBeenNthCalledWith(1, {
+                pubkeyHex: PUBKEY_HEX,
+                visibleUntil: target.createdAt + 1,
+                eventId: target.eventId,
+                limit: 150,
+                keepAbove: 50,
+            });
+            expect(repositoryMock.getVisibleChunkAroundEventId).toHaveBeenNthCalledWith(2, {
                 pubkeyHex: PUBKEY_HEX,
                 visibleUntil: null,
-                createdAt: jumpCreatedAt,
-                limit: 50,
+                eventId: target.eventId,
+                limit: 150,
+                keepAbove: 50,
             });
             expect(screen.queryByRole('searchbox', { name: '検索' })).toBeNull();
-            expect(screen.getByText('日付ジャンプ後')).toBeTruthy();
+            expect(screen.getByText(target.content)).toBeTruthy();
         });
+
+        view.unmount();
+    });
+
+    it('検索対象eventIdを取得できない場合は検索状態を維持して日付fallbackしない', async () => {
+        const target = createRecord({
+            eventId: 'missing-search-target',
+            content: '取得不能な検索対象',
+            createdAt: 1_690_100_000,
+        });
+        repositoryMock.countForPubkey.mockResolvedValue(1);
+        repositoryMock.getLatestVisibleChunk.mockResolvedValueOnce([
+            createRecord({ eventId: 'failure-normal', content: '通常履歴' }),
+        ]);
+        repositoryMock.getNewerVisibleChunk.mockResolvedValue([]);
+        repositoryMock.getOlderVisibleChunk.mockResolvedValue([]);
+        localSearchServiceMock.searchLocalPosts.mockResolvedValue({
+            items: [target],
+            total: 1,
+            hasNext: false,
+        });
+        repositoryMock.getVisibleChunkAroundEventId.mockResolvedValue([]);
+
+        const view = render(PostHistoryDialog, {
+            props: { show: true, onClose: vi.fn(), pubkeyHex: PUBKEY_HEX },
+        });
+        const searchInput = await openSearchBar();
+        await fireEvent.input(searchInput, { target: { value: 'missing' } });
+        await waitForSearchDebounce();
+        await waitFor(() => expect(screen.getByText(target.content)).toBeTruthy());
+
+        await fireEvent.click(screen.getByRole('button', { name: 'アクションを表示' }));
+        await fireEvent.click(await screen.findByRole('menuitem', { name: 'この投稿へ移動' }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('searchbox', { name: '検索' })).toBeTruthy();
+            expect(screen.getByText(target.content)).toBeTruthy();
+        });
+        expect(repositoryMock.getVisibleChunkFromCreatedAt).not.toHaveBeenCalled();
+        expect(screen.queryByText('通常履歴')).toBeNull();
 
         view.unmount();
     });

--- a/src/test/unit/postHistoryDialogTimelineSearch.test.ts
+++ b/src/test/unit/postHistoryDialogTimelineSearch.test.ts
@@ -930,7 +930,7 @@ describe('PostHistoryDialog timeline search', () => {
         view.unmount();
     });
 
-    it('検索結果投稿のメニューからこの投稿へ移動すると対象eventIdの履歴へ移動する', async () => {
+    it('検索結果投稿のメニューから前後の投稿を表示すると対象eventIdの履歴へ移動する', async () => {
         const jumpCreatedAt = 1_690_100_000;
 
         visibleRangeRepositoryMock.get.mockResolvedValue({
@@ -992,7 +992,7 @@ describe('PostHistoryDialog timeline search', () => {
 
         const actionTrigger = screen.getAllByRole('button', { name: 'アクションを表示' })[0];
         await fireEvent.click(actionTrigger);
-        await fireEvent.click(await screen.findByRole('menuitem', { name: 'この投稿へ移動' }));
+        await fireEvent.click(await screen.findByRole('menuitem', { name: '前後の投稿を表示' }));
 
         await waitFor(() => {
             expect(repositoryMock.getVisibleChunkAroundEventId).toHaveBeenCalledWith({
@@ -1052,7 +1052,7 @@ describe('PostHistoryDialog timeline search', () => {
         await waitFor(() => expect(screen.getByText(target.content)).toBeTruthy());
 
         await fireEvent.click(screen.getByRole('button', { name: 'アクションを表示' }));
-        await fireEvent.click(await screen.findByRole('menuitem', { name: 'この投稿へ移動' }));
+        await fireEvent.click(await screen.findByRole('menuitem', { name: '前後の投稿を表示' }));
 
         await waitFor(() => {
             expect(repositoryMock.getVisibleChunkAroundEventId).toHaveBeenNthCalledWith(1, {
@@ -1104,7 +1104,7 @@ describe('PostHistoryDialog timeline search', () => {
         await waitFor(() => expect(screen.getByText(target.content)).toBeTruthy());
 
         await fireEvent.click(screen.getByRole('button', { name: 'アクションを表示' }));
-        await fireEvent.click(await screen.findByRole('menuitem', { name: 'この投稿へ移動' }));
+        await fireEvent.click(await screen.findByRole('menuitem', { name: '前後の投稿を表示' }));
 
         await waitFor(() => {
             expect(screen.getByRole('searchbox', { name: '検索' })).toBeTruthy();


### PR DESCRIPTION
## Summary
- Change the post-history search result action from the createdAt approximation to an exact eventId jump.
- Use the existing visible-range event window first; use an unbounded local eventId window as `sparseSource: "jump"` when the saved post is outside that range.
- Reuse the existing viewport anchor restoration after rendering to align the selected post to the container top.
- Keep the search state on lookup failure and do not fall back to a date or unrelated history.

## Validation
- `npm test` — 342 files passed, 3957 tests passed; 1 file/test skipped by the existing suite.
- `npm run check` — passed with 0 errors and 0 warnings.
- `npx playwright test src/test/e2e/postHistoryDialog.spec.ts --project=desktop-chromium --project=mobile-chromium` — 32 passed, 10 existing skips.
- `npm run build` — not run; this change does not affect Vite/PWA/worker/asset build contracts.