### PR TITLE
Tune agent guidance for GPT-6 Astra

### DIFF
--- a/.agents/skills/ehagaki-browser-debug/SKILL.md
+++ b/.agents/skills/ehagaki-browser-debug/SKILL.md
@@ -35,7 +35,7 @@ eHagakiの現在のcheckoutを根拠に、ブラウザ制約とアプリケー�
 - 対象inputまたはeditor、再現操作
 - 期待結果と実際の結果
 
-再現できない場合は、既存コードと証拠から原因を特定できるかを明示する。原因を特定できなければ本番コードを推測で変更せず、追加で必要な計測または実端末確認を報告する。
+実端末での再現だけを修正の前提にしない。再現、現在のコード、ログ・計測、テスト、正常経路との決定論的比較から、原因と最小修正を支える十分な根拠が得られれば進める。根拠が不足する場合は推測で本番コードを変更せず、必要な追加調査を行い、実行できない計測や実端末確認は未確認として報告する。
 
 ## 原因層を分類する
 
@@ -81,7 +81,7 @@ nsec、秘密鍵、token、署名payload、認証payload、投稿本文などを
 4. 非同期処理ではowner、generation、abort/unsubscribe、cleanup、stale completionを確認する。
 5. focus、selection、resize、scroll、geometrychangeへ依存する場合はevent列とrAF境界を確認する。
 6. 正常なsibling pathがある場合は、入力、state遷移、event順、cleanupの差を比較する。
-7. 原因が確定するまで本番コードを変更しない。
+7. 本番コードの修正は、上記の証拠で説明できる原因と責務に限定する。仮説だけを根拠に補償的workaroundを追加しない。
 
 ## 回避策を制限する
 
@@ -114,7 +114,7 @@ nsec、秘密鍵、token、署名payload、認証payload、投稿本文などを
 - protocol semanticsだけの変更にはPlaywrightを追加しない。
 - 実ブラウザでしか成立しない回帰は、決定論的に再現できる場合にpersistent E2Eを検討する。
 - 調査専用のspec、HTML、script、screenshot、traceは完了時に削除する。
-- 実装変更では対象テストから始め、`AGENTS.md`に従い原則`npm test`まで広げる。Svelte/TypeScript変更では`npm run check`、PWA/SW/build境界では`npm run build`も実行する。
+- 共通の必須検証と、検証を追加・反復する条件は`AGENTS.md`のVerificationに従う。
 
 Playwrightのdevice設定はuser agent、viewport、screen、touch等のemulationにすぎない。Android IME、iOS Safari keyboard、VirtualKeyboard APIの実geometry、ブラウザ下部バー、PWA standalone固有UI、WebView固有挙動を同一とは扱わない。必要な実端末確認を実行できなければ、未確認と明記する。
 

--- a/.agents/skills/ehagaki-nostr/SKILL.md
+++ b/.agents/skills/ehagaki-nostr/SKILL.md
@@ -25,7 +25,7 @@ eHagakiの既存境界と実装済みライブラリAPIを基準に、Nostr関�
 5. `nostr-tools`と`rx-nostr`の責務を混同しない。
 6. iframeまたはDirect Web Componentを含む場合も、event、tag、signer、relay、subscriptionのprotocol semanticsはこのSkillで扱い、browser realm、postMessage/WebSocket interception、Shadow DOM、geometry、mount/disconnect lifecycleの観測は[ehagaki-browser-debug](../ehagaki-browser-debug/SKILL.md)へ分離する。
 7. 一時的な互換処理やフォールバックは、仕様、対応ブラウザ、再現ログ、既存互換契約のいずれかで必要性を示せる場合だけ追加する。
-8. 曖昧さがevent semanticsや互換性を変える場合は、推測せず`needs confirmation`として扱う。
+8. 曖昧さはまずuser/task context、現在のrepository、適用されるNIP・protocol仕様から解消する。それでも未解決で、event semantics、互換性、安全性などの結果を実質的に変える選択だけを、`AGENTS.md`の確認条件に従い`needs confirmation`として扱う。
 
 ## 取得と購読を検証する
 
@@ -55,8 +55,6 @@ eHagakiの既存境界と実装済みライブラリAPIを基準に、Nostr関�
 1. 最小の既存責務へ変更を置き、無関係なrefactorを混ぜない。
 2. protocol semantics、subscription lifecycle、dedupe、cache、securityの観点でdiffをレビューする。
 3. Nostr関連の責務、主要ファイル、event kind、tag semantics、対応NIP、関連テストを変更した場合は、`references/implementation-map.md`を同じ変更内で更新する。
-4. 変更範囲に応じて、対象unit test、component test、Playwright、`npm run check`を選ぶ。
-5. ブラウザ統合またはユーザー操作を通した一連の挙動が受け入れ条件に含まれる場合はPlaywrightを使う。layout、focus、viewport、clipboard、touchに限定せず、URLクエリ、iframe、ダイアログ操作、アカウント切替、IndexedDBを含むブラウザ内フローも必要に応じて対象にする。
+4. 共通の必須検証、検証を追加・反復する条件、結果の報告は`AGENTS.md`のVerificationに従う。
+5. URLクエリ、iframe、ダイアログ操作、アカウント切替、IndexedDBを含むブラウザ内フローは、下位レベルのテストでは受け入れ条件を証明できない場合にPlaywrightで検証する。
 6. protocol semanticsだけの変更にはPlaywrightを追加せず、unit testまたはcomponent testで検証する。
