### PR TITLE
Fix Web Component playground relay config

### DIFF
--- a/public/web-component-parent-client-example.js
+++ b/public/web-component-parent-client-example.js
@@ -308,7 +308,7 @@ function removeCustomStyles(element) {
 function configureElement(element) {
     element.setAttribute("asset-base", normalizeDirectoryUrl(assetBaseInput.value));
     const relayText = getElement("host-relays").value.trim();
-    if (selectedDistribution === "full" && relayText) {
+    if (relayText) {
         element.relays = JSON.parse(relayText);
     }
 }

--- a/src/test/e2e/webComponentParentClientExample.spec.ts
+++ b/src/test/e2e/webComponentParentClientExample.spec.ts
@@ -886,3 +886,18 @@ test("keeps arbitrary module loading explicit in manual mode", async ({ page }) 
     expect(requests).toContain(securityFixturePath);
     expect(await page.evaluate(() => window.__securityFixtureLoaded === true)).toBe(true);
 });
+
+test("passes non-empty Host Relay Config to the Full element before mounting", async ({ page }) => {
+    await page.goto(`${origin}/ehagaki/web-component-parent-client-example.html?manual=1`);
+    const relays = [
+        { url: "wss://relay.example", read: true, write: true },
+        { url: "wss://read.example", read: true, write: false },
+    ];
+    await page.locator("#host-relays").fill(JSON.stringify(relays));
+    await page.getByRole("button", { name: "作成して表示" }).click();
+    await expect(page.locator("#ready-status")).toHaveText("準備完了（whenReady(): resolved）");
+    await expect(page.locator("ehagaki-composer")).toHaveCount(1);
+    await expect.poll(() => page.locator("ehagaki-composer").evaluate((element) =>
+        (element as HTMLElement & { relays?: unknown }).relays,
+    )).toEqual(relays.map((relay) => ({ ...relay, url: `${relay.url}/` })));
+});


### PR DESCRIPTION
## Summary
- remove the undefined distribution check from the Full Web Component playground relay configuration
- preserve empty-value relay resolution and non-empty connection-before-mount relay assignment
- add Chromium desktop/mobile regression coverage for Host Relay Config

## Verification
- 
px playwright test src/test/e2e/webComponentParentClientExample.spec.ts --project=desktop-chromium --project=mobile-chromium — 28 passed
- 
pm run check — passed
- 
pm test — 3996 passed, 1 skipped
- 
pm run build — passed via E2E web server build
- git diff --check — passed