### PR TITLE
Start post history infinite scroll before edges

### DIFF
--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -312,10 +312,31 @@
     let autoLoadNewerSentinel = $state<HTMLDivElement | null>(null);
     let isAutoLoadingOlder = $state(false);
     let isAutoLoadingNewer = $state(false);
+    let autoLoadRootHeight = $state<number | null>(null);
+    let autoLoadRootResizeGeneration = $state(0);
     let autoLoadOlderAwaitingExit = false;
     let autoLoadNewerAwaitingExit = false;
     let autoLoadOlderSentinelIsIntersecting = false;
     let autoLoadNewerSentinelIsIntersecting = false;
+    let autoLoadRootForHeight: HTMLDivElement | null = null;
+    let observedAutoLoadRootHeight: number | null = null;
+    let nextAutoLoadRootResizeGeneration = 0;
+    let autoLoadOlderObserverContext:
+        | {
+              root: HTMLDivElement;
+              sentinel: HTMLDivElement;
+              resizeGeneration: number;
+              scrollTop: number;
+          }
+        | null = null;
+    let autoLoadNewerObserverContext:
+        | {
+              root: HTMLDivElement;
+              sentinel: HTMLDivElement;
+              resizeGeneration: number;
+              scrollTop: number;
+          }
+        | null = null;
     const supportsAutoLoadOlder = typeof IntersectionObserver !== "undefined";
     let searchInputElement = $state<HTMLInputElement | null>(null);
     let showDelayedListLoading = $state(false);
