### PR TITLE
Enforce inline submit icon size

### DIFF
--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -1355,7 +1355,7 @@
     flex: 0 0 40px;
   }
 
-  :global(.editor-submit-button .plane-icon) {
+  :global(button.editor-submit-button .plane-icon) {
     mask-image: url("/icons/paper-plane-solid-full.svg");
     width: 22px;
     height: 22px;


### PR DESCRIPTION
Use a more specific selector so the Host-owned Lite Editor submit icon is actually rendered at 22x22px instead of being overridden by Button.svelte's circle icon rule.