### PR TITLE
Fix post history infinite scroll jank

### DIFF
--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -884,6 +884,7 @@
             const changed = await history.loadOlder();
             if (changed && show) {
                 await tick();
+                await previewCollapse.flushPendingMeasurements();
                 historyViewport.restoreHistoryScrollAnchor(scrollAnchor);
             }
         } finally {

--- a/src/lib/hooks/usePostHistoryDialogViewport.svelte.ts
+++ b/src/lib/hooks/usePostHistoryDialogViewport.svelte.ts
@@ -224,6 +224,15 @@ export function usePostHistoryDialogViewport({
                 : formatPostHistoryMonthLabel(postedAt, getLocale());
     }
 
+    function updateCurrentMonthLabelImmediately(): void {
+        // A scroll anchor is meaningful only after the heading has its final
+        // scroll-dependent height. Cancel the already-scheduled frame rather
+        // than letting it change the heading after the anchor is restored.
+        cancelCurrentMonthLabelFrame();
+        updateCurrentMonthLabel();
+        flushSync();
+    }
+
     function cancelCurrentMonthLabelFrame(): void {
         if (historyMonthLabelFrameId === null) {
             return;
@@ -248,6 +257,14 @@ export function usePostHistoryDialogViewport({
     function handleHistoryScroll(): void {
         updateHistoryScrolledToTop();
         updateHistoryScrolledToBottom();
+        if (isHistoryScrolledToBottom) {
+            // The auto-load path captures its anchor immediately after the
+            // bottom sentinel becomes visible. Settle the heading geometry in
+            // the same scroll turn, rather than changing it after that anchor
+            // has been captured.
+            updateCurrentMonthLabelImmediately();
+            return;
+        }
         scheduleCurrentMonthLabelUpdate();
     }
 

--- a/src/lib/hooks/usePostHistoryListing.svelte.ts
+++ b/src/lib/hooks/usePostHistoryListing.svelte.ts
@@ -2527,6 +2527,13 @@ export function usePostHistoryListing({
         if (mergedResult.didDeferOlderPosts) {
             state.hasOlderLocal = true;
         }
+        if (mergedResult.didTrimForOlderAppend) {
+            // The bounded window just discarded known local posts from its
+            // newer side. Publish that availability before the caller restores
+            // the scroll anchor; the background confirmation must not insert
+            // the newer-navigation control afterwards and move the anchor.
+            state.hasNewerLocal = true;
+        }
         const newlyVisibleCount = newlyVisibleOlderPosts.length;
         if (progressAfterQuery) {
             contiguousProgress = {
@@ -2559,11 +2566,16 @@ export function usePostHistoryListing({
                 clearContiguousProgress();
             }
         }
+        const canDeriveOlderAvailability = useContiguousProgress
+            && progressAfterQuery !== null
+            && contiguousProgress !== null;
         const hasReachedVisibleEnd = !!contiguousProgress
             && contiguousProgress.reachedVisibleCount >=
                 contiguousProgress.totalVisibleCount;
-        if (hasReachedVisibleEnd) {
-            state.hasOlderLocal = false;
+        if (canDeriveOlderAvailability && contiguousProgress) {
+            state.hasOlderLocal =
+                contiguousProgress.totalVisibleCount
+                > contiguousProgress.reachedVisibleCount;
         }
         if (metrics) {
             metrics.loadedPostsAfterLength = mergedResult.posts.length;
@@ -2574,6 +2586,16 @@ export function usePostHistoryListing({
             metrics.didTrimForOlderAppend = mergedResult.didTrimForOlderAppend;
             metrics.didDeferOlderPosts = mergedResult.didDeferOlderPosts;
         }
+        if (canDeriveOlderAvailability) {
+            void refreshTimelineAvailability(
+                pubkeyHex,
+                mergedResult.posts,
+                requestId,
+                { skipOlderCheck: true },
+            ).catch(() => undefined);
+            return true;
+        }
+
         await refreshTimelineAvailability(
             pubkeyHex,
             mergedResult.posts,

--- a/src/lib/hooks/usePostHistoryPreviewCollapse.svelte.ts
+++ b/src/lib/hooks/usePostHistoryPreviewCollapse.svelte.ts
@@ -27,6 +27,13 @@ export function usePostHistoryPreviewCollapse<
     let expandedPosts = $state<Record<string, boolean>>({});
     let postPreviewElements: Record<string, HTMLElement | null> = {};
     let resizeObserver: ResizeObserver | null = null;
+    let observedPostInputs = new Map<
+        string,
+        Pick<PreviewCollapseItem, "content" | "forceCollapsible">
+    >();
+    let dirtyPostEventIds = new Set<string>();
+    let measureAllVisiblePreviews = false;
+    let scheduledMeasurement: Promise<void> | null = null;
 
     function getLineHeight(element: HTMLElement): number {
         const style = getComputedStyle(element);
@@ -42,7 +49,7 @@ export function usePostHistoryPreviewCollapse<
 
     function previewRef(node: HTMLElement, eventId: string) {
         postPreviewElements[eventId] = node;
-        void measureCollapsiblePosts();
+        void requestMeasurement(eventId);
 
         return {
             destroy() {
@@ -53,18 +60,50 @@ export function usePostHistoryPreviewCollapse<
         };
     }
 
-    async function measureCollapsiblePosts(): Promise<void> {
-        await tick();
-
-        if (!getShow()) {
-            collapsiblePosts = {};
+    function replaceCollapsiblePosts(
+        nextCollapsiblePosts: Record<string, boolean>,
+    ): void {
+        const currentEventIds = Object.keys(collapsiblePosts);
+        const nextEventIds = Object.keys(nextCollapsiblePosts);
+        if (
+            currentEventIds.length === nextEventIds.length
+            && currentEventIds.every(
+                (eventId) =>
+                    collapsiblePosts[eventId]
+                    === nextCollapsiblePosts[eventId],
+            )
+        ) {
             return;
         }
 
+        collapsiblePosts = nextCollapsiblePosts;
+    }
+
+    function measureRequestedPreviews(): void {
+        if (!getShow()) {
+            dirtyPostEventIds.clear();
+            measureAllVisiblePreviews = false;
+            replaceCollapsiblePosts({});
+            return;
+        }
+
+        const posts = getPosts();
+        const dirtyEventIds = dirtyPostEventIds;
+        const measureAll = measureAllVisiblePreviews;
+        dirtyPostEventIds = new Set();
+        measureAllVisiblePreviews = false;
         const nextCollapsiblePosts: Record<string, boolean> = {};
 
-        for (const post of getPosts()) {
+        for (const post of posts) {
             if (post.forceCollapsible) {
+                continue;
+            }
+
+            if (!measureAll && !dirtyEventIds.has(post.eventId)) {
+                const existingResult = collapsiblePosts[post.eventId];
+                if (existingResult !== undefined) {
+                    nextCollapsiblePosts[post.eventId] = existingResult;
+                }
                 continue;
             }
 
@@ -81,7 +120,39 @@ export function usePostHistoryPreviewCollapse<
                 : post.content.split("\n").length > maxLines;
         }
 
-        collapsiblePosts = nextCollapsiblePosts;
+        replaceCollapsiblePosts(nextCollapsiblePosts);
+    }
+
+    function scheduleMeasurement(): Promise<void> {
+        if (scheduledMeasurement) {
+            return scheduledMeasurement;
+        }
+
+        scheduledMeasurement = tick().then(() => {
+            scheduledMeasurement = null;
+            measureRequestedPreviews();
+        });
+        return scheduledMeasurement;
+    }
+
+    function requestMeasurement(eventId?: string): Promise<void> {
+        if (eventId) {
+            dirtyPostEventIds.add(eventId);
+        } else {
+            measureAllVisiblePreviews = true;
+        }
+
+        return scheduleMeasurement();
+    }
+
+    async function flushPendingMeasurements(): Promise<void> {
+        const pendingMeasurement = scheduledMeasurement;
+        if (!pendingMeasurement) {
+            return;
+        }
+
+        await pendingMeasurement;
+        await tick();
     }
 
     function setupResizeObserver(): void {
@@ -95,7 +166,7 @@ export function usePostHistoryPreviewCollapse<
         }
 
         resizeObserver = new ResizeObserver(() => {
-            void measureCollapsiblePosts();
+            void requestMeasurement();
         });
         resizeObserver.observe(historyContainer);
     }
@@ -106,9 +177,12 @@ export function usePostHistoryPreviewCollapse<
     }
 
     function resetState(): void {
-        collapsiblePosts = {};
+        replaceCollapsiblePosts({});
         expandedPosts = {};
         postPreviewElements = {};
+        observedPostInputs.clear();
+        dirtyPostEventIds.clear();
+        measureAllVisiblePreviews = false;
         disposeResizeObserver();
     }
 
@@ -141,8 +215,28 @@ export function usePostHistoryPreviewCollapse<
             return;
         }
 
-        getPosts();
-        void measureCollapsiblePosts();
+        const posts = getPosts();
+        const nextObservedPostInputs = new Map<
+            string,
+            Pick<PreviewCollapseItem, "content" | "forceCollapsible">
+        >();
+        for (const post of posts) {
+            const nextInput = {
+                content: post.content,
+                forceCollapsible: post.forceCollapsible,
+            };
+            const previousInput = observedPostInputs.get(post.eventId);
+            if (
+                previousInput?.content !== nextInput.content
+                || previousInput.forceCollapsible !== nextInput.forceCollapsible
+            ) {
+                dirtyPostEventIds.add(post.eventId);
+            }
+            nextObservedPostInputs.set(post.eventId, nextInput);
+        }
+        observedPostInputs = nextObservedPostInputs;
+
+        void scheduleMeasurement();
     });
 
     $effect(() => {
@@ -162,8 +256,9 @@ export function usePostHistoryPreviewCollapse<
 
     return {
         previewRef,
+        flushPendingMeasurements,
         isPostExpanded,
-        remeasure: measureCollapsiblePosts,
+        remeasure: () => requestMeasurement(),
         togglePostExpanded,
         shouldCollapsePost,
     };

--- a/src/lib/hooks/usePostHistoryThreadGraph.svelte.ts
+++ b/src/lib/hooks/usePostHistoryThreadGraph.svelte.ts
@@ -43,6 +43,7 @@ import {
 } from "../storage/postHistoryDeletionRequestsRepository";
 import {
     postHistoryDirectReplyFetchMetadataRepository,
+    type PostHistoryDirectReplyFetchMetadata,
     type PostHistoryDirectReplyFetchMetadataRepository,
 } from "../storage/postHistoryDirectReplyFetchMetadataRepository";
 import { parsePostHistoryThreadReferences } from "../postHistoryNip10Utils";
@@ -165,7 +166,7 @@ interface UsePostHistoryThreadGraphParams {
     childInteractionsRepositoryImpl?: Pick<
         PostHistoryChildInteractionsRepository,
         "upsertChildInteractions" | "deleteChildInteractionByEventId"
-    >;
+    > & Partial<Pick<PostHistoryChildInteractionsRepository, "getChildInteractionsForParents">>;
     deletionRequestsRepositoryImpl?: Pick<
         PostHistoryDeletionRequestsRepository,
         "getDeletedTargets" | "upsertValidDeletionRequests"
@@ -173,7 +174,7 @@ interface UsePostHistoryThreadGraphParams {
     directReplyFetchMetadataRepositoryImpl?: Pick<
         PostHistoryDirectReplyFetchMetadataRepository,
         "get" | "save"
-    >;
+    > & Partial<Pick<PostHistoryDirectReplyFetchMetadataRepository, "getForParentEventIds">>;
     profileSyncCoordinator?: PostHistoryProfileSyncCoordinator;
     contextFetchService?: Pick<PostHistoryContextFetchService, "fetchEventById">;
     replyFetchService?: Pick<PostHistoryReplyFetchService, "fetchDirectReplies">;
@@ -2099,12 +2100,29 @@ export function usePostHistoryThreadGraph({
         return true;
     }
 
-    function preloadCachedReactionSummaryForParent(
-        parentEventId: string,
-        cachedRecords: PostHistoryChildInteractionRecord[],
-    ): void {
-        setReactionSummary(parentEventId, cachedRecords);
-        setReactionRecords(parentEventId, cachedRecords);
+    function groupCachedChildInteractionRecords(
+        records: PostHistoryChildInteractionRecord[],
+        parentEventIds: string[],
+    ): Map<string, PostHistoryChildInteractionRecord[]> {
+        const targetParentIds = new Set(parentEventIds);
+        const recordsByParentId = new Map<string, PostHistoryChildInteractionRecord[]>();
+        for (const record of records) {
+            if (!targetParentIds.has(record.parentEventId)) {
+                continue;
+            }
+            const parentRecords = recordsByParentId.get(record.parentEventId) ?? [];
+            parentRecords.push(record);
+            recordsByParentId.set(record.parentEventId, parentRecords);
+        }
+        for (const parentRecords of recordsByParentId.values()) {
+            parentRecords.sort((left, right) => {
+                if (left.createdAt !== right.createdAt) {
+                    return left.createdAt - right.createdAt;
+                }
+                return left.eventId.localeCompare(right.eventId);
+            });
+        }
+        return recordsByParentId;
     }
 
     function markEmptyChildrenIncompleteIfNeeded(input: {
@@ -2127,58 +2145,180 @@ export function usePostHistoryThreadGraph({
         return true;
     }
 
-    async function preloadCachedDirectReplyStateForParent(input: {
-        post: PostHistoryRecord;
-        parentEventId: string;
-        cachedRecords: PostHistoryChildInteractionRecord[];
-        anchorNode: PostHistoryThreadGraphNode;
-        ensureActive: () => boolean;
-    }): Promise<void> {
-        const { metadata, readFailed } = await readDirectReplyFetchMetadata(
-            input.parentEventId,
-        );
+    function applyCachedChildInteractionStateBatch(input: {
+        postsByParentId: Map<string, PostHistoryRecord>;
+        targetParentIds: string[];
+        anchorNodesByParentId: Map<string, PostHistoryThreadGraphNode>;
+        reactionRecordsByParentId: Map<string, PostHistoryChildInteractionRecord[]>;
+        directReplyRecordsByParentId: Map<string, PostHistoryChildInteractionRecord[]>;
+        metadataByParentId: Map<string, PostHistoryDirectReplyFetchMetadata>;
+        cachedReactionProfilesByPubkey: Record<string, ProfileData | null>;
+        knownNodeProfilesByPubkey: Map<string, ProfileData | null>;
+    }): void {
+        const nextNodesById = { ...nodesById };
+        const nextParentByChildId = { ...parentByChildId };
+        const nextChildrenByParentId = { ...childrenByParentId };
+        const nextExpansionByAnchorNodeKey = { ...expansionByAnchorNodeKey };
+        const nextReactionSummaryByParentId = { ...reactionSummaryByParentId };
+        const nextReactionRecordsByParentId = { ...reactionRecordsByParentId };
+        const nextReactionProfilesByPubkey = { ...reactionProfilesByPubkey };
+        const nextReactionReadModelByParentId = { ...reactionReadModelByParentId };
+        let nodesChanged = false;
+        let parentEdgesChanged = false;
+        let childrenChanged = false;
+        let expansionsChanged = false;
+        const childIdsByParentId = new Map<string, string[]>();
 
-        const cachedDirectReplies = input.cachedRecords.filter(
-            (record) => record.kind === 1 || record.kind === 42,
-        );
-        if (cachedDirectReplies.length === 0 && !metadata) {
-            return;
+        const upsertDraftNode = (nextNode: PostHistoryThreadGraphNode) => {
+            const mergedNode = mergeThreadGraphNode(
+                nextNodesById[nextNode.eventId],
+                nextNode,
+            );
+            nextNodesById[mergedNode.eventId] = mergedNode;
+            nodesChanged = true;
+            return mergedNode;
+        };
+        const upsertDraftParentEdge = (
+            childEventId: string,
+            parentEventId: string | null,
+        ) => {
+            if (!parentEventId) {
+                return;
+            }
+            nextParentByChildId[childEventId] = parentEventId;
+            parentEdgesChanged = true;
+        };
+
+        for (const parentEventId of input.targetParentIds) {
+            const anchorNode = input.anchorNodesByParentId.get(parentEventId);
+            if (!anchorNode) {
+                continue;
+            }
+            const mergedAnchorNode = upsertDraftNode(anchorNode);
+            upsertDraftParentEdge(
+                mergedAnchorNode.eventId,
+                mergedAnchorNode.parentEventId,
+            );
+
+            const reactionRecords = input.reactionRecordsByParentId.get(parentEventId) ?? [];
+            nextReactionSummaryByParentId[parentEventId] =
+                summarizePostHistoryReactionRecords(reactionRecords);
+            nextReactionRecordsByParentId[parentEventId] = reactionRecords;
         }
 
-        const acceptedRecords = await upsertReplyRecords(
-            input.anchorNode,
-            cachedDirectReplies,
-            ["reply-db", "inbound-sync"],
-            {
-                resolveProfiles: false,
-            },
-        );
-        if (!input.ensureActive() || (acceptedRecords.length === 0 && !metadata)) {
-            return;
-        }
-        if (
-            metadata?.completeness === "partial"
-            && markEmptyChildrenIncompleteIfNeeded({
-                anchorEventId: input.post.eventId,
-                nodeEventId: input.parentEventId,
-                effectiveFetchedAt: null,
-                replyCount: acceptedRecords.length,
-            })
-        ) {
-            return;
+        for (const [pubkey, profile] of Object.entries(
+            input.cachedReactionProfilesByPubkey,
+        )) {
+            nextReactionProfilesByPubkey[pubkey] = profile;
         }
 
-        const cachedFetchedAt = readFailed
-            ? null
-            : metadata
-                ? resolveEffectiveDirectReplyFetchedAt(metadata)
-                : resolveCachedReplyFetchedAt(acceptedRecords);
-        updateExpansion(input.post.eventId, input.parentEventId, (state) => ({
-            ...buildChildrenLoadedExpansionState(state, {
-                lastFetchedChildrenAt: cachedFetchedAt,
-            }),
-        }));
-        refreshProfileForPubkeyInBackground(input.anchorNode.authorPubkey, input.anchorNode.relayUrls);
+        for (const parentEventId of input.targetParentIds) {
+            const anchorNode = input.anchorNodesByParentId.get(parentEventId);
+            if (!anchorNode) {
+                continue;
+            }
+            const acceptedRecords: PostHistoryChildInteractionRecord[] = [];
+            const childEventIds: string[] = [];
+            for (const record of input.directReplyRecordsByParentId.get(parentEventId) ?? []) {
+                const event = toEventFromReplyRecord(record);
+                if (isDeletedEvent(event.pubkey, event.id)) {
+                    continue;
+                }
+                const childNode = upsertDraftNode(buildThreadGraphNode({
+                    event,
+                    relayUrls: sanitizeRelayUrls(record.relayUrls),
+                    sources: ["reply-db", "inbound-sync"],
+                }));
+                if (childNode.eventId === parentEventId) {
+                    continue;
+                }
+                upsertDraftParentEdge(childNode.eventId, parentEventId);
+                childEventIds.push(childNode.eventId);
+                acceptedRecords.push(record);
+            }
+            childIdsByParentId.set(parentEventId, childEventIds);
+
+            const metadata = input.metadataByParentId.get(parentEventId) ?? null;
+            if (acceptedRecords.length === 0 && !metadata) {
+                continue;
+            }
+            const post = input.postsByParentId.get(parentEventId);
+            if (!post) {
+                continue;
+            }
+            const expansionKey = buildAnchorNodeKey(post.eventId, parentEventId);
+            const currentExpansion = nextExpansionByAnchorNodeKey[expansionKey]
+                ?? buildInitialExpansionState();
+            nextExpansionByAnchorNodeKey[expansionKey] =
+                metadata?.completeness === "partial" && acceptedRecords.length === 0
+                    ? {
+                        ...currentExpansion,
+                        loadedChildren: false,
+                        loadingChildren: false,
+                        revalidatingChildren: false,
+                        childrenError: null,
+                        lastFetchedChildrenAt: null,
+                    }
+                    : buildChildrenLoadedExpansionState(currentExpansion, {
+                        lastFetchedChildrenAt: metadata
+                            ? resolveEffectiveDirectReplyFetchedAt(metadata)
+                            : resolveCachedReplyFetchedAt(acceptedRecords),
+                    });
+            expansionsChanged = true;
+        }
+
+        for (const [parentEventId, childEventIds] of childIdsByParentId) {
+            const currentChildEventIds = nextChildrenByParentId[parentEventId] ?? [];
+            nextChildrenByParentId[parentEventId] = sortEventIdsByEvent(
+                uniqueEventIds([...currentChildEventIds, ...childEventIds]).filter(
+                    (eventId) =>
+                        eventId !== parentEventId
+                        && !isDeletedNodeEventId(eventId),
+                ),
+                nextNodesById,
+            );
+            childrenChanged = true;
+        }
+
+        for (const [pubkey, profile] of input.knownNodeProfilesByPubkey) {
+            if (!profile) {
+                continue;
+            }
+            for (const [eventId, node] of Object.entries(nextNodesById)) {
+                if (node.authorPubkey === pubkey) {
+                    nextNodesById[eventId] = mergeThreadGraphNode(node, {
+                        ...node,
+                        profile,
+                    });
+                    nodesChanged = true;
+                }
+            }
+        }
+
+        for (const parentEventId of input.targetParentIds) {
+            nextReactionReadModelByParentId[parentEventId] =
+                buildPostHistoryReactionReadModel(
+                    nextReactionRecordsByParentId[parentEventId] ?? [],
+                    nextReactionProfilesByPubkey,
+                );
+        }
+
+        if (nodesChanged) {
+            nodesById = nextNodesById;
+        }
+        if (parentEdgesChanged) {
+            parentByChildId = nextParentByChildId;
+        }
+        if (childrenChanged) {
+            childrenByParentId = nextChildrenByParentId;
+        }
+        if (expansionsChanged) {
+            expansionByAnchorNodeKey = nextExpansionByAnchorNodeKey;
+        }
+        reactionSummaryByParentId = nextReactionSummaryByParentId;
+        reactionRecordsByParentId = nextReactionRecordsByParentId;
+        reactionProfilesByPubkey = nextReactionProfilesByPubkey;
+        reactionReadModelByParentId = nextReactionReadModelByParentId;
     }
 
     async function loadCachedChildInteractionStateForPosts(
@@ -2202,10 +2342,10 @@ export function usePostHistoryThreadGraph({
             items: targetParentIds,
             isActive: () => activeRequestId === taskTracker.getRequestId() && getShow(),
             run: async ({ ensureActive }) => {
-                for (const parentEventId of targetParentIds) {
+                const preloadTargets = targetParentIds.flatMap((parentEventId) => {
                     const post = postByEventId.get(parentEventId);
                     if (!post || !ensureActive()) {
-                        continue;
+                        return [];
                     }
 
                     const preloadKey = buildAnchorNodeKey(post.eventId, parentEventId);
@@ -2220,64 +2360,161 @@ export function usePostHistoryThreadGraph({
                         )
                     ) {
                         replyBadgePreloadKeys.add(preloadKey);
-                        continue;
+                        return [];
                     }
 
                     replyBadgePreloadKeys.add(preloadKey);
-
-                    const anchorNode = ensureAnchorNode(post);
-                    const [rawCachedReactionRecords, rawCachedDirectReplyRecords] = await Promise.all([
-                        selectPostHistoryReactionRecords(parentEventId, reactionRecordsAdapterImpl),
-                        directReplyRecordsAdapterImpl.getDirectReplyRecords(parentEventId),
-                    ]);
-                    if (!ensureActive()) {
-                        continue;
-                    }
-
-                    const [cachedReactionRecords, cachedDirectReplyRecords] = await Promise.all([
-                        filterVisibleReplyRecords(rawCachedReactionRecords),
-                        filterVisibleReplyRecords(rawCachedDirectReplyRecords),
-                    ]);
-                    if (!ensureActive()) {
-                        continue;
-                    }
-
-                    preloadCachedReactionSummaryForParent(parentEventId, cachedReactionRecords);
-
-                    const reactionAuthorPubkeys = Array.from(new Set(
-                        cachedReactionRecords
-                            .map((record) => record.authorPubkey)
-                            .filter((pubkey): pubkey is string => !!pubkey),
-                    ));
-                    if (reactionAuthorPubkeys.length > 0) {
-                        const cachedProfilesByPubkey = await profileMetadataCache.getProfiles(
-                            reactionAuthorPubkeys,
-                            {
-                                allowBackgroundRefresh: false,
-                            },
-                        );
-                        if (!ensureActive()) {
-                            continue;
-                        }
-
-                        for (const pubkey of reactionAuthorPubkeys) {
-                            const profile = cachedProfilesByPubkey[pubkey] ?? null;
-                            setReactionProfile(pubkey, profile);
-                            refreshProfileForPubkeyInBackground(
-                                pubkey,
-                                anchorNode.relayUrls,
-                            );
-                        }
-                    }
-
-                    await preloadCachedDirectReplyStateForParent({
-                        post,
-                        parentEventId,
-                        cachedRecords: cachedDirectReplyRecords,
-                        anchorNode,
-                        ensureActive,
-                    });
+                    return [{ parentEventId, post }];
+                });
+                if (preloadTargets.length === 0 || !ensureActive()) {
+                    return;
                 }
+
+                const preloadParentIds = preloadTargets.map(
+                    ({ parentEventId }) => parentEventId,
+                );
+                const rawCachedRecords = childInteractionsRepositoryImpl
+                    .getChildInteractionsForParents
+                    ? await childInteractionsRepositoryImpl
+                        .getChildInteractionsForParents(preloadParentIds)
+                    : (
+                        await Promise.all(preloadParentIds.map(async (parentEventId) => {
+                            const [reactionRecords, directReplyRecords] = await Promise.all([
+                                selectPostHistoryReactionRecords(
+                                    parentEventId,
+                                    reactionRecordsAdapterImpl,
+                                ),
+                                directReplyRecordsAdapterImpl.getDirectReplyRecords(parentEventId),
+                            ]);
+                            return [...reactionRecords, ...directReplyRecords];
+                        }))
+                    ).flat();
+                if (!ensureActive()) {
+                    return;
+                }
+
+                let metadataRecords: PostHistoryDirectReplyFetchMetadata[] = [];
+                try {
+                    metadataRecords = directReplyFetchMetadataRepositoryImpl
+                        .getForParentEventIds
+                        ? await directReplyFetchMetadataRepositoryImpl
+                            .getForParentEventIds(preloadParentIds)
+                        : (
+                            await Promise.all(preloadParentIds.map((parentEventId) =>
+                                readDirectReplyFetchMetadata(parentEventId),
+                            ))
+                        ).flatMap(({ metadata, readFailed }) =>
+                            !readFailed && metadata ? [metadata] : [],
+                        );
+                } catch {
+                    metadataRecords = [];
+                }
+                if (!ensureActive()) {
+                    return;
+                }
+
+                const visibleRecordsByParentId = groupCachedChildInteractionRecords(
+                    await filterVisibleReplyRecords(rawCachedRecords),
+                    preloadParentIds,
+                );
+                if (!ensureActive()) {
+                    return;
+                }
+
+                const anchorNodesByParentId = new Map(
+                    preloadTargets.map(({ parentEventId, post }) => [
+                        parentEventId,
+                        buildAnchorNodeFromPost(post),
+                    ]),
+                );
+                const reactionRecordsByParentId = new Map<
+                    string,
+                    PostHistoryChildInteractionRecord[]
+                >();
+                const directReplyRecordsByParentId = new Map<
+                    string,
+                    PostHistoryChildInteractionRecord[]
+                >();
+                const invalidDirectReplyRecordIds: string[] = [];
+                const reactionAuthorPubkeys = new Set<string>();
+                const profileRelayUrlsByPubkey = new Map<string, string[]>();
+                const rememberProfileRelayUrls = (pubkey: string, relayUrls: string[]) => {
+                    profileRelayUrlsByPubkey.set(pubkey, sanitizeRelayUrls([
+                        ...(profileRelayUrlsByPubkey.get(pubkey) ?? []),
+                        ...relayUrls,
+                    ]));
+                };
+
+                for (const parentEventId of preloadParentIds) {
+                    const anchorNode = anchorNodesByParentId.get(parentEventId);
+                    if (!anchorNode) {
+                        continue;
+                    }
+                    rememberProfileRelayUrls(anchorNode.authorPubkey, anchorNode.relayUrls);
+                    const reactionRecords: PostHistoryChildInteractionRecord[] = [];
+                    const directReplyRecords: PostHistoryChildInteractionRecord[] = [];
+                    for (const record of visibleRecordsByParentId.get(parentEventId) ?? []) {
+                        if (record.kind === 7) {
+                            reactionRecords.push(record);
+                            if (record.authorPubkey) {
+                                reactionAuthorPubkeys.add(record.authorPubkey);
+                                rememberProfileRelayUrls(record.authorPubkey, anchorNode.relayUrls);
+                            }
+                        } else if (record.kind === 1 || record.kind === 42) {
+                            if (!isValidPostHistoryCachedDirectReply({
+                                parentNode: anchorNode,
+                                record,
+                            })) {
+                                invalidDirectReplyRecordIds.push(record.eventId);
+                            } else {
+                                directReplyRecords.push(record);
+                                rememberProfileRelayUrls(record.authorPubkey, record.relayUrls);
+                            }
+                        }
+                    }
+                    reactionRecordsByParentId.set(parentEventId, reactionRecords);
+                    directReplyRecordsByParentId.set(parentEventId, directReplyRecords);
+                }
+
+                if (invalidDirectReplyRecordIds.length > 0) {
+                    await Promise.all(invalidDirectReplyRecordIds.map((eventId) =>
+                        childInteractionsRepositoryImpl.deleteChildInteractionByEventId(eventId),
+                    ));
+                    if (!ensureActive()) {
+                        return;
+                    }
+                }
+
+                const cachedReactionProfilesByPubkey = reactionAuthorPubkeys.size > 0
+                    ? await profileMetadataCache.getProfiles(
+                        Array.from(reactionAuthorPubkeys),
+                        { allowBackgroundRefresh: false },
+                    )
+                    : {};
+                if (!ensureActive()) {
+                    return;
+                }
+
+                const knownNodeProfilesByPubkey = new Map<string, ProfileData | null>();
+                for (const [pubkey, relayUrls] of profileRelayUrlsByPubkey) {
+                    knownNodeProfilesByPubkey.set(
+                        pubkey,
+                        profileSync.ensureProfile(pubkey, relayUrls),
+                    );
+                }
+
+                applyCachedChildInteractionStateBatch({
+                    postsByParentId: postByEventId,
+                    targetParentIds: preloadParentIds,
+                    anchorNodesByParentId,
+                    reactionRecordsByParentId,
+                    directReplyRecordsByParentId,
+                    metadataByParentId: new Map(
+                        metadataRecords.map((metadata) => [metadata.parentEventId, metadata]),
+                    ),
+                    cachedReactionProfilesByPubkey,
+                    knownNodeProfilesByPubkey,
+                });
             },
         });
     }

--- a/src/lib/hooks/usePostHistoryThreadGraph.svelte.ts
+++ b/src/lib/hooks/usePostHistoryThreadGraph.svelte.ts
@@ -2152,6 +2152,7 @@ export function usePostHistoryThreadGraph({
         reactionRecordsByParentId: Map<string, PostHistoryChildInteractionRecord[]>;
         directReplyRecordsByParentId: Map<string, PostHistoryChildInteractionRecord[]>;
         metadataByParentId: Map<string, PostHistoryDirectReplyFetchMetadata>;
+        metadataReadFailedParentIds: Set<string>;
         cachedReactionProfilesByPubkey: Record<string, ProfileData | null>;
         knownNodeProfilesByPubkey: Map<string, ProfileData | null>;
     }): void {
@@ -2239,6 +2240,7 @@ export function usePostHistoryThreadGraph({
             childIdsByParentId.set(parentEventId, childEventIds);
 
             const metadata = input.metadataByParentId.get(parentEventId) ?? null;
+            const metadataReadFailed = input.metadataReadFailedParentIds.has(parentEventId);
             if (acceptedRecords.length === 0 && !metadata) {
                 continue;
             }
@@ -2260,9 +2262,11 @@ export function usePostHistoryThreadGraph({
                         lastFetchedChildrenAt: null,
                     }
                     : buildChildrenLoadedExpansionState(currentExpansion, {
-                        lastFetchedChildrenAt: metadata
-                            ? resolveEffectiveDirectReplyFetchedAt(metadata)
-                            : resolveCachedReplyFetchedAt(acceptedRecords),
+                        lastFetchedChildrenAt: metadataReadFailed
+                            ? null
+                            : metadata
+                                ? resolveEffectiveDirectReplyFetchedAt(metadata)
+                                : resolveCachedReplyFetchedAt(acceptedRecords),
                     });
             expansionsChanged = true;
         }
@@ -2394,20 +2398,27 @@ export function usePostHistoryThreadGraph({
                 }
 
                 let metadataRecords: PostHistoryDirectReplyFetchMetadata[] = [];
+                const metadataReadFailedParentIds = new Set<string>();
                 try {
-                    metadataRecords = directReplyFetchMetadataRepositoryImpl
-                        .getForParentEventIds
-                        ? await directReplyFetchMetadataRepositoryImpl
-                            .getForParentEventIds(preloadParentIds)
-                        : (
-                            await Promise.all(preloadParentIds.map((parentEventId) =>
-                                readDirectReplyFetchMetadata(parentEventId),
-                            ))
-                        ).flatMap(({ metadata, readFailed }) =>
-                            !readFailed && metadata ? [metadata] : [],
-                        );
+                    if (directReplyFetchMetadataRepositoryImpl.getForParentEventIds) {
+                        metadataRecords = await directReplyFetchMetadataRepositoryImpl
+                            .getForParentEventIds(preloadParentIds);
+                    } else {
+                        const metadataResults = await Promise.all(preloadParentIds.map(
+                            (parentEventId) => readDirectReplyFetchMetadata(parentEventId),
+                        ));
+                        metadataRecords = metadataResults.flatMap(({ metadata, readFailed }, index) => {
+                            if (readFailed) {
+                                metadataReadFailedParentIds.add(preloadParentIds[index]!);
+                                return [];
+                            }
+                            return metadata ? [metadata] : [];
+                        });
+                    }
                 } catch {
-                    metadataRecords = [];
+                    for (const parentEventId of preloadParentIds) {
+                        metadataReadFailedParentIds.add(parentEventId);
+                    }
                 }
                 if (!ensureActive()) {
                     return;
@@ -2512,6 +2523,7 @@ export function usePostHistoryThreadGraph({
                     metadataByParentId: new Map(
                         metadataRecords.map((metadata) => [metadata.parentEventId, metadata]),
                     ),
+                    metadataReadFailedParentIds,
                     cachedReactionProfilesByPubkey,
                     knownNodeProfilesByPubkey,
                 });

--- a/src/lib/postHistoryChildInteractionsAdapter.ts
+++ b/src/lib/postHistoryChildInteractionsAdapter.ts
@@ -6,10 +6,16 @@ import {
 
 export interface PostHistoryReactionRecordsAdapter {
     getReactionRecords(parentEventId: string): Promise<PostHistoryChildInteractionRecord[]>;
+    getReactionRecordsForParents?(
+        parentEventIds: string[],
+    ): Promise<PostHistoryChildInteractionRecord[]>;
 }
 
 export interface PostHistoryDirectReplyRecordsAdapter {
     getDirectReplyRecords(parentEventId: string): Promise<PostHistoryChildInteractionRecord[]>;
+    getDirectReplyRecordsForParents?(
+        parentEventIds: string[],
+    ): Promise<PostHistoryChildInteractionRecord[]>;
 }
 
 export interface PostHistoryChildInteractionsAdapter {
@@ -17,26 +23,114 @@ export interface PostHistoryChildInteractionsAdapter {
     getDirectReplyRecords(parentEventId: string): Promise<PostHistoryChildInteractionRecord[]>;
 }
 
+function sortRecordsForParent(
+    records: PostHistoryChildInteractionRecord[],
+): PostHistoryChildInteractionRecord[] {
+    return records.sort((left, right) => {
+        if (left.createdAt !== right.createdAt) {
+            return left.createdAt - right.createdAt;
+        }
+
+        return left.eventId.localeCompare(right.eventId);
+    });
+}
+
+function selectRecordsForParents(
+    records: PostHistoryChildInteractionRecord[],
+    parentEventIds: string[],
+    matches: (record: PostHistoryChildInteractionRecord) => boolean,
+): PostHistoryChildInteractionRecord[] {
+    const uniqueParentEventIds = Array.from(
+        new Set(parentEventIds.filter((eventId) => !!eventId)),
+    );
+    const recordsByParentEventId = new Map(
+        uniqueParentEventIds.map((parentEventId) => [
+            parentEventId,
+            [] as PostHistoryChildInteractionRecord[],
+        ]),
+    );
+
+    for (const record of records) {
+        if (!matches(record)) {
+            continue;
+        }
+
+        recordsByParentEventId.get(record.parentEventId)?.push(record);
+    }
+
+    return uniqueParentEventIds.flatMap((parentEventId) =>
+        sortRecordsForParent(recordsByParentEventId.get(parentEventId) ?? []),
+    );
+}
+
 export class RepositoryPostHistoryReactionRecordsAdapter implements PostHistoryReactionRecordsAdapter {
     constructor(
-        private repository: Pick<PostHistoryChildInteractionsRepository, "getChildInteractions"> =
-            postHistoryChildInteractionsRepository,
+        private repository: Pick<
+            PostHistoryChildInteractionsRepository,
+            "getChildInteractions"
+        > & Partial<Pick<
+            PostHistoryChildInteractionsRepository,
+            "getChildInteractionsForParents"
+        >> = postHistoryChildInteractionsRepository,
     ) {}
 
     async getReactionRecords(parentEventId: string): Promise<PostHistoryChildInteractionRecord[]> {
         return (await this.repository.getChildInteractions(parentEventId))
             .filter((record) => record.kind === 7);
     }
+
+    async getReactionRecordsForParents(
+        parentEventIds: string[],
+    ): Promise<PostHistoryChildInteractionRecord[]> {
+        const uniqueParentEventIds = Array.from(
+            new Set(parentEventIds.filter((eventId) => !!eventId)),
+        );
+        const records = this.repository.getChildInteractionsForParents
+            ? await this.repository.getChildInteractionsForParents(uniqueParentEventIds)
+            : (await Promise.all(uniqueParentEventIds.map((parentEventId) =>
+                this.getReactionRecords(parentEventId),
+            ))).flat();
+
+        return selectRecordsForParents(
+            records,
+            uniqueParentEventIds,
+            (record) => record.kind === 7,
+        );
+    }
 }
 
 export class RepositoryPostHistoryDirectReplyRecordsAdapter implements PostHistoryDirectReplyRecordsAdapter {
     constructor(
-        private repository: Pick<PostHistoryChildInteractionsRepository, "getDirectReplyInteractions"> =
-            postHistoryChildInteractionsRepository,
+        private repository: Pick<
+            PostHistoryChildInteractionsRepository,
+            "getDirectReplyInteractions"
+        > & Partial<Pick<
+            PostHistoryChildInteractionsRepository,
+            "getChildInteractionsForParents"
+        >> = postHistoryChildInteractionsRepository,
     ) {}
 
     async getDirectReplyRecords(parentEventId: string): Promise<PostHistoryChildInteractionRecord[]> {
         return this.repository.getDirectReplyInteractions(parentEventId);
+    }
+
+    async getDirectReplyRecordsForParents(
+        parentEventIds: string[],
+    ): Promise<PostHistoryChildInteractionRecord[]> {
+        const uniqueParentEventIds = Array.from(
+            new Set(parentEventIds.filter((eventId) => !!eventId)),
+        );
+        const records = this.repository.getChildInteractionsForParents
+            ? await this.repository.getChildInteractionsForParents(uniqueParentEventIds)
+            : (await Promise.all(uniqueParentEventIds.map((parentEventId) =>
+                this.getDirectReplyRecords(parentEventId),
+            ))).flat();
+
+        return selectRecordsForParents(
+            records,
+            uniqueParentEventIds,
+            (record) => record.kind === 1 || record.kind === 42,
+        );
     }
 }
 

--- a/src/lib/postHistoryDirectReplyLifecycleTrigger.ts
+++ b/src/lib/postHistoryDirectReplyLifecycleTrigger.ts
@@ -36,6 +36,7 @@ import {
     type SavePostHistoryDirectReplyLifecycleStateInput,
     type PostHistoryDirectReplyDeletionStateRepository,
 } from "./storage/postHistoryDirectReplyDeletionStateRepository";
+import type { PostHistoryChildInteractionRecord } from "./storage/ehagakiDb";
 import type { RelayConfig } from "./types";
 
 export interface PostHistoryDirectReplyLifecycleTriggerRequest {
@@ -60,12 +61,30 @@ function normalizeParentEventIds(parentEventIds: string[]): string[] {
 
 async function loadDirectReplyLifecycleCandidates(
     parentEventIds: string[],
-    directReplyRecordsAdapter: Pick<PostHistoryDirectReplyRecordsAdapter, "getDirectReplyRecords">,
+    directReplyRecordsAdapter: Pick<
+        PostHistoryDirectReplyRecordsAdapter,
+        "getDirectReplyRecords"
+    > & Partial<Pick<
+        PostHistoryDirectReplyRecordsAdapter,
+        "getDirectReplyRecordsForParents"
+    >>,
 ): Promise<PostHistoryDirectReplyLifecycleCandidate[]> {
     const candidates: PostHistoryDirectReplyLifecycleCandidate[] = [];
+    const recordsByParentEventId = new Map<string, PostHistoryChildInteractionRecord[]>();
+
+    if (directReplyRecordsAdapter.getDirectReplyRecordsForParents) {
+        const records = await directReplyRecordsAdapter.getDirectReplyRecordsForParents(parentEventIds);
+        for (const record of records) {
+            const parentRecords = recordsByParentEventId.get(record.parentEventId) ?? [];
+            parentRecords.push(record);
+            recordsByParentEventId.set(record.parentEventId, parentRecords);
+        }
+    }
 
     for (const parentEventId of parentEventIds) {
-        const records = await directReplyRecordsAdapter.getDirectReplyRecords(parentEventId);
+        const records = directReplyRecordsAdapter.getDirectReplyRecordsForParents
+            ? recordsByParentEventId.get(parentEventId) ?? []
+            : await directReplyRecordsAdapter.getDirectReplyRecords(parentEventId);
         for (const record of records) {
             candidates.push({
                 requestKey: buildPostHistoryDirectReplyLifecycleRequestKey(

--- a/src/lib/postHistoryReactionLifecycleTrigger.ts
+++ b/src/lib/postHistoryReactionLifecycleTrigger.ts
@@ -37,6 +37,7 @@ import {
     type SavePostHistoryReactionLifecycleStateInput,
     type PostHistoryReactionDeletionStateRepository,
 } from "./storage/postHistoryReactionDeletionStateRepository";
+import type { PostHistoryChildInteractionRecord } from "./storage/ehagakiDb";
 import type { RelayConfig } from "./types";
 
 export interface PostHistoryReactionLifecycleTriggerRequest {
@@ -61,12 +62,30 @@ function normalizeParentEventIds(parentEventIds: string[]): string[] {
 
 async function loadReactionLifecycleCandidates(
     parentEventIds: string[],
-    reactionRecordsAdapter: Pick<PostHistoryReactionRecordsAdapter, "getReactionRecords">,
+    reactionRecordsAdapter: Pick<
+        PostHistoryReactionRecordsAdapter,
+        "getReactionRecords"
+    > & Partial<Pick<
+        PostHistoryReactionRecordsAdapter,
+        "getReactionRecordsForParents"
+    >>,
 ): Promise<PostHistoryReactionLifecycleCandidate[]> {
     const candidates: PostHistoryReactionLifecycleCandidate[] = [];
+    const recordsByParentEventId = new Map<string, PostHistoryChildInteractionRecord[]>();
+
+    if (reactionRecordsAdapter.getReactionRecordsForParents) {
+        const records = await reactionRecordsAdapter.getReactionRecordsForParents(parentEventIds);
+        for (const record of records) {
+            const parentRecords = recordsByParentEventId.get(record.parentEventId) ?? [];
+            parentRecords.push(record);
+            recordsByParentEventId.set(record.parentEventId, parentRecords);
+        }
+    }
 
     for (const parentEventId of parentEventIds) {
-        const records = await reactionRecordsAdapter.getReactionRecords(parentEventId);
+        const records = reactionRecordsAdapter.getReactionRecordsForParents
+            ? recordsByParentEventId.get(parentEventId) ?? []
+            : await reactionRecordsAdapter.getReactionRecords(parentEventId);
         for (const record of records) {
             candidates.push({
                 requestKey: buildPostHistoryReactionLifecycleRequestKey(

--- a/src/lib/postHistoryVisibleRangeRelationRepairCoordinator.ts
+++ b/src/lib/postHistoryVisibleRangeRelationRepairCoordinator.ts
@@ -375,7 +375,6 @@ export function createPostHistoryVisibleRangeRelationRepairCoordinator({
         }
 
         const visibleParentEventIds = visibleParentPosts.map((post) => post.eventId);
-        requestChildInteractionBadgeRefresh(visibleParentEventIds);
 
         if (!rxNostr) {
             return;

--- a/src/lib/storage/postHistoryChildInteractionsRepository.ts
+++ b/src/lib/storage/postHistoryChildInteractionsRepository.ts
@@ -35,6 +35,7 @@ export interface UpsertPostHistoryChildInteractionsResult {
 
 export interface PostHistoryChildInteractionsRepository {
     getChildInteractions(parentEventId: string): Promise<PostHistoryChildInteractionRecord[]>;
+    getChildInteractionsForParents(parentEventIds: string[]): Promise<PostHistoryChildInteractionRecord[]>;
     getDirectReplyInteractions(parentEventId: string): Promise<PostHistoryChildInteractionRecord[]>;
     getReactionInteractions(parentEventId: string): Promise<PostHistoryChildInteractionRecord[]>;
     upsertChildInteractions(input: UpsertPostHistoryChildInteractionsInput): Promise<UpsertPostHistoryChildInteractionsResult>;
@@ -143,6 +144,22 @@ export class DexiePostHistoryChildInteractionsRepository
             .toArray();
 
         return sortRelatedEvents(records);
+    }
+
+    async getChildInteractionsForParents(
+        parentEventIds: string[],
+    ): Promise<PostHistoryChildInteractionRecord[]> {
+        const uniqueParentEventIds = Array.from(
+            new Set(parentEventIds.filter((eventId) => !!eventId)),
+        );
+        if (uniqueParentEventIds.length === 0) {
+            return [];
+        }
+
+        return this.db.postHistoryChildInteractions
+            .where("parentEventId")
+            .anyOf(uniqueParentEventIds)
+            .toArray();
     }
 
     async getDirectReplyInteractions(parentEventId: string): Promise<PostHistoryChildInteractionRecord[]> {

--- a/src/lib/storage/postHistoryDirectReplyDeletionStateRepository.ts
+++ b/src/lib/storage/postHistoryDirectReplyDeletionStateRepository.ts
@@ -163,20 +163,20 @@ implements PostHistoryDirectReplyDeletionStateRepository {
             return [];
         }
 
-        const allRecords: PostHistoryDirectReplyLifecycleStateRecord[] = [];
-        for (const parentEventId of uniqueParentEventIds) {
-            const records = await this.db.meta
-                .where("key")
-                .startsWith(buildParentPrefix(parentEventId))
-                .toArray();
-            allRecords.push(
-                ...records
-                    .map((record) => toStateRecord(record))
-                    .filter((record): record is PostHistoryDirectReplyLifecycleStateRecord => !!record),
-            );
-        }
+        const records = await this.db.meta
+            .where("key")
+            .startsWithAnyOf(
+                uniqueParentEventIds.map((parentEventId) =>
+                    buildParentPrefix(parentEventId),
+                ),
+            )
+            .toArray();
 
-        return dedupeStateRecords(allRecords);
+        return dedupeStateRecords(
+            records
+                .map((record) => toStateRecord(record))
+                .filter((record): record is PostHistoryDirectReplyLifecycleStateRecord => !!record),
+        );
     }
 
     async deleteMany(requestKeys: string[]): Promise<void> {

--- a/src/lib/storage/postHistoryDirectReplyFetchMetadataRepository.ts
+++ b/src/lib/storage/postHistoryDirectReplyFetchMetadataRepository.ts
@@ -26,6 +26,9 @@ export interface SavePostHistoryDirectReplyFetchMetadataInput {
 
 export interface PostHistoryDirectReplyFetchMetadataRepository {
     get(parentEventId: string): Promise<PostHistoryDirectReplyFetchMetadata | null>;
+    getForParentEventIds(
+        parentEventIds: string[],
+    ): Promise<PostHistoryDirectReplyFetchMetadata[]>;
     save(
         input: SavePostHistoryDirectReplyFetchMetadataInput,
     ): Promise<PostHistoryDirectReplyFetchMetadata | null>;
@@ -98,6 +101,32 @@ implements PostHistoryDirectReplyFetchMetadataRepository {
             ...record.value,
             updatedAt: record.updatedAt,
         };
+    }
+
+    async getForParentEventIds(
+        parentEventIds: string[],
+    ): Promise<PostHistoryDirectReplyFetchMetadata[]> {
+        const uniqueParentEventIds = Array.from(
+            new Set(parentEventIds.filter((eventId) => !!eventId)),
+        );
+        if (uniqueParentEventIds.length === 0) {
+            return [];
+        }
+
+        const records = await this.db.meta.bulkGet(
+            uniqueParentEventIds.map((parentEventId) =>
+                buildMetadataKey(parentEventId),
+            ),
+        );
+        return records.flatMap((record) => {
+            if (!record || !isValidMetadataValue(record.value)) {
+                return [];
+            }
+            return [{
+                ...record.value,
+                updatedAt: record.updatedAt,
+            }];
+        });
     }
 
     async save(

--- a/src/lib/storage/postHistoryReactionDeletionStateRepository.ts
+++ b/src/lib/storage/postHistoryReactionDeletionStateRepository.ts
@@ -160,20 +160,20 @@ implements PostHistoryReactionDeletionStateRepository {
             return [];
         }
 
-        const allRecords: PostHistoryReactionLifecycleStateRecord[] = [];
-        for (const parentEventId of uniqueParentEventIds) {
-            const records = await this.db.meta
-                .where("key")
-                .startsWith(buildParentPrefix(parentEventId))
-                .toArray();
-            allRecords.push(
-                ...records
-                    .map((record) => toStateRecord(record))
-                    .filter((record): record is PostHistoryReactionLifecycleStateRecord => !!record),
-            );
-        }
+        const records = await this.db.meta
+            .where("key")
+            .startsWithAnyOf(
+                uniqueParentEventIds.map((parentEventId) =>
+                    buildParentPrefix(parentEventId),
+                ),
+            )
+            .toArray();
 
-        return dedupeStateRecords(allRecords);
+        return dedupeStateRecords(
+            records
+                .map((record) => toStateRecord(record))
+                .filter((record): record is PostHistoryReactionLifecycleStateRecord => !!record),
+        );
     }
 
     async deleteMany(requestKeys: string[]): Promise<void> {

--- a/src/test/unit/fixtures/PostHistoryPreviewCollapseHarness.svelte
+++ b/src/test/unit/fixtures/PostHistoryPreviewCollapseHarness.svelte
@@ -1,52 +1,70 @@
 <script lang="ts">
     import { usePostHistoryPreviewCollapse } from "../../../lib/hooks/usePostHistoryPreviewCollapse.svelte";
 
-    interface Props {
+    interface PreviewItem {
+        eventId: string;
         content: string;
         forceCollapsible?: boolean;
     }
 
-    let { content, forceCollapsible = false }: Props = $props();
+    interface Props {
+        content?: string;
+        forceCollapsible?: boolean;
+        items?: PreviewItem[];
+    }
+
+    let { content = "", forceCollapsible = false, items: inputItems }: Props = $props();
     let container = $state<HTMLElement | null>(null);
-    let item = $derived({
-        eventId: "preview-collapse-harness-event",
-        content,
-        forceCollapsible,
-    });
-    let items = $derived([item]);
+    let items = $derived(
+        inputItems ?? [
+            {
+                eventId: "preview-collapse-harness-event",
+                content,
+                forceCollapsible,
+            },
+        ],
+    );
     const collapse = usePostHistoryPreviewCollapse({
         getShow: () => true,
         getPosts: () => items,
         getContainer: () => container,
     });
     const previewRef = collapse.previewRef;
-    let expanded = $derived(collapse.isPostExpanded(item));
-    let shouldCollapse = $derived(collapse.shouldCollapsePost(item));
-    const contentId = "preview-collapse-harness-content";
+    const getContentId = (eventId: string) =>
+        `preview-collapse-harness-content-${eventId}`;
 </script>
 
 <div bind:this={container}>
-    <p
-        id={contentId}
-        class="event-content"
-        class:event-content-collapsed={shouldCollapse && !expanded}
-        style={shouldCollapse && !expanded
-            ? "max-height: calc(7.25em); overflow: hidden;"
-            : undefined}
-        use:previewRef={item.eventId}
-    >
-        {content}
-    </p>
-    {#if shouldCollapse}
-        <button
-            type="button"
-            aria-expanded={expanded}
-            aria-controls={contentId}
-            onclick={() => collapse.togglePostExpanded(item.eventId)}
+    <button type="button" data-testid="remeasure" onclick={() => collapse.remeasure()}>
+        再測定
+    </button>
+    {#each items as item (item.eventId)}
+        {@const expanded = collapse.isPostExpanded(item)}
+        {@const shouldCollapse = collapse.shouldCollapsePost(item)}
+        {@const contentId = getContentId(item.eventId)}
+        <p
+            id={contentId}
+            class="event-content"
+            data-testid={`preview-${item.eventId}`}
+            class:event-content-collapsed={shouldCollapse && !expanded}
+            style={shouldCollapse && !expanded
+                ? "max-height: calc(7.25em); overflow: hidden;"
+                : undefined}
+            use:previewRef={item.eventId}
         >
-            {expanded ? "折りたたむ" : "もっと見る"}
-        </button>
-    {/if}
+            {item.content}
+        </p>
+        {#if shouldCollapse}
+            <button
+                type="button"
+                aria-expanded={expanded}
+                aria-controls={contentId}
+                onclick={() => collapse.togglePostExpanded(item.eventId)}
+            >
+                {expanded ? "折りたたむ" : "もっと見る"}
+            </button>
+        {/if}
+    {/each}
 </div>
 
 <style>

--- a/src/test/unit/postHistoryChildInteractionsAdapter.test.ts
+++ b/src/test/unit/postHistoryChildInteractionsAdapter.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+    RepositoryPostHistoryDirectReplyRecordsAdapter,
+    RepositoryPostHistoryReactionRecordsAdapter,
+} from "../../lib/postHistoryChildInteractionsAdapter";
+
+const FIRST_PARENT_ID = "1".repeat(64);
+const SECOND_PARENT_ID = "2".repeat(64);
+
+function record(input: {
+    eventId: string;
+    parentEventId: string;
+    kind: 1 | 7 | 42;
+    createdAt: number;
+}) {
+    return {
+        ...input,
+        id: input.eventId,
+        rootEventId: input.parentEventId,
+        authorPubkey: "a".repeat(64),
+        content: "",
+        tags: [],
+        rawEvent: {
+            id: input.eventId,
+            pubkey: "a".repeat(64),
+            created_at: input.createdAt,
+            kind: input.kind,
+            tags: [],
+            content: "",
+            sig: "b".repeat(128),
+        },
+        relayUrls: [],
+        discoveredAs: input.kind === 7 ? ["reaction"] : ["direct-reply"],
+        fetchedAt: input.createdAt,
+        updatedAt: input.createdAt,
+        schemaVersion: 1,
+    };
+}
+
+describe("Repository post-history child-interaction adapters", () => {
+    it("reads and sorts reaction records for multiple parents with one repository batch", async () => {
+        const getChildInteractionsForParents = vi.fn(async () => [
+            record({ eventId: "reaction-second", parentEventId: SECOND_PARENT_ID, kind: 7, createdAt: 4 }),
+            record({ eventId: "reply", parentEventId: FIRST_PARENT_ID, kind: 1, createdAt: 1 }),
+            record({ eventId: "reaction-later", parentEventId: FIRST_PARENT_ID, kind: 7, createdAt: 3 }),
+            record({ eventId: "reaction-first", parentEventId: FIRST_PARENT_ID, kind: 7, createdAt: 2 }),
+        ]);
+        const adapter = new RepositoryPostHistoryReactionRecordsAdapter({
+            getChildInteractions: vi.fn(),
+            getChildInteractionsForParents,
+        });
+
+        await expect(adapter.getReactionRecordsForParents([
+            FIRST_PARENT_ID,
+            SECOND_PARENT_ID,
+            FIRST_PARENT_ID,
+        ])).resolves.toMatchObject([
+            { eventId: "reaction-first" },
+            { eventId: "reaction-later" },
+            { eventId: "reaction-second" },
+        ]);
+        expect(getChildInteractionsForParents).toHaveBeenCalledTimes(1);
+        expect(getChildInteractionsForParents).toHaveBeenCalledWith([
+            FIRST_PARENT_ID,
+            SECOND_PARENT_ID,
+        ]);
+    });
+
+    it("reads and sorts direct replies for multiple parents with one repository batch", async () => {
+        const getChildInteractionsForParents = vi.fn(async () => [
+            record({ eventId: "reaction", parentEventId: FIRST_PARENT_ID, kind: 7, createdAt: 1 }),
+            record({ eventId: "reply-second", parentEventId: SECOND_PARENT_ID, kind: 42, createdAt: 4 }),
+            record({ eventId: "reply-later", parentEventId: FIRST_PARENT_ID, kind: 1, createdAt: 3 }),
+            record({ eventId: "reply-first", parentEventId: FIRST_PARENT_ID, kind: 1, createdAt: 2 }),
+        ]);
+        const adapter = new RepositoryPostHistoryDirectReplyRecordsAdapter({
+            getDirectReplyInteractions: vi.fn(),
+            getChildInteractionsForParents,
+        });
+
+        await expect(adapter.getDirectReplyRecordsForParents([
+            FIRST_PARENT_ID,
+            SECOND_PARENT_ID,
+        ])).resolves.toMatchObject([
+            { eventId: "reply-first" },
+            { eventId: "reply-later" },
+            { eventId: "reply-second" },
+        ]);
+        expect(getChildInteractionsForParents).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/test/unit/postHistoryChildInteractionsRepository.test.ts
+++ b/src/test/unit/postHistoryChildInteractionsRepository.test.ts
@@ -1,6 +1,6 @@
 import "fake-indexeddb/auto";
 import Dexie from "dexie";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { EHAGAKI_DB_NAME, EHagakiDB } from "../../lib/storage/ehagakiDb";
 import { DexiePostHistoryChildInteractionsRepository } from "../../lib/storage/postHistoryChildInteractionsRepository";
 
@@ -153,6 +153,69 @@ describe("DexiePostHistoryChildInteractionsRepository", () => {
                 discoveredAs: ["reaction"],
             },
         ]);
+
+        db.close();
+    });
+
+    it("複数 parent の child interaction を parentEventId index の一回の read で取得する", async () => {
+        const db = createTestDb();
+        const repository = new DexiePostHistoryChildInteractionsRepository(db, () => 1000);
+        const firstParentEventId = "1".repeat(64);
+        const secondParentEventId = "2".repeat(64);
+        await repository.upsertChildInteractions({
+            parentEventId: firstParentEventId,
+            events: [
+                {
+                    event: createSignedEvent({
+                        id: "3".repeat(64),
+                        created_at: 200,
+                        tags: [["e", firstParentEventId, "", "reply"]],
+                    }),
+                },
+                {
+                    event: createSignedEvent({
+                        id: "4".repeat(64),
+                        kind: 7,
+                        created_at: 100,
+                        tags: [["e", firstParentEventId]],
+                    }),
+                },
+            ],
+        });
+        await repository.upsertChildInteractions({
+            parentEventId: secondParentEventId,
+            events: [{
+                event: createSignedEvent({
+                    id: "5".repeat(64),
+                    created_at: 150,
+                    tags: [["e", secondParentEventId, "", "reply"]],
+                }),
+            }],
+        });
+
+        const whereSpy = vi.spyOn(db.postHistoryChildInteractions, "where");
+        const records = await repository.getChildInteractionsForParents([
+            firstParentEventId,
+            secondParentEventId,
+            firstParentEventId,
+        ]);
+
+        expect(whereSpy).toHaveBeenCalledTimes(1);
+        expect(whereSpy).toHaveBeenCalledWith("parentEventId");
+        expect(records).toHaveLength(3);
+        const recordsByParent = new Map<string, typeof records>();
+        for (const record of records) {
+            const parentRecords = recordsByParent.get(record.parentEventId) ?? [];
+            parentRecords.push(record);
+            recordsByParent.set(record.parentEventId, parentRecords);
+        }
+        expect(
+            Array.from(recordsByParent.get(firstParentEventId) ?? [])
+                .sort((left, right) => left.createdAt - right.createdAt)
+                .map((record) => record.eventId),
+        ).toEqual(["4".repeat(64), "3".repeat(64)]);
+        expect(recordsByParent.get(secondParentEventId)?.map((record) => record.eventId))
+            .toEqual(["5".repeat(64)]);
 
         db.close();
     });

--- a/src/test/unit/postHistoryDirectReplyDeletionStateRepository.test.ts
+++ b/src/test/unit/postHistoryDirectReplyDeletionStateRepository.test.ts
@@ -1,6 +1,6 @@
 import "fake-indexeddb/auto";
 import Dexie from "dexie";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { EHAGAKI_DB_NAME, EHagakiDB } from "../../lib/storage/ehagakiDb";
 import { DexiePostHistoryDirectReplyDeletionStateRepository } from "../../lib/storage/postHistoryDirectReplyDeletionStateRepository";
 
@@ -62,6 +62,40 @@ describe("DexiePostHistoryDirectReplyDeletionStateRepository", () => {
             parentEventId,
             replyEventId,
         }])).resolves.toMatchObject([{ requestKey, kind: 1 }]);
+
+        db.close();
+    });
+
+    it("複数 parent の deletion state を prefix query 一回で取得する", async () => {
+        const { db, repository } = createRepository();
+        const firstParentEventId = "5".repeat(64);
+        const secondParentEventId = "6".repeat(64);
+        const firstReplyEventId = "7".repeat(64);
+        const secondReplyEventId = "8".repeat(64);
+        await repository.saveMany([
+            {
+                requestKey: `${firstParentEventId}:${firstReplyEventId}:1`,
+                parentEventId: firstParentEventId,
+                replyEventId: firstReplyEventId,
+            },
+            {
+                requestKey: `${secondParentEventId}:${secondReplyEventId}:42`,
+                parentEventId: secondParentEventId,
+                replyEventId: secondReplyEventId,
+                kind: 42,
+            },
+        ]);
+
+        const whereSpy = vi.spyOn(db.meta, "where");
+        await expect(repository.getForParentEventIds([
+            firstParentEventId,
+            secondParentEventId,
+            firstParentEventId,
+        ])).resolves.toMatchObject([
+            { parentEventId: firstParentEventId, replyEventId: firstReplyEventId },
+            { parentEventId: secondParentEventId, replyEventId: secondReplyEventId },
+        ]);
+        expect(whereSpy).toHaveBeenCalledTimes(1);
 
         db.close();
     });

--- a/src/test/unit/postHistoryDirectReplyFetchMetadataRepository.test.ts
+++ b/src/test/unit/postHistoryDirectReplyFetchMetadataRepository.test.ts
@@ -1,6 +1,6 @@
 import "fake-indexeddb/auto";
 import Dexie from "dexie";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { EHAGAKI_DB_NAME, EHagakiDB } from "../../lib/storage/ehagakiDb";
 import {
     DexiePostHistoryDirectReplyFetchMetadataRepository,
@@ -126,6 +126,40 @@ describe("DexiePostHistoryDirectReplyFetchMetadataRepository", () => {
             completeness: "complete",
             fetchedAt: 4000,
         });
+        db.close();
+    });
+
+    it("複数 parent の metadata を bulkGet 一回で読み、無効な値を除外する", async () => {
+        const db = createTestDb();
+        const repository = new DexiePostHistoryDirectReplyFetchMetadataRepository(db);
+        const firstParentEventId = "5".repeat(64);
+        const secondParentEventId = "6".repeat(64);
+        const missingParentEventId = "7".repeat(64);
+        await repository.save({
+            parentEventId: firstParentEventId,
+            completeness: "complete",
+            fetchedAt: 1000,
+            requestStartedAt: 900,
+        });
+        await repository.save({
+            parentEventId: secondParentEventId,
+            completeness: "partial",
+            fetchedAt: 1100,
+            requestStartedAt: 1000,
+        });
+
+        const bulkGetSpy = vi.spyOn(db.meta, "bulkGet");
+        await expect(repository.getForParentEventIds([
+            firstParentEventId,
+            secondParentEventId,
+            missingParentEventId,
+            firstParentEventId,
+        ])).resolves.toMatchObject([
+            { parentEventId: firstParentEventId, completeness: "complete" },
+            { parentEventId: secondParentEventId, completeness: "partial" },
+        ]);
+        expect(bulkGetSpy).toHaveBeenCalledTimes(1);
+
         db.close();
     });
 });

--- a/src/test/unit/postHistoryReactionDeletionStateRepository.test.ts
+++ b/src/test/unit/postHistoryReactionDeletionStateRepository.test.ts
@@ -1,0 +1,65 @@
+import "fake-indexeddb/auto";
+import Dexie from "dexie";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EHAGAKI_DB_NAME, EHagakiDB } from "../../lib/storage/ehagakiDb";
+import { DexiePostHistoryReactionDeletionStateRepository } from "../../lib/storage/postHistoryReactionDeletionStateRepository";
+
+const testDbNames = new Set<string>();
+
+function createRepository() {
+    const name = `${EHAGAKI_DB_NAME}-reaction-state-${Date.now()}-${Math.random()}`;
+    testDbNames.add(name);
+    const db = new EHagakiDB(name);
+    return {
+        db,
+        repository: new DexiePostHistoryReactionDeletionStateRepository(db, () => 1000),
+    };
+}
+
+afterEach(async () => {
+    for (const name of testDbNames) {
+        await Dexie.delete(name);
+    }
+    testDbNames.clear();
+});
+
+describe("DexiePostHistoryReactionDeletionStateRepository", () => {
+    it("複数 parent の deletion state を prefix query 一回で取得する", async () => {
+        const { db, repository } = createRepository();
+        const firstParentEventId = "1".repeat(64);
+        const secondParentEventId = "2".repeat(64);
+        const firstReactionEventId = "3".repeat(64);
+        const secondReactionEventId = "4".repeat(64);
+        await repository.saveMany([
+            {
+                requestKey: `${firstParentEventId}:${firstReactionEventId}`,
+                parentEventId: firstParentEventId,
+                reactionEventId: firstReactionEventId,
+            },
+            {
+                requestKey: `${secondParentEventId}:${secondReactionEventId}`,
+                parentEventId: secondParentEventId,
+                reactionEventId: secondReactionEventId,
+            },
+        ]);
+
+        const whereSpy = vi.spyOn(db.meta, "where");
+        await expect(repository.getForParentEventIds([
+            firstParentEventId,
+            secondParentEventId,
+            firstParentEventId,
+        ])).resolves.toMatchObject([
+            {
+                parentEventId: firstParentEventId,
+                reactionEventId: firstReactionEventId,
+            },
+            {
+                parentEventId: secondParentEventId,
+                reactionEventId: secondReactionEventId,
+            },
+        ]);
+        expect(whereSpy).toHaveBeenCalledTimes(1);
+
+        db.close();
+    });
+});

--- a/src/test/unit/postHistoryThreadGraphPrefetchIntent.test.ts
+++ b/src/test/unit/postHistoryThreadGraphPrefetchIntent.test.ts
@@ -136,6 +136,11 @@ function createGraph(
     });
     const getFetchMetadata = vi.fn(async (parentEventId: string) =>
         metadataByParent.get(parentEventId) ?? null);
+    const getFetchMetadataForParents = vi.fn(async (parentEventIds: string[]) =>
+        parentEventIds.flatMap((parentEventId) => {
+            const metadata = metadataByParent.get(parentEventId);
+            return metadata ? [metadata] : [];
+        }));
     let childCacheProbePending = !!childCacheProbe;
     const getDirectReplyRecords = vi.fn(async (parentEventId: string) => {
         if (parentEventId === childId && childCacheProbe && childCacheProbePending) {
@@ -144,6 +149,11 @@ function createGraph(
         }
         return recordsByParent.get(parentEventId) ?? [];
     });
+    const getChildInteractionsForParents = vi.fn(async (parentEventIds: string[]) =>
+        parentEventIds.flatMap((parentEventId) =>
+            recordsByParent.get(parentEventId) ?? [],
+        ));
+    const getReactionRecords = vi.fn().mockResolvedValue([]);
 
     const deferred = createDeferred<{
         status: "success" | "partial" | "failed" | "cancelled";
@@ -187,15 +197,17 @@ function createGraph(
             getDirectReplyRecords,
         },
         reactionRecordsAdapterImpl: {
-            getReactionRecords: vi.fn().mockResolvedValue([]),
+            getReactionRecords,
         },
         childInteractionsRepositoryImpl: {
             upsertChildInteractions,
             deleteChildInteractionByEventId: vi.fn().mockResolvedValue(undefined),
+            getChildInteractionsForParents,
         },
         directReplyFetchMetadataRepositoryImpl: {
             get: getFetchMetadata,
             save: saveFetchMetadata,
+            getForParentEventIds: getFetchMetadataForParents,
         },
         deletionRequestsRepositoryImpl: {
             getDeletedTargets: vi.fn().mockResolvedValue(new Map()),
@@ -252,6 +264,9 @@ function createGraph(
         post,
         fetchDirectReplies,
         getDirectReplyRecords,
+        getReactionRecords,
+        getChildInteractionsForParents,
+        getFetchMetadataForParents,
         resolvePrefetch,
         getFetchMetadata,
         saveFetchMetadata,
@@ -278,6 +293,22 @@ async function startChildPrefetch(input: ReturnType<typeof createGraph>): Promis
 }
 
 describe("post history child prefetch reveal intent", () => {
+    it("visible cache preload は child interaction と metadata を各一回だけ batch read する", async () => {
+        const harness = createGraph();
+
+        await harness.graph.loadCachedChildInteractionStateForPosts([harness.post]);
+
+        expect(harness.getChildInteractionsForParents).toHaveBeenCalledTimes(1);
+        expect(harness.getChildInteractionsForParents).toHaveBeenCalledWith([anchorId]);
+        expect(harness.getFetchMetadataForParents).toHaveBeenCalledTimes(1);
+        expect(harness.getDirectReplyRecords).not.toHaveBeenCalled();
+        expect(harness.getReactionRecords).not.toHaveBeenCalled();
+        harness.graph.toggleChildren(harness.post);
+        expect(harness.graph.getAnchorState(harness.post).replyNodeStates[0]?.node.eventId)
+            .toBe(childId);
+        harness.dispose();
+    });
+
     it("prefetch中の手動展開を保持し、重複REQなしで取得後に表示する", async () => {
         const harness = createGraph();
         await startChildPrefetch(harness);

--- a/src/test/unit/postHistoryThreadGraphPrefetchIntent.test.ts
+++ b/src/test/unit/postHistoryThreadGraphPrefetchIntent.test.ts
@@ -309,6 +309,25 @@ describe("post history child prefetch reveal intent", () => {
         harness.dispose();
     });
 
+    it("metadata batch read失敗時もcached direct replyを表示しつつ再検証する", async () => {
+        const harness = createGraph(Date.now());
+        harness.getFetchMetadataForParents.mockRejectedValueOnce(
+            new Error("metadata batch read failed"),
+        );
+
+        await harness.graph.loadCachedChildInteractionStateForPosts([harness.post]);
+
+        harness.graph.toggleChildren(harness.post);
+
+        await vi.waitFor(() => {
+            expect(harness.graph.getAnchorState(harness.post).replyNodeStates[0]?.node.eventId)
+                .toBe(childId);
+            expect(countFetchCallsForParent(harness, anchorId)).toBe(1);
+        });
+        harness.resolvePrefetch({ events: [] });
+        harness.dispose();
+    });
+
     it("prefetch中の手動展開を保持し、重複REQなしで取得後に表示する", async () => {
         const harness = createGraph();
         await startChildPrefetch(harness);

--- a/src/test/unit/postHistoryVisibleRangeRelationRepairCoordinator.test.ts
+++ b/src/test/unit/postHistoryVisibleRangeRelationRepairCoordinator.test.ts
@@ -175,6 +175,33 @@ describe("postHistoryVisibleRangeRelationRepairCoordinator", () => {
         )).toEqual(["stale-parent", "unchecked-parent"]);
     });
 
+    it("does not refresh badges before an older reveal repair or deletion changes cached data", async () => {
+        const deferred = createDeferred<PostHistoryVisibleRangeRelationRepairResult>();
+        const task = createRepairTask(deferred.promise);
+        const {
+            coordinator,
+            onChildInteractionBadgeRefreshRequested,
+        } = createCoordinator({
+            loadedPosts: [createPost("parent")],
+            repairTask: task,
+        });
+
+        coordinator.scheduleOlderRevealRepair([createPost("parent")]);
+        await Promise.resolve();
+        expect(onChildInteractionBadgeRefreshRequested).not.toHaveBeenCalled();
+
+        deferred.resolve(createRelationRepairResult({
+            checkedParentEventIds: ["parent"],
+            savedParentEventIds: ["parent"],
+        }));
+        await vi.waitFor(() => {
+            expect(onChildInteractionBadgeRefreshRequested).toHaveBeenCalledWith(
+                [expect.objectContaining({ eventId: "parent" })],
+                ["parent"],
+            );
+        });
+    });
+
     it("cancels the tracked current-view relation repair and rejects its late callback", async () => {
         const deferred = createDeferred<PostHistoryVisibleRangeRelationRepairResult>();
         const task = createRepairTask(deferred.promise);

--- a/src/test/unit/usePostHistoryPreviewCollapse.test.ts
+++ b/src/test/unit/usePostHistoryPreviewCollapse.test.ts
@@ -1,11 +1,29 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/svelte";
-import { afterEach, describe, expect, it } from "vitest";
+import {
+    cleanup,
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+} from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import PostHistoryPreviewCollapseHarness from "./fixtures/PostHistoryPreviewCollapseHarness.svelte";
 
 describe("usePostHistoryPreviewCollapse", () => {
     afterEach(() => {
         cleanup();
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
     });
+
+    function createItems(count: number, startAt = 0) {
+        return Array.from({ length: count }, (_, index) => ({
+            eventId: `preview-${startAt + index}`,
+            content: Array.from(
+                { length: 6 },
+                (_, lineIndex) => `item ${startAt + index}, line ${lineIndex}`,
+            ).join("\n"),
+        }));
+    }
 
     it("forceCollapsibleを測定前の初回描画から同期的に折りたたむ", () => {
         const content = Array.from(
@@ -59,5 +77,94 @@ describe("usePostHistoryPreviewCollapse", () => {
                 screen.getByRole("button", { name: "もっと見る" }),
             ).not.toBeNull();
         });
+    });
+
+    it("mount と posts 更新が重なっても、新規 50 件だけを一度ずつ測定する", async () => {
+        const getComputedStyleSpy = vi.spyOn(window, "getComputedStyle");
+        const initialItems = createItems(50);
+        const view = render(PostHistoryPreviewCollapseHarness, {
+            items: initialItems,
+        });
+
+        await waitFor(() => {
+            expect(getComputedStyleSpy).toHaveBeenCalledTimes(50);
+        });
+
+        await view.rerender({
+            items: [...initialItems, ...createItems(50, 50)],
+        });
+
+        await waitFor(() => {
+            expect(getComputedStyleSpy).toHaveBeenCalledTimes(100);
+        });
+    });
+
+    it("resize と emoji 再判定では visible preview 全件を一度だけ再測定する", async () => {
+        let resizeCallback: ResizeObserverCallback | undefined;
+        vi.stubGlobal(
+            "ResizeObserver",
+            class {
+                constructor(callback: ResizeObserverCallback) {
+                    resizeCallback = callback;
+                }
+
+                disconnect() {}
+                observe() {}
+                unobserve() {}
+            },
+        );
+        const getComputedStyleSpy = vi.spyOn(window, "getComputedStyle");
+        render(PostHistoryPreviewCollapseHarness, {
+            items: createItems(50),
+        });
+
+        await waitFor(() => {
+            expect(getComputedStyleSpy).toHaveBeenCalledTimes(50);
+        });
+
+        await fireEvent.click(screen.getByTestId("remeasure"));
+        await waitFor(() => {
+            expect(getComputedStyleSpy).toHaveBeenCalledTimes(100);
+        });
+
+        resizeCallback?.([], {} as ResizeObserver);
+        await waitFor(() => {
+            expect(getComputedStyleSpy).toHaveBeenCalledTimes(150);
+        });
+    });
+
+    it("forceCollapsible は測定せず、展開状態は維持する", async () => {
+        const getComputedStyleSpy = vi.spyOn(window, "getComputedStyle");
+        const forceContent = Array.from(
+            { length: 6 },
+            (_, index) => `line ${index + 1}`,
+        ).join("\n");
+        const { getByTestId } = render(PostHistoryPreviewCollapseHarness, {
+            items: [
+                {
+                    eventId: "forced",
+                    content: forceContent,
+                    forceCollapsible: true,
+                },
+                {
+                    eventId: "measured",
+                    content: forceContent,
+                },
+            ],
+        });
+
+        await waitFor(() => {
+            expect(getComputedStyleSpy).toHaveBeenCalledTimes(1);
+        });
+
+        const forcePreview = getByTestId("preview-forced");
+        expect(forcePreview.classList).toContain("event-content-collapsed");
+        const forceButton = screen.getAllByRole("button", {
+            name: "もっと見る",
+        })[0];
+        await fireEvent.click(forceButton);
+
+        expect(forcePreview.classList).not.toContain("event-content-collapsed");
+        expect(forceButton.getAttribute("aria-expanded")).toBe("true");
     });
 });


### PR DESCRIPTION
## Root cause and fix

A 50-post older-window shift caused each mount action and the posts effect to independently remeasure the same 150 visible previews. It also repeated per-parent child-interaction and deletion-state IndexedDB work, while thread-graph cache application copied reactive maps per parent.

This change coalesces preview measurements into one post-`tick()` batch, limits normal updates to dirty previews, batches child-interaction/direct-reply/deletion reads, applies thread-graph preload results through local drafts with bounded map commits, and removes duplicate older-reveal preload ownership. Validated contiguous older reveals now derive older availability on the critical path and defer only the newer availability confirmation until after DOM/anchor restoration.

## Chromium re-measurement

In the 251-post Chromium harness, shifting the 150-post window 50 posts toward older history changed the primary work as follows:

| Metric | Before | After |
| --- | ---: | ---: |
| Preview `getComputedStyle` calls | 7,650 | 50 |
| Preview `scrollHeight` reads | 15,300 | 100 |
| Child-interaction parent-index reads | 298 | 3 |
| Visible-preview layout scans | 5 / 750 items | 6 / 900 items |

The after-profile recorded `TaskDuration` delta of 0.188732 s (`Task: 189ms`). This is the aggregate cumulative task duration over the measured window, not the maximum duration of one individual task. Layout was 5.003 ms after the shift, so viewport scanning was not the dominant layout source and no extra viewport optimization was added.

## Verification

- `npm test` — passed: 344 test files passed, 1 skipped; 3,968 tests passed, 1 skipped.
- `npm run check` — passed with 0 errors and 0 warnings.
- `npx playwright test src/test/e2e/postHistoryDialog.spec.ts --project=desktop-chromium --project=mobile-chromium --project=mobile-webkit` — passed: 48 passed, 18 skipped.

## Build

`npm run build` was not run. The change does not alter Vite, PWA/service-worker, asset, worker, or bundling boundaries, and the implementation plan explicitly did not require it.