### PR TITLE
Add infinite scroll to post history

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
                 '**/webComponentLite.spec.ts',
                 '**/webComponentParentClientExample.spec.ts',
                 '**/postEditorSending.spec.ts',
+                '**/postHistoryDialog.spec.ts',
             ],
             use: {
                 ...devices['iPhone 13'],

--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -307,6 +307,11 @@
     let fullscreenIndex = $state(-1);
     let showImageFullscreen = $state(false);
     let historyContainer = $state<HTMLDivElement | null>(null);
+    let autoLoadOlderSentinel = $state<HTMLDivElement | null>(null);
+    let isAutoLoadingOlder = $state(false);
+    let autoLoadOlderAwaitingExit = false;
+    let autoLoadOlderSentinelIsIntersecting = false;
+    const supportsAutoLoadOlder = typeof IntersectionObserver !== "undefined";
     let searchInputElement = $state<HTMLInputElement | null>(null);
     let showDelayedListLoading = $state(false);
     const previewCollapse = usePostHistoryPreviewCollapse({
@@ -627,6 +632,57 @@
         };
     });
 
+    $effect(() => {
+        const sentinel = autoLoadOlderSentinel;
+        const root = historyContainer;
+        const enabled =
+            show
+            && !!sentinel
+            && !!root
+            && !history.isSearchMode
+            && history.state.listingMode === "contiguous"
+            && history.state.hasOlderLocal
+            && !history.isRefetchingAroundCurrentView;
+
+        if (!enabled || !supportsAutoLoadOlder) {
+            autoLoadOlderAwaitingExit = false;
+            autoLoadOlderSentinelIsIntersecting = false;
+            return;
+        }
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                const isIntersecting = entries.some(
+                    (entry) => entry.isIntersecting,
+                );
+                autoLoadOlderSentinelIsIntersecting = isIntersecting;
+
+                if (!isIntersecting) {
+                    if (
+                        autoLoadOlderAwaitingExit
+                        && !isAutoLoadingOlder
+                    ) {
+                        autoLoadOlderAwaitingExit = false;
+                    }
+                    return;
+                }
+
+                void handleAutoLoadOlder();
+            },
+            {
+                root,
+                threshold: 0,
+            },
+        );
+        observer.observe(sentinel);
+
+        return () => {
+            observer.disconnect();
+            autoLoadOlderAwaitingExit = false;
+            autoLoadOlderSentinelIsIntersecting = false;
+        };
+    });
+
     onDestroy(() => {
         cancelExport();
         resetPendingDeletionRequests();
@@ -800,6 +856,41 @@
 
         if (changed && isSearchMode) {
             historyViewport.restoreHistoryScrollAnchor(scrollAnchor);
+        }
+    }
+
+    function canAutoLoadOlderPosts(): boolean {
+        return show
+            && !history.isSearchMode
+            && history.state.listingMode === "contiguous"
+            && history.state.hasOlderLocal
+            && !history.isRefetchingAroundCurrentView;
+    }
+
+    async function handleAutoLoadOlder(): Promise<void> {
+        if (
+            isAutoLoadingOlder
+            || autoLoadOlderAwaitingExit
+            || !canAutoLoadOlderPosts()
+        ) {
+            return;
+        }
+
+        const scrollAnchor = historyViewport.captureHistoryScrollAnchor();
+        isAutoLoadingOlder = true;
+        autoLoadOlderAwaitingExit = true;
+
+        try {
+            const changed = await history.loadOlder();
+            if (changed && show) {
+                await tick();
+                historyViewport.restoreHistoryScrollAnchor(scrollAnchor);
+            }
+        } finally {
+            isAutoLoadingOlder = false;
+            if (!autoLoadOlderSentinelIsIntersecting) {
+                autoLoadOlderAwaitingExit = false;
+            }
         }
     }
 
@@ -1992,7 +2083,7 @@
         class="post-history-container"
         bind:this={historyContainer}
         onscroll={historyViewport.handleHistoryScroll}
-        aria-busy={isHistoryListLoading ? "true" : "false"}
+        aria-busy={isHistoryListLoading || isAutoLoadingOlder ? "true" : "false"}
     >
         {#if history.posts.length === 0 && showDelayedListLoading}
             <div class="post-history-list-loading" aria-hidden="true">
@@ -2843,6 +2934,23 @@
                 {/each}
             </ul>
 
+            {#if supportsAutoLoadOlder && !history.isSearchMode && history.state.listingMode === "contiguous" && history.state.hasOlderLocal && !history.showSavedPostsBoundary}
+                <div
+                    bind:this={autoLoadOlderSentinel}
+                    class="post-history-auto-load-sentinel"
+                    aria-hidden="true"
+                >
+                    {#if isAutoLoadingOlder}
+                        <LoadingPlaceholder
+                            variant="spinner"
+                            showLoader={true}
+                            loaderSize={24}
+                            ariaHidden={true}
+                        />
+                    {/if}
+                </div>
+            {/if}
+
             {#if history.isShowingSavedOlderPosts}
                 <div class="post-history-sparse-state" role="status">
                     <p>{$_("postHistory.savedOlderPostsShowing")}</p>
@@ -2885,7 +2993,24 @@
                         </Button>
                     </div>
                 </div>
-            {:else if history.isSearchMode ? history.canLoadOlder : history.state.hasOlderLocal}
+            {:else if history.isSearchMode && history.canLoadOlder}
+                <div class="post-history-nav-row post-history-nav-row-bottom">
+                    <Button
+                        type="button"
+                        variant="default"
+                        className="post-history-nav-button"
+                        contentLayout="iconText"
+                        disabled={!history.canLoadOlder}
+                        onClick={() => void handleLoadOlder()}
+                    >
+                        <div
+                            class="keyboard-arrow-down-icon svg-icon"
+                            aria-hidden="true"
+                        ></div>
+                        {getLoadOlderLabel()}
+                    </Button>
+                </div>
+            {:else if !history.isSearchMode && history.state.hasOlderLocal && (history.state.listingMode === "sparse" || !supportsAutoLoadOlder)}
                 <div class="post-history-nav-row post-history-nav-row-bottom">
                     <Button
                         type="button"
@@ -3455,6 +3580,12 @@
         padding-top: 0;
     }
 
+    .post-history-auto-load-sentinel {
+        display: grid;
+        min-height: 1px;
+        place-items: center;
+    }
+
     :global(.post-history-nav-button.primary) {
         opacity: 1;
     }
@@ -3503,6 +3634,7 @@
         min-height: 0;
         width: 100%;
         overflow-y: auto;
+        overflow-anchor: none;
     }
 
     .empty-state {

--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -2080,7 +2080,7 @@
     {/if}
 
     <div
-        class="post-history-container"
+        class={`post-history-container${supportsAutoLoadOlder && !history.isSearchMode && history.state.listingMode === "contiguous" ? " post-history-auto-load-enabled" : ""}`}
         bind:this={historyContainer}
         onscroll={historyViewport.handleHistoryScroll}
         aria-busy={isHistoryListLoading || isAutoLoadingOlder ? "true" : "false"}
@@ -3634,6 +3634,9 @@
         min-height: 0;
         width: 100%;
         overflow-y: auto;
+    }
+
+    .post-history-container.post-history-auto-load-enabled {
         overflow-anchor: none;
     }
 

--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -2562,6 +2562,9 @@ export function usePostHistoryListing({
         const hasReachedVisibleEnd = !!contiguousProgress
             && contiguousProgress.reachedVisibleCount >=
                 contiguousProgress.totalVisibleCount;
+        if (hasReachedVisibleEnd) {
+            state.hasOlderLocal = false;
+        }
         if (metrics) {
             metrics.loadedPostsAfterLength = mergedResult.posts.length;
             metrics.visibleOldestAfter =

--- a/src/test/e2e/PostHistoryDialogHarness.svelte
+++ b/src/test/e2e/PostHistoryDialogHarness.svelte
@@ -18,8 +18,13 @@
 
     const HARNESS_SECRET_KEY = generateSecretKey();
     const HARNESS_PUBKEY = getPublicKey(HARNESS_SECRET_KEY);
+    const isInfiniteScrollScenario = new URLSearchParams(window.location.search).has("infinite-scroll");
     const isSparseOldestScenario = new URLSearchParams(window.location.search).has("sparse-oldest");
-    const TOTAL_POSTS = isSparseOldestScenario ? 120 : 70;
+    const TOTAL_POSTS = isInfiniteScrollScenario
+        ? 251
+        : isSparseOldestScenario
+          ? 120
+          : 70;
     const SEARCH_MATCHING_POSTS = 55;
     const isSparseScenario = new URLSearchParams(window.location.search).has("sparse")
         || isSparseOldestScenario;
@@ -63,6 +68,8 @@
         sparseStoredPostContent: string;
         sparseStoredPostEventId: string;
         absoluteOldestPostContent: string;
+        infiniteScrollEventIds: string[];
+        infiniteScrollOldestPostContent: string;
     };
 
     type HarnessWindow = Window &
@@ -343,6 +350,8 @@
         sparseStoredPostContent: sparseStoredPost.content,
         sparseStoredPostEventId: sparseStoredPost.eventId,
         absoluteOldestPostContent: absoluteOldestPost.content,
+        infiniteScrollEventIds: posts.map((post) => post.eventId),
+        infiniteScrollOldestPostContent: absoluteOldestPost.content,
     };
 
     onMount(async () => {
@@ -412,6 +421,8 @@
             sparseStoredPostContent: sparseStoredPost.content,
             sparseStoredPostEventId: sparseStoredPost.eventId,
             absoluteOldestPostContent: absoluteOldestPost.content,
+            infiniteScrollEventIds: posts.map((post) => post.eventId),
+            infiniteScrollOldestPostContent: absoluteOldestPost.content,
         };
     });
 </script>

--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -572,10 +572,9 @@ test.describe('PostHistoryDialog Playwright', () => {
         }
 
         const anchorAfterLoad = await getPostSnapshotByEventId(page, anchorBeforeLoad!.eventId);
-        if (anchorAfterLoad) {
-            expect(anchorAfterLoad.eventId).toBe(anchorBeforeLoad!.eventId);
-            expect(Math.abs(anchorAfterLoad.offsetTop - anchorBeforeLoad!.offsetTop)).toBeLessThanOrEqual(1);
-        }
+        expect(anchorAfterLoad).not.toBeNull();
+        expect(anchorAfterLoad!.eventId).toBe(anchorBeforeLoad!.eventId);
+        expect(Math.abs(anchorAfterLoad!.offsetTop - anchorBeforeLoad!.offsetTop)).toBeLessThanOrEqual(1);
         await expectHistoryIsNotAtBottom(page);
 
         await waitForIntersectionObserverSettle(page);

--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -25,6 +25,8 @@ type HarnessState = {
     sparseStoredPostContent: string;
     sparseStoredPostEventId: string;
     absoluteOldestPostContent: string;
+    infiniteScrollEventIds: string[];
+    infiniteScrollOldestPostContent: string;
 };
 
 type HarnessWindow = Window & typeof globalThis & {
@@ -45,6 +47,12 @@ async function gotoSparseHarness(page: Page) {
 
 async function gotoSparseOldestHarness(page: Page) {
     await page.goto('post-history-dialog-playwright.html?sparse-oldest=1');
+    await page.waitForFunction(() => Boolean((window as HarnessWindow).__POST_HISTORY_HARNESS__?.ready));
+    return page.evaluate<HarnessState>(() => (window as HarnessWindow).__POST_HISTORY_HARNESS__ as HarnessState);
+}
+
+async function gotoInfiniteScrollHarness(page: Page) {
+    await page.goto('post-history-dialog-playwright.html?infinite-scroll=1');
     await page.waitForFunction(() => Boolean((window as HarnessWindow).__POST_HISTORY_HARNESS__?.ready));
     return page.evaluate<HarnessState>(() => (window as HarnessWindow).__POST_HISTORY_HARNESS__ as HarnessState);
 }
@@ -143,6 +151,38 @@ async function jumpToDate(page: Page, date: string) {
 
 async function expectVisiblePostCount(page: Page, count: number) {
     await expect(page.locator('.post-history-list li')).toHaveCount(count);
+}
+
+async function scrollHistoryToBottom(page: Page) {
+    await page.locator('.post-history-container').evaluate((element) => {
+        const container = element as HTMLDivElement;
+        container.scrollTop = container.scrollHeight;
+        container.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+}
+
+async function historyEventIds(page: Page): Promise<string[]> {
+    return page.locator('.post-history-list').evaluate((list) =>
+        Array.from(list.querySelectorAll<HTMLElement>('.post-history-item'))
+            .map((item) => item.dataset.postHistoryEventId ?? ''),
+    );
+}
+
+async function expectHistoryIsNotAtBottom(page: Page) {
+    await expect.poll(() => page.locator('.post-history-container').evaluate((element) => {
+        const container = element as HTMLDivElement;
+        return container.scrollHeight - container.clientHeight - container.scrollTop;
+    })).toBeGreaterThan(1);
+}
+
+async function waitForIntersectionObserverSettle(page: Page) {
+    await page.evaluate(async () => {
+        await new Promise<void>((resolve) => {
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => resolve());
+            });
+        });
+    });
 }
 
 async function getFirstVisiblePostSnapshot(page: Page) {
@@ -471,6 +511,101 @@ test.describe('PostHistoryDialog Playwright', () => {
         })).toBeLessThanOrEqual(1);
     });
 
+    test('normal history loads exactly one local chunk for each new bottom arrival', async ({ page }) => {
+        const harness = await gotoInfiniteScrollHarness(page);
+        const expectedEventIds = harness.infiniteScrollEventIds;
+
+        await expectVisiblePostCount(page, 50);
+        await expect(page.getByRole('button', { name: 'さらに古い投稿を表示' })).toHaveCount(0);
+        await expect(page.locator('.post-history-auto-load-sentinel')).toBeVisible();
+        expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(0, 50));
+
+        const observedEventIds = new Set(await historyEventIds(page));
+
+        await scrollHistoryToBottom(page);
+        await expectVisiblePostCount(page, 100);
+        await expect.poll(() => historyEventIds(page)).toEqual(expectedEventIds.slice(0, 100));
+        for (const eventId of await historyEventIds(page)) {
+            observedEventIds.add(eventId);
+        }
+        await waitForIntersectionObserverSettle(page);
+        expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(0, 100));
+
+        await scrollHistoryToBottom(page);
+        await expectVisiblePostCount(page, 150);
+        await expect.poll(() => historyEventIds(page)).toEqual(expectedEventIds.slice(0, 150));
+        for (const eventId of await historyEventIds(page)) {
+            observedEventIds.add(eventId);
+        }
+        await waitForIntersectionObserverSettle(page);
+        expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(0, 150));
+
+        const anchorBeforeLoad = await page.locator('.post-history-container').evaluate((element) => {
+            const container = element as HTMLDivElement;
+            container.scrollTop = container.scrollHeight;
+            container.dispatchEvent(new Event('scroll', { bubbles: true }));
+
+            const containerRect = container.getBoundingClientRect();
+            const item = Array.from(
+                container.querySelectorAll<HTMLElement>('.post-history-item'),
+            ).find((candidate) => {
+                const rect = candidate.getBoundingClientRect();
+                return rect.bottom > containerRect.top + 1 && rect.top < containerRect.bottom - 1;
+            });
+            if (!item) {
+                return null;
+            }
+
+            return {
+                eventId: item.dataset.postHistoryEventId ?? '',
+                offsetTop: item.getBoundingClientRect().top - containerRect.top,
+            };
+        });
+        expect(anchorBeforeLoad).not.toBeNull();
+        await expect.poll(() => historyEventIds(page)).toEqual(expectedEventIds.slice(50, 200));
+        await expectVisiblePostCount(page, 150);
+        const shiftedWindowEventIds = await historyEventIds(page);
+        expect(new Set(shiftedWindowEventIds).size).toBe(150);
+        expect(shiftedWindowEventIds).toContain(expectedEventIds[199]);
+        for (const eventId of shiftedWindowEventIds) {
+            observedEventIds.add(eventId);
+        }
+
+        const anchorAfterLoad = await getPostSnapshotByEventId(page, anchorBeforeLoad!.eventId);
+        if (anchorAfterLoad) {
+            expect(anchorAfterLoad.eventId).toBe(anchorBeforeLoad!.eventId);
+            expect(Math.abs(anchorAfterLoad.offsetTop - anchorBeforeLoad!.offsetTop)).toBeLessThanOrEqual(1);
+        }
+        await expectHistoryIsNotAtBottom(page);
+
+        await waitForIntersectionObserverSettle(page);
+        expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(50, 200));
+
+        await scrollHistoryToBottom(page);
+        await expect.poll(() => historyEventIds(page)).toEqual(expectedEventIds.slice(100, 250));
+        await expectVisiblePostCount(page, 150);
+        for (const eventId of await historyEventIds(page)) {
+            observedEventIds.add(eventId);
+        }
+        await expect(page.locator('.post-history-auto-load-sentinel')).toBeVisible();
+        await waitForIntersectionObserverSettle(page);
+        expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(100, 250));
+
+        await scrollHistoryToBottom(page);
+        await expect.poll(() => historyEventIds(page)).toEqual(expectedEventIds.slice(101));
+        await expectVisiblePostCount(page, 150);
+        for (const eventId of await historyEventIds(page)) {
+            observedEventIds.add(eventId);
+        }
+        await expect(page.locator('.post-history-auto-load-sentinel')).toHaveCount(0);
+
+        expect(observedEventIds).toEqual(new Set(expectedEventIds));
+        await scrollHistoryToBottom(page);
+        await waitForIntersectionObserverSettle(page);
+        expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(101));
+        await expect(page.getByText(harness.infiniteScrollOldestPostContent, { exact: true })).toBeVisible();
+    });
+
     test('desktop timeline browsing flow works in a real browser', async ({ page, isMobile }) => {
         test.skip(isMobile, 'desktop only');
 
@@ -487,7 +622,8 @@ test.describe('PostHistoryDialog Playwright', () => {
         expect(dialogBox).not.toBeNull();
         expect(dialogBox!.width).toBeLessThanOrEqual((viewport?.width ?? 0) - 16);
 
-        await page.getByRole('button', { name: 'さらに古い投稿を表示' }).click();
+        await expect(page.getByRole('button', { name: 'さらに古い投稿を表示' })).toHaveCount(0);
+        await scrollHistoryToBottom(page);
         await expectSummary(page, harness.totalPosts);
         await expectVisiblePostCount(page, harness.totalPosts);
         await scrollPostIntoView(page, harness.scrollTargetContent);
@@ -532,7 +668,8 @@ test.describe('PostHistoryDialog Playwright', () => {
         await expect(page.getByRole('searchbox', { name: '検索' })).toHaveCount(0);
         await expectSummary(page, harness.totalPosts);
         await expectVisiblePostCount(page, 50);
-        await expect(page.getByRole('button', { name: 'さらに古い投稿を表示' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'さらに古い投稿を表示' })).toHaveCount(0);
+        await expect(page.locator('.post-history-auto-load-sentinel')).toBeVisible();
         await expect(page.getByRole('button', { name: 'さらに古い検索結果を表示' })).toHaveCount(0);
     });
 

--- a/src/test/unit/playwrightWorktreePort.test.ts
+++ b/src/test/unit/playwrightWorktreePort.test.ts
@@ -135,6 +135,7 @@ describe('Playwright config connection values', () => {
                 '**/webComponentLite.spec.ts',
                 '**/webComponentParentClientExample.spec.ts',
                 '**/postEditorSending.spec.ts',
+                '**/postHistoryDialog.spec.ts',
             ]);
         } finally {
             if (originalPortOverride === undefined) {


### PR DESCRIPTION
## 変更概要

通常のローカル投稿履歴を末尾到達で1 chunkずつ追加表示できるようにしました。150件到達後もDOM件数を維持したまま、表示windowを古い方向へ進めます。

## 主な実装内容

- dialog局所の IntersectionObserver を scroll container root で監視し、exit確認後の再到達だけを再arm
- 読込前後に既存 history viewport の scroll anchor を capture/restore し、browser scroll anchoring は無効化
- 最終chunkで hasOlderLocal を確定して sentinel を終了
- 検索・sparse・relay過去取得の既存明示操作は維持
- 251件fixtureのE2Eで bounded window、anchor、非連鎖、全event ID到達を検証
- mobile WebKit に post history E2E を追加

## 検証結果

- npm test: 342 passed, 1 skipped (3957 passed, 1 skipped)
- npm run check: 0 errors, 0 warnings
- npm run build: passed
- postHistoryDialog.spec.ts: desktop Chromium、mobile Chromium、mobile WebKitで実行。mobile各14 passed, 8 skipped。新規無限スクロールケースは3 browser projectでpassed。

## 未実行の検証

- なし