### PR TITLE
Stabilize Lite mobile editor submit geometry tests

### DIFF
--- a/src/test/e2e/webComponentLite.spec.ts
+++ b/src/test/e2e/webComponentLite.spec.ts
@@ -217,8 +217,8 @@ test("Lite editor submit button replaces only the bar submit surface and preserv
     await expect(editorSubmitIcon).toHaveCSS("inline-size", "22px");
     await expect(editorSubmitIcon).toHaveCSS("block-size", "22px");
     const editorSubmitIconBox = await editorSubmitIcon.boundingBox();
-    expect(editorSubmitIconBox?.width).toBe(22);
-    expect(editorSubmitIconBox?.height).toBe(22);
+    expect(editorSubmitIconBox?.width).toBeCloseTo(22, 3);
+    expect(editorSubmitIconBox?.height).toBeCloseTo(22, 3);
 
     await editor.click();
     await editor.pressSequentially("editor button content");
@@ -623,11 +623,14 @@ test("Lite editor submit button centers on each visible auto-grow line", async (
         };
     }, lineCount);
 
-    for (const [content, lineCount] of [["one", 1], ["one\ntwo", 2], ["one\ntwo\nthree", 3]] as const) {
-        await editor.fill(content);
-        await expect.poll(async () => (await getLineGeometry(lineCount)).editorHeight).toBe(20 + lineCount * 30);
+    await editor.click();
+    for (const [text, lineCount] of [["one", 1], ["two", 2], ["three", 3]] as const) {
+        await editor.pressSequentially(text);
+        await expect.poll(async () => (await getLineGeometry(lineCount)).editorHeight)
+            .toBeCloseTo(20 + lineCount * 30, 3);
         const geometry = await getLineGeometry(lineCount);
         expect(Math.abs(geometry.buttonCenter - geometry.expectedLastLineCenter)).toBeLessThanOrEqual(0.5);
+        if (lineCount < 3) await editor.press("Enter");
     }
 });
 


### PR DESCRIPTION
## Summary

- Replace multi-line `editor.fill()` with sequential Tiptap keyboard input and real Enter transactions for the 1/2/3-line auto-grow geometry regression.
- Keep the CSS 22px contract exact while allowing only browser subpixel rounding in `boundingBox()` and rendered editor-height geometry assertions.

## Root cause

- mobile-chromium does not create the expected multi-line Tiptap transaction from `fill("one\\ntwo")`, so the editor remains at its one-line 50px height.
- `boundingBox()` reports a tiny floating-point deviation (`22.00006103515625`) despite computed CSS remaining exactly 22px.

## Verification

- mobile-chromium: targeted 2 tests passed.
- desktop-chromium: all 5 related Lite editor-submit/auto-grow tests passed.
- `npm run check`: passed with 0 errors and 0 warnings.
- `npm test`: 350 test files passed, 1 skipped; 4036 tests passed, 1 skipped.
- `git diff --check`: passed.

Production code was not changed. Real-device Android/iOS verification was not run; Playwright mobile-chromium is browser/device emulation.