-7. 実装変更では狭いテストから実行し、リポジトリ規則に従って原則`npm test`まで広げる。SvelteまたはTypeScript変更では`npm run check`も実行する。
-8. 実行した検証と結果、実行していない検証と理由を分けて報告する。実行していない検証を成功したと報告しない。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,16 @@ eHagaki is a post-focused Nostr client with on-device image and video compressio
 
 Use `npm`. Do not replace it with `pnpm` or `yarn`.
 
+## Instruction priority and clarification
+
+`AGENTS.md` defines repository-wide rules; Skills provide domain-specific guidance. Explicit user/task instructions take precedence over general Skill guidance. Do not infer approval gates, scope expansion, or additional requirements from a Skill that the user/task instructions and `AGENTS.md` do not establish.
+
+If a Skill requires confirmation, pausing, leaving work unfinished, or departing from user intent, identify and link the exact `SKILL.md`, quote the relevant instruction, and explain its applicability. Distinguish an explicit requirement from your interpretation of guidance.
+
+Resolve routine gaps first from explicit user/task context, the current checkout, applicable specifications, existing code, tests, and repository documentation, using ordinary implementation judgment safely supported by those sources. Only mark an unresolved choice as `needs confirmation` when it materially changes user-visible behavior, a public contract, security, secrets or data, compatibility, requested scope, or an irreversible or external action. Continue independent authorized work while that choice is pending.
+
+Do not stop for redundant permission checks on already-authorized read-only investigation or reversible editing and verification. This does not authorize commit, push, PR creation, release, or deployment; the explicit authorization rule below still applies.
+
 ## Before editing
 
 - Read the target files, their callers, related stores or services, and relevant tests.
@@ -31,7 +41,6 @@ Use `npm`. Do not replace it with `pnpm` or `yarn`.
 - Keep changes within the requested scope, and do not mix unrelated refactoring into feature work or bug fixes.
 - Do not modify implementation code and repository instruction files in the same task unless explicitly requested.
 - Do not invent product behavior, protocol behavior, commands, or compatibility requirements.
-- If an ambiguity materially affects behavior and cannot be resolved from the repository or applicable specifications, mark it as `needs confirmation` rather than guessing.
 - Do not commit, push, open a pull request, release, or deploy unless explicitly requested.
 - When implementation depends on current third-party library APIs, use Context7 when available after checking `package.json`, local types, and existing project usage. Prefer the repository code and applicable protocol specifications for project behavior. Do not use Context7 as a substitute for NIPs or eHagaki-specific design decisions.
 
@@ -146,6 +155,8 @@ Run the narrowest relevant verification first, then broaden it according to the 
 - Use Playwright for browser integration and user interactions that unit or component tests cannot prove. For browser-specific investigation, use `.agents/skills/ehagaki-browser-debug/`; prefer relevant existing tests and keep ad hoc artifacts temporary. Device emulation is not evidence of real OS keyboard, browser chrome, PWA standalone UI, or WebView behavior.
 - Run `npm run deploy` only when deployment is explicitly requested, and run `npm run build` first.
 - Documentation-only changes do not require application test suites unless they alter executable configuration or reveal an implementation issue.
+
+Do not add low-value tests that merely mirror the implementation for reversible, low-impact changes. For bug fixes and contract changes, prioritize meaningful regression coverage at the lowest sufficient level. Complete the required and relevant checks above; after they pass, repeat or broaden verification only for new changes, failures, or unresolved concerns.
 
 Do not claim that a check passed unless it was actually run. Report relevant checks that were not run and why.
 


### PR DESCRIPTION
Audits repository instructions against [OpenAI's GPT-6 Astra guidance](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra), while keeping the instruction stack model-agnostic.

- Clarifies user/task instruction priority, repository-wide versus domain guidance, and when unresolved choices need confirmation. Already-authorized investigation, reversible edits, and verification can continue without redundant permission checks.
- Preserves required checks while discouraging implementation-mirroring tests and unjustified repeated or broader verification.
- Allows browser fixes supported by sufficient code, reproduction, measurement, test, or deterministic comparison evidence; narrows Nostr clarification conditions and consolidates shared verification guidance in AGENTS.md.
- Audited all four Skills. Editor and embed-runtime remain unchanged because their domain-specific ownership, lifecycle, and public-contract rules need no adjustment. Existing Git authorization, source-of-truth, protocol/security, real-device evidence, and npm test/check/build/Playwright requirements remain intact.

No application code, reference maps, Skill names/descriptions, or scope routing changed.

Validation: Markdown fence/frontmatter structure, unchanged frontmatter and routing against the baseline, local Markdown links, instruction consistency and diff scope review, and `git diff --check` passed. Application tests were not run because this is instruction-only documentation work and the request explicitly excludes them.
