### PR TITLE
Fix upward post history infinite scroll

### DIFF
--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -256,6 +256,7 @@
 
     let localHistoryDeleteConfirmOpen = $state(false);
     let activeUtilityPanel = $state<PostHistoryUtilityPanel>("none");
+    let isExplicitNavigation = $state(false);
     let jumpDateValue = $state<DateValue | undefined>(createTodayDateValue());
     let jumpDatePlaceholder = $state<DateValue | undefined>(
         createTodayDateValue(),
@@ -308,9 +309,13 @@
     let showImageFullscreen = $state(false);
     let historyContainer = $state<HTMLDivElement | null>(null);
     let autoLoadOlderSentinel = $state<HTMLDivElement | null>(null);
+    let autoLoadNewerSentinel = $state<HTMLDivElement | null>(null);
     let isAutoLoadingOlder = $state(false);
+    let isAutoLoadingNewer = $state(false);
     let autoLoadOlderAwaitingExit = false;
+    let autoLoadNewerAwaitingExit = false;
     let autoLoadOlderSentinelIsIntersecting = false;
+    let autoLoadNewerSentinelIsIntersecting = false;
     const supportsAutoLoadOlder = typeof IntersectionObserver !== "undefined";
     let searchInputElement = $state<HTMLInputElement | null>(null);
     let showDelayedListLoading = $state(false);
@@ -529,6 +534,7 @@
         selectedRawEvent = null;
         localHistoryDeleteConfirmOpen = false;
         activeUtilityPanel = "none";
+        isExplicitNavigation = false;
         jumpDateValue = createTodayDateValue();
         jumpDatePlaceholder = createTodayDateValue();
         jumpDatePickerOpen = false;
@@ -680,6 +686,58 @@
             observer.disconnect();
             autoLoadOlderAwaitingExit = false;
             autoLoadOlderSentinelIsIntersecting = false;
+        };
+    });
+
+    $effect(() => {
+        const sentinel = autoLoadNewerSentinel;
+        const root = historyContainer;
+        const enabled =
+            show
+            && !!sentinel
+            && !!root
+            && !history.isSearchMode
+            && history.state.listingMode === "contiguous"
+            && history.state.hasNewerLocal
+            && !isExplicitNavigation
+            && !history.isRefetchingAroundCurrentView;
+
+        if (!enabled || !supportsAutoLoadOlder) {
+            autoLoadNewerAwaitingExit = false;
+            autoLoadNewerSentinelIsIntersecting = false;
+            return;
+        }
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                const isIntersecting = entries.some(
+                    (entry) => entry.isIntersecting,
+                );
+                autoLoadNewerSentinelIsIntersecting = isIntersecting;
+
+                if (!isIntersecting) {
+                    if (
+                        autoLoadNewerAwaitingExit
+                        && !isAutoLoadingNewer
+                    ) {
+                        autoLoadNewerAwaitingExit = false;
+                    }
+                    return;
+                }
+
+                void handleAutoLoadNewer();
+            },
+            {
+                root,
+                threshold: 0,
+            },
+        );
+        observer.observe(sentinel);
+
+        return () => {
+            observer.disconnect();
+            autoLoadNewerAwaitingExit = false;
+            autoLoadNewerSentinelIsIntersecting = false;
         };
     });
 
@@ -895,6 +953,43 @@
         }
     }
 
