### PR TITLE
Preserve active account on startup restore failure

### DIFF
--- a/src/lib/authManagedRestoreUtils.ts
+++ b/src/lib/authManagedRestoreUtils.ts
@@ -19,12 +19,15 @@ export function buildManagedRestoreCandidates({
 }): ManagedRestoreCandidate[] {
     const candidates: ManagedRestoreCandidate[] = [];
 
-    if (activePubkey && activeType && activeType !== 'parentClient') {
-        candidates.push({
+    if (activePubkey && /^[0-9a-fA-F]{64}$/.test(activePubkey)
+        && activeType && activeType !== 'parentClient'
+        && accounts.some(account => account.pubkeyHex === activePubkey && account.type === activeType)) {
+        // A saved selection is not invalidated by an unavailable credential or signer.
+        return [{
             pubkeyHex: activePubkey,
             type: activeType,
             activateOnSuccess: false,
-        });
+        }];
     }
 
     for (const account of accounts) {

--- a/src/lib/authRestoreUtils.ts
+++ b/src/lib/authRestoreUtils.ts
@@ -13,6 +13,8 @@ const LEGACY_NIP07_STORAGE_KEY = 'nostr-nip07-pubkey';
 
 export type RestoreResult = { hasAuth: boolean; pubkeyHex?: string };
 export type AuthInitializationResult = RestoreResult & {
+    /** The selected account failed to restore; do not automatically choose another identity. */
+    activeSelectionPreserved?: true;
     /** Whether startup restore candidates were evaluated without an infrastructure failure. */
     restoreOutcome?: 'completed' | 'infrastructure-failure';
     /** NIP-07 identity already read while restoring a saved account. */
@@ -488,6 +490,8 @@ export async function runManagedAuthRestore(
     return {
         hasAuth: false,
         restoreOutcome: infrastructureFailureDetected ? 'infrastructure-failure' : 'completed',
+        ...(candidates.some(candidate => !candidate.activateOnSuccess)
+            ? { activeSelectionPreserved: true as const } : {}),
         ...(nip07Identity ? { nip07Identity } : {}),
     };
 }

--- a/src/lib/bootstrap/nip07AutoLoginBootstrap.ts
+++ b/src/lib/bootstrap/nip07AutoLoginBootstrap.ts
@@ -12,6 +12,7 @@ export async function resolveNip07AutoLoginSession(
     deps: Nip07AutoLoginDependencies,
 ): Promise<AuthInitializationResult> {
     if (current.hasAuth) return current;
+    if (current.activeSelectionPreserved) return current;
     if (current.restoreOutcome === 'infrastructure-failure') return current;
 
     try {

--- a/src/test/unit/authManagedRestoreUtils.test.ts
+++ b/src/test/unit/authManagedRestoreUtils.test.ts
@@ -3,20 +3,19 @@ import { describe, expect, it } from 'vitest';
 import { buildManagedRestoreCandidates } from '../../lib/authManagedRestoreUtils';
 
 describe('authManagedRestoreUtils', () => {
-    it('active account を先頭に置き、fallback では active と parentClient を除外する', () => {
+    it('有効なactive accountだけを復元候補にする', () => {
         expect(
             buildManagedRestoreCandidates({
-                activePubkey: 'active-pub',
+                activePubkey: 'aa'.repeat(32),
                 activeType: 'nsec',
                 accounts: [
-                    { pubkeyHex: 'active-pub', type: 'nsec' },
+                    { pubkeyHex: 'aa'.repeat(32), type: 'nsec' },
                     { pubkeyHex: 'parent-pub', type: 'parentClient' },
                     { pubkeyHex: 'fallback-pub', type: 'nip07' },
                 ],
             }),
         ).toEqual([
-            { pubkeyHex: 'active-pub', type: 'nsec', activateOnSuccess: false },
-            { pubkeyHex: 'fallback-pub', type: 'nip07', activateOnSuccess: true },
+            { pubkeyHex: 'aa'.repeat(32), type: 'nsec', activateOnSuccess: false },
         ]);
     });
 

--- a/src/test/unit/authService.initialize.test.ts
+++ b/src/test/unit/authService.initialize.test.ts
@@ -9,6 +9,8 @@ import { AccountManager } from '../../lib/accountManager';
 import { resolveNip07AutoLoginSession } from '../../lib/bootstrap/nip07AutoLoginBootstrap';
 import { getNsecStorageKey } from '../../lib/authStorageKeys';
 import { STORAGE_KEYS } from '../../lib/constants';
+import { runAppInitializationBootstrap } from '../../lib/bootstrap/appInitializationBootstrap';
+import { Nip07AuthService } from '../../lib/nip07AuthService';
 import {
     createWebComponentStorage,
     EHAGAKI_WEB_COMPONENT_STORAGE_PREFIX,
@@ -23,6 +25,140 @@ import {
 const ACTIVE_PUBKEY = 'aa'.repeat(32);
 const FALLBACK_PUBKEY = 'bb'.repeat(32);
 const NIP07_PUBKEY = 'cc'.repeat(32);
+
+describe('startup active selection persistence', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('preserves active NIP-46 when reconnect fails instead of restoring B', async () => {
+        const { Nip46Service, nip46Service } = await import('../../lib/nip46Service');
+        const loadSession = vi.spyOn(Nip46Service, 'loadSession')
+            .mockReturnValue(createMockNip46Session(ACTIVE_PUBKEY));
+        vi.spyOn(nip46Service, 'reconnect').mockRejectedValue(new Error('offline'));
+        const deps = createMockDependencies();
+        const manager = new AccountManager({ localStorage: deps.localStorage! });
+        manager.addAccount(FALLBACK_PUBKEY, 'nsec');
+        manager.addAccount(ACTIVE_PUBKEY, 'nip46');
+        const service = new AuthService(deps);
+        service.setAccountManager(manager);
+        await expect(service.initializeAuth()).resolves.toEqual({
+            hasAuth: false, activeSelectionPreserved: true, restoreOutcome: 'completed',
+        });
+        expect(loadSession).toHaveBeenCalled();
+        expect(nip46Service.reconnect).toHaveBeenCalled();
+        expect((deps.keyManager as MockKeyManager).readStoredKey).not.toHaveBeenCalledWith(FALLBACK_PUBKEY);
+        expect(manager.getActiveAccountPubkey()).toBe(ACTIVE_PUBKEY);
+        loadSession.mockReturnValue(null);
+    });
+
+    it.each(['missing', 'error'] as const)('does not replace active nsec after credential %s', async status => {
+        const deps = createMockDependencies();
+        const manager = new AccountManager({ localStorage: deps.localStorage! });
+        manager.addAccount(FALLBACK_PUBKEY, 'nsec');
+        manager.addAccount(ACTIVE_PUBKEY, 'nsec');
+        const keys = deps.keyManager as MockKeyManager;
+        keys.readStoredKey.mockImplementation((pubkey?: string) => pubkey === ACTIVE_PUBKEY
+            ? { status } : pubkey === FALLBACK_PUBKEY
+                ? { status: 'found', secretKey: 'test-credential' } : { status: 'missing' });
+        keys.isValidNsec.mockReturnValue(true);
+        keys.derivePublicKey.mockReturnValue({ hex: FALLBACK_PUBKEY, npub: 'npub-test', nprofile: 'nprofile-test' });
+        const service = new AuthService(deps);
+        service.setAccountManager(manager);
+        await expect(service.initializeAuth()).resolves.toEqual({
+            hasAuth: false, activeSelectionPreserved: true,
+            restoreOutcome: status === 'error' ? 'infrastructure-failure' : 'completed',
+        });
+        expect(keys.readStoredKey).not.toHaveBeenCalledWith(FALLBACK_PUBKEY);
+        expect(deps.setNsecAuth).not.toHaveBeenCalled();
+        expect(manager.getActiveAccountPubkey()).toBe(ACTIVE_PUBKEY);
+    });
+
+    it.each(['unavailable', 'rejected', 'empty', 'timeout', 'mismatch'] as const)(
+        'preserves A through guest bootstrap and restores A on restart: %s', async (failure) => {
+            vi.useFakeTimers();
+            const deps = createMockDependencies();
+            const storage = deps.localStorage as MockStorage;
+            const manager = new AccountManager({ localStorage: storage });
+            manager.addAccount(FALLBACK_PUBKEY, 'nsec');
+            manager.addAccount(NIP07_PUBKEY, 'nip07');
+            const accountsBefore = storage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS);
+            const keys = deps.keyManager as MockKeyManager;
+            keys.readStoredKey.mockImplementation((pubkey?: string) => pubkey === FALLBACK_PUBKEY
+                ? { status: 'found', secretKey: 'test-credential' } : { status: 'missing' });
+            keys.isValidNsec.mockReturnValue(true);
+            keys.derivePublicKey.mockReturnValue({ hex: FALLBACK_PUBKEY, npub: 'npub-test', nprofile: 'nprofile-test' });
+            const getPublicKey = vi.fn(() => {
+                if (failure === 'rejected') return Promise.reject(new Error('locked'));
+                if (failure === 'timeout') return new Promise<string>(() => undefined);
+                return Promise.resolve(failure === 'empty' ? '' : FALLBACK_PUBKEY);
+            });
+            deps.window = { nostr: { getPublicKey, signEvent: vi.fn() } } as unknown as Window;
+            const discovery = vi.spyOn(Nip07AuthService.prototype, 'waitForExtension')
+                .mockResolvedValue(failure !== 'unavailable');
+            const service = new AuthService(deps);
+            service.setAccountManager(manager);
+            const initialize = service.initializeAuth();
+            if (failure === 'timeout') await vi.advanceTimersByTimeAsync(MANAGED_NIP07_IDENTITY_READ_TIMEOUT_MS);
+            const result = await initialize;
+            expect(result).toMatchObject({ hasAuth: false, activeSelectionPreserved: true });
+            const autoLogin = vi.spyOn(service, 'authenticateWithNip07ForAutoLogin');
+            const guest = vi.fn();
+            const authenticated = vi.fn();
+            await runAppInitializationBootstrap({
+                reloadSettings: vi.fn(), locationSearch: '', clearSharedMediaError: vi.fn(),
+                waitForLocale: async () => {}, markLocaleInitialized: vi.fn(),
+                initializeAuth: async () => result,
+                resolveAuthenticatedSession: current => resolveNip07AutoLoginSession(current, {
+                    authenticateWithNip07: identity => service.authenticateWithNip07ForAutoLogin(identity),
+                    console: { error: vi.fn() },
+                }),
+                handleAuthenticated: authenticated, initializeGuestSession: guest,
+                stopProfileLoading: vi.fn(), refreshAccountList: () => manager.getAccounts(),
+                markAuthInitialized: vi.fn(), externalInputEnabled: false,
+                getExternalInputBootstrapParams: () => { throw new Error('disabled'); },
+                console: { error: vi.fn() },
+            });
+            expect(guest).toHaveBeenCalledOnce();
+            expect(authenticated).not.toHaveBeenCalled();
+            expect(autoLogin).not.toHaveBeenCalled();
+            expect(deps.setNsecAuth).not.toHaveBeenCalled();
+            expect(deps.setNip07Auth).not.toHaveBeenCalled();
+            expect(keys.readStoredKey).not.toHaveBeenCalledWith(FALLBACK_PUBKEY);
+            expect(manager.getActiveAccountPubkey()).toBe(NIP07_PUBKEY);
+            expect(storage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS)).toBe(accountsBefore);
+            discovery.mockRestore();
+
+            const restarted = new AuthService(createMockNip07Dependencies(NIP07_PUBKEY, deps));
+            restarted.setAccountManager(manager);
+            await expect(restarted.initializeAuth()).resolves.toEqual({ hasAuth: true, pubkeyHex: NIP07_PUBKEY });
+            expect(manager.getActiveAccountPubkey()).toBe(NIP07_PUBKEY);
+            expect(storage.getItem(STORAGE_KEYS.NOSTR_ACCOUNTS)).toBe(accountsBefore);
+        },
+    );
+
+    it.each([null, '', 'dd'.repeat(32), 'invalid-pubkey'])(
+        'recovers and persists B without a valid selection: %s', async pointer => {
+            const deps = createMockDependencies();
+            const storage = deps.localStorage as MockStorage;
+            const manager = new AccountManager({ localStorage: storage });
+            manager.addAccount('invalid-pubkey', 'nip07');
+            manager.addAccount(FALLBACK_PUBKEY, 'nsec');
+            if (pointer === null) manager.clearActiveAccount();
+            else storage.setItem(STORAGE_KEYS.NOSTR_ACTIVE_ACCOUNT, pointer);
+            const keys = deps.keyManager as MockKeyManager;
+            keys.readStoredKey.mockImplementation((pubkey?: string) => pubkey === FALLBACK_PUBKEY
+                ? { status: 'found', secretKey: 'test-credential' } : { status: 'missing' });
+            keys.isValidNsec.mockReturnValue(true);
+            keys.derivePublicKey.mockReturnValue({ hex: FALLBACK_PUBKEY, npub: 'npub-test', nprofile: 'nprofile-test' });
+            const service = new AuthService(deps);
+            service.setAccountManager(manager);
+            await expect(service.initializeAuth()).resolves.toEqual({ hasAuth: true, pubkeyHex: FALLBACK_PUBKEY });
+            expect(manager.getActiveAccountPubkey()).toBe(FALLBACK_PUBKEY);
+        },
+    );
+});
 
 describe('AuthService.initializeAuth', () => {
     let mockDependencies: AuthServiceDependencies;
@@ -64,8 +200,8 @@ describe('AuthService.initializeAuth', () => {
         expect(result.pubkeyHex).toBe(ACTIVE_PUBKEY);
     });
 
-    it('マルチアカウント: アクティブ失敗→他アカウントフォールバック成功', async () => {
-        mockAccountManager.getActiveAccountPubkey.mockReturnValue(ACTIVE_PUBKEY);
+    it('active未選択: マルチアカウント: 先行候補失敗→他アカウントフォールバック成功', async () => {
+        mockAccountManager.getActiveAccountPubkey.mockReturnValue(null);
         mockAccountManager.getAccountType.mockReturnValue('nsec');
         mockAccountManager.getAccounts.mockReturnValue([
             { pubkeyHex: ACTIVE_PUBKEY, type: 'nsec', addedAt: 1000 },
@@ -93,8 +229,8 @@ describe('AuthService.initializeAuth', () => {
         expect(mockAccountManager.setActiveAccount).toHaveBeenCalledWith(FALLBACK_PUBKEY);
     });
 
-    it('active候補のcredential読み取り異常後も後続候補を復元・active化し、auto-loginへ進まない', async () => {
-        mockAccountManager.getActiveAccountPubkey.mockReturnValue(ACTIVE_PUBKEY);
+    it('active未選択: 先行候補のcredential読み取り異常後も後続候補を復元・active化し、auto-loginへ進まない', async () => {
+        mockAccountManager.getActiveAccountPubkey.mockReturnValue(null);
         mockAccountManager.getAccountType.mockReturnValue('nsec');
         mockAccountManager.getAccounts.mockReturnValue([
             { pubkeyHex: ACTIVE_PUBKEY, type: 'nsec', addedAt: 1000 },
@@ -128,8 +264,8 @@ describe('AuthService.initializeAuth', () => {
         expect(authenticateWithNip07).not.toHaveBeenCalled();
     });
 
-    it('マルチアカウント: 全アカウント復元失敗', async () => {
-        mockAccountManager.getActiveAccountPubkey.mockReturnValue(ACTIVE_PUBKEY);
+    it('active未選択: マルチアカウント: 全アカウント復元失敗', async () => {
+        mockAccountManager.getActiveAccountPubkey.mockReturnValue(null);
         mockAccountManager.getAccountType.mockReturnValue('nsec');
         mockAccountManager.getAccounts.mockReturnValue([
             { pubkeyHex: ACTIVE_PUBKEY, type: 'nsec', addedAt: 1000 },
@@ -191,7 +327,7 @@ describe('AuthService.initializeAuth', () => {
         expect(mockAccountManager.setActiveAccount).toHaveBeenCalledWith(FALLBACK_PUBKEY);
     });
 
-    it('NIP-07 identity read timeout後に次のmanaged candidateを試す', async () => {
+    it('NIP-07 identity read timeout後もactive選択を保持する', async () => {
         vi.useFakeTimers();
         mockAccountManager.getActiveAccountPubkey.mockReturnValue(NIP07_PUBKEY);
         mockAccountManager.getAccountType.mockImplementation((pubkeyHex: string) => {
@@ -229,17 +365,19 @@ describe('AuthService.initializeAuth', () => {
         await vi.advanceTimersByTimeAsync(MANAGED_NIP07_IDENTITY_READ_TIMEOUT_MS);
 
         await expect(initialize).resolves.toMatchObject({
-            hasAuth: true,
-            pubkeyHex: FALLBACK_PUBKEY,
+            hasAuth: false,
+            activeSelectionPreserved: true,
         });
         expect(mockDependencies.setNip07Auth).not.toHaveBeenCalled();
-        expect(mockAccountManager.setActiveAccount).toHaveBeenCalledWith(FALLBACK_PUBKEY);
+        expect(mockAccountManager.setActiveAccount).not.toHaveBeenCalled();
+        expect(mockDependencies.setNsecAuth).not.toHaveBeenCalled();
+        expect(mockKeyManager.readStoredKey).not.toHaveBeenCalledWith(FALLBACK_PUBKEY);
     });
 
-    it('保存済みNIP-07 mismatchのidentityを保持し、後続候補を最後まで試す', async () => {
+    it('active未選択: 保存済みNIP-07 mismatchのidentityを保持し、後続候補を最後まで試す', async () => {
         const nip07Deps = createMockNip07Dependencies(FALLBACK_PUBKEY, mockDependencies);
         const getPublicKey = (nip07Deps.window as any).nostr.getPublicKey as ReturnType<typeof vi.fn>;
-        mockAccountManager.getActiveAccountPubkey.mockReturnValue(NIP07_PUBKEY);
+        mockAccountManager.getActiveAccountPubkey.mockReturnValue(null);
         mockAccountManager.getAccountType.mockImplementation((pubkeyHex: string) => {
             if (pubkeyHex === NIP07_PUBKEY) return 'nip07';
             if (pubkeyHex === ACTIVE_PUBKEY) return 'nsec';
@@ -263,10 +401,10 @@ describe('AuthService.initializeAuth', () => {
         expect(getPublicKey).toHaveBeenCalledOnce();
     });
 
-    it('保存済みNIP-07 mismatch identityが後続の保存済みNIP-07に一致すれば再問い合わせせず復元する', async () => {
+    it('active未選択: 保存済みNIP-07 mismatch identityが後続の保存済みNIP-07に一致すれば再問い合わせせず復元する', async () => {
         const nip07Deps = createMockNip07Dependencies(FALLBACK_PUBKEY, mockDependencies);
         const getPublicKey = (nip07Deps.window as any).nostr.getPublicKey as ReturnType<typeof vi.fn>;
-        mockAccountManager.getActiveAccountPubkey.mockReturnValue(NIP07_PUBKEY);
+        mockAccountManager.getActiveAccountPubkey.mockReturnValue(null);
         mockAccountManager.getAccountType.mockImplementation((pubkeyHex: string) =>
             pubkeyHex === NIP07_PUBKEY || pubkeyHex === FALLBACK_PUBKEY ? 'nip07' : null,
         );
@@ -291,6 +429,7 @@ describe('AuthService.initializeAuth', () => {
         mockAccountManager.getAccountType.mockReturnValue('nip46');
         mockAccountManager.getAccounts.mockReturnValue([
             { pubkeyHex: ACTIVE_PUBKEY, type: 'nip46', addedAt: 1000 },
+            { pubkeyHex: FALLBACK_PUBKEY, type: 'nsec', addedAt: 2000 },
         ]);
 
         const service = new AuthService(mockDependencies);
@@ -298,8 +437,11 @@ describe('AuthService.initializeAuth', () => {
 
         await expect(service.initializeAuth()).resolves.toEqual({
             hasAuth: false,
+            activeSelectionPreserved: true,
             restoreOutcome: 'completed',
         });
+        expect(mockKeyManager.readStoredKey).not.toHaveBeenCalledWith(FALLBACK_PUBKEY);
+        expect(mockAccountManager.setActiveAccount).not.toHaveBeenCalled();
     });
 
     it('保存credential読み取り異常は通常候補失敗と区別する', async () => {
@@ -315,12 +457,13 @@ describe('AuthService.initializeAuth', () => {
 
         await expect(service.initializeAuth()).resolves.toEqual({
             hasAuth: false,
+            activeSelectionPreserved: true,
             restoreOutcome: 'infrastructure-failure',
         });
     });
 
-    it('全managed候補失敗までにcredential読み取り異常があればauto-loginを抑止する', async () => {
-        mockAccountManager.getActiveAccountPubkey.mockReturnValue(ACTIVE_PUBKEY);
+    it('active未選択: 全managed候補失敗までにcredential読み取り異常があればauto-loginを抑止する', async () => {
+        mockAccountManager.getActiveAccountPubkey.mockReturnValue(null);
         mockAccountManager.getAccountType.mockReturnValue('nsec');
         mockAccountManager.getAccounts.mockReturnValue([
             { pubkeyHex: ACTIVE_PUBKEY, type: 'nsec', addedAt: 1000 },
@@ -404,6 +547,7 @@ describe('AuthService.initializeAuth', () => {
 
         await expect(service.initializeAuth()).resolves.toEqual({
             hasAuth: false,
+            activeSelectionPreserved: true,
             restoreOutcome: 'infrastructure-failure',
         });
         expect(mockAccountManager.getAuthRestoreSnapshot).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Problem and behavior
Startup restore previously tried other saved accounts after the selected account failed, then persisted the successful fallback as active. For example, a temporarily unavailable NIP-07 extension could silently switch the user to a saved nsec account.

Preserve a valid saved non-Parent Client selection and restore only that account. On failure, remain unauthenticated and propagate an internal selection-preserved result so Full Web Component opt-in auto-login cannot replace the identity either. Keep recovery fallback when there is no valid selection, the existing Parent Client startup exception, and existing extension discovery and identity timeouts.

## Verification
- Full `npm test`: 4,091 passed, 1 skipped; thread-graph complexity check passed.
- `npm run check`: 0 errors, 0 warnings.
- `git diff --check`: passed.
- Regression coverage uses the real AccountManager with in-memory storage and startup bootstrap: unavailable/rejected/empty/timed-out/mismatched NIP-07 identity preserves the account list and active pointer, skips B and opt-in auto-login, and restores A on restart. Also covers nsec/NIP-46 failure and recovery without a valid selection.
- Build and browser/E2E checks were not run: no build/runtime packaging or browser API behavior changed; the policy, persistence, and bootstrap boundary are covered below browser level.
