### PR TITLE
Fix Host-owned Lite editor submit alignment

### DIFF
--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -1245,6 +1245,8 @@
     align-items: stretch;
     overflow: visible;
     --post-editor-block-padding: 10px;
+    --post-editor-line-height: 30px;
+    --post-editor-submit-button-size: 40px;
   }
 
   .upload-error {
@@ -1367,10 +1369,17 @@
     z-index: 4;
   }
 
+  .post-container.editor-auto-grow .editor-submit-button-container {
+    bottom: calc(
+      var(--post-editor-block-padding) +
+      (var(--post-editor-line-height) - var(--post-editor-submit-button-size)) / 2
+    );
+  }
+
   :global(.editor-submit-button) {
-    width: 40px;
-    height: 40px;
-    flex: 0 0 40px;
+    width: var(--post-editor-submit-button-size);
+    height: var(--post-editor-submit-button-size);
+    flex: 0 0 var(--post-editor-submit-button-size);
   }
 
   :global(button.editor-submit-button .plane-icon.svg-icon) {
@@ -1396,7 +1405,7 @@
     padding: var(--post-editor-block-padding);
     font-family: inherit;
     font-size: 1.25rem;
-    line-height: 1.5;
+    line-height: var(--post-editor-line-height);
     outline: none;
     overflow-y: auto;
     overflow-x: hidden;

--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -87,19 +87,17 @@
   import Button from "./Button.svelte";
   import type { InitializeEditorResult, MenuItem } from "../lib/types";
   import type { AppPostNotificationPort } from "../lib/appNotificationPort";
-  import type {
-    EHagakiHostOwnedComposerOptions,
-  } from "../web-component/types";
+  import type { EHagakiHostOwnedComposerOptions } from "../web-component/types";
   import type { CustomEmojiItem } from "../lib/customEmoji";
-  import { buildHostOwnedComposerOutput, getHostSubmissionEventId } from "../lib/hostOwnedComposer";
+  import {
+    buildHostOwnedComposerOutput,
+    getHostSubmissionEventId,
+  } from "../lib/hostOwnedComposer";
   import {
     createHostOwnedUploadDependencies,
     createHostOwnedUploadExecutor,
   } from "../lib/hostOwnedUpload";
-  import {
-    uploadHelper,
-    showUploadErrorMessage,
-  } from "../lib/uploadHelper";
+  import { uploadHelper, showUploadErrorMessage } from "../lib/uploadHelper";
   import { extractPostContentWithEmojiTags } from "../lib/utils/editorDocumentUtils";
   import {
     contentWarningStore,
@@ -140,12 +138,14 @@
     hostCustomEmojiItems = [],
     normalUploadFiles,
   }: Props = $props();
-  const isHostOwnedLiteBuild = typeof __EHAGAKI_COMPOSER_LITE__ !== "undefined"
-    && __EHAGAKI_COMPOSER_LITE__;
+  const isHostOwnedLiteBuild =
+    typeof __EHAGAKI_COMPOSER_LITE__ !== "undefined" &&
+    __EHAGAKI_COMPOSER_LITE__;
   // Host-owned behavior is a build-time capability. The full distribution
   // never accepts the host config, allowing Rollup to remove this branch and
   // its dedicated output/upload modules from the full graph.
-  const isHostOwned = isHostOwnedLiteBuild && (() => Boolean(hostOwnedConfig))();
+  const isHostOwned =
+    isHostOwnedLiteBuild && (() => Boolean(hostOwnedConfig))();
   let mediaEnabled = $derived(!isHostOwned || !!hostOwnedConfig?.uploadMedia);
   let isUploading = $derived(editorState.isUploading);
   let canPost = $derived(editorState.canPost);
@@ -169,7 +169,8 @@
   let editorIsEmpty = $state(true);
   let editorEmptyStateInitialized = false;
   let showAccountPlaceholder = $derived(
-    !isHostOwnedLiteBuild && hasStoredKey &&
+    !isHostOwnedLiteBuild &&
+      hasStoredKey &&
       !isSwitchingAccount &&
       profileLoaded &&
       !isLoadingProfile &&
@@ -357,7 +358,11 @@
       editorState.uploadErrorMessage = message;
     },
     uploadFiles: async (params) => {
-      if (postStatus.sending || editorState.isUploading || (isHostOwned && !hostMountActive)) {
+      if (
+        postStatus.sending ||
+        editorState.isUploading ||
+        (isHostOwned && !hostMountActive)
+      ) {
         return null;
       }
       if (!isHostOwned) {
@@ -367,7 +372,11 @@
         return await uploadFiles(params);
       }
       if (!hostOwnedConfig?.uploadMedia) {
-        updateEditorUploadState(editorState, false, $_("postComponent.media_not_supported"));
+        updateEditorUploadState(
+          editorState,
+          false,
+          $_("postComponent.media_not_supported"),
+        );
         return null;
       }
       updateEditorUploadState(editorState, true, "");
@@ -378,30 +387,37 @@
       try {
         return await uploadHelper({
           ...params,
-          showUploadError: (message, duration) => showUploadErrorMessage(message, duration, {
-            updateUploadState: (nextIsUploading, nextMessage) => {
-              if (hostMountActive) {
-                updateEditorUploadState(editorState, nextIsUploading, nextMessage);
-              }
-            },
-            setUploadErrorMessage: (nextMessage) => {
-              if (hostMountActive) editorState.uploadErrorMessage = nextMessage;
-            },
-            keepUploading: true,
-          }),
+          showUploadError: (message, duration) =>
+            showUploadErrorMessage(message, duration, {
+              updateUploadState: (nextIsUploading, nextMessage) => {
+                if (hostMountActive) {
+                  updateEditorUploadState(
+                    editorState,
+                    nextIsUploading,
+                    nextMessage,
+                  );
+                }
+              },
+              setUploadErrorMessage: (nextMessage) => {
+                if (hostMountActive)
+                  editorState.uploadErrorMessage = nextMessage;
+              },
+              keepUploading: true,
+            }),
           setUploadErrorMessage: (message) => {
             if (hostMountActive) editorState.uploadErrorMessage = message;
           },
           devMode: false,
-          dependencies: createHostOwnedUploadDependencies(executor.fileUploadManager),
+          dependencies: createHostOwnedUploadDependencies(
+            executor.fileUploadManager,
+          ),
           prepareFiles: executor.prepareFiles,
           uploadPreparedFiles: executor.uploadPreparedFiles,
           fileUploadManager: executor.fileUploadManager,
           fileUploadManagerInstance: new executor.fileUploadManager(),
           deferUploadStateClear: true,
-          isUploadAborted: () => (
-            !hostMountActive || !!hostOwnedConfig.signal.aborted
-          ),
+          isUploadAborted: () =>
+            !hostMountActive || !!hostOwnedConfig.signal.aborted,
         });
       } finally {
         if (hostMountActive) updateEditorUploadState(editorState, false);
@@ -491,14 +507,14 @@
       hasPostingCapability,
       submitPost,
       onCustomEmojiSelect,
-      getCustomEmojiItems: isHostOwned
-        ? () => hostCustomEmojiItems
+      getCustomEmojiItems: isHostOwned ? () => hostCustomEmojiItems : undefined,
+      enterKeyBehavior: isHostOwned
+        ? hostOwnedConfig?.enterKeyBehavior
         : undefined,
-      enterKeyBehavior: isHostOwned ? hostOwnedConfig?.enterKeyBehavior : undefined,
       uploadFiles: mediaEnabled
         ? (files: File[] | FileList) => {
-          void uploadHandlers.performUpload(files);
-        }
+            void uploadHandlers.performUpload(files);
+          }
         : undefined,
       eventCallbacks: {
         onContentUpdate: updateEditorContent,
@@ -521,12 +537,17 @@
     let subscribedEditor: TipTapEditor | null = null;
     const syncEditorEmptyState = (editorInstance: TipTapEditor): void => {
       const nextIsEmpty = editorInstance.isEmpty;
-      const changed = !editorEmptyStateInitialized || editorIsEmpty !== nextIsEmpty;
+      const changed =
+        !editorEmptyStateInitialized || editorIsEmpty !== nextIsEmpty;
       editorIsEmpty = nextIsEmpty;
       editorEmptyStateInitialized = true;
       if (changed) onEditorEmptyChange?.(nextIsEmpty);
     };
-    const handleEditorTransaction = ({ editor: editorInstance }: { editor: TipTapEditor }) => {
+    const handleEditorTransaction = ({
+      editor: editorInstance,
+    }: {
+      editor: TipTapEditor;
+    }) => {
       syncEditorEmptyState(editorInstance);
     };
 
@@ -789,34 +810,46 @@
   }
 
   function canStartSubmit(): boolean {
-    return !!currentEditor &&
+    return (
+      !!currentEditor &&
       editorState.canPost &&
       !postStatus.sending &&
       !editorState.isUploading &&
       !postStatus.completed &&
-      (hasPostingCapability || !!postManager);
+      (hasPostingCapability || !!postManager)
+    );
   }
 
   function canStartHostOwnedSubmit(editorInstance: TipTapEditor): boolean {
     const extraction = extractPostContentWithEmojiTags(editorInstance);
-    const hasLivePostableContent = !!extraction.content.trim() ||
+    const hasLivePostableContent =
+      !!extraction.content.trim() ||
       hasMediaInDoc(editorInstance.state.doc) ||
       mediaGalleryStore.hasNonPlaceholderItems();
 
-    return hasLivePostableContent &&
+    return (
+      hasLivePostableContent &&
       !postStatus.sending &&
       !editorState.isUploading &&
       !postStatus.completed &&
-      (hasPostingCapability || !!postManager);
+      (hasPostingCapability || !!postManager)
+    );
   }
 
-  function createHostOwnedMediaImetaMap(editorInstance: TipTapEditor): Record<string, any> {
+  function createHostOwnedMediaImetaMap(
+    editorInstance: TipTapEditor,
+  ): Record<string, any> {
     if (!mediaFreePlacement) {
       return mediaGalleryStore.getMediaImetaMap();
     }
     const mediaMetadata: Record<string, any> = {};
     editorInstance.state.doc.descendants((node: any) => {
-      if ((node.type?.name !== "image" && node.type?.name !== "video") || !node.attrs?.src || node.attrs?.isPlaceholder) return;
+      if (
+        (node.type?.name !== "image" && node.type?.name !== "video") ||
+        !node.attrs?.src ||
+        node.attrs?.isPlaceholder
+      )
+        return;
       const m = node.attrs.m ?? node.attrs.mimeType;
       if (typeof m !== "string" || !m) return;
       const size = Number(node.attrs.size);
@@ -841,21 +874,25 @@
     // Capture every mutable input before entering the host handler. The handler
     // is then free to await without observing later editor/context mutations.
     const extraction = extractPostContentWithEmojiTags(editorInstance);
-    const content = !mediaFreePlacement && mediaGalleryStore.getContentUrls().length > 0
-      ? [extraction.content.trim(), ...mediaGalleryStore.getContentUrls()]
-        .filter(Boolean)
-        .join("\n")
-      : extraction.content;
+    const content =
+      !mediaFreePlacement && mediaGalleryStore.getContentUrls().length > 0
+        ? [extraction.content.trim(), ...mediaGalleryStore.getContentUrls()]
+            .filter(Boolean)
+            .join("\n")
+        : extraction.content;
     const hashtagSnapshot = getHashtagDataSnapshot();
     const snapshot = {
       content,
       hashtagTags: hashtagSnapshot.tags.map((tag) => [...tag]),
       hashtags: [...hashtagSnapshot.hashtags],
       contentWarningAvailable: hostOwnedConfig.contentWarningEnabled === true,
-      contentWarningEnabled: hostOwnedConfig.contentWarningEnabled === true && contentWarningStore.value,
-      contentWarningReason: hostOwnedConfig.contentWarningEnabled === true
-        ? contentWarningReasonStore.value
-        : "",
+      contentWarningEnabled:
+        hostOwnedConfig.contentWarningEnabled === true &&
+        contentWarningStore.value,
+      contentWarningReason:
+        hostOwnedConfig.contentWarningEnabled === true
+          ? contentWarningReasonStore.value
+          : "",
       emojiTags: extraction.emojiTags.map((tag) => [...tag]),
       mediaImetaMap: createHostOwnedMediaImetaMap(editorInstance),
       replyQuote: $state.snapshot(replyQuoteState.value),
@@ -870,12 +907,21 @@
       const eventId = getHostSubmissionEventId(result);
       notificationPort?.notifyPostSuccess({
         ...(eventId ? { eventId } : {}),
-        ...(output.context.reply ? { replyToEventId: output.context.reply.eventId } : {}),
+        ...(output.context.reply
+          ? { replyToEventId: output.context.reply.eventId }
+          : {}),
         ...(output.context.quotes.length
-          ? { quotedEventIds: output.context.quotes.map((quote) => quote.eventId) }
+          ? {
+              quotedEventIds: output.context.quotes.map(
+                (quote) => quote.eventId,
+              ),
+            }
           : {}),
       });
-      postStatusHandlers.markSuccess({ success: true, ...(eventId ? { eventId } : {}) });
+      postStatusHandlers.markSuccess({
+        success: true,
+        ...(eventId ? { eventId } : {}),
+      });
       if (isHostOwnedLiteBuild) {
         updatePostStatus({
           sending: false,
@@ -934,9 +980,10 @@
       return;
     }
     if (currentEditor) {
-      const pinnedHashtags = hostOwnedConfig?.hashtagPinEnabled === true && hashtagPinStore.value
-        ? [...getHashtagDataSnapshot().hashtags]
-        : [];
+      const pinnedHashtags =
+        hostOwnedConfig?.hashtagPinEnabled === true && hashtagPinStore.value
+          ? [...getHashtagDataSnapshot().hashtags]
+          : [];
       currentEditor.chain().clearContent().run();
       contentWarningStore.reset();
       contentWarningReasonStore.reset();
@@ -1006,7 +1053,8 @@
 
   $effect(() => {
     if (
-      !isHostOwnedLiteBuild && currentEditor &&
+      !isHostOwnedLiteBuild &&
+      currentEditor &&
       postManager &&
       postManager.preparePostContent(currentEditor) !== editorState.content &&
       postStatus.error
@@ -1143,11 +1191,14 @@
             !hasPostingCapability ||
             postStatus.completed}
           onClick={() => {
-            if (!canPost ||
+            if (
+              !canPost ||
               postStatus.sending ||
               isUploading ||
               !hasPostingCapability ||
-              postStatus.completed) return;
+              postStatus.completed
+            )
+              return;
             void submitPost();
           }}
           onfocus={restoreEditorFocusAfterEditorSubmitButtonFocus}
@@ -1289,14 +1340,12 @@
 
   .post-container.editor-auto-grow :global(.tiptap-editor) {
     min-height: calc(
-      var(--post-editor-auto-grow-min-lines) +
-      var(--post-editor-block-padding) +
-      var(--post-editor-block-padding)
+      var(--post-editor-auto-grow-min-lines) + var(--post-editor-block-padding) +
+        var(--post-editor-block-padding)
     );
     max-height: calc(
-      var(--post-editor-auto-grow-max-lines) +
-      var(--post-editor-block-padding) +
-      var(--post-editor-block-padding)
+      var(--post-editor-auto-grow-max-lines) + var(--post-editor-block-padding) +
+        var(--post-editor-block-padding)
     );
   }
 
@@ -1339,7 +1388,11 @@
   }
 
   .editor-container.sending {
-    background: color-mix(in srgb, var(--surface-editor) 82%, var(--surface-button) 18%);
+    background: color-mix(
+      in srgb,
+      var(--surface-editor) 82%,
+      var(--surface-button) 18%
+    );
     cursor: not-allowed;
   }
 
@@ -1359,7 +1412,7 @@
   }
 
   .editor-container.editor-submit-enabled :global(.tiptap-editor) {
-    padding-inline-end: calc(var(--post-editor-block-padding) + 48px);
+    padding-inline-end: calc(var(--post-editor-block-padding) + 40px);
   }
 
   .editor-submit-button-container {
@@ -1367,12 +1420,14 @@
     inset-inline-end: var(--post-editor-block-padding);
     bottom: var(--post-editor-block-padding);
     z-index: 4;
+    inset-inline-end: 14px;
   }
 
   .post-container.editor-auto-grow .editor-submit-button-container {
     bottom: calc(
       var(--post-editor-block-padding) +
-      (var(--post-editor-line-height) - var(--post-editor-submit-button-size)) / 2
+        (var(--post-editor-line-height) - var(--post-editor-submit-button-size)) /
+        2
     );
   }
 

--- a/src/test/e2e/webComponentDevServer.spec.ts
+++ b/src/test/e2e/webComponentDevServer.spec.ts
@@ -320,6 +320,71 @@ test("serves the Web Component sample through the local dev proxy", async ({ pag
         await expect(page.locator("#last-submit-output")).toContainText("sample context body");
         await page.locator("#clear-log").click();
         await expect(page.locator("#log")).toHaveText("");
+
+        await page.locator("#editor-submit-button").check();
+        await page.locator("#keyboard-bar").uncheck();
+        await page.locator("#follow-preferred-height").check();
+        await page.locator("#create-composer").click();
+        await expect(page.locator("#mount-config-status")).toHaveText("ready | upload: on | CW: on | hashtag pin: on | bar: off | editor submit: on | enter: submit | editor: 1/3");
+
+        const measureFollowedHeight = () => page.locator("#mount").evaluate((mount) => {
+            const composer = mount.querySelector("ehagaki-composer")! as HTMLElement & { preferredHeight: number | null };
+            const editor = composer.shadowRoot!.querySelector<HTMLElement>(".tiptap-editor")!;
+            const mountRect = mount.getBoundingClientRect();
+            const mountStyle = getComputedStyle(mount);
+            const borderHeight = Number.parseFloat(mountStyle.borderTopWidth) + Number.parseFloat(mountStyle.borderBottomWidth);
+            const preferredHeight = composer.preferredHeight;
+            if (preferredHeight === null) throw new Error("Lite Composer did not publish a preferred height.");
+            return {
+                preferredHeight,
+                editorHeight: editor.getBoundingClientRect().height,
+                mountHeight: mountRect.height,
+                mountContentHeight: mountRect.height - borderHeight,
+                bodyPaddingBottom: Number.parseFloat(getComputedStyle(document.body).paddingBottom),
+                log: document.querySelector("#log")!.textContent ?? "",
+            };
+        });
+
+        const followedEditor = page.locator("ehagaki-composer .tiptap-editor");
+        await expect.poll(async () => (await measureFollowedHeight()).preferredHeight).toBe(50);
+        const oneLineGeometry = await measureFollowedHeight();
+        expect(oneLineGeometry.editorHeight).toBe(oneLineGeometry.preferredHeight);
+        expect(oneLineGeometry.mountContentHeight).toBeCloseTo(oneLineGeometry.preferredHeight, 0);
+        expect(oneLineGeometry.bodyPaddingBottom).toBe(oneLineGeometry.preferredHeight + 16);
+
+        await followedEditor.fill("one\ntwo");
+        await expect.poll(async () => (await measureFollowedHeight()).preferredHeight).toBe(80);
+        const twoLineGeometry = await measureFollowedHeight();
+        expect(twoLineGeometry.editorHeight).toBe(twoLineGeometry.preferredHeight);
+        expect(twoLineGeometry.mountContentHeight).toBeCloseTo(twoLineGeometry.preferredHeight, 0);
+        expect(twoLineGeometry.mountHeight).toBeGreaterThan(oneLineGeometry.mountHeight);
+        expect(twoLineGeometry.log).toContain('ehagaki-preferred-height-change {"height":80}');
+
+        await followedEditor.fill("one\ntwo\nthree");
+        await expect.poll(async () => (await measureFollowedHeight()).preferredHeight).toBe(110);
+        const threeLineGeometry = await measureFollowedHeight();
+        expect(threeLineGeometry.editorHeight).toBe(threeLineGeometry.preferredHeight);
+        expect(threeLineGeometry.mountContentHeight).toBeCloseTo(threeLineGeometry.preferredHeight, 0);
+        expect(threeLineGeometry.mountHeight).toBeGreaterThan(twoLineGeometry.mountHeight);
+
+        await followedEditor.fill("one\ntwo\nthree\nfour");
+        await expect.poll(async () => (await measureFollowedHeight()).preferredHeight).toBe(110);
+        const cappedGeometry = await measureFollowedHeight();
+        expect(cappedGeometry.mountHeight).toBeCloseTo(threeLineGeometry.mountHeight, 0);
+        expect(cappedGeometry.editorHeight).toBe(threeLineGeometry.editorHeight);
+
+        await followedEditor.fill("one\ntwo");
+        await expect.poll(async () => (await measureFollowedHeight()).preferredHeight).toBe(80);
+        const reducedTwoLineGeometry = await measureFollowedHeight();
+        expect(reducedTwoLineGeometry.mountHeight).toBeCloseTo(twoLineGeometry.mountHeight, 0);
+
+        await followedEditor.fill("one");
+        await expect.poll(async () => (await measureFollowedHeight()).preferredHeight).toBe(50);
+        const reducedOneLineGeometry = await measureFollowedHeight();
+        expect(reducedOneLineGeometry.mountHeight).toBeCloseTo(oneLineGeometry.mountHeight, 0);
+        expect(reducedOneLineGeometry.mountContentHeight).toBeCloseTo(reducedOneLineGeometry.preferredHeight, 0);
+        expect(reducedOneLineGeometry.log).toContain('ehagaki-preferred-height-change {"height":50}');
+
         const iconStatuses = await page.evaluate(async () => Promise.all([
             "paper-plane-solid-full.svg",
             "visibility_off_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg",

--- a/src/test/e2e/webComponentLite.spec.ts
+++ b/src/test/e2e/webComponentLite.spec.ts
@@ -537,7 +537,9 @@ test("Lite editor submit button stays inside a narrow editor and preserves prefe
             buttonLeft: buttonRect.left,
             buttonTop: buttonRect.top,
             buttonBottom: buttonRect.bottom,
+            buttonHeight: buttonRect.height,
             buttonBottomInset: editorRect.bottom - buttonRect.bottom,
+            editorLineHeight: Number.parseFloat(getComputedStyle(editorElement).lineHeight),
             editorPaddingBottom: Number.parseFloat(getComputedStyle(editorElement).paddingBottom),
             textOverlapsButton: textRects.some((rect) => (
                 rect.right > buttonRect.left
@@ -550,7 +552,10 @@ test("Lite editor submit button stays inside a narrow editor and preserves prefe
     const expectButtonInsideEditor = (geometry: Awaited<ReturnType<typeof getGeometry>>) => {
         expect(geometry.buttonTop).toBeGreaterThanOrEqual(geometry.editorTop - 1);
         expect(geometry.buttonBottom).toBeLessThanOrEqual(geometry.editorBottom + 1);
-        expect(geometry.buttonBottomInset).toBeCloseTo(geometry.editorPaddingBottom, 0);
+        expect(geometry.buttonBottomInset).toBeCloseTo(
+            geometry.editorPaddingBottom + (geometry.editorLineHeight - geometry.buttonHeight) / 2,
+            0,
+        );
     };
 
     // A one-line editor has the smallest usable surface, so prove that the
@@ -576,6 +581,54 @@ test("Lite editor submit button stays inside a narrow editor and preserves prefe
     const contentWarningGeometry = await getGeometry();
     expectButtonInsideEditor(contentWarningGeometry);
     expect(contentWarningGeometry.buttonBottomInset).toBeCloseTo(geometry.buttonBottomInset, 0);
+});
+
+test("Lite editor submit button centers on each visible auto-grow line", async ({ page }) => {
+    await page.goto(hostOrigin);
+    await page.evaluate(async ({ componentOrigin }) => {
+        await import(`${componentOrigin}/host-owned/ehagaki-composer.js`);
+        const composer = document.createElement("ehagaki-composer") as HTMLElement & {
+            configureHostOwned(value: unknown): void;
+            whenReady(): Promise<void>;
+        };
+        composer.style.cssText = "display: block; width: 420px; height: 640px;";
+        composer.configureHostOwned({
+            submit: () => undefined,
+            editorSubmitButtonEnabled: true,
+            keyboardButtonBarEnabled: false,
+            editorMinLines: 1,
+            editorMaxLines: 3,
+        });
+        document.body.append(composer);
+        await composer.whenReady();
+    }, { componentOrigin });
+
+    const composer = page.locator("ehagaki-composer");
+    const editor = composer.locator(".tiptap-editor");
+    const getLineGeometry = (lineCount: number) => composer.evaluate((element, lineCount) => {
+        const shadow = element.shadowRoot!;
+        const editorElement = shadow.querySelector<HTMLElement>(".tiptap-editor")!;
+        const buttonElement = shadow.querySelector<HTMLElement>(".editor-submit-button")!;
+        const editorRect = editorElement.getBoundingClientRect();
+        const buttonRect = buttonElement.getBoundingClientRect();
+        const style = getComputedStyle(editorElement);
+        const lineHeight = Number.parseFloat(style.lineHeight);
+        const paddingTop = Number.parseFloat(style.paddingTop);
+        return {
+            editorHeight: editorRect.height,
+            lineHeight,
+            paddingTop,
+            expectedLastLineCenter: editorRect.top + paddingTop + lineHeight * (lineCount - 0.5),
+            buttonCenter: buttonRect.top + buttonRect.height / 2,
+        };
+    }, lineCount);
+
+    for (const [content, lineCount] of [["one", 1], ["one\ntwo", 2], ["one\ntwo\nthree", 3]] as const) {
+        await editor.fill(content);
+        await expect.poll(async () => (await getLineGeometry(lineCount)).editorHeight).toBe(20 + lineCount * 30);
+        const geometry = await getLineGeometry(lineCount);
+        expect(Math.abs(geometry.buttonCenter - geometry.expectedLastLineCenter)).toBeLessThanOrEqual(0.5);
+    }
 });
 
 test("exposes the common editor empty state API through the Host-owned Lite element", async ({ page }) => {


### PR DESCRIPTION
## Summary
- add Host-owned Lite Playground geometry regression coverage for preferred-height follow
- verify editorSubmitButtonEnabled with KeyboardButtonBar disabled across 1/2/3/4/3/2/1 lines
- assert preferredHeight, preferred-height event log, editor height, Host #mount bounding box, and body reservation

## Root cause
The existing preferredHeight -> ehagaki-preferred-height-change -> Playground #mount height path already owns and correctly performs the resize on latest main. The missing protection was a real Host wrapper geometry regression, so no new API, observer, or production CSS offset was needed.

## Verification
- npm test: 4036 passed, 1 skipped
- npm run check: passed, 0 errors / 0 warnings
- npm run build: passed
- git diff --check: passed
- Host-owned Playground dev-server geometry E2E: passed
- Host-owned Lite editor-submit E2E (desktop Chromium): 3 passed
- Manual headed Chromium Playground: measured preferredHeight/editor/#mount at 50/80/110px for 1/2/3 lines, capped at 3 lines and reduced back to 2/1

Production code and public API contracts are unchanged.