### PR TITLE
Fix Host-owned Lite Android submit tap

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,6 +43,15 @@ export default defineConfig({
             },
         },
         {
+            name: 'android-chromium',
+            testMatch: '**/webComponentLite.spec.ts',
+            grep: /@android-chrome/,
+            use: {
+                ...devices['Pixel 7'],
+                browserName: 'chromium',
+            },
+        },
+        {
             name: 'mobile-webkit',
             testMatch: [
                 '**/composerTargetDialog.spec.ts',

--- a/src/components/CustomEmojiPicker.svelte
+++ b/src/components/CustomEmojiPicker.svelte
@@ -28,6 +28,7 @@
     import {
         preserveKeyboardForScrollableTouch,
         preventKeyboardFocusChange,
+        readComposerKeyboardHeight,
     } from "../lib/utils/keyboardFocusUtils";
     import { getAppStorage } from "../lib/appStorage";
 
@@ -171,18 +172,9 @@
         cacheCustomEmojiImages([url]);
     }
 
-    function readRootPixelValue(name: string): number {
-        if (typeof document === "undefined") return 0;
-        const rawValue = getComputedStyle(document.documentElement)
-            .getPropertyValue(name)
-            .trim();
-        const value = Number.parseFloat(rawValue);
-        return Number.isFinite(value) ? value : 0;
-    }
-
     function getPickerHeightClampViewport(): number {
         const visualViewportHeight = window.visualViewport?.height ?? 0;
-        const keyboardHeight = readRootPixelValue("--keyboard-height");
+        const keyboardHeight = readComposerKeyboardHeight();
         return Math.max(
             window.innerHeight || 0,
             visualViewportHeight + keyboardHeight,

--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -72,6 +72,7 @@
   import { insertCustomEmojiWithoutUnwantedKeyboard } from "../lib/editor/customEmojiInsertion";
   import {
     focusEditorWithoutKeyboardForCurrentTap,
+    isComposerKeyboardVisible,
     preventKeyboardFocusChange,
   } from "../lib/utils/keyboardFocusUtils";
   import { isEditorElement } from "../lib/utils/appDomUtils";
@@ -289,16 +290,10 @@
   }
 
   function handleEditorSubmitButtonPress(event: Event): void {
-    const keyboardHeight = Number.parseFloat(
-      window
-        .getComputedStyle(document.documentElement)
-        .getPropertyValue("--keyboard-height"),
-    );
-
     // On a visible software keyboard, preventing touchstart suppresses the
     // native click on Android. Keep pointerdown prevention to retain editor
     // focus, but allow touchstart to produce the button click.
-    if (keyboardHeight > 80 && event.type === "touchstart") {
+    if (isComposerKeyboardVisible() && event.type === "touchstart") {
       return;
     }
 

--- a/src/lib/utils/keyboardFocusUtils.ts
+++ b/src/lib/utils/keyboardFocusUtils.ts
@@ -1,7 +1,10 @@
+import { getAppRuntimeEnvironment } from "../appRuntimeEnvironment";
+
 let restoreTimeoutId: ReturnType<typeof setTimeout> | null = null;
 let suppressedEditor: [HTMLElement, string | null] | null = null;
 
 export const POST_EDITOR_ROOT_SELECTOR = "[data-post-editor-root]";
+const COMPOSER_KEYBOARD_VISIBLE_THRESHOLD = 80;
 
 function getElementForNode(node: Node | null): Element | null {
     if (node instanceof Element) {
@@ -11,10 +14,13 @@ function getElementForNode(node: Node | null): Element | null {
     return node?.parentElement ?? null;
 }
 
-export function isPostEditorFocusActive(
-    doc: Document = document,
-): boolean {
-    const activeElement = doc.activeElement;
+export function isPostEditorFocusActive(): boolean {
+    const runtimeEnvironment = getAppRuntimeEnvironment();
+    const root = runtimeEnvironment.domRoot;
+    const doc = runtimeEnvironment.document;
+    const activeElement = root && "activeElement" in root
+        ? root.activeElement
+        : doc?.activeElement;
 
     if (activeElement?.closest(POST_EDITOR_ROOT_SELECTOR)) {
         return true;
@@ -22,19 +28,37 @@ export function isPostEditorFocusActive(
 
     if (
         activeElement &&
-        activeElement !== doc.body &&
-        activeElement !== doc.documentElement
+        activeElement !== doc?.body &&
+        activeElement !== doc?.documentElement
     ) {
         return false;
     }
 
-    const selection = doc.getSelection();
+    const selection = doc?.getSelection();
     return Boolean(
         selection?.rangeCount &&
             getElementForNode(selection.anchorNode)?.closest(
                 POST_EDITOR_ROOT_SELECTOR,
             ),
     );
+}
+
+export function readComposerKeyboardHeight(): number {
+    const runtimeEnvironment = getAppRuntimeEnvironment();
+    const rawValue = runtimeEnvironment.window
+        ?.getComputedStyle(runtimeEnvironment.styleTarget)
+        .getPropertyValue("--keyboard-height")
+        .trim()
+        ?? runtimeEnvironment.styleTarget.style
+            .getPropertyValue("--keyboard-height")
+            .trim();
+    const value = Number.parseFloat(rawValue);
+
+    return Number.isFinite(value) ? value : 0;
+}
+
+export function isComposerKeyboardVisible(): boolean {
+    return readComposerKeyboardHeight() > COMPOSER_KEYBOARD_VISIBLE_THRESHOLD;
 }
 
 function restoreEditorKeyboardInput(): void {
@@ -64,15 +88,10 @@ function getActiveElementForEvent(event: Event): HTMLElement | null {
 }
 
 function suppressEditorKeyboardForCurrentTap(event: Event): void {
-    const keyboardHeight = Number.parseFloat(
-        window
-            .getComputedStyle(document.documentElement)
-            .getPropertyValue("--keyboard-height"),
-    );
     if (
         (event.type !== "touchstart" &&
             (event as PointerEvent).pointerType !== "touch") ||
-        keyboardHeight > 80
+        isComposerKeyboardVisible()
     ) {
         return;
     }

--- a/src/test/e2e/webComponentLite.spec.ts
+++ b/src/test/e2e/webComponentLite.spec.ts
@@ -168,7 +168,7 @@ test("Lite minimal configuration exposes only text composition and preserves suc
     await expect(replacement.locator(".tiptap-editor")).toContainText("keep after failure");
 });
 
-test("Lite editor submit button replaces only the bar submit surface and preserves the existing submit flow", async ({ page, isMobile }) => {
+test("Lite editor submit button replaces only the bar submit surface and preserves the existing submit flow", async ({ page }) => {
     await page.goto(hostOrigin);
     await page.evaluate(async ({ componentOrigin }) => {
         await import(`${componentOrigin}/host-owned/ehagaki-composer.js`);
@@ -223,37 +223,9 @@ test("Lite editor submit button replaces only the bar submit surface and preserv
     await editor.click();
     await editor.pressSequentially("editor button content");
     await expect(editorSubmitButton).toBeEnabled();
-    await page.evaluate(() => {
-        document.documentElement.style.setProperty("--keyboard-height", "300px");
-    });
     await editorSubmitButton.focus();
     expect(await composer.evaluate((element) => element.shadowRoot?.activeElement?.classList.contains("tiptap-editor"))).toBe(true);
-    if (isMobile) {
-        const touchPressHandling = await editorSubmitButton.evaluate((button) => {
-            const pointerDown = new PointerEvent("pointerdown", {
-                bubbles: true,
-                cancelable: true,
-                pointerType: "touch",
-            });
-            button.dispatchEvent(pointerDown);
-            const touchStart = new TouchEvent("touchstart", {
-                bubbles: true,
-                cancelable: true,
-            });
-            button.dispatchEvent(touchStart);
-
-            return {
-                pointerDownPrevented: pointerDown.defaultPrevented,
-                touchStartPrevented: touchStart.defaultPrevented,
-            };
-        });
-        expect(touchPressHandling.pointerDownPrevented).toBe(true);
-        expect(touchPressHandling.touchStartPrevented).toBe(false);
-        expect(await composer.evaluate((element) => element.shadowRoot?.activeElement?.classList.contains("tiptap-editor"))).toBe(true);
-        await editorSubmitButton.dispatchEvent("click");
-    } else {
-        await editorSubmitButton.click();
-    }
+    await editorSubmitButton.click();
     await expect.poll(() => page.evaluate(() => (window as any).__liteEditorSubmitState.outputs.length)).toBe(1);
     await expect(editorSubmitButton).toBeDisabled();
     await expect(editor).toHaveAttribute("contenteditable", "true");
@@ -262,12 +234,8 @@ test("Lite editor submit button replaces only the bar submit surface and preserv
     await editor.press("Backspace");
     await editor.press("Control+z");
     await expect(editor).toHaveText("editor button content");
-    await page.evaluate(() => {
-        document.documentElement.style.removeProperty("--keyboard-height");
-    });
 
-    await editorSubmitButton.dispatchEvent("click");
-    await expect.poll(() => page.evaluate(() => (window as any).__liteEditorSubmitState.outputs.length)).toBe(1);
+    expect(await page.evaluate(() => (window as any).__liteEditorSubmitState.outputs.length)).toBe(1);
     await page.evaluate(() => {
         (window as any).__liteEditorSubmitState.resolveSubmit({ eventId: "e".repeat(64) });
     });
@@ -280,6 +248,142 @@ test("Lite editor submit button replaces only the bar submit surface and preserv
     await editorSubmitButton.click();
     await expect.poll(() => page.evaluate(() => (window as any).__liteEditorSubmitState.outputs.length)).toBe(2);
     await expect(editor).toContainText("keep after editor button failure");
+});
+
+test("Lite editor submit tap keeps Android keyboard input active @android-chrome", async ({ page }, testInfo) => {
+    test.skip(
+        testInfo.project.name !== "android-chromium",
+        "This regression uses the dedicated Android Chromium touch profile.",
+    );
+
+    await page.addInitScript(() => {
+        let keyboardHeight = 0;
+        const geometryTarget = new EventTarget();
+        const virtualKeyboard = {
+            overlaysContent: false,
+            get boundingRect() {
+                const width = window.visualViewport?.width ?? window.innerWidth;
+                const top = Math.max(0, window.innerHeight - keyboardHeight);
+                return {
+                    top,
+                    bottom: top + keyboardHeight,
+                    width,
+                    height: keyboardHeight,
+                };
+            },
+            addEventListener(
+                type: string,
+                listener: EventListenerOrEventListenerObject,
+                options?: boolean | AddEventListenerOptions,
+            ) {
+                geometryTarget.addEventListener(type, listener, options);
+            },
+            removeEventListener(
+                type: string,
+                listener: EventListenerOrEventListenerObject,
+                options?: boolean | EventListenerOptions,
+            ) {
+                geometryTarget.removeEventListener(type, listener, options);
+            },
+        };
+
+        Object.defineProperty(navigator, "virtualKeyboard", {
+            configurable: true,
+            value: virtualKeyboard,
+        });
+        (window as any).__setAndroidKeyboardHeight = (height: number) => {
+            keyboardHeight = height;
+            geometryTarget.dispatchEvent(new Event("geometrychange"));
+        };
+    });
+    await page.goto(hostOrigin);
+    await page.evaluate(async ({ componentOrigin }) => {
+        await import(`${componentOrigin}/host-owned/ehagaki-composer.js`);
+        const state = {
+            browserClicks: 0,
+            inputModes: [] as Array<string | null>,
+            submits: 0,
+            touchStartDefaultPrevented: [] as boolean[],
+        };
+        (window as any).__liteAndroidSubmitState = state;
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            configureHostOwned(value: unknown): void;
+            whenReady(): Promise<void>;
+        };
+        composer.style.cssText = "display: block; height: 360px;";
+        composer.configureHostOwned({
+            editorSubmitButtonEnabled: true,
+            submit() {
+                state.submits += 1;
+                return new Promise(() => undefined);
+            },
+        });
+        document.body.append(composer);
+        await composer.whenReady();
+
+        const shadowRoot = composer.shadowRoot!;
+        const editor = shadowRoot.querySelector<HTMLElement>(".tiptap-editor")!;
+        const button = shadowRoot.querySelector<HTMLButtonElement>(".editor-submit-button")!;
+        new MutationObserver(() => {
+            state.inputModes.push(editor.getAttribute("inputmode"));
+        }).observe(editor, {
+            attributes: true,
+            attributeFilter: ["inputmode"],
+        });
+        button.addEventListener("click", () => {
+            state.browserClicks += 1;
+        });
+        button.addEventListener("touchstart", (event) => {
+            state.touchStartDefaultPrevented.push(event.defaultPrevented);
+        });
+    }, { componentOrigin });
+
+    const composer = page.locator("ehagaki-composer");
+    const editor = composer.locator(".tiptap-editor");
+    const editorSubmitButton = composer.locator(".editor-submit-button");
+    await editor.click();
+    await editor.pressSequentially("android tap content");
+    await expect(editorSubmitButton).toBeEnabled();
+    await page.evaluate(() => {
+        (window as any).__setAndroidKeyboardHeight(300);
+    });
+    await expect.poll(() => composer.evaluate((element) =>
+        element.shadowRoot
+            ?.querySelector<HTMLElement>(".ehagaki-web-component-shell")
+            ?.style.getPropertyValue("--keyboard-height"),
+    )).toBe("300px");
+    expect(await page.evaluate(() =>
+        document.documentElement.style.getPropertyValue("--keyboard-height"),
+    )).toBe("");
+    expect(await composer.evaluate((element) => ({
+        documentActiveIsHost: document.activeElement === element,
+        shadowActiveIsEditor: element.shadowRoot?.activeElement?.classList.contains("tiptap-editor") === true,
+    }))).toEqual({
+        documentActiveIsHost: true,
+        shadowActiveIsEditor: true,
+    });
+
+    await editorSubmitButton.tap();
+
+    await expect.poll(() => page.evaluate(() => ({
+        browserClicks: (window as any).__liteAndroidSubmitState.browserClicks,
+        submits: (window as any).__liteAndroidSubmitState.submits,
+    }))).toEqual({ browserClicks: 1, submits: 1 });
+    const interactionState = await page.evaluate(() =>
+        (window as any).__liteAndroidSubmitState as {
+            browserClicks: number;
+            inputModes: Array<string | null>;
+            submits: number;
+            touchStartDefaultPrevented: boolean[];
+        },
+    );
+    expect(interactionState.inputModes).not.toContain("none");
+    expect(interactionState.browserClicks).toBe(1);
+    expect(interactionState.submits).toBe(1);
+    expect(interactionState.touchStartDefaultPrevented).toEqual([false]);
+    expect(await composer.evaluate((element) =>
+        element.shadowRoot?.activeElement?.classList.contains("tiptap-editor"),
+    )).toBe(true);
 });
 
 test("Lite editor submit button works without KeyboardButtonBar", async ({ page }) => {

--- a/src/test/unit/keyboardFocusUtils.test.ts
+++ b/src/test/unit/keyboardFocusUtils.test.ts
@@ -1,10 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
     focusEditorWithoutKeyboardForCurrentTap,
+    isComposerKeyboardVisible,
     isIosTouchDevice,
     isPostEditorFocusActive,
     preserveKeyboardForScrollableTouch,
+    readComposerKeyboardHeight,
 } from '../../lib/utils/keyboardFocusUtils';
+import {
+    configureAppRuntimeEnvironment,
+    getAppRuntimeEnvironment,
+} from '../../lib/appRuntimeEnvironment';
+
+const previousRuntimeEnvironment = getAppRuntimeEnvironment();
 
 function setNavigatorValue(name: keyof Navigator, value: unknown): void {
     Object.defineProperty(navigator, name, {
@@ -12,6 +20,36 @@ function setNavigatorValue(name: keyof Navigator, value: unknown): void {
         configurable: true,
     });
 }
+
+function createShadowRuntime(): {
+    host: HTMLDivElement;
+    shadowRoot: ShadowRoot;
+    styleTarget: HTMLDivElement;
+} {
+    const host = document.createElement('div');
+    const shadowRoot = host.attachShadow({ mode: 'open' });
+    const styleTarget = document.createElement('div');
+    shadowRoot.append(styleTarget);
+    document.body.append(host);
+    configureAppRuntimeEnvironment({
+        window,
+        document,
+        domRoot: shadowRoot,
+        styleTarget,
+        layoutTarget: styleTarget,
+        overlayTarget: styleTarget,
+        themeTarget: host,
+        layoutMode: 'container',
+        runtimeKind: 'web-component',
+    });
+
+    return { host, shadowRoot, styleTarget };
+}
+
+afterEach(() => {
+    configureAppRuntimeEnvironment(previousRuntimeEnvironment);
+    document.documentElement.style.removeProperty('--keyboard-height');
+});
 
 describe('focusEditorWithoutKeyboardForCurrentTap', () => {
     afterEach(() => {
@@ -106,6 +144,23 @@ describe('isPostEditorFocusActive', () => {
         expect(isPostEditorFocusActive()).toBe(true);
     });
 
+    it('ShadowRoot 内の投稿エディター focus を runtime root から検出する', () => {
+        const { host, shadowRoot, styleTarget } = createShadowRuntime();
+        const root = document.createElement('div');
+        root.setAttribute('data-post-editor-root', '');
+        const editor = document.createElement('div');
+        editor.contentEditable = 'true';
+        editor.tabIndex = 0;
+        root.append(editor);
+        styleTarget.append(root);
+
+        editor.focus();
+
+        expect(document.activeElement).toBe(host);
+        expect(shadowRoot.activeElement).toBe(editor);
+        expect(isPostEditorFocusActive()).toBe(true);
+    });
+
     it('投稿エディター内に selection が残っていてもダイアログ input の focus を優先する', () => {
         const root = document.createElement('div');
         root.setAttribute('data-post-editor-root', '');
@@ -123,6 +178,72 @@ describe('isPostEditorFocusActive', () => {
         input.focus();
 
         expect(isPostEditorFocusActive()).toBe(false);
+    });
+
+    it('ShadowRoot 内の別 input focus を残留 editor selection より優先する', () => {
+        const { styleTarget } = createShadowRuntime();
+        const root = document.createElement('div');
+        root.setAttribute('data-post-editor-root', '');
+        const editorText = document.createTextNode('draft');
+        root.append(editorText);
+        const input = document.createElement('input');
+        styleTarget.append(root, input);
+        const range = document.createRange();
+        range.setStart(editorText, 2);
+        range.collapse(true);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+
+        input.focus();
+
+        expect(isPostEditorFocusActive()).toBe(false);
+    });
+});
+
+describe('composer keyboard runtime state', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('runtime styleTarget の keyboard height だけを参照する', () => {
+        const { styleTarget } = createShadowRuntime();
+        styleTarget.style.setProperty('--keyboard-height', '300px');
+
+        expect(document.documentElement.style.getPropertyValue('--keyboard-height')).toBe('');
+        expect(readComposerKeyboardHeight()).toBe(300);
+        expect(isComposerKeyboardVisible()).toBe(true);
+    });
+
+    it('document root だけにある keyboard height へ fallback しない', () => {
+        const { styleTarget } = createShadowRuntime();
+        document.documentElement.style.setProperty('--keyboard-height', '300px');
+        styleTarget.style.setProperty('--keyboard-height', '0px');
+
+        expect(readComposerKeyboardHeight()).toBe(0);
+        expect(isComposerKeyboardVisible()).toBe(false);
+    });
+
+    it('keyboard 表示中の ShadowRoot touch では editor inputmode を変更しない', () => {
+        vi.useFakeTimers();
+        const { styleTarget } = createShadowRuntime();
+        styleTarget.style.setProperty('--keyboard-height', '300px');
+        const editor = document.createElement('div');
+        editor.className = 'tiptap-editor';
+        editor.tabIndex = 0;
+        const surface = document.createElement('div');
+        styleTarget.append(editor, surface);
+        editor.focus();
+        surface.addEventListener('touchstart', preserveKeyboardForScrollableTouch);
+
+        surface.dispatchEvent(new Event('touchstart', {
+            bubbles: true,
+            cancelable: true,
+        }));
+
+        expect(editor.hasAttribute('inputmode')).toBe(false);
+        vi.runAllTimers();
+        vi.useRealTimers();
     });
 });
 

--- a/src/test/unit/playwrightWorktreePort.test.ts
+++ b/src/test/unit/playwrightWorktreePort.test.ts
@@ -126,10 +126,21 @@ describe('Playwright config connection values', () => {
             expect(config.projects?.map((project) => project.name)).toEqual([
                 'desktop-chromium',
                 'mobile-chromium',
+                'android-chromium',
                 'mobile-webkit',
                 'desktop-firefox',
             ]);
-            expect(config.projects?.[2]?.testMatch).toEqual([
+            expect(config.projects?.[2]?.testMatch).toBe(
+                '**/webComponentLite.spec.ts',
+            );
+            expect(config.projects?.[2]?.grep).toEqual(/@android-chrome/);
+            expect(config.projects?.[2]?.use).toMatchObject({
+                browserName: 'chromium',
+                hasTouch: true,
+                isMobile: true,
+                userAgent: expect.stringMatching(/Android.+Chrome\//),
+            });
+            expect(config.projects?.[3]?.testMatch).toEqual([
                 '**/composerTargetDialog.spec.ts',
                 '**/webComponentEmbed.spec.ts',
                 '**/webComponentLite.spec.ts',

--- a/src/test/unit/uiStore.test.ts
+++ b/src/test/unit/uiStore.test.ts
@@ -1115,6 +1115,68 @@ describe('uiStore', () => {
         cancelAnimationFrameSpy.mockRestore();
     });
 
+    it('ShadowRoot editor focus では shell だけに keyboard height を同期する', async () => {
+        setUserAgent('Mozilla/5.0 (Linux; Android 15; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36');
+
+        const runtime = await import('../../lib/appRuntimeEnvironment');
+        const host = document.createElement('div');
+        const shadowRoot = host.attachShadow({ mode: 'open' });
+        const layoutTarget = document.createElement('div');
+        const editorRoot = document.createElement('div');
+        const editor = document.createElement('div');
+        editorRoot.setAttribute('data-post-editor-root', '');
+        editor.className = 'tiptap-editor';
+        editor.contentEditable = 'true';
+        editor.tabIndex = 0;
+        editorRoot.append(editor);
+        layoutTarget.append(editorRoot);
+        shadowRoot.append(layoutTarget);
+        document.body.append(host);
+        Object.defineProperty(layoutTarget, 'getBoundingClientRect', {
+            configurable: true,
+            value: vi.fn(() => ({ bottom: 800, height: 800 })),
+        });
+        runtime.configureAppRuntimeEnvironment({
+            window,
+            document,
+            domRoot: shadowRoot,
+            layoutMode: 'container',
+            styleTarget: layoutTarget,
+            layoutTarget,
+            overlayTarget: layoutTarget,
+            themeTarget: host,
+            runtimeKind: 'web-component',
+        });
+        editor.focus();
+
+        const requestAnimationFrameSpy = vi
+            .spyOn(window, 'requestAnimationFrame')
+            .mockImplementation((callback: FrameRequestCallback) => {
+                callback(0);
+                return 1;
+            });
+        const cancelAnimationFrameSpy = vi
+            .spyOn(window, 'cancelAnimationFrame')
+            .mockImplementation(() => { });
+        createVisualViewportMock(800);
+        const virtualKeyboard = createVirtualKeyboardMock();
+        const { keyboardHeightStore, setupViewportListener } = await import('../../stores/uiStore.svelte');
+        const cleanup = setupViewportListener();
+
+        virtualKeyboard.setHeight(300);
+        virtualKeyboard.emitGeometryChange();
+
+        expect(document.activeElement).toBe(host);
+        expect(shadowRoot.activeElement).toBe(editor);
+        expect(layoutTarget.style.getPropertyValue('--keyboard-height')).toBe('300px');
+        expect(document.documentElement.style.getPropertyValue('--keyboard-height')).toBe('');
+        expect(keyboardHeightStore.value).toBe(300);
+
+        cleanup?.();
+        requestAnimationFrameSpy.mockRestore();
+        cancelAnimationFrameSpy.mockRestore();
+    });
+
     it('container mode は host が設定した VirtualKeyboard policy を cleanup 時に変更しない', async () => {
         setUserAgent('Mozilla/5.0 (Linux; Android 15; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36');
 


### PR DESCRIPTION
## Summary
- Make post-editor focus detection aware of the active AppRuntimeEnvironment DOM root so Host-owned Web Components use ShadowRoot.activeElement while standalone and iframe runtimes retain document behavior.
- Read composer keyboard height only from the runtime styleTarget and share the runtime-aware keyboard-visible check across the editor submit button, focus-preservation utilities, and custom emoji picker.
- Keep the existing click-based submit path and focus behavior; no pointer/touch direct submit, fallback, or additional timeout was added.
- Add focused unit coverage and a dedicated Pixel 7 Android Chromium Playwright case that uses natural tap activation and verifies inputmode never becomes none, browser click fires once, submit fires once, and ShadowRoot editor focus remains active.

## Root cause
Host-owned Lite writes keyboard geometry to the Web Component shell and renders the editor inside a ShadowRoot, but the read side still inspected document.documentElement and document.activeElement. Android keyboard geometry was therefore treated as closed while the editor was focused, allowing the touch focus-preservation path to temporarily set inputmode=none. On a physical Android Chrome keyboard this can dismiss the IME and suppress the expected tap activation.

## Verification
Passed:
- npm test: 350 test files passed, 1 skipped; 4035 tests passed, 1 skipped
- npm run check: 0 errors and 0 warnings
- npm run build
- Focused unit tests: 51/51
- Dedicated android-chromium Host-owned Lite tap regression: 1/1
- Existing desktop Chromium, mobile Chromium, and mobile WebKit Lite submit/focus regression: 3/3
- git diff --check

### Full E2E known exceptions
npm run test:e2e:agent was run, but the full suite did not pass and is not reported as successful. Existing flaky failures outside the Android Host-owned Lite submit path remained:
- The PhotoSwipe focus-return failure reproduced on base commit a6869cfd0446cc9dcc63caf2bfaacdc66599a7b2 in 2 of 5 isolated runs.
- The Post History mobile case passed 6/6 when isolated across mobile Chromium and mobile WebKit.
- The Lite editor empty-state case passed 3/3 when isolated on mobile WebKit.

These existing flaky tests are intentionally not changed in this PR. The Android-targeted E2E, the existing three-profile Lite submit/focus regression, unit tests, npm test, npm run check, npm run build, and git diff --check all passed.

## Android physical-device gate
Android Chrome physical-device IME verification has not been performed. It remains a merge / release gate and is owned by the user:

1. Focus the editor.
2. Enter text.
3. While the software keyboard is visible, tap the Editor submit button once.
4. Confirm the host submit callback fires exactly once, the keyboard does not close, and editor focus is retained.

If this check fails, do not merge or release. Re-investigate the physical touch / pointer / click / focus / inputmode event order instead of adding timeouts, direct submit, or fallback behavior.