@@ -639,12 +660,62 @@
     });
 
     $effect(() => {
+        const root = historyContainer;
+        if (!root) {
+            autoLoadRootForHeight = null;
+            observedAutoLoadRootHeight = null;
+            autoLoadRootHeight = null;
+            return;
+        }
+
+        const syncAutoLoadRootHeight = () => {
+            const nextHeight = Math.max(0, root.clientHeight);
+            if (autoLoadRootForHeight !== root) {
+                autoLoadRootForHeight = root;
+                observedAutoLoadRootHeight = nextHeight;
+                autoLoadRootHeight = nextHeight;
+                return;
+            }
+
+            if (observedAutoLoadRootHeight === nextHeight) {
+                return;
+            }
+
+            observedAutoLoadRootHeight = nextHeight;
+            autoLoadRootHeight = nextHeight;
+            nextAutoLoadRootResizeGeneration += 1;
+            autoLoadRootResizeGeneration = nextAutoLoadRootResizeGeneration;
+        };
+
+        syncAutoLoadRootHeight();
+        if (typeof ResizeObserver === "undefined") {
+            return;
+        }
+
+        const resizeObserver = new ResizeObserver(syncAutoLoadRootHeight);
+        resizeObserver.observe(root);
+
+        return () => {
+            resizeObserver.disconnect();
+            if (autoLoadRootForHeight === root) {
+                autoLoadRootForHeight = null;
+                observedAutoLoadRootHeight = null;
+                autoLoadRootHeight = null;
+            }
+        };
+    });
+
+    $effect(() => {
         const sentinel = autoLoadOlderSentinel;
         const root = historyContainer;
+        const rootHeight = autoLoadRootHeight;
+        const resizeGeneration = autoLoadRootResizeGeneration;
         const enabled =
             show
             && !!sentinel
             && !!root
+            && rootHeight !== null
+            && rootHeight > 0
             && !history.isSearchMode
             && history.state.listingMode === "contiguous"
             && history.state.hasOlderLocal
@@ -653,14 +724,30 @@
         if (!enabled || !supportsAutoLoadOlder) {
             autoLoadOlderAwaitingExit = false;
             autoLoadOlderSentinelIsIntersecting = false;
+            autoLoadOlderObserverContext = null;
             return;
         }
+
+        const suppressInitialIntersectionForResize =
+            autoLoadOlderObserverContext?.root === root
+            && autoLoadOlderObserverContext.sentinel === sentinel
+            && autoLoadOlderObserverContext.resizeGeneration !== resizeGeneration
+            && root.scrollTop <= autoLoadOlderObserverContext.scrollTop;
+        autoLoadOlderObserverContext = {
+            root,
+            sentinel,
+            resizeGeneration,
+            scrollTop: root.scrollTop,
+        };
+        let receivedInitialEntry = false;
 
         const observer = new IntersectionObserver(
             (entries) => {
                 const isIntersecting = entries.some(
                     (entry) => entry.isIntersecting,
                 );
+                const isInitialEntry = !receivedInitialEntry;
+                receivedInitialEntry = true;
                 autoLoadOlderSentinelIsIntersecting = isIntersecting;
 
                 if (!isIntersecting) {
@@ -673,10 +760,15 @@
                     return;
                 }
 
+                if (isInitialEntry && suppressInitialIntersectionForResize) {
+                    return;
+                }
+
                 void handleAutoLoadOlder();
             },
             {
                 root,
+                rootMargin: `0px 0px ${rootHeight}px 0px`,
                 threshold: 0,
             },
         );
@@ -684,18 +776,20 @@
 
         return () => {
             observer.disconnect();
-            autoLoadOlderAwaitingExit = false;
-            autoLoadOlderSentinelIsIntersecting = false;
         };
     });
 
     $effect(() => {
         const sentinel = autoLoadNewerSentinel;
         const root = historyContainer;
+        const rootHeight = autoLoadRootHeight;
+        const resizeGeneration = autoLoadRootResizeGeneration;
         const enabled =
             show
             && !!sentinel
             && !!root
+            && rootHeight !== null
+            && rootHeight > 0
             && !history.isSearchMode
             && history.state.listingMode === "contiguous"
             && history.state.hasNewerLocal
@@ -705,14 +799,30 @@
         if (!enabled || !supportsAutoLoadOlder) {
             autoLoadNewerAwaitingExit = false;
             autoLoadNewerSentinelIsIntersecting = false;
+            autoLoadNewerObserverContext = null;
             return;
         }
+
+        const suppressInitialIntersectionForResize =
+            autoLoadNewerObserverContext?.root === root
+            && autoLoadNewerObserverContext.sentinel === sentinel
+            && autoLoadNewerObserverContext.resizeGeneration !== resizeGeneration
+            && root.scrollTop >= autoLoadNewerObserverContext.scrollTop;
+        autoLoadNewerObserverContext = {
+            root,
+            sentinel,
+            resizeGeneration,
+            scrollTop: root.scrollTop,
+        };
+        let receivedInitialEntry = false;
 
         const observer = new IntersectionObserver(
             (entries) => {
                 const isIntersecting = entries.some(
                     (entry) => entry.isIntersecting,
                 );
+                const isInitialEntry = !receivedInitialEntry;
+                receivedInitialEntry = true;
                 autoLoadNewerSentinelIsIntersecting = isIntersecting;
 
                 if (!isIntersecting) {
@@ -725,10 +835,15 @@
                     return;
                 }
 
+                if (isInitialEntry && suppressInitialIntersectionForResize) {
+                    return;
+                }
+
                 void handleAutoLoadNewer();
             },
             {
                 root,
+                rootMargin: `${rootHeight}px 0px 0px 0px`,
                 threshold: 0,
             },
         );
@@ -736,8 +851,6 @@
 
         return () => {
             observer.disconnect();
-            autoLoadNewerAwaitingExit = false;
-            autoLoadNewerSentinelIsIntersecting = false;
         };
     });
 
@@ -975,15 +1088,20 @@
         isAutoLoadingNewer = true;
         autoLoadNewerAwaitingExit = true;
 
+        let changed = false;
+
         try {
-            const changed = await history.loadNewer();
+            changed = await history.loadNewer();
             if (changed && show) {
                 await tick();
                 await previewCollapse.flushPendingMeasurements();
-                historyViewport.restoreHistoryScrollAnchor(scrollAnchor);
             }
         } finally {
             isAutoLoadingNewer = false;
+            if (changed && show) {
+                await tick();
+                historyViewport.restoreHistoryScrollAnchor(scrollAnchor);
+            }
             if (!autoLoadNewerSentinelIsIntersecting) {
                 autoLoadNewerAwaitingExit = false;
             }

--- a/src/components/PostHistoryDialog.svelte
+++ b/src/components/PostHistoryDialog.svelte
@@ -768,7 +768,7 @@
             },
             {
                 root,
-                rootMargin: `0px 0px ${rootHeight}px 0px`,
+                rootMargin: `0px 0px ${rootHeight * 2}px 0px`,
                 threshold: 0,
             },
         );
