### PR TITLE
Preserve editor focus during submission

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
             testIgnore: '**/webComponentDevServer.spec.ts',
             use: {
                 ...devices['iPhone 13'],
+                browserName: 'chromium',
             },
         },
         {

--- a/src/components/KeyboardButtonBar.svelte
+++ b/src/components/KeyboardButtonBar.svelte
@@ -31,6 +31,7 @@
         hashtagPinAvailable?: boolean;
     }
     const overlayTarget = getAppRuntimeEnvironment().overlayTarget;
+    const isHostOwnedLiteBuild = typeof __EHAGAKI_COMPOSER_LITE__ !== 'undefined' && __EHAGAKI_COMPOSER_LITE__;
 
     let {
         onUploadImage,
@@ -105,11 +106,22 @@
     function isPostDisabled(): boolean {
         return (
             !canPost ||
+            editorState.isSubmitPending ||
             postStatus.sending ||
             isUploading ||
             !hasPostingCapability ||
             !!postStatus.completed
         );
+    }
+
+    function preservePostPressFocus(event: Event) {
+        // Posting must not suppress the active IME when viewport detection is
+        // a false negative. Other toolbar buttons retain their existing policy.
+        if (!isHostOwnedLiteBuild && event.target instanceof Element && event.target.closest('button.post-button')) {
+            event.preventDefault();
+        } else {
+            preventKeyboardFocusChange(event);
+        }
     }
 
     function startLongPress(event: PointerEvent) {
@@ -222,8 +234,8 @@
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
         class="button-container"
-        onpointerdowncapture={preventKeyboardFocusChange}
-        ontouchstartcapture={preventKeyboardFocusChange}
+        onpointerdowncapture={preservePostPressFocus}
+        ontouchstartcapture={preservePostPressFocus}
     >
         <div class="button-group-left">
             {#if mediaEnabled}
@@ -238,6 +250,7 @@
                                 className="image-button"
                                 disabled={!hasPostingCapability ||
                                     postStatus.sending ||
+                                    editorState.isSubmitPending ||
                                     isUploading}
                                 onClick={(e) => {
                                     onUploadImage?.();
@@ -332,6 +345,7 @@
                                     : ''}"
                                 disabled={!canPost ||
                                     postStatus.sending ||
+                                    editorState.isSubmitPending ||
                                     isUploading ||
                                     !hasPostingCapability ||
                                     postStatus.completed}

--- a/src/components/PostComponent.svelte
+++ b/src/components/PostComponent.svelte
@@ -72,6 +72,7 @@
   import { showToolbarCaret } from "../lib/editor/toolbarCaretExtension";
   import { insertCustomEmojiWithoutUnwantedKeyboard } from "../lib/editor/customEmojiInsertion";
   import { focusEditorWithoutKeyboardForCurrentTap } from "../lib/utils/keyboardFocusUtils";
+  import { waitForEditorComposition } from "../lib/editor/waitForEditorComposition";
   import { isEditorElement } from "../lib/utils/appDomUtils";
   import {
     profileDataStore,
@@ -156,6 +157,7 @@
   let hostMountActive = true;
   let editor: any = $state(null);
   let currentEditor: TipTapEditor | null = $state(null);
+  let compositionWait: ReturnType<typeof waitForEditorComposition> | undefined;
   let dragOver = $state(false);
   let fileInput: HTMLInputElement | undefined = $state();
   let postManager: PostManager | undefined = $state();
@@ -202,15 +204,12 @@
   });
 
   $effect(() => {
-    const editorInstance = currentEditor;
-    // The inline Lite submit surface must leave the already-focused editor in
-    // place while its host callback is pending. The sending handlers below
-    // still block editor input and other editor actions for this local mode.
+    // Lite's non-inline submit mode retains its existing editable policy.
+    // Normal composers use the document guard instead of closing the surface.
+    if (!isHostOwned) return;
     const editable = !postStatus.sending || showEditorSubmitButton;
-
-    if (editorInstance && editorInstance.isEditable !== editable) {
-      // Tiptap v3 supports suppressing the update event for this option-only change.
-      editorInstance.setEditable(editable, false);
+    if (currentEditor && currentEditor.isEditable !== editable) {
+      currentEditor.setEditable(editable, false);
     }
   });
 
@@ -275,15 +274,16 @@
   function handleEditorContainerKeydownCapture(event: KeyboardEvent) {
     if (!postStatus.sending) return;
 
-    // Keep the focused contenteditable surface during an inline submit, but
+    // Keep the focused contenteditable surface during submission, but
     // stop the event before Tiptap's target keymap can create a transaction.
     event.preventDefault();
     event.stopPropagation();
   }
 
-  function handleEditorContainerBeforeInput(event: InputEvent) {
+  function blockSendingInput(event: Event) {
     if (postStatus.sending) {
       event.preventDefault();
+      event.stopPropagation();
     }
   }
 
@@ -361,6 +361,7 @@
     uploadFiles: async (params) => {
       if (
         postStatus.sending ||
+        editorState.isSubmitPending ||
         editorState.isUploading ||
         (isHostOwned && !hostMountActive)
       ) {
@@ -501,6 +502,7 @@
   // --- Editor初期化・クリーンアップ ---
   onMount(() => {
     editorResources = initializeEditor({
+      isInputBlocked: isHostOwned ? undefined : () => editorState.postStatus.sending,
       placeholderText: editorPlaceholderText,
       editorContainerEl,
       currentEditor,
@@ -589,6 +591,12 @@
     );
 
     return () => {
+      compositionWait?.cancel();
+      compositionWait = undefined;
+      if (currentEditorStore.value === currentEditor) {
+        editorState.isSubmitPending = false;
+        if (!isHostOwned) postComponentUIStore.hideSecretKeyDialog();
+      }
       window.removeEventListener(
         "image-fullscreen-request",
         handleImageFullscreenRequest,
@@ -826,12 +834,22 @@
 
   function canStartSubmit(): boolean {
     return (
-      !!currentEditor &&
+      canSendNormalPost() &&
       editorState.canPost &&
+      !editorState.isSubmitPending &&
+      !showSecretKeyDialog
+    );
+  }
+
+  function canSendNormalPost(): boolean {
+    return (
+      !!currentEditor &&
+      !!postManager &&
+      !isSwitchingAccount &&
       !postStatus.sending &&
       !editorState.isUploading &&
       !postStatus.completed &&
-      (hasPostingCapability || !!postManager)
+      hasPostingCapability
     );
   }
 
@@ -968,22 +986,43 @@
     if (!canStartSubmit()) return;
     if (isHostOwnedLiteBuild) return;
     if (!postManager) return;
-    const postPayload = postManager.preparePostPayload(currentEditor);
-    if (containsSecretKey(postPayload.content)) {
-      postComponentUIStore.showSecretKeyDialog(
-        postPayload.content,
-        postPayload.emojiTags,
+    const editorInstance = currentEditor;
+    editorState.isSubmitPending = true;
+    try {
+      if (editorInstance.view.composing) {
+        compositionWait = waitForEditorComposition(editorInstance);
+        const ready = await compositionWait.settled;
+        compositionWait = undefined;
+        if (!ready) return;
+      }
+      if (
+        editorInstance.isDestroyed ||
+        currentEditorStore.value !== editorInstance ||
+        !canSendNormalPost()
+      ) return;
+      const postPayload = postManager.preparePostPayload(editorInstance);
+      if (!postPayload.content.trim()) return;
+      if (containsSecretKey(postPayload.content)) {
+        // The existing confirmation store now owns this one submission intent.
+        postComponentUIStore.showSecretKeyDialog(postPayload.content, postPayload.emojiTags);
+        editorState.isSubmitPending = false;
+        return;
+      }
+      await postManager.performPostSubmission(
+        editorInstance,
+        postPayload,
+        imageOxMap,
+        imageXMap,
+        () => {
+          postStatusHandlers.markSending();
+          editorState.isSubmitPending = false;
+        },
+        postStatusHandlers.markSuccess,
+        postStatusHandlers.markFailure,
       );
-      return;
+    } finally {
+      if (currentEditorStore.value === editorInstance) editorState.isSubmitPending = false;
     }
-    await postManager.performPostSubmission(
-      currentEditor,
-      imageOxMap,
-      imageXMap,
-      postStatusHandlers.markSending,
-      postStatusHandlers.markSuccess,
-      postStatusHandlers.markFailure,
-    );
   }
 
   export function resetPostContent() {
@@ -1023,10 +1062,10 @@
 
   // UI状態管理をストアから取得して使用
   async function confirmSendWithSecretKey() {
-    if (!canStartSubmit()) return;
+    if (!showSecretKeyDialog || !canSendNormalPost()) return;
     const pendingPost = postComponentUIStore.getPendingPost();
     const pendingEmojiTags = postComponentUIStore.getPendingEmojiTags();
-    postComponentUIStore.hideSecretKeyDialog();
+    if (!pendingPost.trim()) return;
     if (!isHostOwnedLiteBuild && postManager && currentEditor) {
       await submitPendingPostWithSecretKey({
         postManager,
@@ -1035,7 +1074,10 @@
         imageXMap,
         pendingPost,
         pendingEmojiTags,
-        onStart: postStatusHandlers.markSending,
+        onStart: () => {
+          postStatusHandlers.markSending();
+          postComponentUIStore.hideSecretKeyDialog();
+        },
         onSuccess: postStatusHandlers.markSuccess,
         onFailure: postStatusHandlers.markFailure,
       });
@@ -1085,7 +1127,7 @@
   });
 
   export function openFileDialog() {
-    if (!mediaEnabled || postStatus.sending || editorState.isUploading) return;
+    if (!mediaEnabled || postStatus.sending || editorState.isSubmitPending || editorState.isUploading) return;
     fileInput?.click();
   }
 
@@ -1166,7 +1208,10 @@
     onclick={handleEditorContainerClick}
     onkeydowncapture={handleEditorContainerKeydownCapture}
     onkeydown={handleEditorContainerKeydown}
-    onbeforeinput={handleEditorContainerBeforeInput}
+    onbeforeinputcapture={blockSendingInput}
+    onpastecapture={blockSendingInput}
+    oncutcapture={blockSendingInput}
+    ondropcapture={blockSendingInput}
     use:fileDropActionWithDragState={{
       dragOver: (v: boolean) => (dragOver = v),
     }}

--- a/src/lib/editor/editorConfig.ts
+++ b/src/lib/editor/editorConfig.ts
@@ -16,6 +16,7 @@ import type { CustomEmojiSelection } from '../customEmojiUsage';
 import type { CustomEmojiItem } from '../customEmoji';
 import type { EHagakiHostSubmitShortcut, EHagakiHostSubmitShortcutModifier } from '../../web-component/types';
 import type { EditorSubmitTrigger } from '../types/editor';
+import { EditorInputGuard } from './editorInputGuard';
 
 const MEDIA_NODE_TYPES = new Set(['image', 'video', 'customEmoji']);
 const MEDIA_FOCUS_SELECTOR = '.node-image.is-node-focused, .node-video.is-node-focused, .custom-emoji-wrapper.is-node-focused';
@@ -151,6 +152,7 @@ const GapCursorFocusReset = Extension.create({
 });
 
 export interface EditorConfigOptions {
+    isInputBlocked?: () => boolean;
     placeholderText: string;
     onSubmitPost: (trigger?: EditorSubmitTrigger) => Promise<void>;
     onCustomEmojiSelect?: (emoji: CustomEmojiSelection) => void;
@@ -183,6 +185,9 @@ export function createEditorStore(options: EditorConfigOptions) {
 
     const editorStore = createEditor({
         extensions: [
+            ...(!hostOwnedLite && options.isInputBlocked
+                ? [EditorInputGuard.configure({ isInputBlocked: options.isInputBlocked })]
+                : []),
             StarterKit.configure({
                 paragraph: {
                     HTMLAttributes: {

--- a/src/lib/editor/editorInputGuard.ts
+++ b/src/lib/editor/editorInputGuard.ts
@@ -1,0 +1,15 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+
+/** Keep the editable/focused surface while the composer owns a frozen document. */
+export const EditorInputGuard = Extension.create<{ isInputBlocked: () => boolean }>({
+    name: 'editorInputGuard',
+    addOptions: () => ({ isInputBlocked: () => false }),
+    addProseMirrorPlugins() {
+        return [new Plugin({
+            key: new PluginKey('editorInputGuard'),
+            filterTransaction: (transaction) =>
+                !transaction.docChanged || !this.options.isInputBlocked(),
+        })];
+    },
+});

--- a/src/lib/editor/editorLifecycle.ts
+++ b/src/lib/editor/editorLifecycle.ts
@@ -34,6 +34,7 @@ export function initializeEditor(params: InitializeEditorParams): InitializeEdit
 
     // エディターストアの作成
     const editor = createTiptapEditorStore({
+        isInputBlocked: params.isInputBlocked,
         placeholderText,
         onSubmitPost: submitPost,
         onCustomEmojiSelect,

--- a/src/lib/editor/waitForEditorComposition.ts
+++ b/src/lib/editor/waitForEditorComposition.ts
@@ -1,0 +1,28 @@
+import type { Editor } from '@tiptap/core';
+
+/** Wait for a natural IME end; never finish composition or move focus ourselves. */
+export function waitForEditorComposition(editor: Editor) {
+    const element = editor.view.dom;
+    const ownerWindow = element.ownerDocument.defaultView!;
+    let frame: number | undefined;
+    let resolve: (ready: boolean) => void;
+    const settled = new Promise<boolean>((done) => { resolve = done; });
+    const finish = (ready: boolean) => {
+        element.removeEventListener('compositionend', handleEnd);
+        if (frame !== undefined) ownerWindow.cancelAnimationFrame(frame);
+        frame = undefined;
+        resolve(ready);
+    };
+    function handleEnd() {
+        if (frame !== undefined) ownerWindow.cancelAnimationFrame(frame);
+        // A tested DOM/ProseMirror synchronization boundary, not a platform
+        // guarantee. Do not replace a failing boundary with timed retries.
+        frame = ownerWindow.requestAnimationFrame(() => {
+            frame = undefined;
+            if (editor.isDestroyed) finish(false);
+            else if (!editor.view.composing) finish(true);
+        });
+    }
+    element.addEventListener('compositionend', handleEnd);
+    return { settled, cancel: () => finish(false) };
+}

--- a/src/lib/postManager.ts
+++ b/src/lib/postManager.ts
@@ -733,13 +733,13 @@ export class PostManager {
 
   async performPostSubmission(
     editor: TipTapEditor,
+    postPayload: ExtractedPostContent,
     imageOxMap: Record<string, string>,
     imageXMap: Record<string, string>,
     onStart?: () => void,
     onSuccess?: (result?: PostResult) => void,
     onError?: (error: string) => void
   ): Promise<void> {
-    const postPayload = this.preparePostPayload(editor);
     const imageBlurhashMap = this.prepareImageBlurhashMap(editor, imageOxMap, imageXMap);
 
     onStart?.();
@@ -791,9 +791,8 @@ export class PostManager {
       editor.commands.insertContent(hashtagText);
     }
 
-    // 投稿成功後は、固定ハッシュタグの有無にかかわらずエディターへ戻す。
-    // 固定ハッシュタグがある場合は、復元されたハッシュタグより前に
-    // カレットを置く既存の位置を維持する。
-    editor.commands.focus('start');
+    // Preserve the current focus state, including an intentionally hidden IME.
+    // Keep the caret before any restored pinned hashtags without refocusing.
+    editor.commands.setTextSelection(1);
   }
 }

--- a/src/lib/types/editor.ts
+++ b/src/lib/types/editor.ts
@@ -17,6 +17,7 @@ export interface PostStatus {
 }
 
 export interface EditorState {
+    isSubmitPending: boolean;
     content: string;
     canPost: boolean;
     isUploading: boolean;
@@ -118,6 +119,7 @@ export interface SetupEventListenersParams {
 }
 
 export interface InitializeEditorParams {
+    isInputBlocked?: () => boolean;
     placeholderText: string;
     editorContainerEl: HTMLElement | null;
     currentEditor: TipTapEditor | null;

--- a/src/stores/editorStore.svelte.ts
+++ b/src/stores/editorStore.svelte.ts
@@ -18,6 +18,7 @@ export const currentEditorStore = {
 };
 
 export let editorState = $state<EditorState>({
+    isSubmitPending: false,
     content: '',
     canPost: false,
     isUploading: false,

--- a/src/test/e2e/PostEditorSendingHarness.svelte
+++ b/src/test/e2e/PostEditorSendingHarness.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
     import { onDestroy, onMount } from 'svelte';
     import PostComponent from '../../components/PostComponent.svelte';
+    import KeyboardButtonBar from '../../components/KeyboardButtonBar.svelte';
+    import type { RxNostr } from 'rx-nostr';
+    import { Tooltip } from 'bits-ui';
     import CustomEmojiPicker from '../../components/CustomEmojiPicker.svelte';
     import type { CustomEmojiSelection } from '../../lib/customEmojiUsage';
     import { editorState, resetPostStatus, updatePostStatus } from '../../stores/editorStore.svelte';
@@ -9,6 +12,10 @@
     let sending = $derived(editorState.postStatus.sending);
     let pickerOpen = $state(false);
     let postComponentRef: any = $state(null);
+    let mounted = $state(true);
+    let authorized = $state(true);
+    const inertRxNostr = {} as RxNostr; // Transport is replaced by the entry harness.
+    const withSubmit = new URLSearchParams(window.location.search).has('withSubmit');
 
     const pickerEmoji = {
         shortcode: 'sending-safe',
@@ -90,7 +97,19 @@
         Fail post
     </button>
     <output data-testid="sending-state">{sending ? 'sending' : 'idle'}</output>
-    <PostComponent bind:this={postComponentRef} hasStoredKey={true} />
+    <output data-testid="submit-pending">{editorState.isSubmitPending ? 'pending' : 'idle'}</output>
+    {#if withSubmit}
+        <button data-testid="unmount-editor" onclick={() => mounted = false}>Unmount</button>
+        <button data-testid="revoke-posting" onclick={() => authorized = false}>Revoke</button>
+    {/if}
+    {#if mounted}
+        <PostComponent bind:this={postComponentRef} rxNostr={inertRxNostr} hasStoredKey={authorized} />
+        {#if withSubmit}
+            <Tooltip.Provider>
+                <KeyboardButtonBar hasPostingCapability={authorized} />
+            </Tooltip.Provider>
+        {/if}
+    {/if}
     {#if pickerOpen}
         <div data-testid="custom-emoji-picker-host">
             <CustomEmojiPicker

--- a/src/test/e2e/appComposerPickerHarnessEntry.ts
+++ b/src/test/e2e/appComposerPickerHarnessEntry.ts
@@ -5,6 +5,9 @@ import App from '../../App.svelte';
 import { STORAGE_KEYS } from '../../lib/constants';
 import { updateAuthState } from '../../stores/authStore.svelte';
 import { editorState, updatePostStatus } from '../../stores/editorStore.svelte';
+import { installPostSubmitHarness } from './postSubmitHarness';
+
+installPostSubmitHarness();
 
 const target = document.getElementById('app');
 

--- a/src/test/e2e/composerTargetDialog.spec.ts
+++ b/src/test/e2e/composerTargetDialog.spec.ts
@@ -427,7 +427,9 @@ test.describe("composer target dialog fixture", () => {
         await openDialog(page);
         await page.getByLabel("イベントID").fill(harness.inputs.mediaPost);
 
-        const firstImage = page.locator(".post-history-image-surface").first();
+        // Images become actionable in fetch-completion order. Keep the same
+        // opener even when an earlier image finishes loading after this one.
+        const firstImage = page.getByRole("button", { name: "開く preview-media-1.jpg", exact: true });
         await expect(firstImage).toBeVisible();
         await firstImage.focus();
         await firstImage.press("Enter");

--- a/src/test/e2e/postEditorSending.spec.ts
+++ b/src/test/e2e/postEditorSending.spec.ts
@@ -1,4 +1,278 @@
-import { expect, test } from '@playwright/test';
+import { devices, expect, test, type Page, type Locator } from '@playwright/test';
+
+async function beginLongPress(page: Page, button: Locator, nativeTouch: boolean) {
+    if (nativeTouch) {
+        const session = await page.context().newCDPSession(page);
+        const box = await button.boundingBox();
+        if (!box) throw new Error('No submit button box');
+        await session.send('Input.dispatchTouchEvent', {
+            type: 'touchStart', touchPoints: [{ x: box.x + box.width / 2, y: box.y + box.height / 2 }],
+        });
+        return async () => {
+            await session.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+            await session.detach();
+        };
+    }
+    // WebKit has no CDP touch hold API. Test the real pointer handler with a
+    // synthetic touch pointer, separately from Chromium's native touch input.
+    await button.dispatchEvent('pointerdown', { pointerType: 'touch', pointerId: 1, bubbles: true });
+    return async () => {
+        await button.dispatchEvent('pointerup', { pointerType: 'touch', pointerId: 1, bubbles: true });
+        await button.dispatchEvent('click');
+    };
+}
+
+async function observeFocus(editor: Locator) {
+    await editor.evaluate((element) => {
+        const state = { blurs: 0, focusCalls: 0, invalidAttributes: [] as string[] };
+        (window as any).__focusObservation = state;
+        element.addEventListener('blur', () => state.blurs++);
+        element.addEventListener('focus', () => state.focusCalls++);
+        new MutationObserver((records) => {
+            for (const record of records) {
+                const value = element.getAttribute(record.attributeName!);
+                if (value === 'none' || value === 'false' || record.oldValue === 'none' || record.oldValue === 'false') {
+                    state.invalidAttributes.push(record.attributeName!);
+                }
+            }
+        }).observe(element, { attributes: true, attributeOldValue: true, attributeFilter: ['contenteditable', 'inputmode'] });
+    });
+}
+
+async function finishSubmission(page: Page, success: boolean) {
+    await page.evaluate((ok) => (window as any).__postSubmitHarness.finish(ok), success);
+}
+
+async function endComposition(editor: Locator, text: string) {
+    await editor.evaluate((element, value) => {
+        element.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: value }));
+        // Intentionally update after compositionend in this same task. Reading
+        // synchronously in that handler would capture the old document.
+        element.querySelector('p')!.textContent = value;
+        element.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: value }));
+    }, text);
+}
+
+test('long-press submits once without losing focus and freezes the document until success', async ({ page, browserName, isMobile }) => {
+    await page.goto('post-editor-sending-playwright.html?withSubmit=1');
+    const editor = page.locator('.tiptap-editor');
+    await editor.click();
+    await page.keyboard.type('frozen draft');
+    const button = page.locator('button.post-button');
+    await expect(button).toBeEnabled();
+    await observeFocus(editor);
+    const release = await beginLongPress(page, button, browserName === 'chromium' && isMobile);
+    await expect(page.getByTestId('sending-state')).toHaveText('sending');
+    // Sending must begin before releasing the pointer.
+    await expect(editor).toBeFocused();
+    await release();
+    await expect(editor).toHaveAttribute('contenteditable', 'true');
+    await expect(page.getByRole('textbox')).toMatchAriaSnapshot('- textbox "投稿エディター" [disabled]');
+    for (const key of ['x', 'Enter', 'Shift+Enter', 'Backspace', 'Control+z', 'Control+y']) await page.keyboard.press(key);
+    for (const type of ['paste', 'cut', 'drop']) {
+        await editor.evaluate((element, type) => {
+            const transfer = new DataTransfer();
+            transfer.setData('text/plain', 'blocked');
+            const event = type === 'drop'
+                ? new DragEvent(type, { bubbles: true, cancelable: true, dataTransfer: transfer })
+                : new ClipboardEvent(type, { bubbles: true, cancelable: true, clipboardData: transfer });
+            element.dispatchEvent(event);
+        }, type);
+    }
+    await editor.evaluate((element) => {
+        const ed = (window as any).__currentEditor;
+        ed.view.dispatch(ed.state.tr.insertText('blocked').setMeta('composition', 1));
+        element.querySelector('p')!.textContent = 'uncancellable native input';
+        element.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertCompositionText', isComposing: true }));
+    });
+    await expect(editor).toHaveText('frozen draft');
+    expect(await page.evaluate(() => (window as any).__currentEditor.state.doc.textContent)).toBe('frozen draft');
+    expect(await page.evaluate(() => (window as any).__postSubmitHarness.submissions.length)).toBe(1);
+    await finishSubmission(page, true);
+    await expect(editor).toHaveText('');
+    await expect(editor).toBeFocused();
+    expect(await page.evaluate(() => (window as any).__focusObservation)).toEqual({ blurs: 0, focusCalls: 0, invalidAttributes: [] });
+});
+
+test('composition long-press waits for the final document and keeps one intent', async ({ page, browserName, isMobile }) => {
+    await page.goto('post-editor-sending-playwright.html?withSubmit=1');
+    const editor = page.locator('.tiptap-editor');
+    await editor.click();
+    await page.keyboard.type('draft');
+    const button = page.locator('button.post-button');
+    await expect(button).toBeEnabled();
+    await editor.dispatchEvent('compositionstart', { data: 'draft' });
+    await observeFocus(editor);
+    const release = await beginLongPress(page, button, browserName === 'chromium' && isMobile);
+    await expect(page.getByTestId('submit-pending')).toHaveText('pending');
+    await release();
+    await page.evaluate(() => {
+        const container = document.querySelector('.editor-container') as any;
+        container.__uploadFiles([new File(['blocked'], 'blocked.png', { type: 'image/png' })]);
+    });
+    await expect(editor.locator('img')).toHaveCount(0);
+    await page.evaluate(() => { void (document.querySelector('.editor-container') as any).__submitPost(); });
+    expect(await page.evaluate(() => (window as any).__postSubmitHarness.submissions.length)).toBe(0);
+    await expect(page.getByRole('textbox')).not.toHaveAttribute('aria-disabled');
+    await endComposition(editor, '日本語の最終確定');
+    await expect(page.getByTestId('sending-state')).toHaveText('sending');
+    expect(await page.evaluate(() => (window as any).__postSubmitHarness.submissions.map((p: any) => p.content))).toEqual(['日本語の最終確定']);
+    await expect(editor).toHaveText('日本語の最終確定');
+    await finishSubmission(page, false);
+    await expect(page.getByTestId('sending-state')).toHaveText('idle');
+    await expect(editor).toHaveText('日本語の最終確定');
+    await expect(editor).toBeFocused();
+    expect(await page.evaluate(() => (window as any).__focusObservation)).toEqual({ blurs: 0, focusCalls: 0, invalidAttributes: [] });
+    await page.keyboard.type('再編集');
+    await expect(editor).toContainText('再編集');
+});
+
+test('unfocused submission does not acquire focus on success or failure', async ({ page, browserName, isMobile }) => {
+    for (const success of [true, false]) {
+        await page.goto('post-editor-sending-playwright.html?withSubmit=1');
+        const editor = page.locator('.tiptap-editor');
+        await editor.click();
+        await page.keyboard.type('unfocused draft');
+        await page.getByTestId('toggle-picker').focus();
+        await observeFocus(editor);
+        const button = page.locator('button.post-button');
+        await expect(button).toBeEnabled();
+        const release = await beginLongPress(page, button, browserName === 'chromium' && isMobile);
+        await expect(page.getByTestId('sending-state')).toHaveText('sending');
+        await release();
+        await finishSubmission(page, success);
+        await expect(page.getByTestId('sending-state')).toHaveText('idle');
+        await expect(editor).not.toBeFocused();
+        await expect(editor).toHaveText(success ? '' : 'unfocused draft');
+        expect(await page.evaluate(() => (window as any).__focusObservation.focusCalls)).toBe(0);
+    }
+});
+
+test('composition intent transfers to secret confirmation and is consumed or cancelled once', async ({ page }) => {
+    // Deliberately invalid checksum: exercises detection without containing a key.
+    const detectedText = `nsec1${'q'.repeat(58)}`;
+    for (const confirm of [false, true]) {
+        await page.goto('post-editor-sending-playwright.html?withSubmit=1');
+        const editor = page.locator('.tiptap-editor');
+        await editor.click();
+        await page.keyboard.type('draft');
+        await expect(page.locator('button.post-button')).toBeEnabled();
+        await editor.dispatchEvent('compositionstart');
+        await page.evaluate(() => { void (document.querySelector('.editor-container') as any).__submitPost(); });
+        await expect(page.getByTestId('submit-pending')).toHaveText('pending');
+        await endComposition(editor, detectedText);
+        const dialog = page.locator('.secretkey-warning-dialog');
+        await expect(dialog).toBeVisible();
+        await expect(page.getByTestId('submit-pending')).toHaveText('idle');
+        await page.evaluate(() => { void (document.querySelector('.editor-container') as any).__submitPost(); });
+        expect(await page.evaluate(() => (window as any).__postSubmitHarness.submissions.length)).toBe(0);
+        // The confirmation owns its snapshot, not the mutable editor document.
+        await page.evaluate(() => (window as any).__currentEditor.commands.setContent('<p>changed after dialog</p>'));
+        await dialog.getByRole('button', { name: confirm ? '投稿' : 'キャンセル', exact: true }).click();
+        await expect(dialog).not.toBeVisible();
+        if (confirm) {
+            await expect(page.getByTestId('sending-state')).toHaveText('sending');
+            expect(await page.evaluate((expected) => {
+                const sent = (window as any).__postSubmitHarness.submissions;
+                return sent.length === 1 && sent[0].content === expected;
+            }, detectedText)).toBe(true);
+            await finishSubmission(page, true);
+            await expect(editor).toHaveText('');
+        } else {
+            await editor.dispatchEvent('compositionend');
+            await page.evaluate(() => new Promise<void>(resolve => requestAnimationFrame(() => resolve())));
+            expect(await page.evaluate(() => (window as any).__postSubmitHarness.submissions.length)).toBe(0);
+            await expect(editor).toHaveText('changed after dialog');
+        }
+    }
+});
+
+for (const reason of ['empty', 'revoked', 'destroyed'] as const) {
+    test(`discards a composition submission when ${reason}`, async ({ page }) => {
+        await page.goto('post-editor-sending-playwright.html?withSubmit=1');
+        const editor = page.locator('.tiptap-editor');
+        await editor.click();
+        await page.keyboard.type('draft');
+        await expect(page.locator('button.post-button')).toBeEnabled();
+        await editor.dispatchEvent('compositionstart');
+        await page.evaluate(() => { void (document.querySelector('.editor-container') as any).__submitPost(); });
+        await expect(page.getByTestId('submit-pending')).toHaveText('pending');
+        if (reason === 'destroyed') {
+            await page.getByTestId('unmount-editor').evaluate((el: HTMLButtonElement) => el.click());
+        } else {
+            if (reason === 'revoked') await page.getByTestId('revoke-posting').evaluate((el: HTMLButtonElement) => el.click());
+            await endComposition(editor, reason === 'empty' ? '' : '最終確定');
+        }
+        await expect(page.getByTestId('submit-pending')).toHaveText('idle');
+        expect(await page.evaluate(() => (window as any).__postSubmitHarness.submissions.length)).toBe(0);
+    });
+}
+
+test('App and iframe use the normal submission path without refocusing', async ({ page, browserName, isMobile }) => {
+    await page.goto('app-composer-picker-playwright.html');
+    await page.evaluate(() => (window as any).__APP_COMPOSER_PICKER_HARNESS__.setAuthenticated());
+    const editor = page.locator('.tiptap-editor');
+    await editor.click();
+    await page.keyboard.type('App submit');
+    await expect(page.locator('button.post-button')).toBeEnabled();
+    await observeFocus(editor);
+    const release = await beginLongPress(page, page.locator('button.post-button'), browserName === 'chromium' && isMobile);
+    await expect.poll(() => page.evaluate(() => (window as any).__postSubmitHarness.submissions.length)).toBe(1);
+    await release();
+    await finishSubmission(page, true);
+    await expect(editor).toHaveText('');
+    await expect(editor).toBeFocused();
+    expect(await page.evaluate(() => (window as any).__focusObservation.blurs)).toBe(0);
+
+    const url = new URL('post-editor-sending-playwright.html?withSubmit=1', page.url()).href;
+    const hostURL = new URL('submit-frame-host', page.url()).href;
+    await page.route(hostURL, route => route.fulfill({
+        contentType: 'text/html',
+        body: `<iframe title="composer" src="${url}" style="width:320px;height:600px"></iframe>`,
+    }));
+    await page.goto(hostURL);
+    const frame = page.frameLocator('iframe');
+    const embeddedEditor = frame.locator('.tiptap-editor');
+    await embeddedEditor.click();
+    await page.keyboard.type('iframe submit');
+    await expect(frame.locator('button.post-button')).toBeEnabled();
+    await observeFocus(embeddedEditor);
+    const releaseFrame = await beginLongPress(page, frame.locator('button.post-button'), browserName === 'chromium' && isMobile);
+    await expect(frame.getByTestId('sending-state')).toHaveText('sending');
+    await releaseFrame();
+    await embeddedEditor.evaluate(() => (window as any).__postSubmitHarness.finish(true));
+    await expect(embeddedEditor).toHaveText('');
+    await expect(embeddedEditor).toBeFocused();
+    expect(await embeddedEditor.evaluate(() => (window as any).__focusObservation.blurs)).toBe(0);
+});
+
+test.describe('Android composition submit', () => {
+    const { defaultBrowserType: _browser, ...pixel } = devices['Pixel 7'];
+    test.use(pixel);
+    test('uses Chromium IME input through natural compositionend without missing the commit', async ({ page, browserName }) => {
+        test.skip(browserName !== 'chromium', 'CDP IME input is Chromium-only; WebKit uses the separate DOM event test');
+        await page.goto('post-editor-sending-playwright.html?withSubmit=1');
+        const editor = page.locator('.tiptap-editor');
+        await editor.click();
+        const cdp = await page.context().newCDPSession(page);
+        await cdp.send('Input.imeSetComposition', { text: 'にほん', selectionStart: 3, selectionEnd: 3 });
+        await expect(page.locator('button.post-button')).toBeEnabled();
+        expect(await page.evaluate(() => (window as any).__currentEditor.storage.androidCompositionFix.isComposing)).toBe(true);
+        await observeFocus(editor);
+        const release = await beginLongPress(page, page.locator('button.post-button'), true);
+        await expect(page.getByTestId('submit-pending')).toHaveText('pending');
+        await release();
+        await cdp.send('Input.insertText', { text: '日本' });
+        await expect(page.getByTestId('sending-state')).toHaveText('sending');
+        expect(await page.evaluate(() => (window as any).__postSubmitHarness.submissions.map((p: any) => p.content))).toEqual(['日本']);
+        expect(await page.evaluate(() => (window as any).__currentEditor.storage.androidCompositionFix.keepAliveInterval)).toBeNull();
+        await finishSubmission(page, true);
+        await expect(editor).toHaveText('');
+        await expect(editor).toBeFocused();
+        expect(await page.evaluate(() => (window as any).__focusObservation.blurs)).toBe(0);
+        await cdp.detach();
+    });
+});
 
 test.describe('post editor sending state', () => {
     test('keeps the content readable and blocks editing in light and dark themes', async ({ page }) => {
@@ -18,7 +292,7 @@ test.describe('post editor sending state', () => {
             await expect(page.getByTestId('sending-state')).toHaveText('sending');
             await expect(editorContainer).toHaveClass(/sending/);
             await expect(editorContainer).toHaveAttribute('aria-disabled', 'true');
-            await expect(editor).toHaveAttribute('contenteditable', 'false');
+            await expect(editor).toHaveAttribute('contenteditable', 'true');
             await expect(editor).toContainText('送信中も確認する本文');
             await expect.poll(() => editor.evaluate((element) => getComputedStyle(element).opacity)).toBe('0.72');
 
@@ -183,15 +457,16 @@ test.describe('post editor sending state', () => {
         const pickerIdentity = await pickerHost.locator('.custom-emoji-picker').elementHandle();
         if (!pickerIdentity) throw new Error('Custom emoji picker was not mounted.');
 
-        await page.getByTestId('toggle-sending').click();
-        await expect(editor).toHaveAttribute('contenteditable', 'false');
+        await editor.click();
+        await page.getByTestId('toggle-sending').evaluate((button: HTMLButtonElement) => button.click());
+        await expect(editor).toHaveAttribute('contenteditable', 'true');
         await expect(pickerHost).toBeVisible();
 
         const contentBeforePickerSelection = await editor.textContent();
         await page.getByAltText(':sending-safe:').click();
         await expect(editor).toHaveText(contentBeforePickerSelection ?? '');
 
-        await page.getByTestId('complete-post').click();
+        await page.getByTestId('complete-post').evaluate((button: HTMLButtonElement) => button.click());
         await expect(editor).toHaveAttribute('contenteditable', 'true');
         await expect(editor).toHaveText('');
         await expect(pickerHost).toBeVisible();

--- a/src/test/e2e/postEditorSendingHarnessEntry.ts
+++ b/src/test/e2e/postEditorSendingHarnessEntry.ts
@@ -2,6 +2,9 @@ import '../../app.css';
 import '../../i18n';
 import { mount } from 'svelte';
 import PostEditorSendingHarness from './PostEditorSendingHarness.svelte';
+import { installPostSubmitHarness } from './postSubmitHarness';
+
+installPostSubmitHarness();
 
 const target = document.getElementById('app');
 

--- a/src/test/e2e/postSubmitHarness.ts
+++ b/src/test/e2e/postSubmitHarness.ts
@@ -1,0 +1,23 @@
+import { PostManager } from '../../lib/postManager';
+import type { PostResult } from '../../lib/types';
+
+/** Replace only the transport boundary, keeping extraction and status ownership real. */
+export function installPostSubmitHarness() {
+    const submissions: Array<{ content: string; emojiTags: string[][]; metadata: unknown }> = [];
+    let resolve: ((result: PostResult) => void) | undefined;
+    PostManager.prototype.submitPost = function (content, metadata, emojiTags) {
+        submissions.push({ content, emojiTags: (emojiTags ?? []).map(tag => [...tag]), metadata });
+        return new Promise<PostResult>((done) => { resolve = done; });
+    };
+    const harness = {
+        submissions,
+        finish(success = true) {
+            if (!resolve) throw new Error('No pending submission');
+            const done = resolve;
+            resolve = undefined;
+            done({ success, ...(success ? {} : { error: 'postComponent.post_error' }) });
+        },
+    };
+    (window as any).__postSubmitHarness = harness;
+    return harness;
+}

--- a/src/test/e2e/webComponentEmbed.spec.ts
+++ b/src/test/e2e/webComponentEmbed.spec.ts
@@ -26,6 +26,8 @@ let relayServer: WebSocketServer;
 let relayOrigin = "";
 let relayConnectionCount = 0;
 let relayPublishedEvents: Array<{ event: Record<string, unknown> }> = [];
+let relayEventsPaused = false;
+let pendingEventAcks: Array<() => void> = [];
 let relayRequestsPaused = false;
 let pendingRelayResponses: Array<() => void> = [];
 let failPostComponentLoad = false;
@@ -134,12 +136,11 @@ test.beforeAll(async () => {
                 ) {
                     const event = message[1] as Record<string, unknown>;
                     relayPublishedEvents.push({ event });
-                    socket.send(JSON.stringify([
-                        "OK",
-                        typeof event.id === "string" ? event.id : "",
-                        true,
-                        "accepted",
+                    const acknowledge = () => socket.send(JSON.stringify([
+                        "OK", typeof event.id === "string" ? event.id : "", true, "accepted",
                     ]));
+                    if (relayEventsPaused) pendingEventAcks.push(acknowledge);
+                    else acknowledge();
                 }
             } catch {
                 // The relay only needs to accept the browser connection for this proof.
@@ -206,6 +207,8 @@ test.beforeEach(() => {
     hostRequests.clear();
     relayConnectionCount = 0;
     relayPublishedEvents = [];
+    relayEventsPaused = false;
+    pendingEventAcks = [];
     relayRequestsPaused = false;
     pendingRelayResponses = [];
     failPostComponentLoad = false;
@@ -336,12 +339,8 @@ test("exposes the common editor empty state API through the Full element", async
     await editor.press("ArrowLeft");
     await expect.poll(() => page.evaluate(() => (window as any).__fullEditorEmptyChanges.length)).toBe(2);
 
-    await editor.press("ControlOrMeta+A");
-    await editor.press("Backspace");
-    // Clear the short test input through the editor's normal delete path. A
-    // character-by-character fallback keeps this deterministic on mobile
-    // projects where select-all chords are not exposed reliably.
-    await editor.press("End");
+    // Return from ArrowLeft to the known end, without mobile select-all/End.
+    await editor.press("ArrowRight");
     for (let index = 0; index < "Full text".length; index += 1) {
         await editor.press("Backspace");
     }
@@ -847,7 +846,8 @@ test("uses a preconnection Full relays property instead of saved user relays", a
     ]);
 });
 
-test("publishes EVENT only through the configured Host write relay", async ({ page }) => {
+test("publishes EVENT only through the configured Host write relay", async ({ page, browserName, isMobile }) => {
+    relayEventsPaused = true;
     const savedUserRelay = "wss://saved-user-relay.example";
     const hostReadRelay = "wss://host-read-relay.example";
     const hostWriteRelay = "wss://host-write-relay.example";
@@ -936,9 +936,39 @@ test("publishes EVENT only through the configured Host write relay", async ({ pa
     await expect(editor).toBeVisible();
     await editor.click();
     await editor.pressSequentially(content);
-    await composer.locator("button.post-button").click();
+    await editor.evaluate((element) => {
+        (window as any).__fullSubmitBlurs = 0;
+        element.addEventListener('blur', () => (window as any).__fullSubmitBlurs++);
+    });
+    const postButton = composer.locator("button.post-button");
+    await expect(postButton).toBeEnabled();
+    const touch = browserName === 'chromium' && isMobile ? await page.context().newCDPSession(page) : null;
+    if (touch) {
+        const box = await postButton.boundingBox();
+        if (!box) throw new Error('Submit button has no box');
+        await touch.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [{ x: box.x + box.width / 2, y: box.y + box.height / 2 }] });
+    } else {
+        await postButton.dispatchEvent('pointerdown', { pointerType: 'touch', pointerId: 1 });
+    }
 
     await expect.poll(() => relayPublishedEvents.length).toBe(1);
+    await expect(editor).toHaveAttribute('contenteditable', 'true');
+    expect(await composer.evaluate(el => el.shadowRoot?.activeElement?.classList.contains('tiptap-editor'))).toBe(true);
+    if (touch) {
+        await touch.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+        await touch.detach();
+    } else {
+        await postButton.dispatchEvent('pointerup', { pointerType: 'touch', pointerId: 1 });
+        await postButton.dispatchEvent('click');
+    }
+    await page.keyboard.press('Backspace');
+    await expect(editor).toHaveText(content);
+    relayEventsPaused = false;
+    pendingEventAcks.splice(0).forEach(acknowledge => acknowledge());
+    await expect(editor).toHaveText('');
+    expect(await composer.evaluate(el => el.shadowRoot?.activeElement?.classList.contains('tiptap-editor'))).toBe(true);
+    expect(await page.evaluate(() => (window as any).__fullSubmitBlurs)).toBe(0);
+    expect(relayPublishedEvents).toHaveLength(1);
     const result = await page.evaluate(() => (window as any).__hostRelayPublishState);
     expect(relayPublishedEvents[0]?.event.content).toBe(content);
     expect(result.eventDestinations).toEqual([hostWriteRelay]);

--- a/src/test/e2e/webComponentLite.spec.ts
+++ b/src/test/e2e/webComponentLite.spec.ts
@@ -789,12 +789,9 @@ test("exposes the common editor empty state API through the Host-owned Lite elem
     await expect.poll(() => page.evaluate(() => (window as any).__liteEditorEmptyChanges.length)).toBe(2);
     await editor.press("ArrowLeft");
     await expect.poll(() => page.evaluate(() => (window as any).__liteEditorEmptyChanges.length)).toBe(2);
-    await editor.press("ControlOrMeta+A");
-    await editor.press("Backspace");
-    // Clear the short test input through the editor's normal delete path. A
-    // character-by-character fallback keeps this deterministic on mobile
-    // projects where select-all chords are not exposed reliably.
-    await editor.press("End");
+    // Reverse the selection-only ArrowLeft above, then delete from the known
+    // end position. Mobile emulation does not reliably expose select-all/End.
+    await editor.press("ArrowRight");
     for (let index = 0; index < "Lite text".length; index += 1) {
         await editor.press("Backspace");
     }

--- a/src/test/unit/accessibilityComponent.test.ts
+++ b/src/test/unit/accessibilityComponent.test.ts
@@ -231,7 +231,7 @@ describe('accessibility component tests', () => {
         );
     });
 
-    it('makes the editor read-only only while a post is sending', async () => {
+    it('keeps the editable surface but disables document changes while sending', async () => {
         resetPostStatus();
         const { component, unmount } = render(PostComponent, {
             hasStoredKey: true,
@@ -256,8 +256,13 @@ describe('accessibility component tests', () => {
         updatePostStatus({ ...editorState.postStatus, sending: true });
         await tick();
 
-        expect(editor.isEditable).toBe(false);
-        expect(tiptapEditor.getAttribute('contenteditable')).toBe('false');
+        expect(editor.isEditable).toBe(true);
+        expect(tiptapEditor.getAttribute('contenteditable')).toBe('true');
+        expect(editorContainer.getAttribute('aria-disabled')).toBe('true');
+        const frozenDoc = editor.state.doc;
+        editor.commands.insertContent('blocked');
+        editor.view.dispatch(editor.state.tr.insertText('blocked composition').setMeta('composition', 1));
+        expect(editor.state.doc.eq(frozenDoc)).toBe(true);
         expect(editorContainer.classList.contains('sending')).toBe(true);
         expect(editorContainer.getAttribute('aria-disabled')).toBe('true');
         expect(editorContainer.textContent).toContain('送信中も確認できる本文');

--- a/src/test/unit/androidCompositionFix.test.ts
+++ b/src/test/unit/androidCompositionFix.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+
+afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); });
+
+it('keeps a pending Android composition alive until natural end and cleans up on destroy', async () => {
+    vi.resetModules();
+    vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue('Android Chrome');
+    const { AndroidCompositionFix } = await import('../../lib/editor/androidCompositionFix');
+    vi.useFakeTimers();
+    const editor = new Editor({ extensions: [StarterKit, AndroidCompositionFix], content: '<p>text</p>' });
+    await vi.advanceTimersByTimeAsync(0);
+    const updates = vi.fn();
+    editor.view.dom.addEventListener('compositionupdate', updates);
+    try {
+        editor.view.dom.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+        await vi.advanceTimersByTimeAsync(12000);
+        expect(editor.view.composing).toBe(true);
+        expect(updates).toHaveBeenCalledTimes(3);
+        editor.view.dom.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+        expect((editor.storage as unknown as { androidCompositionFix: { keepAliveInterval: unknown } }).androidCompositionFix.keepAliveInterval).toBeNull();
+        await vi.advanceTimersByTimeAsync(8000);
+        expect(updates).toHaveBeenCalledTimes(3);
+        editor.view.dom.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    } finally {
+        editor.destroy();
+    }
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(updates).toHaveBeenCalledTimes(3);
+});

--- a/src/test/unit/editorSubmitBoundary.test.ts
+++ b/src/test/unit/editorSubmitBoundary.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { EditorInputGuard } from '../../lib/editor/editorInputGuard';
+import { waitForEditorComposition } from '../../lib/editor/waitForEditorComposition';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('submit composition boundary', () => {
+    function setup() {
+        const dom = document.createElement('div');
+        const editor = { view: { dom, composing: true }, isDestroyed: false };
+        let frame: FrameRequestCallback | undefined;
+        vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+            frame = callback;
+            return 1;
+        });
+        const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame');
+        const wait = waitForEditorComposition(editor as unknown as Editor);
+        return { dom, editor, wait, cancelFrame, frame: () => frame?.(0) };
+    }
+
+    it('waits for natural compositionend and a frame, including a restarted composition', async () => {
+        const test = setup();
+        const done = vi.fn();
+        void test.wait.settled.then(done);
+        test.dom.dispatchEvent(new CompositionEvent('compositionupdate'));
+        await Promise.resolve();
+        expect(done).not.toHaveBeenCalled();
+        test.dom.dispatchEvent(new CompositionEvent('compositionend'));
+        test.frame(); // Composition restarted before this frame.
+        await Promise.resolve();
+        expect(done).not.toHaveBeenCalled();
+        test.editor.view.composing = false;
+        test.dom.dispatchEvent(new CompositionEvent('compositionend'));
+        expect(done).not.toHaveBeenCalled();
+        test.frame();
+        await expect(test.wait.settled).resolves.toBe(true);
+    });
+
+    it('cancels pending frames and listeners on owner destruction', async () => {
+        const test = setup();
+        test.dom.dispatchEvent(new CompositionEvent('compositionend'));
+        test.wait.cancel();
+        await expect(test.wait.settled).resolves.toBe(false);
+        expect(test.cancelFrame).toHaveBeenCalledWith(1);
+        vi.mocked(window.requestAnimationFrame).mockClear();
+        test.dom.dispatchEvent(new CompositionEvent('compositionend'));
+        expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+    });
+});
+
+describe('sending document guard', () => {
+    it('rejects user and composition document changes, allows selection, and unlocks success clear', () => {
+        let blocked = false;
+        const editor = new Editor({
+            extensions: [StarterKit, EditorInputGuard.configure({ isInputBlocked: () => blocked })],
+            content: '<p>before</p>',
+        });
+        try {
+            editor.commands.insertContent('allowed');
+            const frozen = editor.state.doc;
+            blocked = true;
+            editor.commands.insertContent('blocked');
+            editor.view.dispatch(editor.state.tr.insertText('composition').setMeta('composition', 1));
+            editor.commands.clearContent();
+            expect(editor.state.doc.eq(frozen)).toBe(true);
+            editor.commands.setTextSelection(2);
+            expect(editor.state.selection.from).toBe(2);
+            expect(editor.isEditable).toBe(true);
+            blocked = false;
+            editor.commands.clearContent();
+            expect(editor.isEmpty).toBe(true);
+        } finally {
+            editor.destroy();
+        }
+    });
+});

--- a/src/test/unit/postManager.test.ts
+++ b/src/test/unit/postManager.test.ts
@@ -99,7 +99,8 @@ function createMockEditor(options?: { paragraphCount?: number; placeholder?: str
     const chain = vi.fn().mockReturnValue({ clearContent });
     const insertContent = vi.fn();
     const focus = vi.fn();
-    const commands = { insertContent, focus };
+    const setTextSelection = vi.fn();
+    const commands = { insertContent, focus, setTextSelection };
     const editor = {
         chain,
         commands,
@@ -409,7 +410,8 @@ describe('PostManager editor state helpers', () => {
 
             expect(mockEditor.clearContent).toHaveBeenCalled();
             expect(mockEditor.insertContent).not.toHaveBeenCalled();
-            expect(mockEditor.focus).toHaveBeenCalledWith('start');
+            expect(mockEditor.editor.commands.setTextSelection).toHaveBeenCalledWith(1);
+            expect(mockEditor.focus).not.toHaveBeenCalled();
             expect(mockDeps.contentWarningStore?.reset).toHaveBeenCalled();
             expect(mockDeps.contentWarningReasonStore?.reset).toHaveBeenCalled();
             expect(mockDeps.mediaGalleryStore?.clearAll).toHaveBeenCalled();
@@ -428,7 +430,8 @@ describe('PostManager editor state helpers', () => {
 
             expect(mockEditor.clearContent).toHaveBeenCalled();
             expect(mockEditor.insertContent).toHaveBeenCalledWith(' #test #hello');
-            expect(mockEditor.focus).toHaveBeenCalledWith('start');
+            expect(mockEditor.editor.commands.setTextSelection).toHaveBeenCalledWith(1);
+            expect(mockEditor.focus).not.toHaveBeenCalled();
         });
 
         it('ピン留めON+ハッシュタグなしの場合: insertContentを呼ばない', () => {
@@ -441,11 +444,21 @@ describe('PostManager editor state helpers', () => {
 
             expect(mockEditor.clearContent).toHaveBeenCalled();
             expect(mockEditor.insertContent).not.toHaveBeenCalled();
-            expect(mockEditor.focus).toHaveBeenCalledWith('start');
+            expect(mockEditor.editor.commands.setTextSelection).toHaveBeenCalledWith(1);
+            expect(mockEditor.focus).not.toHaveBeenCalled();
         });
     });
 
     describe('performPostSubmission', () => {
+        it('sends the checked content and emoji snapshot without extracting again', async () => {
+            const snapshot = { content: 'checked :wave:', emojiTags: [['emoji', 'wave', 'https://example.invalid/wave.png']] };
+            const extract = vi.spyOn(manager, 'preparePostPayload');
+            const submit = vi.spyOn(manager, 'submitPost').mockResolvedValue({ success: true });
+            vi.mocked(mockDeps.extractImageBlurhashMapFn!).mockReturnValue({});
+            await manager.performPostSubmission(createMockEditor().editor, snapshot, {}, {});
+            expect(extract).not.toHaveBeenCalled();
+            expect(submit).toHaveBeenCalledWith(snapshot.content, expect.any(Object), snapshot.emojiTags);
+        });
         let mockRxNostr: RxNostr;
         let mockAuthState: AuthState;
         let mockHashtagStore: HashtagStore;
@@ -513,7 +526,7 @@ describe('PostManager editor state helpers', () => {
 
             vi.mocked(mockRxNostr.send).mockReturnValue(mockObservable as any);
 
-            await manager.performPostSubmission(mockEditor.editor, imageOxMap, imageXMap, onStart, onSuccess, onError);
+            await manager.performPostSubmission(mockEditor.editor, { content: expectedContent, emojiTags: [] }, imageOxMap, imageXMap, onStart, onSuccess, onError);
 
             expect(onStart).toHaveBeenCalled();
             expect(onSuccess).toHaveBeenCalled();
@@ -544,7 +557,7 @@ describe('PostManager editor state helpers', () => {
 
             vi.mocked(mockRxNostr.send).mockReturnValue(mockObservable as any);
 
-            await manager.performPostSubmission(mockEditor.editor, imageOxMap, imageXMap, onStart, onSuccess, onError);
+            await manager.performPostSubmission(mockEditor.editor, { content: expectedContent, emojiTags: [] }, imageOxMap, imageXMap, onStart, onSuccess, onError);
 
             expect(onStart).toHaveBeenCalled();
             expect(onSuccess).not.toHaveBeenCalled();

--- a/src/test/unit/secretSubmitIntent.test.ts
+++ b/src/test/unit/secretSubmitIntent.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, expect, it, vi } from 'vitest';
+vi.unmock('../../stores/postUIStore.svelte');
+import { postComponentUIStore } from '../../stores/postUIStore.svelte';
+import { submitPendingPostWithSecretKey } from '../../lib/postComponentUtils';
+
+afterEach(() => postComponentUIStore.hideSecretKeyDialog());
+
+it('owns copied content/emoji tags until consumption and computes metadata at confirmation', async () => {
+    const tags = [['emoji', 'wave', 'https://example.invalid/wave.png']];
+    postComponentUIStore.showSecretKeyDialog('checked :wave:', tags);
+    tags[0][1] = 'changed';
+    const pendingPost = postComponentUIStore.getPendingPost();
+    const pendingEmojiTags = postComponentUIStore.getPendingEmojiTags();
+    const currentEditor = {} as any;
+    const metadata = { image: { blurhash: 'confirmation-time' } };
+    const postManager = {
+        prepareImageBlurhashMap: vi.fn(() => metadata),
+        submitPost: vi.fn(async () => ({ success: true })),
+    };
+    await submitPendingPostWithSecretKey({
+        postManager, currentEditor, imageOxMap: {}, imageXMap: {}, pendingPost, pendingEmojiTags,
+        onStart: () => postComponentUIStore.hideSecretKeyDialog(), onSuccess: vi.fn(), onFailure: vi.fn(),
+    });
+    expect(postManager.prepareImageBlurhashMap).toHaveBeenCalledOnce();
+    expect(postManager.submitPost).toHaveBeenCalledWith('checked :wave:', metadata, [['emoji', 'wave', 'https://example.invalid/wave.png']]);
+    expect(postComponentUIStore.value.showSecretKeyDialog).toBe(false);
+    expect(postComponentUIStore.getPendingPost()).toBe('');
+    expect(postComponentUIStore.getPendingEmojiTags()).toEqual([]);
+});
+
+it('discards all pending values on cancellation', () => {
+    postComponentUIStore.showSecretKeyDialog('pending', [['emoji', 'wave', 'url']]);
+    postComponentUIStore.hideSecretKeyDialog();
+    expect(postComponentUIStore.value.showSecretKeyDialog).toBe(false);
+    expect(postComponentUIStore.getPendingPost()).toBe('');
+    expect(postComponentUIStore.getPendingEmojiTags()).toEqual([]);
+});


### PR DESCRIPTION
Normal submission made the focused editor non-editable at sending start, which blurred it and closed the mobile keyboard. Success also focused an editor that had intentionally been left unfocused. Keep the normal composer editable, block editing at capture and ProseMirror transaction boundaries while sending, and reset the successful selection without acquiring focus. Normal post presses no longer apply the shared inputmode suppression. Standalone, iframe and Full Web Component share this path; Lite retains its host callback, inline submit and existing focus/editable policy.

Accept one pending submit while IME composition is active. Wait for natural compositionend and inspect the live document at the first animation frame, waiting for another natural end if composition restarts. Keep Android composition keepalive active until natural completion; cancel listeners/frames on destruction. Pending submission excludes another submit or upload but permits the IME to finish. Secret detection transfers ownership synchronously to the existing confirmation store; confirmation consumes that intent when sending starts and cancellation discards it.

Extract content and emoji tags once and pass that payload to normal submission or the existing secret confirmation store. Image metadata keeps its existing timing (normal send start / secret confirmation), with no new snapshot store or public API. Existing ARIA, clear/pinned hashtags, failure preservation and confirmation focus management remain in place.

Verification also explicitly selects Chromium for the mobile-chromium Playwright project, which previously inherited WebKit from its iPhone device descriptor. Existing empty-state tests now delete from a known caret position instead of mobile select-all/End shortcuts. The image-viewer focus test identifies its opener by image name because asynchronously loaded images can change which button matches first(). Assertions remain intact; no retries or timing extensions were added.

Validation:
- npm test: 355 files passed, 1 skipped; 4106 tests passed, 1 skipped, including the thread-graph complexity check.
- npm run check: zero errors and warnings.
- npm run build: standalone, Full/Lite Web Components and site assembly passed.
- Relevant Playwright tests passed on desktop/mobile Chromium, mobile WebKit and the applicable desktop Firefox project. Chromium CDP touch/IME input is separate from WebKit synthetic composition-event coverage. The 320px iframe and Full shadow-root path are covered.
- npm run test:e2e:agent: dev-server stage 1 passed; main stage 450 passed, 29 skipped (5.3m).
- git diff --check passed. Temporary probes were removed; browser/build artifacts are not committed.

Required user gate after PR creation and before merge/release (NOT yet verified):
- [ ] Android Chrome and Firefox; iOS Safari. Record OS, browser, IME, runtime and result here. Cover standalone and representative iframe/Full Web Component hosts, plus Lite inline submit regression.
- [ ] Keyboard stays open and editor keeps focus throughout input, long press, sending and success.
- [ ] Japanese composition -> long press -> natural commit -> one automatic send preserves the final visible/document/posted text, with no missing characters or duplicate submission.
- [ ] The first-frame document synchronization boundary holds. This is a tested boundary, not a browser platform guarantee. If it fails, re-investigate composition/ProseMirror synchronization on this same branch/PR; do not add timeouts or extra frames.
- [ ] IME operations during sending cannot change content or leak stale characters into the successful clear; failure preserves content.
- [ ] Submitting with the keyboard already closed does not open it. Secret confirmation/cancellation retains the existing UX.

Do not merge or release while this physical-device gate is incomplete or failing. No merge, release or deployment is performed by this task.
