### PR TITLE
Stop Web Component from overriding host keyboard viewport

### DIFF
--- a/public/host-owned-composer-lite-example.html
+++ b/public/host-owned-composer-lite-example.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content" />
     <title>Host-owned Composer Lite Playground</title>
     <style>
       :root { color-scheme: light dark; }
@@ -11,6 +11,7 @@
         margin: 0 auto;
         max-width: 900px;
         padding: 1rem;
+        padding-bottom: calc(1rem + var(--composer-dock-height, 460px));
       }
       h1 { margin-top: 0; }
       fieldset { margin: 1rem 0; padding: .75rem 1rem 1rem; }
@@ -25,7 +26,18 @@
       .control-row > label:first-child { min-width: 9rem; }
       .hint { color: #666; font-size: .9rem; margin: .25rem 0 .5rem; }
       @media (prefers-color-scheme: dark) { .hint { color: #aaa; } }
-      #mount { height: 460px; border: 1px solid #999; margin: 1rem 0; }
+      #mount {
+        position: fixed;
+        z-index: 100;
+        left: 50%;
+        bottom: 0;
+        width: min(calc(100vw - 2rem - 2px), 900px);
+        height: 460px;
+        margin: 0;
+        border: 1px solid #999;
+        background: Canvas;
+        transform: translateX(-50%);
+      }
       ehagaki-composer { display: block; height: 100%; }
       output { display: block; margin: .5rem 0; overflow-wrap: anywhere; }
       pre {
@@ -213,6 +225,10 @@ note1424242424242424242424242424242424242424242424242424qv3q9y6</textarea>
         status.textContent = text;
         mountConfigStatus.textContent = text;
       };
+      const setMountHeight = (height) => {
+        mount.style.height = height;
+        document.body.style.setProperty('--composer-dock-height', height);
+      };
       const applyPreferredHeight = (config) => {
         if (
           !checked('follow-preferred-height')
@@ -221,7 +237,7 @@ note1424242424242424242424242424242424242424242424242424qv3q9y6</textarea>
         ) {
           return false;
         }
-        mount.style.height = `${composer.preferredHeight}px`;
+        setMountHeight(`${composer.preferredHeight}px`);
         status.textContent = `host applied preferred height: ${composer.preferredHeight}px`;
         return true;
       };
@@ -283,7 +299,7 @@ note1424242424242424242424242424242424242424242424242424qv3q9y6</textarea>
         const generation = ++creationGeneration;
         const config = currentMountConfig();
         composer?.remove();
-        mount.style.height = defaultMountHeight;
+        setMountHeight(defaultMountHeight);
         composer = document.createElement('ehagaki-composer');
         composer.id = 'composer';
         composer.assetBase = new URL('./web-component/host-owned/', import.meta.url).href;
@@ -362,7 +378,7 @@ note1424242424242424242424242424242424242424242424242424qv3q9y6</textarea>
       get('create-composer').onclick = () => void createComposer().catch((error) => write('create error:', safeError(error)));
       get('follow-preferred-height').onchange = () => {
         if (!checked('follow-preferred-height')) {
-          mount.style.height = defaultMountHeight;
+          setMountHeight(defaultMountHeight);
           return;
         }
         applyPreferredHeight(mountedConfig ?? currentMountConfig());

--- a/src/stores/uiStore.svelte.ts
+++ b/src/stores/uiStore.svelte.ts
@@ -36,6 +36,7 @@ let lastViewportOffsetTop = 0;
 let lastVisibleViewportBottom = 0;
 let lastPhysicalKeyboardVisible = false;
 let lastPhysicalKeyboardHeight = 0;
+let lastUsesVirtualKeyboardGeometry = false;
 const keyboardTouchScrollLock =
     typeof document === "undefined"
         ? null
@@ -51,16 +52,6 @@ function setRootStyleProperty(name: string, value: string): void {
     }
 
     getAppRuntimeEnvironment().styleTarget.style.setProperty(name, value);
-}
-
-function isVirtualKeyboardOverlayActive(): boolean {
-    const virtualKeyboard = (
-        navigator as Navigator & {
-            virtualKeyboard?: { overlaysContent?: boolean };
-        }
-    ).virtualKeyboard;
-
-    return isNonPwaAndroidChrome() && virtualKeyboard?.overlaysContent === true;
 }
 
 function getFooterReservedHeight(
@@ -118,6 +109,10 @@ function syncLayoutCssVariables(
 
     if (viewportMetrics.physicalKeyboardHeight !== undefined) {
         lastPhysicalKeyboardHeight = viewportMetrics.physicalKeyboardHeight;
+    }
+
+    if (viewportMetrics.usesKeyboardOverlay !== undefined) {
+        lastUsesVirtualKeyboardGeometry = viewportMetrics.usesKeyboardOverlay;
     }
 
     const isContainerLayout =
@@ -283,7 +278,7 @@ export const reasonInputVisibleStore = {
         reasonInputVisible = v;
         syncLayoutCssVariables(
             lastPhysicalKeyboardVisible && isPostEditorFocusActive(),
-            { usesKeyboardOverlay: isVirtualKeyboardOverlayActive() },
+            { usesKeyboardOverlay: lastUsesVirtualKeyboardGeometry },
         );
     },
 };
@@ -348,6 +343,7 @@ export function setupViewportListener(
     layoutCapabilities.hasFooter = capabilities.hasFooter ?? true;
     layoutCapabilities.hasKeyboardButtonBar = capabilities.hasKeyboardButtonBar ?? true;
     bottomPosition = layoutCapabilities.hasFooter ? FOOTER_HEIGHT : 0;
+    lastUsesVirtualKeyboardGeometry = false;
     syncLayoutCssVariables(false);
 
     if (typeof window === "undefined" || !window.visualViewport) {
@@ -360,14 +356,18 @@ export function setupViewportListener(
     const virtualKeyboard = (
         navigator as Navigator & { virtualKeyboard?: VirtualKeyboardInfo }
     ).virtualKeyboard;
-    const usesKeyboardOverlay =
+    const canObserveVirtualKeyboardGeometry =
         isNonPwaAndroidChrome() &&
         virtualKeyboard?.boundingRect !== undefined &&
         typeof virtualKeyboard.addEventListener === "function" &&
         typeof virtualKeyboard.removeEventListener === "function";
-    const previousOverlaysContent = virtualKeyboard?.overlaysContent;
+    const managesVirtualKeyboardOverlay =
+        !isContainerLayout && canObserveVirtualKeyboardGeometry;
+    const previousOverlaysContent = managesVirtualKeyboardOverlay
+        ? virtualKeyboard?.overlaysContent
+        : undefined;
 
-    if (usesKeyboardOverlay && virtualKeyboard) {
+    if (managesVirtualKeyboardOverlay && virtualKeyboard) {
         virtualKeyboard.overlaysContent = true;
     }
 
@@ -457,22 +457,24 @@ export function setupViewportListener(
             // キーボードが開いているかどうかを閾値で判定
             const virtualKeyboardRect = virtualKeyboard?.boundingRect;
             const virtualKeyboardLayoutInset =
-                usesKeyboardOverlay && virtualKeyboardRect
+                canObserveVirtualKeyboardGeometry && virtualKeyboardRect
                     ? getVirtualKeyboardLayoutInset(
                         virtualKeyboardRect,
                         viewport.width,
                         layoutViewportHeight,
                     )
                     : 0;
-            const visibleViewportBottom = usesKeyboardOverlay
+            const usesVirtualKeyboardGeometry =
+                virtualKeyboardLayoutInset > 0;
+            const visibleViewportBottom = usesVirtualKeyboardGeometry
                 ? layoutViewportHeight - virtualKeyboardLayoutInset
                 : visibleBottom;
-            const isKeyboardOpen = usesKeyboardOverlay
+            const isKeyboardOpen = usesVirtualKeyboardGeometry
                 ? virtualKeyboardLayoutInset > KEYBOARD_THRESHOLD
                 : isSafariViewportMode
                     ? keyboardViewportReduction > KEYBOARD_THRESHOLD
                     : calculatedKeyboardHeight > KEYBOARD_THRESHOLD;
-            const keyboardStoreHeight = usesKeyboardOverlay
+            const keyboardStoreHeight = usesVirtualKeyboardGeometry
                 ? virtualKeyboardLayoutInset
                 : isSafariViewportMode
                     ? keyboardViewportReduction
@@ -489,7 +491,7 @@ export function setupViewportListener(
                         true,
                         visibleViewportBottom,
                     )
-                    : usesKeyboardOverlay
+                    : usesVirtualKeyboardGeometry
                     ? virtualKeyboardLayoutInset
                     : calculatedKeyboardHeight
                 : FOOTER_HEIGHT;
@@ -502,7 +504,7 @@ export function setupViewportListener(
             syncLayoutCssVariables(isComposerKeyboardActive, {
                 height: viewport.height,
                 offsetTop: viewportOffsetTop,
-                usesKeyboardOverlay,
+                usesKeyboardOverlay: usesVirtualKeyboardGeometry,
                 physicalKeyboardVisible: isKeyboardOpen,
                 physicalKeyboardHeight: isKeyboardOpen
                     ? keyboardStoreHeight
@@ -532,7 +534,7 @@ export function setupViewportListener(
         "selectionchange",
         handleDocumentSelectionChange,
     );
-    if (usesKeyboardOverlay) {
+    if (canObserveVirtualKeyboardGeometry) {
         virtualKeyboard?.addEventListener?.(
             "geometrychange",
             handleVirtualKeyboardGeometryChange,
@@ -554,14 +556,18 @@ export function setupViewportListener(
             "selectionchange",
             handleDocumentSelectionChange,
         );
-        if (usesKeyboardOverlay) {
+        if (canObserveVirtualKeyboardGeometry) {
             virtualKeyboard?.removeEventListener?.(
                 "geometrychange",
                 handleVirtualKeyboardGeometryChange,
             );
-            if (virtualKeyboard && previousOverlaysContent !== undefined) {
-                virtualKeyboard.overlaysContent = previousOverlaysContent;
-            }
+        }
+        if (
+            managesVirtualKeyboardOverlay
+            && virtualKeyboard
+            && previousOverlaysContent !== undefined
+        ) {
+            virtualKeyboard.overlaysContent = previousOverlaysContent;
         }
 
         if (isSafariViewportMode) {

--- a/src/test/e2e/webComponentDevServer.spec.ts
+++ b/src/test/e2e/webComponentDevServer.spec.ts
@@ -141,14 +141,25 @@ test("serves the Web Component sample through the local dev proxy", async ({ pag
             const buttonBarRect = buttonBar.getBoundingClientRect();
             const mount = document.querySelector<HTMLElement>("#mount")!;
             const mountRect = mount.getBoundingClientRect();
+            const mountStyle = getComputedStyle(mount);
+            const bodyStyle = getComputedStyle(document.body);
             return {
                 mountHeight: mountRect.height,
+                mountTop: mountRect.top,
+                mountBottom: mountRect.bottom,
+                mountLeft: mountRect.left,
+                mountRight: mountRect.right,
                 composerHeight: component.height,
+                composerTop: component.top,
                 topSpacing: getComputedStyle(content).paddingTop,
                 buttonBarHeight: buttonBarRect.height,
                 buttonBarBottom: buttonBarRect.bottom,
                 componentBottom: component.bottom,
-                mountBottom: mountRect.bottom,
+                viewportHeight: window.innerHeight,
+                viewportWidth: window.innerWidth,
+                mountPosition: mountStyle.position,
+                mountBottomOffset: mountStyle.bottom,
+                bodyPaddingBottom: Number.parseFloat(bodyStyle.paddingBottom),
                 footerPresent: !!shadow.querySelector(".footer-bar"),
             };
         });
@@ -156,7 +167,14 @@ test("serves the Web Component sample through the local dev proxy", async ({ pag
         expect(closedHostOwnedGeometry.mountHeight).toBeGreaterThanOrEqual(460);
         expect(closedHostOwnedGeometry.composerHeight).toBeGreaterThanOrEqual(459);
         expect(Math.abs(closedHostOwnedGeometry.mountHeight - closedHostOwnedGeometry.composerHeight)).toBeLessThanOrEqual(2);
+        expect(closedHostOwnedGeometry.mountPosition).toBe("fixed");
+        expect(closedHostOwnedGeometry.mountBottomOffset).toBe("0px");
+        expect(Math.abs(closedHostOwnedGeometry.mountBottom - closedHostOwnedGeometry.viewportHeight)).toBeLessThanOrEqual(1);
+        expect(Math.abs(closedHostOwnedGeometry.composerTop - closedHostOwnedGeometry.mountTop)).toBeLessThanOrEqual(2);
         expect(Math.abs(closedHostOwnedGeometry.componentBottom - closedHostOwnedGeometry.mountBottom)).toBeLessThanOrEqual(2);
+        expect(closedHostOwnedGeometry.mountLeft).toBeGreaterThanOrEqual(0);
+        expect(closedHostOwnedGeometry.mountRight).toBeLessThanOrEqual(closedHostOwnedGeometry.viewportWidth);
+        expect(closedHostOwnedGeometry.bodyPaddingBottom).toBeGreaterThanOrEqual(460);
         expect(closedHostOwnedGeometry.buttonBarHeight).toBe(50);
         expect(Math.abs(closedHostOwnedGeometry.buttonBarBottom - closedHostOwnedGeometry.componentBottom)).toBeLessThanOrEqual(1);
         expect(closedHostOwnedGeometry.footerPresent).toBe(false);
@@ -201,6 +219,20 @@ test("serves the Web Component sample through the local dev proxy", async ({ pag
         });
         expect(autoGrowPickerGeometry.height).toBeCloseTo(autoGrowPickerGeometry.minHeight, 1);
         expect(autoGrowPickerGeometry.maxHeight).toBeGreaterThan(autoGrowPickerGeometry.minHeight);
+        const preferredHeight = await page.locator("ehagaki-composer").evaluate((element) => (
+            (element as HTMLElement & { preferredHeight: number | null }).preferredHeight
+        ));
+        if (preferredHeight === null) throw new Error("Lite Composer did not publish a preferred height.");
+        expect(preferredHeight).toBeGreaterThan(0);
+        await page.locator("#follow-preferred-height").check();
+        await expect.poll(() => page.locator("#mount").evaluate((element) => (
+            Number.parseFloat(getComputedStyle(element).height)
+        ))).toBe(preferredHeight);
+        await expect.poll(() => page.locator("body").evaluate((element) => (
+            Number.parseFloat(getComputedStyle(element).paddingBottom)
+        ))).toBe(preferredHeight + 16);
+        await page.locator("#follow-preferred-height").uncheck();
+        await expect(page.locator("#mount")).toHaveCSS("height", "460px");
         await expect.poll(() => page.locator("ehagaki-composer .emoji-button img").evaluateAll((images) => images.every((image) => {
             const img = image as HTMLImageElement;
             return img.complete && img.naturalWidth > 0;

--- a/src/test/unit/uiStore.test.ts
+++ b/src/test/unit/uiStore.test.ts
@@ -333,6 +333,31 @@ describe('uiStore', () => {
         expect(virtualKeyboard.virtualKeyboard.overlaysContent).toBe(false);
     });
 
+    it('viewport mode は既存の VirtualKeyboard policy を cleanup 時に復元する', async () => {
+        setUserAgent('Mozilla/5.0 (Linux; Android 15; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36');
+
+        const requestAnimationFrameSpy = vi
+            .spyOn(window, 'requestAnimationFrame')
+            .mockImplementation((callback: FrameRequestCallback) => {
+                callback(0);
+                return 1;
+            });
+        const cancelAnimationFrameSpy = vi
+            .spyOn(window, 'cancelAnimationFrame')
+            .mockImplementation(() => { });
+        createVisualViewportMock(800);
+        const virtualKeyboard = createVirtualKeyboardMock();
+        virtualKeyboard.virtualKeyboard.overlaysContent = true;
+        const { setupViewportListener } = await import('../../stores/uiStore.svelte');
+
+        const cleanup = setupViewportListener();
+        cleanup?.();
+
+        expect(virtualKeyboard.virtualKeyboard.overlaysContent).toBe(true);
+        requestAnimationFrameSpy.mockRestore();
+        cancelAnimationFrameSpy.mockRestore();
+    });
+
     it('「宛先を指定」ダイアログの入力欄では投稿エディター向けレイアウトを有効にしない', async () => {
         setUserAgent('Mozilla/5.0 (Linux; Android 15; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36');
 
@@ -1022,6 +1047,163 @@ describe('uiStore', () => {
         expect(layoutTarget.style.getPropertyValue('--app-overlay-position')).toBe('absolute');
         expect(layoutTarget.style.getPropertyValue('--keyboard-button-bar-bottom')).toBe('66px');
         expect(layoutTarget.style.getPropertyValue('--main-content-keyboard-adjustment')).toBe('0px');
+        expect(keyboardHeightStore.value).toBe(0);
+
+        cleanup?.();
+        requestAnimationFrameSpy.mockRestore();
+        cancelAnimationFrameSpy.mockRestore();
+    });
+
+    it('container mode は host policy を変更せず、getter が false でも VirtualKeyboard rect を使う', async () => {
+        setUserAgent('Mozilla/5.0 (Linux; Android 15; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36');
+
+        const runtime = await import('../../lib/appRuntimeEnvironment');
+        const layoutTarget = document.createElement('div');
+        Object.defineProperty(layoutTarget, 'getBoundingClientRect', {
+            configurable: true,
+            value: vi.fn(() => ({ bottom: 700, height: 600 })),
+        });
+        runtime.configureAppRuntimeEnvironment({
+            layoutMode: 'container',
+            styleTarget: layoutTarget,
+            layoutTarget,
+            overlayTarget: layoutTarget,
+            themeTarget: layoutTarget,
+        });
+
+        const requestAnimationFrameSpy = vi
+            .spyOn(window, 'requestAnimationFrame')
+            .mockImplementation((callback: FrameRequestCallback) => {
+                callback(0);
+                return 1;
+            });
+        const cancelAnimationFrameSpy = vi
+            .spyOn(window, 'cancelAnimationFrame')
+            .mockImplementation(() => { });
+        createVisualViewportMock(800);
+        const virtualKeyboard = createVirtualKeyboardMock();
+        const {
+            bottomPositionStore,
+            keyboardHeightStore,
+            reasonInputVisibleStore,
+            setupViewportListener,
+        } = await import('../../stores/uiStore.svelte');
+
+        const cleanup = setupViewportListener();
+
+        expect(virtualKeyboard.virtualKeyboard.overlaysContent).toBe(false);
+        expect(virtualKeyboard.virtualKeyboard.addEventListener).toHaveBeenCalledWith(
+            'geometrychange',
+            expect.any(Function),
+        );
+
+        virtualKeyboard.setHeight(300);
+        virtualKeyboard.emitGeometryChange();
+
+        expect(layoutTarget.style.getPropertyValue('--keyboard-button-bar-bottom')).toBe('200px');
+        expect(layoutTarget.style.getPropertyValue('--reason-input-bottom')).toBe('250px');
+        expect(layoutTarget.style.getPropertyValue('--main-content-keyboard-adjustment')).toBe('200px');
+        expect(keyboardHeightStore.value).toBe(300);
+        expect(bottomPositionStore.value).toBe(200);
+
+        reasonInputVisibleStore.set(true);
+        expect(layoutTarget.style.getPropertyValue('--reason-input-bottom')).toBe('250px');
+
+        cleanup?.();
+        expect(virtualKeyboard.virtualKeyboard.overlaysContent).toBe(false);
+        requestAnimationFrameSpy.mockRestore();
+        cancelAnimationFrameSpy.mockRestore();
+    });
+
+    it('container mode は host が設定した VirtualKeyboard policy を cleanup 時に変更しない', async () => {
+        setUserAgent('Mozilla/5.0 (Linux; Android 15; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36');
+
+        const runtime = await import('../../lib/appRuntimeEnvironment');
+        const layoutTarget = document.createElement('div');
+        Object.defineProperty(layoutTarget, 'getBoundingClientRect', {
+            configurable: true,
+            value: vi.fn(() => ({ bottom: 700, height: 600 })),
+        });
+        runtime.configureAppRuntimeEnvironment({
+            layoutMode: 'container',
+            styleTarget: layoutTarget,
+            layoutTarget,
+            overlayTarget: layoutTarget,
+            themeTarget: layoutTarget,
+        });
+
+        const requestAnimationFrameSpy = vi
+            .spyOn(window, 'requestAnimationFrame')
+            .mockImplementation((callback: FrameRequestCallback) => {
+                callback(0);
+                return 1;
+            });
+        const cancelAnimationFrameSpy = vi
+            .spyOn(window, 'cancelAnimationFrame')
+            .mockImplementation(() => { });
+        createVisualViewportMock(800);
+        const virtualKeyboard = createVirtualKeyboardMock();
+        virtualKeyboard.virtualKeyboard.overlaysContent = true;
+        const {
+            bottomPositionStore,
+            keyboardHeightStore,
+            setupViewportListener,
+        } = await import('../../stores/uiStore.svelte');
+
+        const cleanup = setupViewportListener();
+        virtualKeyboard.setHeight(300);
+        virtualKeyboard.emitGeometryChange();
+
+        expect(layoutTarget.style.getPropertyValue('--keyboard-button-bar-bottom')).toBe('200px');
+        expect(keyboardHeightStore.value).toBe(300);
+        expect(bottomPositionStore.value).toBe(200);
+
+        cleanup?.();
+
+        expect(virtualKeyboard.virtualKeyboard.overlaysContent).toBe(true);
+        requestAnimationFrameSpy.mockRestore();
+        cancelAnimationFrameSpy.mockRestore();
+    });
+
+    it('container mode は resizes-content の縮小済み host layout に inset を追加しない', async () => {
+        setUserAgent('Mozilla/5.0 (Linux; Android 15; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36');
+
+        const runtime = await import('../../lib/appRuntimeEnvironment');
+        const layoutTarget = document.createElement('div');
+        Object.defineProperty(layoutTarget, 'getBoundingClientRect', {
+            configurable: true,
+            value: vi.fn(() => ({ bottom: 500, height: 500 })),
+        });
+        runtime.configureAppRuntimeEnvironment({
+            layoutMode: 'container',
+            styleTarget: layoutTarget,
+            layoutTarget,
+            overlayTarget: layoutTarget,
+            themeTarget: layoutTarget,
+        });
+        Object.defineProperty(window, 'innerHeight', {
+            configurable: true,
+            value: 500,
+        });
+
+        const requestAnimationFrameSpy = vi
+            .spyOn(window, 'requestAnimationFrame')
+            .mockImplementation((callback: FrameRequestCallback) => {
+                callback(0);
+                return 1;
+            });
+        const cancelAnimationFrameSpy = vi
+            .spyOn(window, 'cancelAnimationFrame')
+            .mockImplementation(() => { });
+        createVisualViewportMock(500);
+        const virtualKeyboard = createVirtualKeyboardMock();
+        const { keyboardHeightStore, setupViewportListener } = await import('../../stores/uiStore.svelte');
+
+        const cleanup = setupViewportListener();
+
+        expect(virtualKeyboard.virtualKeyboard.overlaysContent).toBe(false);
+        expect(layoutTarget.style.getPropertyValue('--main-content-keyboard-adjustment')).toBe('0px');
+        expect(layoutTarget.style.getPropertyValue('--keyboard-button-bar-bottom')).toBe('66px');
         expect(keyboardHeightStore.value).toBe(0);
 
         cleanup?.();


### PR DESCRIPTION
## Root cause
Direct Full and Host-owned Lite Web Components share the host Window and container layout, but setupViewportListener previously set navigator.virtualKeyboard.overlaysContent to true. That global write overrides the host viewport interactive-widget policy.

## Runtime changes
- Container-mode Web Components no longer change or restore the host VirtualKeyboard policy.
- Container mode observes VirtualKeyboard geometry regardless of the overlaysContent getter, so meta interactive-widget=overlays-content can use the existing component-local inset path.
- Zero geometry continues through the existing resizes-content/resizes-visual VisualViewport behavior.
- Viewport-mode non-PWA Android Chrome preserves the existing policy write and cleanup restoration. Iframe behavior was not changed.

## Verification
- npm run test -- src/test/unit/uiStore.test.ts src/test/unit/viewportLayout.test.ts
- npm test (350 files passed, 1 skipped; 4,024 tests passed, 1 skipped)
- npm run check
- npm run build
- npx playwright test src/test/e2e/webComponentLite.spec.ts --reporter=dot (73 passed, 2 skipped)

## Android HTTPS device verification
User device verification pending. Before merge, verify the trusted-HTTPS Android Chrome scenarios from the implementation plan, including policy values, viewport metrics, DOMRects, and the meta interactive-widget=overlays-content geometry case. No physical Android IME result is claimed by this PR.

## Playground layout for Android verification
- Host-owned Lite Playground now uses a bottom-fixed host Composer dock so Android Chrome can be checked with the host layout viewport contract.
- The Playground viewport meta explicitly sets `interactive-widget=resizes-content`.
- The Playground adds no VisualViewport, VirtualKeyboard, or other keyboard-following JavaScript; the dock relies on host CSS `position: fixed; bottom: 0` and static fixed-UI reservation.
- The updated Playground E2E covers fixed geometry, Composer filling the mount, KeyboardButtonBar/footer-less Lite behavior, preferred height reservation, auto-grow, recreate, and reconnect flows.
- Android trusted-HTTPS device verification remains user verification pending and is not claimed as completed by Codex.