@@ -843,7 +843,7 @@
             },
             {
                 root,
-                rootMargin: `${rootHeight}px 0px 0px 0px`,
+                rootMargin: `${rootHeight * 2}px 0px 0px 0px`,
                 threshold: 0,
             },
         );

--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -180,7 +180,7 @@ async function scrollHistoryNearBottom(page: Page) {
         const remaining = Math.max(
             1,
             Math.min(
-                container.clientHeight - 24,
+                container.clientHeight * 2 - 24,
                 container.scrollHeight - container.clientHeight,
             ),
         );
@@ -195,7 +195,7 @@ async function scrollHistoryNearTopAndCaptureAnchor(page: Page) {
     return page.locator('.post-history-container').evaluate((element) => {
         const container = element as HTMLDivElement;
         container.scrollTop = Math.min(
-            container.clientHeight - 24,
+            container.clientHeight * 2 - 24,
             container.scrollHeight - container.clientHeight,
         );
         container.dispatchEvent(new Event('scroll', { bubbles: true }));
@@ -225,7 +225,7 @@ async function scrollHistoryAwayFromTop(page: Page) {
     await page.locator('.post-history-container').evaluate((element) => {
         const container = element as HTMLDivElement;
         container.scrollTop = Math.min(
-            container.clientHeight + 2,
+            container.clientHeight * 2 + 2,
             container.scrollHeight - container.clientHeight,
         );
         container.dispatchEvent(new Event('scroll', { bubbles: true }));
@@ -236,7 +236,7 @@ async function scrollHistoryAwayFromBottom(page: Page) {
     await page.locator('.post-history-container').evaluate((element) => {
         const container = element as HTMLDivElement;
         const remaining = Math.min(
-            container.clientHeight + 2,
+            container.clientHeight * 2 + 2,
             container.scrollHeight - container.clientHeight,
         );
         container.scrollTop = container.scrollHeight - container.clientHeight - remaining;
@@ -739,7 +739,8 @@ test.describe('PostHistoryDialog Playwright', () => {
         await waitForHistoryContainerHeightToSettle(page);
         const olderApproach = await scrollHistoryNearBottom(page);
         expect(olderApproach.remaining).toBeGreaterThan(1);
-        expect(olderApproach.remaining).toBeLessThan(olderApproach.clientHeight);
+        expect(olderApproach.remaining).toBeLessThan(olderApproach.clientHeight * 2);
+        expect(olderApproach.remaining).toBeGreaterThan(olderApproach.clientHeight);
         await expect.poll(() => historyEventIds(page)).toEqual(expectedEventIds.slice(0, 100));
         await waitForIntersectionObserverSettle(page);
         expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(0, 100));
@@ -762,7 +763,8 @@ test.describe('PostHistoryDialog Playwright', () => {
         await waitForIntersectionObserverSettle(page);
         const newerApproach = await scrollHistoryNearTopAndCaptureAnchor(page);
         expect(newerApproach.topOffset).toBeGreaterThan(1);
-        expect(newerApproach.topOffset).toBeLessThan(newerApproach.clientHeight);
+        expect(newerApproach.topOffset).toBeLessThan(newerApproach.clientHeight * 2);
+        expect(newerApproach.topOffset).toBeGreaterThan(newerApproach.clientHeight);
         expect(newerApproach.anchor).not.toBeNull();
         await expect.poll(() => historyEventIds(page)).toEqual(expectedEventIds.slice(51, 201));
         const restoredAnchor = await getPostSnapshotByEventId(

--- a/src/test/e2e/postHistoryDialog.spec.ts
+++ b/src/test/e2e/postHistoryDialog.spec.ts
@@ -54,6 +54,11 @@ async function gotoSparseOldestHarness(page: Page) {
 async function gotoInfiniteScrollHarness(page: Page) {
     await page.goto('post-history-dialog-playwright.html?infinite-scroll=1');
     await page.waitForFunction(() => Boolean((window as HarnessWindow).__POST_HISTORY_HARNESS__?.ready));
+    await page.locator('.post-history-container').evaluate((element) => {
+        const container = element as HTMLDivElement;
+        container.style.height = `${container.clientHeight}px`;
+    });
+    await waitForHistoryContainerHeightToSettle(page);
     return page.evaluate<HarnessState>(() => (window as HarnessWindow).__POST_HISTORY_HARNESS__ as HarnessState);
 }
 
@@ -169,14 +174,88 @@ async function scrollHistoryToTop(page: Page) {
     });
 }
 
+async function scrollHistoryNearBottom(page: Page) {
+    return page.locator('.post-history-container').evaluate((element) => {
+        const container = element as HTMLDivElement;
+        const remaining = Math.max(
+            1,
+            Math.min(
+                container.clientHeight - 24,
+                container.scrollHeight - container.clientHeight,
+            ),
+        );
+        container.scrollTop =
+            container.scrollHeight - container.clientHeight - remaining;
+        container.dispatchEvent(new Event('scroll', { bubbles: true }));
+        return { remaining, clientHeight: container.clientHeight };
+    });
+}
+
+async function scrollHistoryNearTopAndCaptureAnchor(page: Page) {
+    return page.locator('.post-history-container').evaluate((element) => {
+        const container = element as HTMLDivElement;
+        container.scrollTop = Math.min(
+            container.clientHeight - 24,
+            container.scrollHeight - container.clientHeight,
+        );
+        container.dispatchEvent(new Event('scroll', { bubbles: true }));
+
+        const containerRect = container.getBoundingClientRect();
+        const item = Array.from(
+            container.querySelectorAll<HTMLElement>('.post-history-item'),
+        ).find((candidate) => {
+            const rect = candidate.getBoundingClientRect();
+            return rect.bottom > containerRect.top + 1 && rect.top < containerRect.bottom - 1;
+        });
+
+        return {
+            topOffset: container.scrollTop,
+            clientHeight: container.clientHeight,
+            anchor: item
+                ? {
+                      eventId: item.dataset.postHistoryEventId ?? '',
+                      offsetTop: item.getBoundingClientRect().top - containerRect.top,
+                  }
+                : null,
+        };
+    });
+}
+
 async function scrollHistoryAwayFromTop(page: Page) {
     await page.locator('.post-history-container').evaluate((element) => {
         const container = element as HTMLDivElement;
         container.scrollTop = Math.min(
-            container.clientHeight,
+            container.clientHeight + 2,
             container.scrollHeight - container.clientHeight,
         );
         container.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+}
+
+async function scrollHistoryAwayFromBottom(page: Page) {
+    await page.locator('.post-history-container').evaluate((element) => {
+        const container = element as HTMLDivElement;
+        const remaining = Math.min(
+            container.clientHeight + 2,
+            container.scrollHeight - container.clientHeight,
+        );
+        container.scrollTop = container.scrollHeight - container.clientHeight - remaining;
+        container.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+}
+
+async function waitForHistoryContainerHeightToSettle(page: Page) {
+    await page.locator('.post-history-container').evaluate(async (element) => {
+        const container = element as HTMLDivElement;
+        let lastHeight = container.clientHeight;
+        let stableFrames = 0;
+
+        for (let frame = 0; frame < 60 && stableFrames < 8; frame += 1) {
+            await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+            const nextHeight = container.clientHeight;
+            stableFrames = nextHeight === lastHeight ? stableFrames + 1 : 0;
+            lastHeight = nextHeight;
+        }
     });
 }
 
@@ -211,7 +290,7 @@ async function getFirstVisiblePostSnapshot(page: Page) {
         const items = Array.from(
             container.querySelectorAll<HTMLElement>('.post-history-item'),
         );
-        const visibleEdgeTolerancePx = 1;
+        const visibleEdgeTolerancePx = 4;
         const item = items.find((candidate) => {
             const rect = candidate.getBoundingClientRect();
             return (
@@ -550,6 +629,8 @@ test.describe('PostHistoryDialog Playwright', () => {
         await waitForIntersectionObserverSettle(page);
         expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(0, 100));
 
+        await scrollHistoryAwayFromBottom(page);
+        await waitForIntersectionObserverSettle(page);
         await scrollHistoryToBottom(page);
         await expectVisiblePostCount(page, 150);
         await expect.poll(() => historyEventIds(page)).toEqual(expectedEventIds.slice(0, 150));
@@ -559,26 +640,19 @@ test.describe('PostHistoryDialog Playwright', () => {
         await waitForIntersectionObserverSettle(page);
         expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(0, 150));
 
-        const anchorBeforeLoad = await page.locator('.post-history-container').evaluate((element) => {
-            const container = element as HTMLDivElement;
-            container.scrollTop = container.scrollHeight;
-            container.dispatchEvent(new Event('scroll', { bubbles: true }));
-
-            const containerRect = container.getBoundingClientRect();
-            const item = Array.from(
-                container.querySelectorAll<HTMLElement>('.post-history-item'),
-            ).find((candidate) => {
-                const rect = candidate.getBoundingClientRect();
-                return rect.bottom > containerRect.top + 1 && rect.top < containerRect.bottom - 1;
-            });
-            if (!item) {
-                return null;
-            }
-
-            return {
-                eventId: item.dataset.postHistoryEventId ?? '',
-                offsetTop: item.getBoundingClientRect().top - containerRect.top,
-            };
+        const olderSentinel = page.locator(
+            '.post-history-auto-load-sentinel:not(.post-history-auto-load-newer-sentinel)',
+        );
+        await olderSentinel.evaluate((element) => {
+            (element as HTMLElement).style.display = 'none';
+        });
+        await scrollHistoryAwayFromBottom(page);
+        await waitForIntersectionObserverSettle(page);
+        await scrollHistoryToBottom(page);
+        await waitForHistoryContainerHeightToSettle(page);
+        const anchorBeforeLoad = await getFirstVisiblePostSnapshot(page);
+        await olderSentinel.evaluate((element) => {
+            (element as HTMLElement).style.removeProperty('display');
         });
         expect(anchorBeforeLoad).not.toBeNull();
         await expect.poll(() => historyEventIds(page)).toEqual(expectedEventIds.slice(50, 200));
@@ -599,6 +673,8 @@ test.describe('PostHistoryDialog Playwright', () => {
         await waitForIntersectionObserverSettle(page);
         expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(50, 200));
 
+        await scrollHistoryAwayFromBottom(page);
+        await waitForIntersectionObserverSettle(page);
         await scrollHistoryToBottom(page);
         await expect.poll(() => historyEventIds(page)).toEqual(expectedEventIds.slice(100, 250));
         await expectVisiblePostCount(page, 150);
@@ -609,6 +685,8 @@ test.describe('PostHistoryDialog Playwright', () => {
         await waitForIntersectionObserverSettle(page);
         expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(100, 250));
 
+        await scrollHistoryAwayFromBottom(page);
+        await waitForIntersectionObserverSettle(page);
         await scrollHistoryToBottom(page);
         await expect.poll(() => historyEventIds(page)).toEqual(expectedEventIds.slice(101));
         await expectVisiblePostCount(page, 150);
@@ -649,6 +727,61 @@ test.describe('PostHistoryDialog Playwright', () => {
         await scrollHistoryToTop(page);
         await waitForIntersectionObserverSettle(page);
         expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(0, 150));
+    });
+
+    test('normal history preloads one local chunk before either edge and rearms after exit', async ({ page }) => {
+        const harness = await gotoInfiniteScrollHarness(page);
+        const expectedEventIds = harness.infiniteScrollEventIds;
+
+        await expectVisiblePostCount(page, 50);
+        await scrollHistoryAwayFromBottom(page);
+        await waitForIntersectionObserverSettle(page);
+        await waitForHistoryContainerHeightToSettle(page);
+        const olderApproach = await scrollHistoryNearBottom(page);
+        expect(olderApproach.remaining).toBeGreaterThan(1);
+        expect(olderApproach.remaining).toBeLessThan(olderApproach.clientHeight);
+        await expect.poll(() => historyEventIds(page)).toEqual(expectedEventIds.slice(0, 100));
+        await waitForIntersectionObserverSettle(page);
+        expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(0, 100));
+
+        for (const expectedWindow of [
+            expectedEventIds.slice(0, 150),
+            expectedEventIds.slice(50, 200),
+            expectedEventIds.slice(100, 250),
+            expectedEventIds.slice(101),
+        ]) {
+            await waitForHistoryContainerHeightToSettle(page);
+            await scrollHistoryAwayFromBottom(page);
+            await waitForIntersectionObserverSettle(page);
+            await waitForHistoryContainerHeightToSettle(page);
+            await scrollHistoryToBottom(page);
+            await expect.poll(() => historyEventIds(page)).toEqual(expectedWindow);
+        }
+
+        await scrollHistoryAwayFromTop(page);
+        await waitForIntersectionObserverSettle(page);
+        const newerApproach = await scrollHistoryNearTopAndCaptureAnchor(page);
+        expect(newerApproach.topOffset).toBeGreaterThan(1);
+        expect(newerApproach.topOffset).toBeLessThan(newerApproach.clientHeight);
+        expect(newerApproach.anchor).not.toBeNull();
+        await expect.poll(() => historyEventIds(page)).toEqual(expectedEventIds.slice(51, 201));
+        const restoredAnchor = await getPostSnapshotByEventId(
+            page,
+            newerApproach.anchor!.eventId,
+        );
+        expect(restoredAnchor).not.toBeNull();
+        expect(Math.abs(
+            restoredAnchor!.offsetTop - newerApproach.anchor!.offsetTop,
+        )).toBeLessThanOrEqual(1);
+        await waitForIntersectionObserverSettle(page);
+        expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(51, 201));
+
+        await scrollHistoryAwayFromTop(page);
+        await waitForIntersectionObserverSettle(page);
+        await scrollHistoryNearTopAndCaptureAnchor(page);
+        await expect.poll(() => historyEventIds(page)).toEqual(expectedEventIds.slice(1, 151));
+        await waitForIntersectionObserverSettle(page);
+        expect(await historyEventIds(page)).toEqual(expectedEventIds.slice(1, 151));
     });
 
     test('desktop timeline browsing flow works in a real browser', async ({ page, isMobile }) => {

--- a/src/test/unit/postHistoryDialogTimeline.test.ts
+++ b/src/test/unit/postHistoryDialogTimeline.test.ts
@@ -355,7 +355,7 @@ describe('PostHistoryDialog timeline navigation', () => {
         const initialObserver = MockIntersectionObserver.instances.find(
             (observer) => observer.observedTargets.has(olderSentinel),
         );
-        expect(initialObserver?.rootMargin).toBe('0px 0px 320px 0px');
+        expect(initialObserver?.rootMargin).toBe('0px 0px 640px 0px');
 
         initialObserver?.trigger(olderSentinel, true);
         await waitFor(() => expect(pageChunkRequestCount).toBe(1));
@@ -370,7 +370,7 @@ describe('PostHistoryDialog timeline navigation', () => {
             expect(MockIntersectionObserver.instances).toHaveLength(2);
         });
         const resizeObserver = MockIntersectionObserver.instances.at(-1);
-        expect(resizeObserver?.rootMargin).toBe('0px 0px 400px 0px');
+        expect(resizeObserver?.rootMargin).toBe('0px 0px 800px 0px');
 
         resizeObserver?.trigger(olderSentinel, true);
         await Promise.resolve();

--- a/src/test/unit/postHistoryDialogTimeline.test.ts
+++ b/src/test/unit/postHistoryDialogTimeline.test.ts
@@ -30,6 +30,74 @@ import { readPersistedPostHistoryListingSnapshotForPubkey } from '../../lib/hook
 import { markPostHistoryShouldReturnToLatestAfterLocalPost } from '../../lib/postHistoryLatestRequest';
 import { bumpPostHistorySearchRevision } from '../../lib/postHistoryLocalSearchRevision';
 
+class MockIntersectionObserver {
+    static instances: MockIntersectionObserver[] = [];
+
+    readonly observedTargets = new Set<Element>();
+    readonly root: Element | Document | null;
+    readonly rootMargin: string;
+    readonly thresholds: readonly number[];
+    readonly disconnect = vi.fn();
+    readonly observe = vi.fn((target: Element) => {
+        this.observedTargets.add(target);
+    });
+    readonly unobserve = vi.fn((target: Element) => {
+        this.observedTargets.delete(target);
+    });
+    readonly takeRecords = vi.fn(() => []);
+
+    constructor(
+        private readonly callback: IntersectionObserverCallback,
+        options: IntersectionObserverInit = {},
+    ) {
+        this.root = options.root ?? null;
+        this.rootMargin = options.rootMargin ?? '0px';
+        this.thresholds = Array.isArray(options.threshold)
+            ? options.threshold
+            : [options.threshold ?? 0];
+        MockIntersectionObserver.instances.push(this);
+    }
+
+    trigger(target: Element, isIntersecting: boolean): void {
+        this.callback(
+            [{ target, isIntersecting } as IntersectionObserverEntry],
+            this as unknown as IntersectionObserver,
+        );
+    }
+
+    static reset(): void {
+        MockIntersectionObserver.instances = [];
+    }
+}
+
+class MockResizeObserver {
+    static instances: MockResizeObserver[] = [];
+
+    readonly observedTargets = new Set<Element>();
+    readonly disconnect = vi.fn();
+    readonly observe = vi.fn((target: Element) => {
+        this.observedTargets.add(target);
+    });
+    readonly unobserve = vi.fn((target: Element) => {
+        this.observedTargets.delete(target);
+    });
+
+    constructor(private readonly callback: ResizeObserverCallback) {
+        MockResizeObserver.instances.push(this);
+    }
+
+    trigger(target: Element): void {
+        this.callback(
+            [{ target } as ResizeObserverEntry],
+            this as unknown as ResizeObserver,
+        );
+    }
+
+    static reset(): void {
+        MockResizeObserver.instances = [];
+    }
+}
+
 function createMockRect(top: number, height: number) {
     return {
         top,
@@ -216,6 +284,132 @@ describe('PostHistoryDialog timeline navigation', () => {
         expect(screen.queryByText('fallback post 0')).toBeNull();
         expect(screen.getByRole('button', { name: '新しい投稿を表示' })).toBeTruthy();
         expect(document.querySelector('.post-history-auto-load-newer-sentinel')).toBeNull();
+
+        view.unmount();
+    });
+
+    it('先読みobserverは初回交差で読み込み、resize再構成ではlatch中に追加読み込みしない', async () => {
+        let containerHeight = 320;
+        const firstChunk = createDeferred<ReturnType<typeof createRecord>[]>();
+        const posts = Array.from({ length: 200 }, (_, index) =>
+            createRecord({
+                eventId: index.toString(16).padStart(64, '0'),
+                id: index.toString(16).padStart(64, '0'),
+                content: `prefetch post ${index}`,
+                createdAt: 1_700_000_000 - index,
+                postedAt: Date.UTC(2024, 0, 2) - index * 1_000,
+            }),
+        );
+        let pageChunkRequestCount = 0;
+
+        MockIntersectionObserver.reset();
+        MockResizeObserver.reset();
+        vi.stubGlobal(
+            'IntersectionObserver',
+            MockIntersectionObserver as unknown as typeof IntersectionObserver,
+        );
+        vi.stubGlobal(
+            'ResizeObserver',
+            MockResizeObserver as unknown as typeof ResizeObserver,
+        );
+        vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockImplementation(function (this: HTMLElement) {
+            return this.classList.contains('post-history-container')
+                ? containerHeight
+                : 0;
+        });
+
+        repositoryMock.countForPubkey.mockResolvedValue(posts.length);
+        repositoryMock.getLatestVisibleChunk.mockResolvedValue(posts.slice(0, 50));
+        repositoryMock.getOlderVisibleChunk.mockImplementation(async ({ limit }: { limit: number }) => {
+            if (limit === 1) {
+                return [posts[50]];
+            }
+
+            pageChunkRequestCount += 1;
+            return pageChunkRequestCount === 1
+                ? firstChunk.promise
+                : posts.slice(
+                      pageChunkRequestCount * 50,
+                      pageChunkRequestCount * 50 + 50,
+                  );
+        });
+
+        const view = render(PostHistoryDialog, {
+            props: {
+                show: true,
+                onClose: vi.fn(),
+                pubkeyHex: PUBKEY_HEX,
+            },
+        });
+
+        await screen.findByText('prefetch post 0');
+        const container = getHistoryContainer();
+        await waitFor(() => {
+            expect(document.querySelector(
+                '.post-history-auto-load-sentinel:not(.post-history-auto-load-newer-sentinel)',
+            )).toBeInstanceOf(HTMLElement);
+        });
+        const olderSentinel = document.querySelector(
+            '.post-history-auto-load-sentinel:not(.post-history-auto-load-newer-sentinel)',
+        ) as HTMLElement;
+        const initialObserver = MockIntersectionObserver.instances.find(
+            (observer) => observer.observedTargets.has(olderSentinel),
+        );
+        expect(initialObserver?.rootMargin).toBe('0px 0px 320px 0px');
+
+        initialObserver?.trigger(olderSentinel, true);
+        await waitFor(() => expect(pageChunkRequestCount).toBe(1));
+
+        containerHeight = 400;
+        for (const observer of MockResizeObserver.instances) {
+            if (observer.observedTargets.has(container)) {
+                observer.trigger(container);
+            }
+        }
+        await waitFor(() => {
+            expect(MockIntersectionObserver.instances).toHaveLength(2);
+        });
+        const resizeObserver = MockIntersectionObserver.instances.at(-1);
+        expect(resizeObserver?.rootMargin).toBe('0px 0px 400px 0px');
+
+        resizeObserver?.trigger(olderSentinel, true);
+        await Promise.resolve();
+        expect(pageChunkRequestCount).toBe(1);
+
+        firstChunk.resolve(posts.slice(50, 100));
+        await screen.findByText('prefetch post 99');
+        await waitFor(() => {
+            expect(container.getAttribute('aria-busy')).toBe('false');
+        });
+
+        const rearmedObserver = MockIntersectionObserver.instances
+            .filter((observer) => observer.observedTargets.has(olderSentinel))
+            .at(-1);
+        rearmedObserver?.trigger(olderSentinel, false);
+        rearmedObserver?.trigger(olderSentinel, true);
+        await waitFor(() => expect(pageChunkRequestCount).toBe(2));
+        await screen.findByText('prefetch post 149');
+
+        await view.rerender({
+            show: false,
+            onClose: vi.fn(),
+            pubkeyHex: PUBKEY_HEX,
+        });
+        await view.rerender({
+            show: true,
+            onClose: vi.fn(),
+            pubkeyHex: PUBKEY_HEX,
+        });
+
+        await screen.findByText('prefetch post 0');
+        const reopenedOlderSentinel = document.querySelector(
+            '.post-history-auto-load-sentinel:not(.post-history-auto-load-newer-sentinel)',
+        ) as HTMLElement;
+        const reopenedObserver = MockIntersectionObserver.instances
+            .filter((observer) => observer.observedTargets.has(reopenedOlderSentinel))
+            .at(-1);
+        reopenedObserver?.trigger(reopenedOlderSentinel, true);
+        await waitFor(() => expect(pageChunkRequestCount).toBe(3));
 
         view.unmount();
     });


### PR DESCRIPTION
## Summary
- Start normal post-history loading one container viewport before either edge.
- Sync pixel observer margins from the scroll container with ResizeObserver.
- Preserve bounded-window, one-approach/rearm, and scroll-anchor behavior across observer reconstruction.

## Prefetch behavior
Older uses a bottom margin equal to the current container client height; newer uses the same top margin. Resize-only observer reconstruction synchronizes intersection state without causing a duplicate load while a direction is latched; an actual approach remains eligible.

## Verification
- Focused post-history timeline unit coverage.
- Target post-history E2E: desktop Chromium, mobile Chromium, and mobile WebKit.
- npm run check.
- npm test.

No build run: this change does not affect Vite, PWA, worker, or bundling boundaries.