### PR TITLE
Stabilize iframe theme E2E lifecycle synchronization

### DIFF
--- a/src/test/e2e/embedParentClientExample.spec.ts
+++ b/src/test/e2e/embedParentClientExample.spec.ts
@@ -664,10 +664,44 @@ test("applies iframe color defaults, persists user colors, and releases runtime 
     appUrl.searchParams.set("defaultAccentColor", "#ABCDEF");
     appUrl.searchParams.set("defaultBaseColor", "#CDEFAB");
     await page.getByLabel("eHagaki URL").fill(appUrl.toString());
-    await page.getByRole("button", { name: "iframe を再読み込み" }).click();
 
     const frame = page.frameLocator("#ehagaki-iframe");
-    await expect(frame.locator(".tiptap-editor")).toBeVisible();
+    const readyLogRecord = "[info] ready を受信しました。eHagaki は既定で signEvent を要求し、親クライアントがログインした時点で auth.login を送信します";
+    const countReadyLogRecords = async () => {
+        const eventLog = await page.locator("#event-log").inputValue();
+        return eventLog.split(readyLogRecord).length - 1;
+    };
+    const reloadIframeForThemeSnapshot = async () => {
+        const readyLogCount = await countReadyLogRecords();
+        const expectedUrl = await page.locator("#iframe-src").textContent();
+        if (!expectedUrl) {
+            throw new Error("iframe URL was unavailable before reload");
+        }
+        const childFrames = page.frames().filter((candidate) =>
+            candidate.parentFrame() === page.mainFrame(),
+        );
+        if (childFrames.length !== 1) {
+            throw new Error("expected one current iframe frame before reload");
+        }
+        const [childFrame] = childFrames;
+
+        const navigation = page.waitForEvent("framenavigated", (candidate) =>
+            candidate === childFrame && candidate.url() === expectedUrl,
+        );
+        await page.getByRole("button", { name: "iframe を再読み込み" }).click();
+        await navigation;
+        await expect.poll(countReadyLogRecords).toBe(readyLogCount + 1);
+        await Promise.all([
+            expect(frame.locator(".header-actions button").first()).toBeAttached(),
+            expect(frame.locator(".settings-btn").first()).toBeAttached(),
+            expect(frame.locator(".ehagaki-app-root").first()).toBeAttached(),
+            expect(frame.locator(".editor-container").first()).toBeAttached(),
+            expect(frame.locator(".footer-bar").first()).toBeAttached(),
+            expect(frame.locator(".footer-button-bar").first()).toBeAttached(),
+            expect(frame.locator(".site-icon path").first()).toBeAttached(),
+        ]);
+    };
+    await reloadIframeForThemeSnapshot();
     const readFrameColors = () => frame.locator("html").evaluate((html) => ({
         accent: getComputedStyle(html).getPropertyValue("--accent-color").trim().toLowerCase(),
         base: getComputedStyle(html).getPropertyValue("--base-color").trim().toLowerCase(),
@@ -720,8 +754,7 @@ test("applies iframe color defaults, persists user colors, and releases runtime 
         localStorage.setItem("ehagaki.embed.storage.v1:accentColor", "#112233");
         localStorage.setItem("ehagaki.embed.storage.v1:baseColor", "#223344");
     });
-    await page.getByRole("button", { name: "iframe を再読み込み" }).click();
-    await expect(frame.locator(".tiptap-editor")).toBeVisible();
+    await reloadIframeForThemeSnapshot();
     await expect.poll(readFrameColors).toMatchObject({ accent: "#112233", base: "#223344" });
     const userUi = await readFrameThemeUi();
     expect(userUi.headerBorder).toBe("rgb(17, 34, 51)");


### PR DESCRIPTION
## Root cause

The iframe theme E2E could observe the prior iframe document or a partially attached new document after reload. `.tiptap-editor` visibility and CSS custom-property checks did not prove that the intended child frame had navigated, emitted `ready`, and attached every element read by the computed-style snapshot.

## Change

The affected test waits for the current child frame to navigate to the expected iframe URL, verifies one new parent event-log `ready` record, and asserts attachment of the exact snapshot elements before reading computed styles. No production lifecycle, protocol, public API, retry, timeout, or worker configuration changed.

## Verification

- Target mobile Chromium test: 20/20 passed in one Playwright invocation with `--repeat-each=20` and 2 workers.
- `src/test/e2e/embedParentClientExample.spec.ts` on mobile Chromium, covered by the successful full parallel E2E runs.
- `npm run check` (0 errors, 0 warnings).
- `npm test` (4,020 passed, 1 skipped).
- `npm run test:e2e:dev-server` (1 passed).
- `npm run test:e2e:parallel` twice (355 passed, 22 skipped each).