+    function canAutoLoadNewerPosts(): boolean {
+        return show
+            && !history.isSearchMode
+            && history.state.listingMode === "contiguous"
+            && history.state.hasNewerLocal
+            && !isExplicitNavigation
+            && !history.isRefetchingAroundCurrentView;
+    }
+
+    async function handleAutoLoadNewer(): Promise<void> {
+        if (
+            isAutoLoadingNewer
+            || autoLoadNewerAwaitingExit
+            || !canAutoLoadNewerPosts()
+        ) {
+            return;
+        }
+
+        const scrollAnchor = historyViewport.captureHistoryScrollAnchor();
+        isAutoLoadingNewer = true;
+        autoLoadNewerAwaitingExit = true;
+
+        try {
+            const changed = await history.loadNewer();
+            if (changed && show) {
+                await tick();
+                await previewCollapse.flushPendingMeasurements();
+                historyViewport.restoreHistoryScrollAnchor(scrollAnchor);
+            }
+        } finally {
+            isAutoLoadingNewer = false;
+            if (!autoLoadNewerSentinelIsIntersecting) {
+                autoLoadNewerAwaitingExit = false;
+            }
+        }
+    }
+
     async function handleShowSavedOlderPosts(): Promise<void> {
         const changed = await history.showSavedOlderPosts();
         if (changed) {
@@ -972,6 +1067,7 @@
         const changed = history.canReturnToLatest
             ? await history.returnToLatest()
             : false;
+        isExplicitNavigation = false;
         if (changed || !historyViewport.isHistoryScrolledToTop) {
             historyViewport.resetHistoryScrollSoon();
         }
@@ -984,7 +1080,11 @@
         }
 
         historyViewport.clearAllSessionScrollAnchorsForCurrentPubkey();
+        isExplicitNavigation = true;
         const changed = await history.jumpToCreatedAt(createdAt);
+        if (!changed) {
+            isExplicitNavigation = false;
+        }
         if (changed) {
             activeUtilityPanel = "none";
             jumpDatePickerOpen = false;
@@ -1428,8 +1528,10 @@
     async function handleShowSurroundingPosts(
         post: PostHistoryRecord,
     ): Promise<void> {
+        isExplicitNavigation = true;
         const changed = await history.jumpToEventId(post.eventId);
         if (!changed) {
+            isExplicitNavigation = false;
             return;
         }
 
@@ -2103,7 +2205,12 @@
                 </div>
             </div>
         {:else}
-            {#if history.isSearchMode ? history.canLoadNewer : history.state.hasNewerLocal}
+            {#if history.isSearchMode
+                ? history.canLoadNewer
+                : history.state.hasNewerLocal &&
+                    (isExplicitNavigation ||
+                        !supportsAutoLoadOlder ||
+                        history.state.listingMode !== "contiguous")}
                 <div class="post-history-nav-row post-history-nav-row-top">
                     <Button
                         type="button"
@@ -2119,6 +2226,22 @@
                         ></div>
                         {getLoadNewerLabel()}
                     </Button>
+                </div>
+            {/if}
+            {#if supportsAutoLoadOlder && !history.isSearchMode && history.state.listingMode === "contiguous" && history.state.hasNewerLocal && !isExplicitNavigation}
+                <div
+                    bind:this={autoLoadNewerSentinel}
+                    class="post-history-auto-load-sentinel post-history-auto-load-newer-sentinel"
+                    aria-hidden="true"
+                >
+                    {#if isAutoLoadingNewer}
+                        <LoadingPlaceholder
+                            variant="spinner"
+                            showLoader={true}
+                            loaderSize={24}
+                            ariaHidden={true}
+                        />
+                    {/if}
                 </div>
             {/if}
             <ul class="post-history-list">

--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -161,6 +161,25 @@ async function scrollHistoryToBottom(page: Page) {
     });
 }
 
+async function scrollHistoryToTop(page: Page) {
+    await page.locator('.post-history-container').evaluate((element) => {
+        const container = element as HTMLDivElement;
+        container.scrollTop = 0;
+        container.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+}
+
+async function scrollHistoryAwayFromTop(page: Page) {
+    await page.locator('.post-history-container').evaluate((element) => {
+        const container = element as HTMLDivElement;
+        container.scrollTop = Math.min(
+            container.clientHeight,
+            container.scrollHeight - container.clientHeight,
+        );
+        container.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+}
+
 async function historyEventIds(page: Page): Promise<string[]> {
     return page.locator('.post-history-list').evaluate((list) =>
         Array.from(list.querySelectorAll<HTMLElement>('.post-history-item'))
@@ -517,7 +536,7 @@ test.describe('PostHistoryDialog Playwright', () => {
 
         await expectVisiblePostCount(page, 50);
         await expect(page.getByRole('button', { name: 'さらに古い投稿を表示' })).toHaveCount(0);
-        await expect(page.locator('.post-history-auto-load-sentinel')).toBeVisible();
+        await expect(page.locator('.post-history-auto-load-sentinel:not(.post-history-auto-load-newer-sentinel)')).toBeVisible();
         expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(0, 50));
 
         const observedEventIds = new Set(await historyEventIds(page));
@@ -586,7 +605,7 @@ test.describe('PostHistoryDialog Playwright', () => {
         for (const eventId of await historyEventIds(page)) {
             observedEventIds.add(eventId);
         }
-        await expect(page.locator('.post-history-auto-load-sentinel')).toBeVisible();
+        await expect(page.locator('.post-history-auto-load-sentinel:not(.post-history-auto-load-newer-sentinel)')).toBeVisible();
         await waitForIntersectionObserverSettle(page);
         expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(100, 250));
 
@@ -596,13 +615,40 @@ test.describe('PostHistoryDialog Playwright', () => {
         for (const eventId of await historyEventIds(page)) {
             observedEventIds.add(eventId);
         }
-        await expect(page.locator('.post-history-auto-load-sentinel')).toHaveCount(0);
+        await expect(page.locator('.post-history-auto-load-sentinel:not(.post-history-auto-load-newer-sentinel)')).toHaveCount(0);
 
         expect(observedEventIds).toEqual(new Set(expectedEventIds));
         await scrollHistoryToBottom(page);
         await waitForIntersectionObserverSettle(page);
         expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(101));
         await expect(page.getByText(harness.infiniteScrollOldestPostContent, { exact: true })).toBeVisible();
+
+        await expect(page.getByRole('button', { name: '新しい投稿を表示' })).toHaveCount(0);
+        const upwardWindows = [
+            expectedEventIds.slice(51, 201),
+            expectedEventIds.slice(1, 151),
+            expectedEventIds.slice(0, 150),
+        ];
+        for (const [index, expectedWindow] of upwardWindows.entries()) {
+            await scrollHistoryToTop(page);
+            await expect.poll(() => historyEventIds(page)).toEqual(expectedWindow);
+            await expectVisiblePostCount(page, 150);
+            await waitForIntersectionObserverSettle(page);
+            expect(await historyEventIds(page)).toEqual(expectedWindow);
+            await expect(page.getByRole('button', { name: '新しい投稿を表示' })).toHaveCount(0);
+
+            if (index < upwardWindows.length - 1) {
+                await scrollHistoryAwayFromTop(page);
+                await waitForIntersectionObserverSettle(page);
+            }
+        }
+
+        await expect(
+            page.locator(`.post-history-item[data-post-history-event-id="${expectedEventIds[0]}"]`),
+        ).toBeVisible();
+        await scrollHistoryToTop(page);
+        await waitForIntersectionObserverSettle(page);
+        expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(0, 150));
     });
 
     test('desktop timeline browsing flow works in a real browser', async ({ page, isMobile }) => {
@@ -668,7 +714,7 @@ test.describe('PostHistoryDialog Playwright', () => {
         await expectSummary(page, harness.totalPosts);
         await expectVisiblePostCount(page, 50);
         await expect(page.getByRole('button', { name: 'さらに古い投稿を表示' })).toHaveCount(0);
-        await expect(page.locator('.post-history-auto-load-sentinel')).toBeVisible();
+        await expect(page.locator('.post-history-auto-load-sentinel:not(.post-history-auto-load-newer-sentinel)')).toBeVisible();
         await expect(page.getByRole('button', { name: 'さらに古い検索結果を表示' })).toHaveCount(0);
     });
 

--- a/src/test/unit/postHistoryDialogTimeline.test.ts
+++ b/src/test/unit/postHistoryDialogTimeline.test.ts
@@ -169,6 +169,57 @@ describe('PostHistoryDialog timeline navigation', () => {
         view.unmount();
     });
 
+    it('IntersectionObserver 非対応時は通常 contiguous の新しい投稿ボタンを維持する', async () => {
+        const posts = Array.from({ length: 200 }, (_, index) =>
+            createRecord({
+                eventId: index.toString(16).padStart(64, '0'),
+                id: index.toString(16).padStart(64, '0'),
+                content: `fallback post ${index}`,
+                createdAt: 1_700_000_000 - index,
+                postedAt: Date.UTC(2024, 0, 2) - index * 1_000,
+            }),
+        );
+        let olderChunkCall = 0;
+
+        repositoryMock.countForPubkey.mockResolvedValue(posts.length);
+        repositoryMock.getLatestVisibleChunk.mockResolvedValue(posts.slice(0, 50));
+        repositoryMock.getNewerVisibleChunk.mockImplementation(async ({ cursor }: { cursor: { eventId: string } }) =>
+            cursor.eventId === posts[0].eventId ? [] : [posts[0]],
+        );
+        repositoryMock.getOlderVisibleChunk.mockImplementation(async ({ limit }: { limit: number }) => {
+            if (limit === 1) {
+                return olderChunkCall < 3 ? [posts[50 + olderChunkCall * 50]] : [];
+            }
+
+            const chunk = posts.slice(50 + olderChunkCall * 50, 100 + olderChunkCall * 50);
+            olderChunkCall += 1;
+            return chunk;
+        });
+
+        const view = render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: PUBKEY_HEX,
+            },
+        });
+
+        await screen.findByText('fallback post 0');
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'さらに古い投稿を表示' })).toBeTruthy();
+        });
+        for (const expectedLastIndex of [99, 149, 199]) {
+            await fireEvent.click(screen.getByRole('button', { name: 'さらに古い投稿を表示' }));
+            await waitFor(() => expect(screen.getByText(`fallback post ${expectedLastIndex}`)).toBeTruthy());
+        }
+
+        expect(screen.queryByText('fallback post 0')).toBeNull();
+        expect(screen.getByRole('button', { name: '新しい投稿を表示' })).toBeTruthy();
+        expect(document.querySelector('.post-history-auto-load-newer-sentinel')).toBeNull();
+
+        view.unmount();
+    });
+
     it('連続範囲の末尾で保存済みの古い投稿を明示的に表示し、relay を呼ばない', async () => {
         const newest = createRecord({
             eventId: 'boundary-newest',


### PR DESCRIPTION
## Summary

- Add a symmetric IntersectionObserver sentinel for newer local chunks in normal contiguous post history.
- Preserve the existing exit-to-rearm guard and await preview measurement before restoring the scroll anchor.
- Keep manual newer controls for search, sparse, explicit date/surrounding jumps, and IntersectionObserver fallback environments.

## Verification

- npm test: 344 files passed, 3,970 tests passed, 1 skipped
- npm run check: passed with 0 errors and 0 warnings
- npx playwright test src/test/e2e/postHistoryDialog.spec.ts --project=desktop-chromium --project=mobile-chromium --project=mobile-webkit: 48 passed, 18 skipped
- Focused upward infinite-scroll E2E: passed in desktop Chromium, mobile Chromium, and mobile WebKit

Production build was not run because this change does not touch Vite, PWA, worker, or bundling boundaries.