### PR TITLE
Set inline submit icon dimensions

### DIFF
--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -1357,8 +1357,8 @@
 
   :global(button.editor-submit-button .plane-icon) {
     mask-image: url("/icons/paper-plane-solid-full.svg");
-    width: 22px;
-    height: 22px;
+    inline-size: 22px;
+    block-size: 22px;
     margin-inline-end: 1px;
     margin-top: 1px;
   }

--- a/src/test/e2e/webComponentLite.spec.ts
+++ b/src/test/e2e/webComponentLite.spec.ts
@@ -213,8 +213,12 @@ test("Lite editor submit button replaces only the bar submit surface and preserv
     await expect(composer.locator(".custom-emoji-button")).toHaveCount(1);
     await expect(composer.locator(".button-group-right button")).toHaveCount(2);
     await expect(editorSubmitButton).toBeDisabled();
-    await expect(editorSubmitButton.locator(".plane-icon")).toHaveCSS("width", "22px");
-    await expect(editorSubmitButton.locator(".plane-icon")).toHaveCSS("height", "22px");
+    const editorSubmitIcon = editorSubmitButton.locator(".plane-icon");
+    await expect(editorSubmitIcon).toHaveCSS("inline-size", "22px");
+    await expect(editorSubmitIcon).toHaveCSS("block-size", "22px");
+    const editorSubmitIconBox = await editorSubmitIcon.boundingBox();
+    expect(editorSubmitIconBox?.width).toBe(22);
+    expect(editorSubmitIconBox?.height).toBe(22);
 
     await editor.click();
     await editor.pressSequentially("editor button content");


### PR DESCRIPTION
Fix the Host-owned Composer Lite Editor submit icon sizing by setting inline-size and block-size to 22px. The shared svg-icon rule uses logical dimensions, so width/height alone did not change the rendered 28px icon. Extend the E2E assertion to check logical size and bounding box.