### PR TITLE
Fix mobile editor submit button interaction

### DIFF
--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -1113,6 +1113,7 @@
         class="editor-submit-button-container"
         onpointerdowncapture={preventKeyboardFocusChange}
         ontouchstartcapture={preventKeyboardFocusChange}
+        onmousedowncapture={preventKeyboardFocusChange}
       >
         <Button
           variant="primary"
@@ -1356,8 +1357,8 @@
 
   :global(.editor-submit-button .plane-icon) {
     mask-image: url("/icons/paper-plane-solid-full.svg");
-    width: 24px;
-    height: 24px;
+    width: 22px;
+    height: 22px;
     margin-inline-end: 1px;
     margin-top: 1px;
   }

--- a/src/test/e2e/webComponentLite.spec.ts
+++ b/src/test/e2e/webComponentLite.spec.ts
@@ -168,7 +168,7 @@ test("Lite minimal configuration exposes only text composition and preserves suc
     await expect(replacement.locator(".tiptap-editor")).toContainText("keep after failure");
 });
 
-test("Lite editor submit button replaces only the bar submit surface and preserves the existing submit flow", async ({ page }) => {
+test("Lite editor submit button replaces only the bar submit surface and preserves the existing submit flow", async ({ page, isMobile }) => {
     await page.goto(hostOrigin);
     await page.evaluate(async ({ componentOrigin }) => {
         await import(`${componentOrigin}/host-owned/ehagaki-composer.js`);
@@ -213,11 +213,17 @@ test("Lite editor submit button replaces only the bar submit surface and preserv
     await expect(composer.locator(".custom-emoji-button")).toHaveCount(1);
     await expect(composer.locator(".button-group-right button")).toHaveCount(2);
     await expect(editorSubmitButton).toBeDisabled();
+    await expect(editorSubmitButton.locator(".plane-icon")).toHaveCSS("width", "22px");
+    await expect(editorSubmitButton.locator(".plane-icon")).toHaveCSS("height", "22px");
 
     await editor.click();
     await editor.pressSequentially("editor button content");
     await expect(editorSubmitButton).toBeEnabled();
-    await editorSubmitButton.click();
+    if (isMobile) {
+        await editorSubmitButton.tap();
+    } else {
+        await editorSubmitButton.click();
+    }
     await expect.poll(() => page.evaluate(() => (window as any).__liteEditorSubmitState.outputs.length)).toBe(1);
     await expect(editorSubmitButton).toBeDisabled();
     await expect(editor).toHaveAttribute("contenteditable", "true");


### PR DESCRIPTION
## Summary\n- Reduce the inline editor submit icon to 22x22px.\n- Preserve editor focus on Android touch compatibility mousedown events.\n- Exercise mobile tap submission and icon sizing in the Lite E2E.\n\n## Verification\n- npm run check\n- npx vitest run src/test/unit/keyboardFocusUtils.test.ts\n- git diff --check\n\nThe targeted Web Component E2E could not start because an existing dev server held the shared Web Component build lease.