### PR TITLE
Reduce test output for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,24 +108,21 @@ npm run check
 npm run complexity:thread-graph
 npm test
 npm run test:unit
-npm run test:agent
-npm run test:unit:agent
 npm run test:ui
 npm run test:e2e
 npm run test:e2e:agent
 npm run deploy
 ```
 
-For routine verification by a coding agent, prefer the quiet agent paths: use
-`npm run test:agent` for the full Vitest suite, `npm run test:unit:agent` for
-unit tests, and `npm run test:e2e:agent` for the full two-stage Playwright
-suite. These paths use Vitest's standard `agent` reporter and Playwright's
-standard `dot` reporter; the human-oriented commands above remain unchanged.
+Vitest automatically selects its minimal (`agent`) reporter in coding-agent
+environments, so use the existing `npm test` and `npm run test:unit` commands
+for Vitest verification. Use `npm run test:e2e:agent` for the full
+two-stage Playwright suite.
 
 Run one Vitest file:
 
 ```pwsh
-npm run test:agent -- <file>
+npm run test -- <file>
 ```
 
 Run selected Playwright tests:
@@ -143,7 +140,7 @@ Use a repository-pinned Node version when one is defined. Otherwise, inspect the
 Run the narrowest relevant verification first, then broaden it according to the impact area.
 
 - Run affected unit or integration tests while implementing.
-- For implementation changes, run `npm run test:agent` by default before finishing. It also runs the thread-graph complexity check. Use the human-oriented `npm test` when its full progress output is specifically useful.
+- For implementation changes, run `npm test` by default before finishing. It also runs the thread-graph complexity check. In coding-agent environments, Vitest automatically selects its minimal (`agent`) reporter.
 - Run `npm run check` for Svelte or TypeScript changes.
 - Run `npm run build` for changes affecting Vite, PWA behavior, service workers, workers, generated output, asset paths, bundling, FFmpeg, Mediabunny, WebCodecs, or WASM assets.
 - Use Playwright for browser integration and user interactions that unit or component tests cannot prove. For browser-specific investigation, use `.agents/skills/ehagaki-browser-debug/`; prefer relevant existing tests and keep ad hoc artifacts temporary. Device emulation is not evidence of real OS keyboard, browser chrome, PWA standalone UI, or WebView behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,21 +108,30 @@ npm run check
 npm run complexity:thread-graph
 npm test
 npm run test:unit
+npm run test:agent
+npm run test:unit:agent
 npm run test:ui
 npm run test:e2e
+npm run test:e2e:agent
 npm run deploy
 ```
+
+For routine verification by a coding agent, prefer the quiet agent paths: use
+`npm run test:agent` for the full Vitest suite, `npm run test:unit:agent` for
+unit tests, and `npm run test:e2e:agent` for the full two-stage Playwright
+suite. These paths use Vitest's standard `agent` reporter and Playwright's
+standard `dot` reporter; the human-oriented commands above remain unchanged.
 
 Run one Vitest file:
 
 ```pwsh
-npm run test -- <file>
+npm run test:agent -- <file>
 ```
 
 Run selected Playwright tests:
 
 ```pwsh
-npx playwright test <file-or-filter>
+npx playwright test <file-or-filter> --reporter=dot
 ```
 
 `prebuild` is an npm lifecycle hook and runs automatically before `npm run build`.
@@ -134,7 +143,7 @@ Use a repository-pinned Node version when one is defined. Otherwise, inspect the
 Run the narrowest relevant verification first, then broaden it according to the impact area.
 
 - Run affected unit or integration tests while implementing.
-- For implementation changes, run `npm test` by default before finishing. It also runs the thread-graph complexity check.
+- For implementation changes, run `npm run test:agent` by default before finishing. It also runs the thread-graph complexity check. Use the human-oriented `npm test` when its full progress output is specifically useful.
 - Run `npm run check` for Svelte or TypeScript changes.
 - Run `npm run build` for changes affecting Vite, PWA behavior, service workers, workers, generated output, asset paths, bundling, FFmpeg, Mediabunny, WebCodecs, or WASM assets.
 - Use Playwright for browser integration and user interactions that unit or component tests cannot prove. For browser-specific investigation, use `.agents/skills/ehagaki-browser-debug/`; prefer relevant existing tests and keep ad hoc artifacts temporary. Device emulation is not evidence of real OS keyboard, browser chrome, PWA standalone UI, or WebView behavior.

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "complexity:thread-graph": "node scripts/threadGraphComplexityCheck.mjs",
     "test": "npm run complexity:thread-graph && vitest run",
     "test:unit": "npm run complexity:thread-graph && vitest run src/test/unit",
-    "test:agent": "npm run test -- --reporter=agent",
-    "test:unit:agent": "npm run test:unit -- --reporter=agent",
     "test:ui": "vitest --ui",
     "test:e2e": "npm run test:e2e:dev-server && npm run test:e2e:parallel",
     "test:e2e:dev-server": "playwright test --config=playwright.web-component-dev.config.ts",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,13 @@
     "complexity:thread-graph": "node scripts/threadGraphComplexityCheck.mjs",
     "test": "npm run complexity:thread-graph && vitest run",
     "test:unit": "npm run complexity:thread-graph && vitest run src/test/unit",
+    "test:agent": "npm run test -- --reporter=agent",
+    "test:unit:agent": "npm run test:unit -- --reporter=agent",
     "test:ui": "vitest --ui",
     "test:e2e": "npm run test:e2e:dev-server && npm run test:e2e:parallel",
     "test:e2e:dev-server": "playwright test --config=playwright.web-component-dev.config.ts",
     "test:e2e:parallel": "playwright test --workers=2",
+    "test:e2e:agent": "npm run test:e2e:dev-server -- --reporter=dot && npm run test:e2e:parallel -- --reporter=dot",
     "deploy": "gh-pages -d dist"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Vitestはcoding-agent環境で標準のminimal (`agent`) reporterを自動選択するため、既存の `npm test` / `npm run test:unit` をそのまま使用
- Playwright向けに `npm run test:e2e:agent` を追加し、標準 `dot` reporterで成功時の出力を削減
- 選択Playwright実行でもcoding agentには `--reporter=dot` を案内
- `AGENTS.md` をこの運用に合わせて更新
- 既存の人間向けテストコマンドは変更なし

## Verification

- `npm test`: 4020 passed / 1 skipped
- `npm run test:unit`: 3815 passed
- `npm run check`: 0 errors / 0 warnings
- `git diff --check`: passed
- `npm run test:e2e:agent`: 今回の変更による新規failureなし。既存の2件以外は成功
- 一時ファイル・fixtureは差分に残っていない